### PR TITLE
feat(editor): render math formulas

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -34,6 +34,7 @@
     "@tauri-apps/plugin-store": "^2.4.3",
     "@tauri-apps/plugin-updater": "2.10.1",
     "codemirror": "6.0.2",
+    "katex": "0.16.45",
     "lucide-react": "1.14.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -280,6 +280,22 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".paper-scroll")).toHaveClass("h-full", "min-h-0", "overflow-auto");
   });
 
+  it("renders block and inline math formulas with KaTeX while preserving markdown source", async () => {
+    const blockFormula = String.raw`$$ A = P \left(1 + \frac{r}{n}\right)^{nt} $$`;
+    const source = [blockFormula, "", "Where $A$ is the final amount."].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-display .katex")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-math-render-inline .katex")).toBeInTheDocument();
+    expect(
+      Array.from(container.querySelectorAll(".ProseMirror .markra-math-source-hidden")).map((node) => node.textContent)
+    ).toEqual([blockFormula, "$A$"]);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(blockFormula);
+    expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
+  });
+
   it("saves pasted clipboard images and inserts markdown image references", async () => {
     const onMarkdownChange = vi.fn();
     const onSaveClipboardImage = vi.fn().mockResolvedValue({

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -28,6 +28,7 @@ import { markraLinkImageLivePlugin } from "@markra/editor";
 import { markraRawHtmlPlugin } from "@markra/editor";
 import { serializeLinkImageLiveMarkdown } from "@markra/editor";
 import { markraMarkdownShortcuts } from "@markra/editor";
+import { markraMathPlugin } from "@markra/editor";
 import { markraTableControlsPlugin } from "@markra/editor";
 import { markraAiEditorPreviewPlugin } from "@markra/editor";
 import { markraAiSelectionHoldPlugin } from "@markra/editor";
@@ -303,6 +304,7 @@ function MilkdownSurface({
         .use(markraCommonmark)
         .use(markraGfm)
         .use(markraMarkdownShortcuts)
+        .use(markraMathPlugin)
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)
         .use(

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2,6 +2,7 @@
 @source "../../../packages/ui/src";
 @import "@milkdown/kit/prose/view/style/prosemirror.css";
 @import "@milkdown/kit/prose/tables/style/tables.css";
+@import "katex/dist/katex.css";
 
 @keyframes markra-ai-float-in {
   from {
@@ -677,6 +678,42 @@
 
   .markdown-paper .markra-live-image-preview {
     @apply my-6 block max-w-full rounded-[3px] border border-(--border-default);
+  }
+
+  .markdown-paper .markra-math-render {
+    color: var(--text-primary);
+    letter-spacing: 0;
+    user-select: text;
+  }
+
+  .markdown-paper .markra-math-render .katex {
+    font-size: 1em;
+  }
+
+  .markdown-paper .markra-math-render-inline {
+    display: inline-flex;
+    margin: 0 0.08em;
+    vertical-align: -0.08em;
+  }
+
+  .markdown-paper .markra-math-render-display {
+    display: block;
+    max-width: 100%;
+    margin: 0.85em 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    text-align: center;
+  }
+
+  .markdown-paper .markra-math-render-display .katex-display {
+    margin: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .markdown-paper .markra-math-render-invalid {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    color: var(--text-secondary);
   }
 
   .markdown-paper strong {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -18,6 +18,7 @@
     "@markra/ai": "workspace:*",
     "@markra/shared": "workspace:*",
     "@milkdown/kit": "^7.20.0",
+    "katex": "0.16.45",
     "prosemirror-tables": "1.8.5"
   },
   "devDependencies": {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ai-preview.ts";
 export * from "./clipboard-images.ts";
 export * from "./input-rules.ts";
 export * from "./link-image-rules.ts";
+export * from "./math.ts";
 export * from "./raw-html.ts";
 export * from "./selection-hold.ts";
 export * from "./shortcuts.ts";

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -1,0 +1,197 @@
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+import { renderToString } from "katex";
+
+type MathRangeKind = "display" | "inline";
+
+type MathRange = {
+  from: number;
+  kind: MathRangeKind;
+  source: string;
+  tex: string;
+  to: number;
+};
+
+const mathRenderKey = new PluginKey("markra-math-render");
+
+function isEscaped(text: string, index: number) {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+
+  return slashCount % 2 === 1;
+}
+
+function findClosingDelimiter(text: string, delimiter: "$" | "$$", from: number) {
+  for (let index = from; index < text.length; index += 1) {
+    if (text[index] !== "$" || isEscaped(text, index)) continue;
+
+    if (delimiter === "$$") {
+      if (text.startsWith("$$", index)) return index;
+      continue;
+    }
+
+    if (text[index - 1] !== "$" && text[index + 1] !== "$") return index;
+  }
+
+  return -1;
+}
+
+function getMathRanges(text: string) {
+  const ranges: MathRange[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] !== "$" || isEscaped(text, index)) {
+      index += 1;
+      continue;
+    }
+
+    if (text.startsWith("$$", index)) {
+      const closingIndex = findClosingDelimiter(text, "$$", index + 2);
+      if (closingIndex === -1) {
+        index += 2;
+        continue;
+      }
+
+      const to = closingIndex + 2;
+      const tex = text.slice(index + 2, closingIndex).trim();
+      if (tex) {
+        ranges.push({
+          from: index,
+          kind: "display",
+          source: text.slice(index, to),
+          tex,
+          to
+        });
+      }
+
+      index = to;
+      continue;
+    }
+
+    if (text[index - 1] === "$" || text[index + 1] === "$") {
+      index += 1;
+      continue;
+    }
+
+    const closingIndex = findClosingDelimiter(text, "$", index + 1);
+    if (closingIndex === -1) {
+      index += 1;
+      continue;
+    }
+
+    const to = closingIndex + 1;
+    const tex = text.slice(index + 1, closingIndex).trim();
+    if (tex) {
+      ranges.push({
+        from: index,
+        kind: "inline",
+        source: text.slice(index, to),
+        tex,
+        to
+      });
+    }
+
+    index = to;
+  }
+
+  return ranges;
+}
+
+function makeAbsoluteRange(range: MathRange, blockStart: number): MathRange {
+  return {
+    ...range,
+    from: blockStart + range.from,
+    to: blockStart + range.to
+  };
+}
+
+function findActiveMathRange(state: EditorState) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection)) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock) return null;
+  if ($from.parent.type.spec.code) return null;
+  if (!$from.sameParent(selection.$to)) return null;
+
+  const from = Math.min($from.parentOffset, selection.$to.parentOffset);
+  const to = Math.max($from.parentOffset, selection.$to.parentOffset);
+  const relativeRange = getMathRanges($from.parent.textContent).find((candidate) =>
+    selection.empty ? candidate.from < from && from < candidate.to : candidate.from <= from && to <= candidate.to
+  );
+
+  return relativeRange ? makeAbsoluteRange(relativeRange, $from.start()) : null;
+}
+
+function renderFormula(range: MathRange) {
+  return renderToString(range.tex, {
+    displayMode: range.kind === "display",
+    output: "htmlAndMathml",
+    strict: "ignore",
+    throwOnError: false
+  });
+}
+
+function createMathWidget(range: MathRange) {
+  return (view: EditorView) => {
+    const element = view.dom.ownerDocument.createElement("span");
+    element.className = `markra-math-render markra-math-render-${range.kind}`;
+    element.setAttribute("aria-label", range.kind === "display" ? "Math formula" : "Inline math formula");
+
+    try {
+      element.innerHTML = renderFormula(range);
+    } catch {
+      element.classList.add("markra-math-render-invalid");
+      element.textContent = range.source;
+    }
+
+    return element;
+  };
+}
+
+function buildMathDecorations(doc: ProseNode, activeRange: MathRange | null) {
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, position) => {
+    if (!node.isTextblock || node.type.spec.code) return;
+
+    const blockStart = position + 1;
+    for (const relativeRange of getMathRanges(node.textContent)) {
+      const range = makeAbsoluteRange(relativeRange, blockStart);
+      const isActive = activeRange?.from === range.from && activeRange.to === range.to;
+      decorations.push(
+        Decoration.inline(range.from, range.to, {
+          class: isActive
+            ? "markra-math-source markra-md-delimiter"
+            : "markra-math-source markra-math-source-hidden markra-md-hidden-delimiter"
+        })
+      );
+
+      if (!isActive) {
+        decorations.push(
+          Decoration.widget(range.from, createMathWidget(range), {
+            ignoreSelection: true,
+            key: `markra-math-${range.kind}-${range.from}-${range.to}`,
+            side: -1
+          })
+        );
+      }
+    }
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const markraMathPlugin = $prose(() => {
+  return new Plugin({
+    key: mathRenderKey,
+    props: {
+      decorations: (state) => buildMathDecorations(state.doc, findActiveMathRange(state))
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       codemirror:
         specifier: 6.0.2
         version: 6.0.2
+      katex:
+        specifier: 0.16.45
+        version: 0.16.45
       lucide-react:
         specifier: 1.14.0
         version: 1.14.0(react@19.2.5)
@@ -181,6 +184,9 @@ importers:
       '@milkdown/kit':
         specifier: ^7.20.0
         version: 7.20.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(typescript@6.0.3)
+      katex:
+        specifier: 0.16.45
+        version: 0.16.45
       prosemirror-tables:
         specifier: 1.8.5
         version: 1.8.5


### PR DESCRIPTION
## Summary
- Render `$...$` and `$$...$$` formulas in the Markdown editor with KaTeX.
- Preserve the original Markdown source for serialization and reveal the source while editing a formula.
- Add KaTeX styles/dependencies and integration coverage for block and inline formulas.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "renders block and inline math formulas"` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/desktop build` passed

## Risk
- Formula detection is delimiter-based; malformed or unclosed dollar delimiters remain as plain source text.