### PR TITLE
feat(editor): add editable code block highlighting

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -82,6 +82,18 @@ function insertTextDirectly(view: EditorView, text: string) {
   view.dispatch(view.state.tr.insertText(text, from, to).scrollIntoView());
 }
 
+function insertTextThroughInputHandler(view: EditorView, text: string) {
+  const { from, to } = view.state.selection;
+  const insertText = () => view.state.tr.insertText(text, from, to).scrollIntoView();
+  const handled = view.someProp("handleTextInput", (handler) => handler(view, from, to, text, insertText));
+
+  if (!handled) {
+    view.dispatch(insertText());
+  }
+
+  return Boolean(handled);
+}
+
 function moveCursor(view: EditorView, position: number) {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, position)));
 }
@@ -92,6 +104,10 @@ function selectNode(view: EditorView, position: number) {
 
 function selectText(view: EditorView, from: number, to: number) {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+}
+
+function splitCurrentTextBlockDirectly(view: EditorView) {
+  view.dispatch(view.state.tr.split(view.state.selection.from).scrollIntoView());
 }
 
 function findTextPosition(view: EditorView, text: string, offset = 0) {
@@ -278,6 +294,158 @@ describe("MarkdownPaper editing", () => {
 
     expect(container.querySelector(".paper-scroll")).toHaveClass("overscroll-none");
     expect(container.querySelector(".paper-scroll")).toHaveClass("h-full", "min-h-0", "overflow-auto");
+  });
+
+  it("renders fenced code blocks with syntax highlighting and line numbers", async () => {
+    const source = ["```ts", "const answer = 42;", "return answer;", "```"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toHaveAttribute("data-language", "ts");
+    expect(
+      Array.from(container.querySelectorAll(".ProseMirror .markra-code-line-number")).map((node) => node.textContent)
+    ).toEqual(["1", "2"]);
+    expect(container.querySelector(".ProseMirror .hljs-keyword")).toHaveTextContent("const");
+    expect(container.querySelector(".ProseMirror .hljs-number")).toHaveTextContent("42");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+  });
+
+  it("updates a code block language from the inline language selector", async () => {
+    const source = ["```ts", "const answer = 42;", "```"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const languageSelect = container.querySelector<HTMLSelectElement>(
+      ".ProseMirror .markra-code-language-select"
+    );
+
+    expect(languageSelect).toHaveValue("ts");
+    expect(Array.from(languageSelect!.options).map((option) => option.value)).toEqual(
+      expect.arrayContaining(["", "json", "ts", "tsx", "python"])
+    );
+
+    fireEvent.change(languageSelect!, { target: { value: "json" } });
+
+    await waitFor(() => expect(view.state.doc.child(0).attrs.language).toBe("json"));
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toHaveAttribute("data-language", "json");
+    expect(container.querySelector(".ProseMirror .markra-code-content")).toHaveClass("language-json");
+    expect(serializeMarkdown(view.state.doc)).toContain(["```json", "const answer = 42;", "```"].join("\n"));
+  });
+
+  it("keeps uncommon code block languages available in the inline selector", async () => {
+    const source = ["```custom-lang", "alpha", "```"].join("\n");
+    const { container } = await renderEditor(source);
+    const languageSelect = container.querySelector<HTMLSelectElement>(
+      ".ProseMirror .markra-code-language-select"
+    );
+
+    expect(languageSelect).toHaveValue("custom-lang");
+    expect(Array.from(languageSelect!.options).map((option) => option.value)).toContain("custom-lang");
+  });
+
+  it("turns typed triple backticks into a code block when pressing Enter", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "```");
+
+    expect(pressEnter(view)).toBe(true);
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toBeInTheDocument();
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  it("turns typed language fences into a code block when pressing Enter", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "```json");
+
+    expect(pressEnter(view)).toBe(true);
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toHaveAttribute("data-language", "json");
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.child(0).attrs.language).toBe("json");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  it("normalizes a language fence even if Enter first inserts a new paragraph", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "```json");
+    splitCurrentTextBlockDirectly(view);
+
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toHaveAttribute("data-language", "json");
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.child(0).attrs.language).toBe("json");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  it("turns typed triple backticks into a code block after existing text", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "Before");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "```");
+    expect(pressEnter(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toBeInTheDocument();
+    expect(view.state.doc.child(0).type.name).toBe("paragraph");
+    expect(view.state.doc.child(0).textContent).toBe("Before");
+    expect(view.state.doc.child(1).type.name).toBe("code_block");
+  });
+
+  it("turns typed triple backticks into a code block when pressing Space", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "``` ");
+
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toBeInTheDocument();
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  it("turns a single triple-backtick text insertion into a code block", async () => {
+    const { container, view } = await renderEditor();
+
+    expect(insertTextThroughInputHandler(view, "```")).toBe(true);
+
+    expect(container.querySelector(".ProseMirror .markra-code-block")).toBeInTheDocument();
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.textContent).toBe("");
+  });
+
+  it("closes a code block when typing a trailing triple backtick fence", async () => {
+    const { editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "```");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "const answer = 42;");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "```");
+    typeText(view, "After");
+
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.child(0).textContent).toBe("const answer = 42;");
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).textContent).toBe("After");
+    expect(serializeMarkdown(view.state.doc)).toContain(["```", "const answer = 42;", "```", "", "After"].join("\n"));
+  });
+
+  it("closes a code block when a trailing triple-backtick fence is inserted at once", async () => {
+    const { editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "```");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "const answer = 42;");
+    expect(pressEnter(view)).toBe(true);
+    expect(insertTextThroughInputHandler(view, "```")).toBe(true);
+    typeText(view, "After");
+
+    expect(view.state.doc.child(0).type.name).toBe("code_block");
+    expect(view.state.doc.child(0).textContent).toBe("const answer = 42;");
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).textContent).toBe("After");
+    expect(serializeMarkdown(view.state.doc)).toContain(["```", "const answer = 42;", "```", "", "After"].join("\n"));
   });
 
   it("renders block and inline math formulas with KaTeX while preserving markdown source", async () => {

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -24,6 +24,7 @@ import { Plugin } from "@milkdown/kit/prose/state";
 import { $prose } from "@milkdown/kit/utils";
 import { markraLiveMarkdownPlugin } from "@markra/editor";
 import { markraClipboardImagePlugin, type SaveClipboardImage } from "@markra/editor";
+import { markraCodeBlockPlugin } from "@markra/editor";
 import { markraLinkImageLivePlugin } from "@markra/editor";
 import { markraRawHtmlPlugin } from "@markra/editor";
 import { serializeLinkImageLiveMarkdown } from "@markra/editor";
@@ -304,6 +305,7 @@ function MilkdownSurface({
         .use(markraCommonmark)
         .use(markraGfm)
         .use(markraMarkdownShortcuts)
+        .use(markraCodeBlockPlugin)
         .use(markraMathPlugin)
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -878,6 +878,82 @@
     @apply border-0 bg-transparent p-0;
   }
 
+  .markdown-paper .markra-code-block {
+    @apply relative mt-5 mb-7 grid overflow-hidden rounded border border-(--border-default) bg-(--bg-code);
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .markdown-paper .markra-code-language-control {
+    @apply absolute top-2 right-2 z-[1] flex items-center;
+  }
+
+  .markdown-paper .markra-code-language-select {
+    @apply h-9 min-w-40 rounded-md border border-(--border-default) bg-(--bg-primary)/96 px-3 text-[0.82rem] font-medium text-(--text-secondary) outline-none transition-[border-color,color,background-color,box-shadow];
+    max-width: min(18rem, calc(100vw - 4rem));
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    line-height: 1;
+  }
+
+  .markdown-paper .markra-code-language-select:focus {
+    @apply border-(--border-focus) bg-(--bg-primary) text-(--text-primary);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--border-focus) 18%, transparent);
+  }
+
+  .markdown-paper .markra-code-line-numbers {
+    @apply border-r border-(--border-default) px-3 py-4 text-right text-[0.9em] leading-[1.65] text-(--text-secondary);
+    background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-code));
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    user-select: none;
+  }
+
+  .markdown-paper .markra-code-line-number {
+    display: block;
+    min-width: 2ch;
+  }
+
+  .markdown-paper .markra-code-block pre {
+    @apply m-0 min-w-0 overflow-auto rounded-none border-0 bg-transparent px-4 py-4;
+  }
+
+  .markdown-paper .markra-code-block code {
+    @apply block border-0 bg-transparent p-0 text-[0.9em];
+    color: var(--text-primary);
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    line-height: 1.65;
+    white-space: pre;
+  }
+
+  .markdown-paper .hljs-keyword,
+  .markdown-paper .hljs-selector-tag,
+  .markdown-paper .hljs-literal {
+    color: oklch(43% 0.17 283);
+    font-weight: 650;
+  }
+
+  .markdown-paper .hljs-string,
+  .markdown-paper .hljs-regexp,
+  .markdown-paper .hljs-addition {
+    color: oklch(42% 0.13 151);
+  }
+
+  .markdown-paper .hljs-number,
+  .markdown-paper .hljs-attr,
+  .markdown-paper .hljs-variable {
+    color: oklch(47% 0.16 42);
+  }
+
+  .markdown-paper .hljs-title,
+  .markdown-paper .hljs-function,
+  .markdown-paper .hljs-built_in {
+    color: oklch(44% 0.15 247);
+  }
+
+  .markdown-paper .hljs-comment,
+  .markdown-paper .hljs-quote {
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
   .markdown-paper hr {
     @apply my-8 border-0 border-t border-(--border-default);
   }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,6 +19,7 @@
     "@markra/shared": "workspace:*",
     "@milkdown/kit": "^7.20.0",
     "katex": "0.16.45",
+    "lowlight": "3.3.0",
     "prosemirror-tables": "1.8.5"
   },
   "devDependencies": {

--- a/packages/editor/src/code-block.ts
+++ b/packages/editor/src/code-block.ts
@@ -1,0 +1,442 @@
+import { codeBlockSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode, NodeType } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, TextSelection, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView, type NodeView, type ViewMutationRecord } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+import { common, createLowlight } from "lowlight";
+
+type HighlightAstNode = {
+  children?: HighlightAstNode[];
+  properties?: {
+    className?: unknown;
+  };
+  type: string;
+  value?: string;
+};
+
+type HighlightRange = {
+  className: string;
+  from: number;
+  to: number;
+};
+
+type SplitFenceParagraph = {
+  from: number;
+  language: string;
+  to: number;
+};
+
+type CodeBlockGetPosition = () => number | undefined;
+
+const codeLanguageOptions = [
+  { label: "Plain Text", value: "" },
+  { label: "Bash", value: "bash" },
+  { label: "C", value: "c" },
+  { label: "C++", value: "cpp" },
+  { label: "C#", value: "csharp" },
+  { label: "CSS", value: "css" },
+  { label: "Diff", value: "diff" },
+  { label: "Dockerfile", value: "dockerfile" },
+  { label: "Go", value: "go" },
+  { label: "GraphQL", value: "graphql" },
+  { label: "HTML", value: "html" },
+  { label: "INI", value: "ini" },
+  { label: "Java", value: "java" },
+  { label: "JavaScript", value: "javascript" },
+  { label: "JSX", value: "jsx" },
+  { label: "JSON", value: "json" },
+  { label: "Kotlin", value: "kotlin" },
+  { label: "Less", value: "less" },
+  { label: "Lua", value: "lua" },
+  { label: "Makefile", value: "makefile" },
+  { label: "Markdown", value: "markdown" },
+  { label: "Mermaid", value: "mermaid" },
+  { label: "Nginx", value: "nginx" },
+  { label: "Objective-C", value: "objectivec" },
+  { label: "Perl", value: "perl" },
+  { label: "PHP", value: "php" },
+  { label: "PowerShell", value: "powershell" },
+  { label: "Python", value: "python" },
+  { label: "R", value: "r" },
+  { label: "Ruby", value: "ruby" },
+  { label: "Rust", value: "rust" },
+  { label: "SCSS", value: "scss" },
+  { label: "Shell", value: "sh" },
+  { label: "SQL", value: "sql" },
+  { label: "Svelte", value: "svelte" },
+  { label: "Swift", value: "swift" },
+  { label: "TOML", value: "toml" },
+  { label: "TSX", value: "tsx" },
+  { label: "TypeScript", value: "ts" },
+  { label: "Vue", value: "vue" },
+  { label: "XML", value: "xml" },
+  { label: "YAML", value: "yaml" }
+] as const;
+
+const codeBlockHighlightKey = new PluginKey("markra-code-block-highlight");
+const lowlight = createLowlight(common);
+const codeFencePattern = /^```(?<language>[^\s`]*)$/u;
+
+function normalizeCodeLanguage(language: unknown) {
+  if (typeof language !== "string") return "";
+
+  return language.trim().replace(/[\s`]+/gu, "-");
+}
+
+function codeLanguage(node: ProseNode) {
+  return normalizeCodeLanguage(node.attrs.language);
+}
+
+function codeLanguageClass(language: string) {
+  return language ? `language-${language.replace(/[^\w-]/gu, "-")}` : "";
+}
+
+function highlightClassNames(node: HighlightAstNode) {
+  const className = node.properties?.className;
+  if (!Array.isArray(className)) return [];
+
+  return className.filter((value): value is string => typeof value === "string");
+}
+
+function collectHighlightRanges(
+  node: HighlightAstNode,
+  offset: number,
+  inheritedClassNames: string[],
+  ranges: HighlightRange[]
+) {
+  if (node.type === "text") {
+    const value = node.value ?? "";
+    if (value.length > 0 && inheritedClassNames.length > 0) {
+      ranges.push({
+        className: inheritedClassNames.join(" "),
+        from: offset,
+        to: offset + value.length
+      });
+    }
+
+    return offset + value.length;
+  }
+
+  const classNames = [...inheritedClassNames, ...highlightClassNames(node)];
+  let cursor = offset;
+  for (const child of node.children ?? []) {
+    cursor = collectHighlightRanges(child, cursor, classNames, ranges);
+  }
+
+  return cursor;
+}
+
+function highlightCode(language: string, code: string) {
+  if (!code.trim()) return [];
+
+  const ranges: HighlightRange[] = [];
+  try {
+    const tree = language && lowlight.registered(language)
+      ? lowlight.highlight(language, code)
+      : lowlight.highlightAuto(code);
+    collectHighlightRanges(tree as HighlightAstNode, 0, [], ranges);
+  } catch {
+    return [];
+  }
+
+  return ranges;
+}
+
+function buildCodeBlockDecorations(doc: ProseNode, codeBlockType: NodeType) {
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, position) => {
+    if (node.type !== codeBlockType) return;
+
+    const blockStart = position + 1;
+    for (const range of highlightCode(codeLanguage(node), node.textContent)) {
+      if (range.from >= range.to) continue;
+
+      decorations.push(
+        Decoration.inline(blockStart + range.from, blockStart + range.to, {
+          class: range.className
+        })
+      );
+    }
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+function lineCountForCodeBlock(node: ProseNode) {
+  return Math.max(1, node.textContent.split("\n").length);
+}
+
+function targetIsInside(target: EventTarget | Node | null, container: HTMLElement) {
+  return target instanceof Node && container.contains(target);
+}
+
+function openCodeBlockWithInsertedFence(view: EditorView, codeBlock: NodeType, text: string) {
+  const languageMatch = codeFencePattern.exec(text);
+  if (!languageMatch) return false;
+
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock || $from.parent.type.spec.code) return false;
+
+  const beforeCursor = $from.parent.textContent.slice(0, $from.parentOffset);
+  const afterCursor = $from.parent.textContent.slice($from.parentOffset);
+  if (beforeCursor.length > 0 || afterCursor.length > 0) return false;
+
+  return replaceCurrentBlockWithCodeBlock(view, codeBlock, languageMatch.groups?.language ?? "");
+}
+
+function replaceCurrentBlockWithCodeBlock(view: EditorView, codeBlock: NodeType, language: string) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection)) return false;
+
+  const { $from } = selection;
+  const position = $from.before();
+  const transaction = view.state.tr.replaceWith(position, $from.after(), codeBlock.create({
+    language: normalizeCodeLanguage(language)
+  }));
+  view.dispatch(
+    transaction.setSelection(TextSelection.create(transaction.doc, position + 1)).scrollIntoView()
+  );
+  return true;
+}
+
+function openCodeBlockWithFenceEnter(view: EditorView, codeBlock: NodeType, event: KeyboardEvent) {
+  if (event.key !== "Enter" || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const text = selection.$from.parent.textContent;
+  const languageMatch = codeFencePattern.exec(text);
+  if (!languageMatch) return false;
+  if (selection.$from.parentOffset !== text.length) return false;
+
+  event.preventDefault();
+  return replaceCurrentBlockWithCodeBlock(view, codeBlock, languageMatch.groups?.language ?? "");
+}
+
+function findSplitFenceParagraph(state: EditorState): SplitFenceParagraph | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  let splitFence: SplitFenceParagraph | null = null;
+
+  state.doc.descendants((node, position, parent, index) => {
+    if (splitFence) return false;
+    if (!parent || index >= parent.childCount - 1) return true;
+    if (!node.isTextblock || node.type.spec.code) return true;
+
+    const languageMatch = codeFencePattern.exec(node.textContent);
+    if (!languageMatch) return true;
+
+    const nextNode = parent.child(index + 1);
+    if (!nextNode.isTextblock || nextNode.type.spec.code || nextNode.textContent.length > 0) return true;
+
+    const nextPosition = position + node.nodeSize;
+    const selectionIsInNextNode = selection.from > nextPosition && selection.from < nextPosition + nextNode.nodeSize;
+    if (!selectionIsInNextNode) return true;
+
+    splitFence = {
+      from: position,
+      language: languageMatch.groups?.language ?? "",
+      to: nextPosition + nextNode.nodeSize
+    };
+    return false;
+  });
+
+  return splitFence;
+}
+
+function normalizeSplitFenceParagraph(
+  transactions: readonly Transaction[],
+  state: EditorState,
+  codeBlock: NodeType
+) {
+  if (!transactions.some((transaction) => transaction.docChanged)) return null;
+
+  const splitFence = findSplitFenceParagraph(state);
+  if (!splitFence) return null;
+
+  const transaction = state.tr.replaceWith(splitFence.from, splitFence.to, codeBlock.create({
+    language: splitFence.language
+  }));
+  return transaction.setSelection(TextSelection.create(transaction.doc, splitFence.from + 1)).scrollIntoView();
+}
+
+function closeCodeBlockWithTrailingFence(view: EditorView, text: string) {
+  const { selection } = view.state;
+  if ((text !== "`" && text !== "```") || !(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const { $from } = selection;
+  if ($from.parent.type.name !== "code_block") return false;
+
+  const code = $from.parent.textContent;
+  const beforeCursor = code.slice(0, $from.parentOffset);
+  const afterCursor = code.slice($from.parentOffset);
+  const lineStart = beforeCursor.lastIndexOf("\n") + 1;
+  const nextLineBreak = afterCursor.indexOf("\n");
+  const lineAfterCursor = nextLineBreak === -1 ? afterCursor : afterCursor.slice(0, nextLineBreak);
+  const expectedLineBeforeCursor = text === "`" ? "``" : "";
+  if (beforeCursor.slice(lineStart) !== expectedLineBeforeCursor || lineAfterCursor.length > 0) return false;
+
+  const paragraph = view.state.schema.nodes.paragraph;
+  if (!paragraph) return false;
+
+  const deleteFrom = $from.start() + lineStart - (lineStart > 0 ? 1 : 0);
+  const deleteTo = $from.pos;
+  let transaction = view.state.tr.delete(deleteFrom, deleteTo);
+  const insertPosition = transaction.mapping.map($from.after());
+  transaction = transaction.insert(insertPosition, paragraph.create());
+  view.dispatch(
+    transaction.setSelection(TextSelection.create(transaction.doc, insertPosition + 1)).scrollIntoView()
+  );
+  return true;
+}
+
+class MarkraCodeBlockNodeView implements NodeView {
+  readonly dom: HTMLElement;
+  readonly contentDOM: HTMLElement;
+
+  private node: ProseNode;
+  private readonly lineNumbers: HTMLElement;
+  private readonly languageControl: HTMLElement;
+  private readonly languageSelect: HTMLSelectElement;
+  private readonly code: HTMLElement;
+
+  constructor(
+    node: ProseNode,
+    private readonly view: EditorView,
+    private readonly getPos: CodeBlockGetPosition
+  ) {
+    this.node = node;
+    this.dom = view.dom.ownerDocument.createElement("div");
+    this.lineNumbers = view.dom.ownerDocument.createElement("div");
+    this.languageControl = view.dom.ownerDocument.createElement("div");
+    this.languageSelect = view.dom.ownerDocument.createElement("select");
+    const pre = view.dom.ownerDocument.createElement("pre");
+    this.code = view.dom.ownerDocument.createElement("code");
+    this.contentDOM = this.code;
+
+    this.dom.className = "markra-code-block";
+    this.languageControl.className = "markra-code-language-control";
+    this.languageControl.contentEditable = "false";
+    this.languageSelect.className = "markra-code-language-select";
+    this.languageSelect.setAttribute("aria-label", "Code block language");
+    this.lineNumbers.className = "markra-code-line-numbers";
+    this.lineNumbers.contentEditable = "false";
+    this.lineNumbers.setAttribute("aria-hidden", "true");
+    this.code.className = "markra-code-content";
+
+    this.populateLanguageOptions();
+    this.languageSelect.addEventListener("change", this.handleLanguageChange);
+    this.languageControl.append(this.languageSelect);
+    pre.append(this.code);
+    this.dom.append(this.languageControl, this.lineNumbers, pre);
+    this.syncLanguage();
+    this.syncLineNumbers();
+  }
+
+  update(nextNode: ProseNode) {
+    if (nextNode.type !== this.node.type) return false;
+
+    this.node = nextNode;
+    this.syncLanguage();
+    this.syncLineNumbers();
+    return true;
+  }
+
+  stopEvent(event: Event) {
+    return targetIsInside(event.target, this.lineNumbers) || targetIsInside(event.target, this.languageControl);
+  }
+
+  ignoreMutation(mutation: ViewMutationRecord) {
+    return targetIsInside(mutation.target, this.lineNumbers) || targetIsInside(mutation.target, this.languageControl);
+  }
+
+  destroy() {
+    this.languageSelect.removeEventListener("change", this.handleLanguageChange);
+  }
+
+  private syncLanguage() {
+    const language = codeLanguage(this.node);
+    this.syncLanguageOptions(language);
+    this.languageSelect.value = language;
+
+    if (language) {
+      this.dom.dataset.language = language;
+      this.code.className = `markra-code-content ${codeLanguageClass(language)}`;
+    } else {
+      delete this.dom.dataset.language;
+      this.code.className = "markra-code-content";
+    }
+  }
+
+  private syncLineNumbers() {
+    const ownerDocument = this.dom.ownerDocument;
+    const lines = Array.from({ length: lineCountForCodeBlock(this.node) }, (_, index) => {
+      const line = ownerDocument.createElement("span");
+      line.className = "markra-code-line-number";
+      line.textContent = String(index + 1);
+      return line;
+    });
+
+    this.lineNumbers.replaceChildren(...lines);
+  }
+
+  private populateLanguageOptions() {
+    for (const language of codeLanguageOptions) {
+      const option = this.dom.ownerDocument.createElement("option");
+      option.value = language.value;
+      option.textContent = language.label;
+      this.languageSelect.append(option);
+    }
+  }
+
+  private syncLanguageOptions(language: string) {
+    this.languageSelect.querySelector("[data-markra-custom-language='true']")?.remove();
+    if (!language || codeLanguageOptions.some((option) => option.value === language)) return;
+
+    const option = this.dom.ownerDocument.createElement("option");
+    option.value = language;
+    option.textContent = language;
+    option.dataset.markraCustomLanguage = "true";
+    this.languageSelect.append(option);
+  }
+
+  private readonly handleLanguageChange = () => {
+    const language = normalizeCodeLanguage(this.languageSelect.value);
+    if (language === codeLanguage(this.node)) return;
+
+    const position = this.getPos();
+    if (typeof position !== "number") return;
+
+    this.view.dispatch(
+      this.view.state.tr.setNodeMarkup(position, undefined, {
+        ...this.node.attrs,
+        language
+      })
+    );
+  };
+}
+
+export const markraCodeBlockPlugin = $prose((ctx) => {
+  const codeBlock = codeBlockSchema.type(ctx);
+
+  return new Plugin({
+    key: codeBlockHighlightKey,
+    appendTransaction: (transactions, _oldState, newState) =>
+      normalizeSplitFenceParagraph(transactions, newState, codeBlock),
+    props: {
+      decorations: (state) => buildCodeBlockDecorations(state.doc, codeBlock),
+      handleKeyDown: (view, event) => openCodeBlockWithFenceEnter(view, codeBlock, event),
+      handleTextInput: (view, _from, _to, text) =>
+        closeCodeBlockWithTrailingFence(view, text) || openCodeBlockWithInsertedFence(view, codeBlock, text),
+      nodeViews: {
+        code_block: (node, view, getPos) => new MarkraCodeBlockNodeView(node, view, getPos)
+      }
+    }
+  });
+});

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ai-preview.ts";
+export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
 export * from "./input-rules.ts";
 export * from "./link-image-rules.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       katex:
         specifier: 0.16.45
         version: 0.16.45
+      lowlight:
+        specifier: 3.3.0
+        version: 3.3.0
       prosemirror-tables:
         specifier: 1.8.5
         version: 1.8.5
@@ -1796,6 +1799,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1959,6 +1966,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -4922,6 +4932,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  highlight.js@11.11.1: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
@@ -5075,6 +5087,12 @@ snapshots:
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@11.3.5: {}
 


### PR DESCRIPTION
## Summary
- Render fenced code blocks with a Markra code block node view that adds a line-number gutter.
- Add `lowlight`-powered syntax highlighting as ProseMirror decorations so code stays editable.
- Add a larger inline language selector so changing a code block tag updates the editor node, highlighting class, and serialized Markdown.
- Include common language options while preserving uncommon existing tags as selectable custom options.
- Support opening code blocks from typed triple backticks, typed language fences such as ` ```json `, after existing text, and from chunked triple-backtick insertions.
- Normalize the fallback case where Enter first creates a plain newline after a language fence, converting it back into a code block.
- Support closing code blocks with typed or chunked trailing triple-backtick fences.
- Style highlighted tokens, line numbers, and the language selector in the Markdown editor.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "inline language selector"` passed
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop build` passed

## Risk
- Highlighting depends on `lowlight` common grammars; unsupported languages fall back to auto-detection or plain editable text.
- The language selector is part of the code block node view rather than Markdown text, so it should not alter the code content itself.
