### PR TITLE
fix(editor): improve math formula editing

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -464,6 +464,111 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
   });
 
+  it("reveals math source for editing when a rendered formula is clicked", async () => {
+    const source = "Where $A$ is the final amount.";
+    const { container, view } = await renderEditor(source);
+    const inlineFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-inline");
+
+    expect(inlineFormula).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).toHaveTextContent("$A$");
+
+    fireEvent.mouseDown(inlineFormula!);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
+    });
+    expect(container.querySelector(".ProseMirror .markra-math-render-inline")).not.toBeInTheDocument();
+    expect(view.state.selection.from).toBeGreaterThan(source.indexOf("$A$") + 1);
+    expect(view.state.selection.from).toBeLessThan(source.indexOf("$A$") + "$A$".length + 1);
+  });
+
+  it("reveals math source for editing from keyboard activation", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, view } = await renderEditor(source);
+    const blockFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-display");
+
+    expect(blockFormula).toBeInTheDocument();
+
+    fireEvent.keyDown(blockFormula!, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
+    });
+    expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+    expect(view.state.selection.from).toBeGreaterThan(source.indexOf("E"));
+    expect(view.state.selection.from).toBeLessThan(source.indexOf("$$", 2) + 1);
+  });
+
+  it("keeps math source visible after moving past the closing delimiter until Enter", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, view } = await renderEditor(source);
+    const blockFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-display");
+
+    fireEvent.mouseDown(blockFormula!);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
+    });
+
+    moveCursor(view, source.length + 1);
+
+    expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
+    });
+    expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).toHaveTextContent(source);
+  });
+
+  it("deletes a rendered math block from either side", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
+
+    moveCursor(view, 1);
+    expect(pressShortcut(view, "Delete")).toBe(true);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+    });
+    expect(serializeMarkdown(view.state.doc)).not.toContain(source);
+
+    insertTextDirectly(view, source);
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
+    });
+
+    moveCursor(view, source.length + 1);
+    expect(pressShortcut(view, "Backspace")).toBe(true);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+    });
+    expect(serializeMarkdown(view.state.doc)).not.toContain(source);
+  });
+
+  it("deletes a focused rendered math block with Delete", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const blockFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-display");
+
+    expect(blockFormula).toBeInTheDocument();
+
+    moveCursor(view, source.length + 1);
+    fireEvent.keyDown(blockFormula!, { key: "Delete" });
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+    });
+    expect(serializeMarkdown(view.state.doc)).not.toContain(source);
+  });
+
   it("saves pasted clipboard images and inserts markdown image references", async () => {
     const onMarkdownChange = vi.fn();
     const onSaveClipboardImage = vi.fn().mockResolvedValue({

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -683,6 +683,7 @@
   .markdown-paper .markra-math-render {
     color: var(--text-primary);
     letter-spacing: 0;
+    cursor: text;
     user-select: text;
   }
 

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -14,7 +14,21 @@ type MathRange = {
   to: number;
 };
 
-const mathRenderKey = new PluginKey("markra-math-render");
+type ActiveMathSource = {
+  from: number;
+  to: number;
+};
+
+type MathRenderMeta =
+  | {
+      range: MathRange;
+      type: "activate";
+    }
+  | {
+      type: "deactivate";
+    };
+
+const mathRenderKey = new PluginKey<ActiveMathSource | null>("markra-math-render");
 
 function isEscaped(text: string, index: number) {
   let slashCount = 0;
@@ -128,6 +142,63 @@ function findActiveMathRange(state: EditorState) {
   return relativeRange ? makeAbsoluteRange(relativeRange, $from.start()) : null;
 }
 
+function findMathRangeByBounds(doc: ProseNode, bounds: ActiveMathSource) {
+  let activeRange: MathRange | null = null;
+
+  doc.descendants((node, position) => {
+    if (activeRange) return false;
+    if (!node.isTextblock || node.type.spec.code) return;
+
+    const blockStart = position + 1;
+    for (const relativeRange of getMathRanges(node.textContent)) {
+      const range = makeAbsoluteRange(relativeRange, blockStart);
+      if (range.from !== bounds.from || range.to !== bounds.to) continue;
+
+      activeRange = range;
+      return false;
+    }
+  });
+
+  return activeRange;
+}
+
+function getActiveMathSource(state: EditorState) {
+  const activeSource = mathRenderKey.getState(state) as ActiveMathSource | null;
+  if (!activeSource) return null;
+
+  return findMathRangeByBounds(state.doc, activeSource);
+}
+
+function getEditableMathRange(state: EditorState) {
+  return getActiveMathSource(state) ?? findActiveMathRange(state);
+}
+
+function findAdjacentMathRange(state: EditorState, direction: "backward" | "forward") {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+  if (getActiveMathSource(state)) return null;
+
+  let adjacentRange: MathRange | null = null;
+  const cursor = selection.from;
+
+  state.doc.descendants((node, position) => {
+    if (adjacentRange) return false;
+    if (!node.isTextblock || node.type.spec.code) return;
+
+    const blockStart = position + 1;
+    for (const relativeRange of getMathRanges(node.textContent)) {
+      const range = makeAbsoluteRange(relativeRange, blockStart);
+      const touchesCursor = direction === "forward" ? range.from === cursor : range.to === cursor;
+      if (!touchesCursor) continue;
+
+      adjacentRange = range;
+      return false;
+    }
+  });
+
+  return adjacentRange;
+}
+
 function renderFormula(range: MathRange) {
   return renderToString(range.tex, {
     displayMode: range.kind === "display",
@@ -137,11 +208,101 @@ function renderFormula(range: MathRange) {
   });
 }
 
+function mathSourceEditPosition(range: MathRange) {
+  const delimiterLength = range.kind === "display" ? 2 : 1;
+  const sourceAfterDelimiter = range.source.slice(delimiterLength);
+  const firstContentOffset = sourceAfterDelimiter.search(/\S/u);
+  const fallbackPosition = range.from + delimiterLength;
+  if (firstContentOffset === -1) return fallbackPosition;
+
+  return Math.min(range.to - 1, fallbackPosition + firstContentOffset);
+}
+
+function revealMathSource(view: EditorView, range: MathRange) {
+  view.dispatch(
+    view.state.tr
+      .setMeta(mathRenderKey, {
+        range,
+        type: "activate"
+      } satisfies MathRenderMeta)
+      .setSelection(TextSelection.create(view.state.doc, mathSourceEditPosition(range)))
+      .scrollIntoView()
+  );
+  view.focus();
+}
+
+function closeActiveMathSource(view: EditorView, event: KeyboardEvent) {
+  if (event.key !== "Enter" || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+
+  const range = getEditableMathRange(view.state);
+  if (!range) return false;
+
+  event.preventDefault();
+  view.dispatch(
+    view.state.tr
+      .setMeta(mathRenderKey, {
+        type: "deactivate"
+      } satisfies MathRenderMeta)
+      .setSelection(TextSelection.create(view.state.doc, range.to))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
+function deleteMathRange(view: EditorView, range: MathRange) {
+  let transaction = view.state.tr
+    .setMeta(mathRenderKey, {
+      type: "deactivate"
+    } satisfies MathRenderMeta)
+    .delete(range.from, range.to);
+  const cursor = Math.min(range.from, transaction.doc.content.size);
+  transaction = transaction.setSelection(TextSelection.create(transaction.doc, cursor)).scrollIntoView();
+  view.dispatch(transaction);
+  view.focus();
+}
+
+function deleteAdjacentMathSource(view: EditorView, event: KeyboardEvent) {
+  if (event.key !== "Backspace" && event.key !== "Delete") return false;
+
+  const range = findAdjacentMathRange(view.state, event.key === "Delete" ? "forward" : "backward");
+  if (!range) return false;
+
+  event.preventDefault();
+  deleteMathRange(view, range);
+  return true;
+}
+
+function handleMathKeyDown(view: EditorView, event: KeyboardEvent) {
+  return closeActiveMathSource(view, event) || deleteAdjacentMathSource(view, event);
+}
+
 function createMathWidget(range: MathRange) {
   return (view: EditorView) => {
     const element = view.dom.ownerDocument.createElement("span");
     element.className = `markra-math-render markra-math-render-${range.kind}`;
     element.setAttribute("aria-label", range.kind === "display" ? "Math formula" : "Inline math formula");
+    element.tabIndex = 0;
+
+    element.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      revealMathSource(view, range);
+    });
+    element.addEventListener("keydown", (event) => {
+      if (event.key === "Backspace" || event.key === "Delete") {
+        event.preventDefault();
+        event.stopPropagation();
+        deleteMathRange(view, range);
+        return;
+      }
+
+      if (event.key !== "Enter" && event.key !== " ") return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      revealMathSource(view, range);
+    });
 
     try {
       element.innerHTML = renderFormula(range);
@@ -190,8 +351,32 @@ function buildMathDecorations(doc: ProseNode, activeRange: MathRange | null) {
 export const markraMathPlugin = $prose(() => {
   return new Plugin({
     key: mathRenderKey,
+    state: {
+      init: (): ActiveMathSource | null => null,
+      apply(transaction, activeSource: ActiveMathSource | null, _oldState, newState): ActiveMathSource | null {
+        const meta = transaction.getMeta(mathRenderKey) as MathRenderMeta | undefined;
+        if (meta?.type === "deactivate") return null;
+        if (meta?.type === "activate") {
+          return {
+            from: meta.range.from,
+            to: meta.range.to
+          } satisfies ActiveMathSource;
+        }
+
+        if (!activeSource) return null;
+
+        const mappedSource = {
+          from: transaction.mapping.map(activeSource.from, 1),
+          to: transaction.mapping.map(activeSource.to, -1)
+        } satisfies ActiveMathSource;
+        if (mappedSource.from >= mappedSource.to) return null;
+
+        return findMathRangeByBounds(newState.doc, mappedSource) ? mappedSource : null;
+      }
+    },
     props: {
-      decorations: (state) => buildMathDecorations(state.doc, findActiveMathRange(state))
+      decorations: (state) => buildMathDecorations(state.doc, getEditableMathRange(state)),
+      handleKeyDown: handleMathKeyDown
     }
   });
 });


### PR DESCRIPTION
## Summary
- Keep math formula source visible after entering edit mode until the user presses Enter.
- Support deleting rendered math blocks from either side with Delete or Backspace.
- Support deleting a focused rendered math block with Delete or Backspace.
- Add focused tests for math editing, explicit commit-to-render behavior, and deletion flows.

## Why
- Moving the caret past the closing `$$` previously caused formulas to render too early, making editing feel jumpy.
- Rendered formula blocks previously had no reliable direct-delete path while their markdown source was hidden.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "deletes a rendered math block|deletes a focused rendered math block"` passed
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop build` passed

## Risk
- Low: this changes only the math rendering plugin interaction model and covered keyboard paths.
