### PR TITLE
fix(editor): disable substitutions in code blocks

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -343,6 +343,16 @@ describe("MarkdownPaper editing", () => {
     expect(Array.from(languageSelect!.options).map((option) => option.value)).toContain("custom-lang");
   });
 
+  it("disables text substitutions inside editable code blocks", async () => {
+    const source = ["```python", "print('')", "```"].join("\n");
+    const { container } = await renderEditor(source);
+    const codeContent = container.querySelector<HTMLElement>(".ProseMirror .markra-code-content");
+
+    expect(codeContent).toHaveAttribute("spellcheck", "false");
+    expect(codeContent).toHaveAttribute("autocorrect", "off");
+    expect(codeContent).toHaveAttribute("autocapitalize", "off");
+  });
+
   it("turns typed triple backticks into a code block when pressing Enter", async () => {
     const { container, view } = await renderEditor();
 

--- a/packages/editor/src/code-block.ts
+++ b/packages/editor/src/code-block.ts
@@ -329,6 +329,10 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.lineNumbers.contentEditable = "false";
     this.lineNumbers.setAttribute("aria-hidden", "true");
     this.code.className = "markra-code-content";
+    this.code.spellcheck = false;
+    this.code.setAttribute("spellcheck", "false");
+    this.code.setAttribute("autocorrect", "off");
+    this.code.setAttribute("autocapitalize", "off");
 
     this.populateLanguageOptions();
     this.languageSelect.addEventListener("change", this.handleLanguageChange);


### PR DESCRIPTION
## Summary
- Disable spellcheck, autocorrect, and autocapitalization inside editable code blocks.
- Add a regression test ensuring code blocks opt out of text substitutions.

## Why
- Code blocks currently inherit the editor root input assistance settings, which can allow macOS/WebView smart punctuation to turn straight quotes into curly quotes while typing code.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop build` passed

Closes #6
