### PR TITLE
build(release): label platform assets and add portable zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,15 @@ jobs:
             artifact_name: macOS-apple-silicon
             os: macos-15
             target: aarch64-apple-darwin
-            asset_arch: aarch64
+            asset_platform: macos
+            asset_arch: arm64
             updater_platform: darwin-aarch64
             args: --target aarch64-apple-darwin
           - name: macOS (Intel)
             artifact_name: macOS-intel
             os: macos-15-intel
             target: x86_64-apple-darwin
+            asset_platform: macos
             asset_arch: x64
             updater_platform: darwin-x86_64
             args: --target x86_64-apple-darwin
@@ -56,12 +58,16 @@ jobs:
             artifact_name: Linux-x64
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            asset_platform: linux
+            asset_arch: x64
             updater_platform: linux-x86_64
             args: --target x86_64-unknown-linux-gnu
           - name: Windows (x64)
             artifact_name: Windows-x64
             os: windows-latest
             target: x86_64-pc-windows-msvc
+            asset_platform: windows
+            asset_arch: x64
             updater_platform: windows-x86_64
             args: --target x86_64-pc-windows-msvc
 
@@ -208,31 +214,6 @@ jobs:
           projectPath: ${{ env.DESKTOP_DIR }}
           args: ${{ matrix.args }} --config tauri.updater.conf.json
 
-      - name: Rename macOS updater bundle
-        if: startsWith(matrix.os, 'macos-')
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          VERSION="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
-          BUNDLE_DIR="${DESKTOP_DIR}/src-tauri/target/${{ matrix.target }}/release/bundle/macos"
-          SOURCE_BUNDLE="$(find "${BUNDLE_DIR}" -maxdepth 1 -type f -name '*.app.tar.gz' | head -n 1)"
-
-          if [[ -z "${SOURCE_BUNDLE}" ]]; then
-            echo "macOS updater bundle not found" >&2
-            exit 1
-          fi
-
-          TARGET_BUNDLE="${BUNDLE_DIR}/${APP_SLUG}_${VERSION}_${{ matrix.asset_arch }}.app.tar.gz"
-
-          if [[ "${SOURCE_BUNDLE}" != "${TARGET_BUNDLE}" ]]; then
-            mv "${SOURCE_BUNDLE}" "${TARGET_BUNDLE}"
-          fi
-
-          if [[ -f "${SOURCE_BUNDLE}.sig" && "${SOURCE_BUNDLE}.sig" != "${TARGET_BUNDLE}.sig" ]]; then
-            mv "${SOURCE_BUNDLE}.sig" "${TARGET_BUNDLE}.sig"
-          fi
-
       - name: Add macOS open helper to DMG
         if: startsWith(matrix.os, 'macos-')
         shell: bash
@@ -246,6 +227,15 @@ jobs:
 
           OUTPUT_PATH="${HELPER_PATH}" node .release-scripts/scripts/release/create-macos-open-helper.mjs
           node .release-scripts/scripts/release/rebuild-macos-dmg-with-helper.mjs
+
+      - name: Normalize release asset names
+        shell: bash
+        env:
+          ASSET_ARCH: ${{ matrix.asset_arch }}
+          ASSET_PLATFORM: ${{ matrix.asset_platform }}
+          RELEASE_VERSION: ${{ env.RELEASE_TAG }}
+          TARGET: ${{ matrix.target }}
+        run: node .release-scripts/scripts/release/normalize-release-artifacts.mjs
 
       - name: Collect bundle paths
         id: bundle_paths
@@ -293,6 +283,22 @@ jobs:
             if (!fs.existsSync(root)) return;
 
             const stack = [root];
+            const releaseFileSuffixes = [
+              ".app.tar.gz",
+              ".AppImage",
+              ".deb",
+              ".dmg",
+              ".exe",
+              ".msi",
+              ".rpm",
+              ".sig",
+              ".tar.gz",
+              ".zip",
+            ];
+
+            function isReleaseFile(fileName) {
+              return releaseFileSuffixes.some((suffix) => fileName.endsWith(suffix));
+            }
 
             while (stack.length > 0) {
               const current = stack.pop();
@@ -306,9 +312,8 @@ jobs:
                   continue;
                 }
 
-                if (entry.name.endsWith(".sig")) {
+                if (isReleaseFile(entry.name)) {
                   addArtifact(entryPath);
-                  addArtifact(entryPath.slice(0, -4));
                 }
               }
             }

--- a/scripts/release/create-updater-metadata.test.mjs
+++ b/scripts/release/create-updater-metadata.test.mjs
@@ -33,8 +33,8 @@ function runMetadataScript(env) {
 
 test("create-updater-metadata prefers the Windows setup updater bundle", () => {
   const rootDir = makeTempDir();
-  const [, msiSignature] = writeBundle(rootDir, "Markra_0.0.8_x64_en-US.msi");
-  const [setupBundle, setupSignature] = writeBundle(rootDir, "Markra_0.0.8_x64-setup.exe");
+  const [, msiSignature] = writeBundle(rootDir, "Markra_0.0.8_windows_x64_en-US.msi");
+  const [setupBundle, setupSignature] = writeBundle(rootDir, "Markra_0.0.8_windows_x64_setup.exe");
   const outputPath = path.join(rootDir, "release-metadata.json");
 
   const result = runMetadataScript({
@@ -53,7 +53,7 @@ test("create-updater-metadata prefers the Windows setup updater bundle", () => {
 
 test("create-updater-metadata selects AppImage bundles for Linux updater metadata", () => {
   const rootDir = makeTempDir();
-  const [bundlePath, signaturePath] = writeBundle(rootDir, "Markra_0.0.8_amd64.AppImage");
+  const [bundlePath, signaturePath] = writeBundle(rootDir, "Markra_0.0.8_linux_x64.AppImage");
   const outputPath = path.join(rootDir, "release-metadata.json");
 
   const result = runMetadataScript({
@@ -72,7 +72,7 @@ test("create-updater-metadata selects AppImage bundles for Linux updater metadat
 
 test("create-updater-metadata selects renamed macOS updater tarballs", () => {
   const rootDir = makeTempDir();
-  const [bundlePath, signaturePath] = writeBundle(rootDir, "markra_0.0.8_aarch64.app.tar.gz");
+  const [bundlePath, signaturePath] = writeBundle(rootDir, "Markra_0.0.8_macos_arm64_updater.app.tar.gz");
   const outputPath = path.join(rootDir, "release-metadata.json");
 
   const result = runMetadataScript({

--- a/scripts/release/generate-updater-manifest.test.mjs
+++ b/scripts/release/generate-updater-manifest.test.mjs
@@ -48,10 +48,10 @@ test("generate-updater-manifest writes latest.json for every updater platform", 
   const rootDir = makeTempDir();
   const notesPath = path.join(rootDir, "release-notes.md");
 
-  writeArtifact(rootDir, "darwin-aarch64", "markra_0.0.8_aarch64.app.tar.gz", "mac-arm-signature");
-  writeArtifact(rootDir, "darwin-x86_64", "markra_0.0.8_x64.app.tar.gz", "mac-intel-signature");
-  writeArtifact(rootDir, "linux-x86_64", "Markra_0.0.8_amd64.AppImage", "linux-signature");
-  writeArtifact(rootDir, "windows-x86_64", "Markra_0.0.8_x64-setup.exe", "windows-signature");
+  writeArtifact(rootDir, "darwin-aarch64", "Markra_0.0.8_macos_arm64_updater.app.tar.gz", "mac-arm-signature");
+  writeArtifact(rootDir, "darwin-x86_64", "Markra_0.0.8_macos_x64_updater.app.tar.gz", "mac-intel-signature");
+  writeArtifact(rootDir, "linux-x86_64", "Markra_0.0.8_linux_x64.AppImage", "linux-signature");
+  writeArtifact(rootDir, "windows-x86_64", "Markra_0.0.8_windows_x64_setup.exe", "windows-signature");
   fs.writeFileSync(notesPath, "Release notes");
 
   const result = runManifestScript({
@@ -70,19 +70,19 @@ test("generate-updater-manifest writes latest.json for every updater platform", 
   assert.deepEqual(manifest.platforms, {
     "darwin-aarch64": {
       signature: "mac-arm-signature",
-      url: "https://github.com/murongg/markra/releases/latest/download/markra_0.0.8_aarch64.app.tar.gz",
+      url: "https://github.com/murongg/markra/releases/latest/download/Markra_0.0.8_macos_arm64_updater.app.tar.gz",
     },
     "darwin-x86_64": {
       signature: "mac-intel-signature",
-      url: "https://github.com/murongg/markra/releases/latest/download/markra_0.0.8_x64.app.tar.gz",
+      url: "https://github.com/murongg/markra/releases/latest/download/Markra_0.0.8_macos_x64_updater.app.tar.gz",
     },
     "linux-x86_64": {
       signature: "linux-signature",
-      url: "https://github.com/murongg/markra/releases/latest/download/Markra_0.0.8_amd64.AppImage",
+      url: "https://github.com/murongg/markra/releases/latest/download/Markra_0.0.8_linux_x64.AppImage",
     },
     "windows-x86_64": {
       signature: "windows-signature",
-      url: "https://github.com/murongg/markra/releases/latest/download/Markra_0.0.8_x64-setup.exe",
+      url: "https://github.com/murongg/markra/releases/latest/download/Markra_0.0.8_windows_x64_setup.exe",
     },
   });
 });
@@ -93,14 +93,14 @@ test("generate-updater-manifest fails when metadata points at a missing bundle",
   const notesPath = path.join(rootDir, "release-notes.md");
 
   fs.mkdirSync(artifactDir, { recursive: true });
-  fs.writeFileSync(path.join(artifactDir, "Markra_0.0.8_x64-setup.exe.sig"), "signature");
+  fs.writeFileSync(path.join(artifactDir, "Markra_0.0.8_windows_x64_setup.exe.sig"), "signature");
   fs.writeFileSync(
     path.join(artifactDir, "release-metadata.json"),
     `${JSON.stringify(
       {
         updaterPlatform: "windows-x86_64",
-        bundleName: "Markra_0.0.8_x64-setup.exe",
-        signatureName: "Markra_0.0.8_x64-setup.exe.sig",
+        bundleName: "Markra_0.0.8_windows_x64_setup.exe",
+        signatureName: "Markra_0.0.8_windows_x64_setup.exe.sig",
       },
       null,
       2,
@@ -123,7 +123,7 @@ test("generate-updater-manifest fails when an expected platform is missing", () 
   const rootDir = makeTempDir();
   const notesPath = path.join(rootDir, "release-notes.md");
 
-  writeArtifact(rootDir, "windows-x86_64", "Markra_0.0.8_x64-setup.exe", "windows-signature");
+  writeArtifact(rootDir, "windows-x86_64", "Markra_0.0.8_windows_x64_setup.exe", "windows-signature");
   fs.writeFileSync(notesPath, "Release notes");
 
   const result = runManifestScript({

--- a/scripts/release/normalize-release-artifacts.mjs
+++ b/scripts/release/normalize-release-artifacts.mjs
@@ -1,0 +1,366 @@
+import fs from "node:fs";
+import path from "node:path";
+import zlib from "node:zlib";
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+
+  return value;
+}
+
+function readVersion() {
+  const explicitVersion = process.env.RELEASE_VERSION?.trim();
+
+  if (explicitVersion) {
+    return explicitVersion.replace(/^v/, "");
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+
+  if (!packageJson.version) {
+    throw new Error("package.json version is required.");
+  }
+
+  return packageJson.version;
+}
+
+function walkFiles(rootDir) {
+  const stack = [rootDir];
+  const files = [];
+
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+
+    if (!currentDir || !fs.existsSync(currentDir)) {
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function moveFile(sourcePath, targetPath, { optional = false } = {}) {
+  if (sourcePath === targetPath) {
+    return;
+  }
+
+  if (!fs.existsSync(sourcePath)) {
+    if (optional) {
+      return;
+    }
+
+    throw new Error(`Release artifact not found: ${sourcePath}`);
+  }
+
+  if (fs.existsSync(targetPath)) {
+    throw new Error(`Refusing to overwrite release artifact: ${targetPath}`);
+  }
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.renameSync(sourcePath, targetPath);
+}
+
+function renameArtifact(sourcePath, targetName) {
+  const targetPath = path.join(path.dirname(sourcePath), targetName);
+
+  moveFile(sourcePath, targetPath);
+  moveFile(`${sourcePath}.sig`, `${targetPath}.sig`, { optional: true });
+}
+
+function renameMatchingArtifacts(bundleRoot, getTargetName) {
+  const files = walkFiles(bundleRoot).sort();
+
+  for (const filePath of files) {
+    const name = path.basename(filePath);
+
+    if (name.endsWith(".sig")) {
+      continue;
+    }
+
+    const targetName = getTargetName(name);
+
+    if (targetName) {
+      renameArtifact(filePath, targetName);
+    }
+  }
+}
+
+function getMacosTargetName(name, context) {
+  const { productName, version, arch } = context;
+
+  if (name.endsWith(".app.tar.gz")) {
+    return `${productName}_${version}_macos_${arch}_updater.app.tar.gz`;
+  }
+
+  if (name.endsWith(".dmg")) {
+    return `${productName}_${version}_macos_${arch}.dmg`;
+  }
+
+  return null;
+}
+
+function getLinuxTargetName(name, context) {
+  const { productName, version, arch } = context;
+
+  if (name.endsWith(".AppImage")) {
+    return `${productName}_${version}_linux_${arch}.AppImage`;
+  }
+
+  if (name.endsWith(".deb")) {
+    return `${productName}_${version}_linux_${arch}.deb`;
+  }
+
+  if (name.endsWith(".rpm")) {
+    return `${productName}_${version}_linux_${arch}.rpm`;
+  }
+
+  return null;
+}
+
+function getWindowsTargetName(name, context) {
+  const { productName, version, arch } = context;
+
+  if (/setup\.exe$/i.test(name)) {
+    return `${productName}_${version}_windows_${arch}_setup.exe`;
+  }
+
+  if (/\.msi$/i.test(name)) {
+    const locale = name.match(/_([a-z]{2}(?:-[a-z]{2})?)\.msi$/i)?.[1];
+    const localeSuffix = locale ? `_${locale}` : "";
+
+    return `${productName}_${version}_windows_${arch}${localeSuffix}.msi`;
+  }
+
+  return null;
+}
+
+function makeCrcTable() {
+  const table = new Uint32Array(256);
+
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+
+    table[index] = value >>> 0;
+  }
+
+  return table;
+}
+
+const crcTable = makeCrcTable();
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+
+  for (const byte of buffer) {
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function writeUInt16(value) {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16LE(value);
+  return buffer;
+}
+
+function writeUInt32(value) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+}
+
+function makeLocalFileHeader(entry) {
+  return Buffer.concat([
+    writeUInt32(0x04034b50),
+    writeUInt16(20),
+    writeUInt16(0x0800),
+    writeUInt16(8),
+    writeUInt16(0),
+    writeUInt16(33),
+    writeUInt32(entry.crc),
+    writeUInt32(entry.compressedSize),
+    writeUInt32(entry.uncompressedSize),
+    writeUInt16(entry.name.length),
+    writeUInt16(0),
+  ]);
+}
+
+function makeCentralDirectoryHeader(entry) {
+  return Buffer.concat([
+    writeUInt32(0x02014b50),
+    writeUInt16(20),
+    writeUInt16(20),
+    writeUInt16(0x0800),
+    writeUInt16(8),
+    writeUInt16(0),
+    writeUInt16(33),
+    writeUInt32(entry.crc),
+    writeUInt32(entry.compressedSize),
+    writeUInt32(entry.uncompressedSize),
+    writeUInt16(entry.name.length),
+    writeUInt16(0),
+    writeUInt16(0),
+    writeUInt16(0),
+    writeUInt16(0),
+    writeUInt32(0),
+    writeUInt32(entry.offset),
+  ]);
+}
+
+function makeEndOfCentralDirectory(entryCount, centralDirectorySize, centralDirectoryOffset) {
+  return Buffer.concat([
+    writeUInt32(0x06054b50),
+    writeUInt16(0),
+    writeUInt16(0),
+    writeUInt16(entryCount),
+    writeUInt16(entryCount),
+    writeUInt32(centralDirectorySize),
+    writeUInt32(centralDirectoryOffset),
+    writeUInt16(0),
+  ]);
+}
+
+function writeZip(outputPath, inputFiles) {
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+
+  for (const inputFile of inputFiles) {
+    const name = Buffer.from(inputFile.name.replace(/\\/g, "/"), "utf8");
+    const data = fs.readFileSync(inputFile.path);
+    const compressedData = zlib.deflateRawSync(data, { level: 9 });
+    const entry = {
+      name,
+      crc: crc32(data),
+      compressedSize: compressedData.length,
+      uncompressedSize: data.length,
+      offset,
+    };
+    const localHeader = makeLocalFileHeader(entry);
+    const centralHeader = makeCentralDirectoryHeader(entry);
+
+    localParts.push(localHeader, name, compressedData);
+    centralParts.push(centralHeader, name);
+    offset += localHeader.length + name.length + compressedData.length;
+  }
+
+  const centralDirectoryOffset = offset;
+  const centralDirectorySize = centralParts.reduce((size, part) => size + part.length, 0);
+  const endRecord = makeEndOfCentralDirectory(inputFiles.length, centralDirectorySize, centralDirectoryOffset);
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, Buffer.concat([...localParts, ...centralParts, endRecord]));
+}
+
+function findWindowsExecutable(releaseRoot, context) {
+  const { appSlug, productName } = context;
+  const explicitPath = process.env.WINDOWS_EXECUTABLE_PATH?.trim();
+
+  if (explicitPath) {
+    if (!fs.existsSync(explicitPath)) {
+      throw new Error(`Windows executable not found: ${explicitPath}`);
+    }
+
+    return explicitPath;
+  }
+
+  const candidates = [path.join(releaseRoot, `${appSlug}.exe`), path.join(releaseRoot, `${productName}.exe`)];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  const executable = fs
+    .readdirSync(releaseRoot, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".exe"))
+    .map((entry) => path.join(releaseRoot, entry.name))
+    .find((candidate) => !/setup|install/i.test(path.basename(candidate)));
+
+  if (!executable) {
+    throw new Error(`Windows portable executable not found in ${releaseRoot}.`);
+  }
+
+  return executable;
+}
+
+function createWindowsPortableZip(releaseRoot, bundleRoot, context) {
+  const { productName, version, arch } = context;
+  const executablePath = findWindowsExecutable(releaseRoot, context);
+  const executableDir = path.dirname(executablePath);
+  const appFolder = productName;
+  const portableFiles = [
+    {
+      path: executablePath,
+      name: `${appFolder}/${productName}.exe`,
+    },
+  ];
+
+  for (const entry of fs.readdirSync(executableDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".dll")) {
+      continue;
+    }
+
+    portableFiles.push({
+      path: path.join(executableDir, entry.name),
+      name: `${appFolder}/${entry.name}`,
+    });
+  }
+
+  const outputPath = path.join(bundleRoot, "portable", `${productName}_${version}_windows_${arch}_portable.zip`);
+  writeZip(outputPath, portableFiles);
+}
+
+const appSlug = process.env.APP_SLUG?.trim() || "markra";
+const productName = process.env.APP_PRODUCT_NAME?.trim() || "Markra";
+const desktopDir = process.env.DESKTOP_DIR?.trim() || "apps/desktop";
+const target = requireEnv("TARGET");
+const platform = requireEnv("ASSET_PLATFORM");
+const arch = requireEnv("ASSET_ARCH");
+const version = readVersion();
+const releaseRoot = path.join(desktopDir, "src-tauri", "target", target, "release");
+const bundleRoot = path.join(releaseRoot, "bundle");
+const context = {
+  appSlug,
+  productName,
+  version,
+  arch,
+};
+
+if (!fs.existsSync(bundleRoot)) {
+  throw new Error(`Bundle directory not found: ${bundleRoot}`);
+}
+
+if (platform === "macos") {
+  renameMatchingArtifacts(bundleRoot, (name) => getMacosTargetName(name, context));
+} else if (platform === "linux") {
+  renameMatchingArtifacts(bundleRoot, (name) => getLinuxTargetName(name, context));
+} else if (platform === "windows") {
+  renameMatchingArtifacts(bundleRoot, (name) => getWindowsTargetName(name, context));
+  createWindowsPortableZip(releaseRoot, bundleRoot, context);
+} else {
+  throw new Error(`Unsupported release asset platform: ${platform}`);
+}

--- a/scripts/release/normalize-release-artifacts.test.mjs
+++ b/scripts/release/normalize-release-artifacts.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const releaseWorkflowPath = path.join(repoRoot, ".github", "workflows", "release.yml");
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "markra-release-assets-"));
+}
+
+function writeFile(filePath, content = "asset") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function runNormalizeScript(rootDir, env) {
+  return spawnSync(process.execPath, ["scripts/release/normalize-release-artifacts.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      APP_PRODUCT_NAME: "Markra",
+      APP_SLUG: "markra",
+      DESKTOP_DIR: path.join(rootDir, "apps", "desktop"),
+      RELEASE_VERSION: "0.0.8",
+      ...env,
+    },
+  });
+}
+
+function readReleaseMatrixEntry(name) {
+  const workflow = fs.readFileSync(releaseWorkflowPath, "utf8");
+  const start = workflow.indexOf(`- name: ${name}`);
+
+  assert.notEqual(start, -1, `${name} matrix entry should exist`);
+
+  const next = workflow.indexOf("\n          - name:", start + 1);
+  return next === -1 ? workflow.slice(start) : workflow.slice(start, next);
+}
+
+test("release workflow uses arm64 in Apple Silicon file names while keeping the Tauri updater platform", () => {
+  const appleSiliconEntry = readReleaseMatrixEntry("macOS (Apple Silicon)");
+
+  assert.match(appleSiliconEntry, /asset_arch:\s*arm64/);
+  assert.match(appleSiliconEntry, /updater_platform:\s*darwin-aarch64/);
+  assert.doesNotMatch(appleSiliconEntry, /asset_arch:\s*aarch64/);
+});
+
+test("normalize-release-artifacts adds macOS platform labels to updater and dmg assets", () => {
+  const rootDir = makeTempDir();
+  const bundleRoot = path.join(
+    rootDir,
+    "apps",
+    "desktop",
+    "src-tauri",
+    "target",
+    "x86_64-apple-darwin",
+    "release",
+    "bundle",
+  );
+  const oldUpdater = path.join(bundleRoot, "macos", "markra_0.0.8_x64.app.tar.gz");
+  const oldDmg = path.join(bundleRoot, "dmg", "Markra_0.0.8_x64.dmg");
+
+  writeFile(oldUpdater);
+  writeFile(`${oldUpdater}.sig`, "signature");
+  writeFile(oldDmg);
+
+  const result = runNormalizeScript(rootDir, {
+    ASSET_ARCH: "x64",
+    ASSET_PLATFORM: "macos",
+    TARGET: "x86_64-apple-darwin",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(oldUpdater), false);
+  assert.equal(fs.existsSync(`${oldUpdater}.sig`), false);
+  assert.equal(fs.existsSync(oldDmg), false);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "macos", "Markra_0.0.8_macos_x64_updater.app.tar.gz")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "macos", "Markra_0.0.8_macos_x64_updater.app.tar.gz.sig")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "dmg", "Markra_0.0.8_macos_x64.dmg")), true);
+});
+
+test("normalize-release-artifacts adds Windows platform labels and creates a portable zip", () => {
+  const rootDir = makeTempDir();
+  const releaseRoot = path.join(
+    rootDir,
+    "apps",
+    "desktop",
+    "src-tauri",
+    "target",
+    "x86_64-pc-windows-msvc",
+    "release",
+  );
+  const bundleRoot = path.join(releaseRoot, "bundle");
+  const oldSetup = path.join(bundleRoot, "nsis", "Markra_0.0.8_x64-setup.exe");
+  const oldMsi = path.join(bundleRoot, "msi", "Markra_0.0.8_x64_en-US.msi");
+  const portableZip = path.join(bundleRoot, "portable", "Markra_0.0.8_windows_x64_portable.zip");
+
+  writeFile(path.join(releaseRoot, "markra.exe"), "portable-binary");
+  writeFile(path.join(releaseRoot, "support.dll"), "portable-library");
+  writeFile(oldSetup);
+  writeFile(`${oldSetup}.sig`, "setup-signature");
+  writeFile(oldMsi);
+  writeFile(`${oldMsi}.sig`, "msi-signature");
+
+  const result = runNormalizeScript(rootDir, {
+    ASSET_ARCH: "x64",
+    ASSET_PLATFORM: "windows",
+    TARGET: "x86_64-pc-windows-msvc",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(oldSetup), false);
+  assert.equal(fs.existsSync(`${oldSetup}.sig`), false);
+  assert.equal(fs.existsSync(oldMsi), false);
+  assert.equal(fs.existsSync(`${oldMsi}.sig`), false);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "nsis", "Markra_0.0.8_windows_x64_setup.exe")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "nsis", "Markra_0.0.8_windows_x64_setup.exe.sig")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "msi", "Markra_0.0.8_windows_x64_en-US.msi")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "msi", "Markra_0.0.8_windows_x64_en-US.msi.sig")), true);
+  assert.equal(fs.existsSync(portableZip), true);
+
+  const zipContents = fs.readFileSync(portableZip);
+  assert.equal(zipContents.subarray(0, 4).toString("latin1"), "PK\u0003\u0004");
+  assert.match(zipContents.toString("latin1"), /Markra\/Markra\.exe/);
+  assert.match(zipContents.toString("latin1"), /Markra\/support\.dll/);
+});
+
+test("normalize-release-artifacts adds Linux platform labels to package assets", () => {
+  const rootDir = makeTempDir();
+  const bundleRoot = path.join(
+    rootDir,
+    "apps",
+    "desktop",
+    "src-tauri",
+    "target",
+    "x86_64-unknown-linux-gnu",
+    "release",
+    "bundle",
+  );
+  const oldAppImage = path.join(bundleRoot, "appimage", "Markra_0.0.8_amd64.AppImage");
+  const oldDeb = path.join(bundleRoot, "deb", "Markra_0.0.8_amd64.deb");
+  const oldRpm = path.join(bundleRoot, "rpm", "Markra-0.0.8-1.x86_64.rpm");
+
+  writeFile(oldAppImage);
+  writeFile(`${oldAppImage}.sig`, "appimage-signature");
+  writeFile(oldDeb);
+  writeFile(`${oldDeb}.sig`, "deb-signature");
+  writeFile(oldRpm);
+  writeFile(`${oldRpm}.sig`, "rpm-signature");
+
+  const result = runNormalizeScript(rootDir, {
+    ASSET_ARCH: "x64",
+    ASSET_PLATFORM: "linux",
+    TARGET: "x86_64-unknown-linux-gnu",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "appimage", "Markra_0.0.8_linux_x64.AppImage")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "appimage", "Markra_0.0.8_linux_x64.AppImage.sig")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "deb", "Markra_0.0.8_linux_x64.deb")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "deb", "Markra_0.0.8_linux_x64.deb.sig")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "rpm", "Markra_0.0.8_linux_x64.rpm")), true);
+  assert.equal(fs.existsSync(path.join(bundleRoot, "rpm", "Markra_0.0.8_linux_x64.rpm.sig")), true);
+});


### PR DESCRIPTION
## Summary
- Normalize release asset names so platform labels are explicit across macOS, Linux, and Windows.
- Publish a Windows portable zip named `Markra_<version>_windows_x64_portable.zip` alongside installer artifacts.
- Use `macos_arm64` for Apple Silicon public filenames while keeping updater metadata on `darwin-aarch64`.

## Why
Release assets previously mixed architecture-only names with platform-specific formats, making `x64.app.tar.gz` look like a Windows download even though it was a macOS updater bundle.

## Validation
- `pnpm test:release` passed: 13 release script tests.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'` passed.
- `git diff --check` passed.

## Risk
- Existing release files are unchanged; this only affects future release asset names.
- Any external scripts hardcoding old future asset name patterns will need to use the new platform-labeled filenames.
