### PR TITLE
feat(editor): enrich native context menu

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -20,6 +20,7 @@ import {
   mockedGetStoredTheme,
   mockedGetStoredWorkspaceState,
   mockedInstallNativeApplicationMenu,
+  mockedInstallNativeEditorContextMenu,
   mockedInstallNativeMarkdownFileDrop,
   mockedListNativeMarkdownFilesForPath,
   mockedListenAppLanguageChanged,
@@ -1511,6 +1512,16 @@ describe("Markra workspace", () => {
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
     expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 1");
     expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 2");
+  });
+
+  it("does not expose native editor AI context actions without selected text", async () => {
+    renderApp();
+
+    await screen.findByText("Welcome to Markra");
+    await waitFor(() => expect(mockedInstallNativeEditorContextMenu).toHaveBeenCalledTimes(1));
+    const options = mockedInstallNativeEditorContextMenu.mock.calls[0]?.[3];
+
+    expect(options?.getAiCommandsAvailable?.()).toBe(false);
   });
 
   it("reloads the current file when a native watcher reports an external change", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { AppToaster } from "./components/AppToaster";
 import { AiCommandBar } from "./components/AiCommandBar";
 import { AiAgentPanel } from "./components/AiAgentPanel";
@@ -36,7 +37,7 @@ import { aiTranslationLanguageName, t, type I18nKey } from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver } from "@markra/markdown";
 import { openNativeExternalUrl, openSettingsWindow } from "./lib/tauri";
-import type { AiDiffResult, AiSelectionContext } from "@markra/ai";
+import type { AiDiffResult, AiEditIntent, AiSelectionContext } from "@markra/ai";
 import {
   AI_EDITOR_PREVIEW_APPLIED_EVENT,
   AI_EDITOR_PREVIEW_ACTION_EVENT,
@@ -67,6 +68,7 @@ const aiAgentPanelDefaultWidth = 384;
 const aiAgentPanelMinWidth = 320;
 const aiAgentPanelMaxWidth = 760;
 const aiResultSignatureSeparator = "\u001f";
+type AiQuickActionIntent = Exclude<AiEditIntent, "custom">;
 
 function isSettingsWindowRoute() {
   return new URLSearchParams(window.location.search).has("settings");
@@ -88,6 +90,12 @@ function aiPreviewActionKey(result: AiDiffResult, previewId?: string) {
   return previewId ? `preview${aiResultSignatureSeparator}${previewId}` : `result${aiResultSignatureSeparator}${aiResultSignature(result)}`;
 }
 
+function explicitAiTextSelection(selection: AiSelectionContext | null | undefined) {
+  if (selection?.source !== "selection" || !selection.text.trim()) return null;
+
+  return selection;
+}
+
 export default function App() {
   if (isSettingsWindowRoute()) {
     return <SettingsWindow />;
@@ -105,11 +113,13 @@ export default function App() {
   const [aiResults, setAiResults] = useState<AiDiffResult[]>([]);
   const [activeImageFile, setActiveImageFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [activeAiSelection, setActiveAiSelection] = useState<AiSelectionContext | null>(null);
+  const [aiContextMenuActionPending, setAiContextMenuActionPending] = useState(false);
   const [editorMode, setEditorMode] = useState<"source" | "visual">("visual");
   const sourceMode = editorMode === "source";
   const aiResultsRef = useRef<AiDiffResult[]>([]);
   const appliedAiPreviewKeysRef = useRef(new Set<string>());
   const activeAiSelectionRef = useRef<AiSelectionContext | null>(null);
+  const aiContextMenuActionIdRef = useRef(0);
   const reconciledAiWorkspaceKeyRef = useRef<string | null | undefined>(undefined);
   const translate = useCallback((key: I18nKey) => t(appLanguage.language, key), [appLanguage.language]);
   const editor = useEditorController();
@@ -355,6 +365,8 @@ export default function App() {
   }, [activeAiAgentSessionId, aiAgentSessions, createAiAgentInitialSessionOptions, createWorkspaceSession, selectWorkspaceSession, workspaceKey]);
   const restoreAiCommand = aiCommand.restoreAiCommand;
   const handleAiCommandClose = useCallback(() => {
+    aiContextMenuActionIdRef.current += 1;
+    setAiContextMenuActionPending(false);
     aiCommand.closeAiCommand();
     editor.clearAiSelection();
   }, [aiCommand, editor]);
@@ -482,6 +494,67 @@ export default function App() {
     editorPreferences.preferences.closeAiCommandOnAgentPanelOpen,
     updateActiveAiSelection
   ]);
+  const getEditorSelection = editor.getSelection;
+  const holdAiSelection = editor.holdAiSelection;
+  const interruptAiCommandPrompt = aiCommand.interruptPrompt;
+  const openAiCommand = aiCommand.openAiCommand;
+  const submitAiCommandPrompt = aiCommand.submitPrompt;
+  const updateAiCommandPrompt = aiCommand.updatePrompt;
+  const aiContextMenuActionRef = useRef<((intent: AiQuickActionIntent, prompt: string) => unknown) | null>(null);
+  useEffect(() => {
+    aiContextMenuActionRef.current = (intent: AiQuickActionIntent, prompt: string) => {
+      const selection = explicitAiTextSelection(getActiveAiSelection()) ?? explicitAiTextSelection(getEditorSelection());
+      if (!selection) return;
+
+      holdAiSelection(selection);
+      const actionId = aiContextMenuActionIdRef.current + 1;
+      let opened = false;
+      aiContextMenuActionIdRef.current = actionId;
+
+      flushSync(() => {
+        updateActiveAiSelection(selection);
+        setAiContextMenuActionPending(true);
+        opened = openAiCommand(selection);
+        updateAiCommandPrompt(prompt);
+      });
+
+      if (!opened) {
+        setAiContextMenuActionPending(false);
+        return;
+      }
+
+      window.setTimeout(() => {
+        if (aiContextMenuActionIdRef.current !== actionId) return;
+
+        Promise.resolve(submitAiCommandPrompt(prompt, intent)).finally(() => {
+          if (aiContextMenuActionIdRef.current !== actionId) return;
+
+          setAiContextMenuActionPending(false);
+        });
+      }, 0);
+    };
+  }, [
+    getEditorSelection,
+    getActiveAiSelection,
+    holdAiSelection,
+    openAiCommand,
+    submitAiCommandPrompt,
+    updateActiveAiSelection,
+    updateAiCommandPrompt
+  ]);
+  const handleAiContextMenuAction = useCallback((intent: AiQuickActionIntent, prompt: string) => {
+    return aiContextMenuActionRef.current?.(intent, prompt);
+  }, []);
+  const getAiContextMenuAvailable = useCallback(() => {
+    const selection = explicitAiTextSelection(getActiveAiSelection()) ?? explicitAiTextSelection(getEditorSelection());
+
+    return Boolean(selection);
+  }, [getActiveAiSelection, getEditorSelection]);
+  const handleAiCommandInterrupt = useCallback(() => {
+    aiContextMenuActionIdRef.current += 1;
+    setAiContextMenuActionPending(false);
+    interruptAiCommandPrompt();
+  }, [interruptAiCommandPrompt]);
   const saveDocumentAs = useCallback(() => saveCurrentDocument(true), [saveCurrentDocument]);
   const handleApplyAiResult = useCallback((restoredResult?: AiDiffResult | null, previewId?: string) => {
     const result = restoredResult ?? aiResults.at(-1) ?? null;
@@ -698,14 +771,18 @@ export default function App() {
   const nativeMenuHandlers = useNativeMenuHandlers({
     insertMarkdownSnippet: editor.insertMarkdownSnippet,
     insertMarkdownTable: editor.insertMarkdownTable,
+    language: appLanguage.language,
     openDocument: handleOpenMarkdownFile,
+    runAiQuickAction: handleAiContextMenuAction,
     runEditorShortcut: editor.runEditorShortcut,
     saveDocument: handleSaveClick,
     saveDocumentAs
   });
 
   useNativeMarkdownDrop(handleDroppedMarkdownPath);
-  useNativeMenus(nativeMenuHandlers, appLanguage.ready ? appLanguage.language : null);
+  useNativeMenus(nativeMenuHandlers, appLanguage.ready ? appLanguage.language : null, {
+    getAiCommandsAvailable: getAiContextMenuAvailable
+  });
   useAutoUpdater(appLanguage.language, appLanguage.ready, {
     confirmRestart: confirmCanDiscardCurrentDocument
   });
@@ -955,15 +1032,16 @@ export default function App() {
           availableModels={aiSettings.availableTextModels}
           editorLeftInset={fileTreeOpen ? `${fileTreeWidth}px` : "0px"}
           editorRightInset={aiAgentInset}
+          externalActionPending={aiContextMenuActionPending}
           language={appLanguage.language}
-          open={aiCommand.open && (hasActiveAiSelection || Boolean(aiResult))}
+          open={aiCommand.open && (hasActiveAiSelection || Boolean(aiResult) || aiContextMenuActionPending)}
           prompt={aiCommand.prompt}
           selectedModelId={aiSettings.inlineModelId}
           selectedProviderId={aiSettings.inlineProviderId}
           submitting={aiCommand.submitting}
           supportsThinking={supportsAiThinking}
           onClose={handleAiCommandClose}
-          onInterrupt={aiCommand.interruptPrompt}
+          onInterrupt={handleAiCommandInterrupt}
           onPromptChange={aiCommand.updatePrompt}
           onSelectModel={aiSettings.selectInlineModel}
           onSubmit={aiCommand.submitPrompt}

--- a/apps/desktop/src/components/AiCommandBar.test.tsx
+++ b/apps/desktop/src/components/AiCommandBar.test.tsx
@@ -114,6 +114,31 @@ describe("AiCommandBar", () => {
     expect(screen.queryByText("Generating suggestion")).not.toBeInTheDocument();
   });
 
+  it("shows expanded thinking feedback for an external AI context action before submission starts", () => {
+    render(
+      <AiCommandBar
+        externalActionPending
+        language="zh-CN"
+        open
+        prompt="润色"
+        submitting={false}
+        onClose={vi.fn()}
+        onPromptChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    const input = screen.getByRole("textbox", { name: "AI 命令" });
+    const status = screen.getByRole("status");
+    const commandBox = input.closest(".ai-command-box");
+
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveTextContent(/^正在思考$/);
+    expect(commandBox).toHaveClass("min-h-21", "rounded-lg", "border-(--accent)");
+    expect(commandBox).not.toHaveClass("h-14", "rounded-xl");
+  });
+
   it("submits with Enter instead of inserting a newline", () => {
     const onPromptChange = vi.fn();
     const onSubmit = vi.fn();

--- a/apps/desktop/src/components/AiCommandBar.tsx
+++ b/apps/desktop/src/components/AiCommandBar.tsx
@@ -86,6 +86,7 @@ type AiCommandBarProps = {
   availableModels?: AiCommandModelOption[];
   editorLeftInset?: string;
   editorRightInset?: string;
+  externalActionPending?: boolean;
   language?: AppLanguage;
   open: boolean;
   prompt: string;
@@ -105,6 +106,7 @@ export function AiCommandBar({
   availableModels = [],
   editorLeftInset = "0px",
   editorRightInset = "0px",
+  externalActionPending = false,
   language = "en",
   open,
   prompt,
@@ -134,8 +136,9 @@ export function AiCommandBar({
   const [thinkingEnabled, setThinkingEnabled] = useState(false);
   const previousSubmittingRef = useRef(submitting);
   const { handleCompositionEnd, handleCompositionStart, isComposingEnter } = useImeInputGuard();
+  const busy = submitting || externalActionPending;
   const label = (key: I18nKey) => t(language, key);
-  const canSubmit = prompt.trim().length > 0 && !submitting;
+  const canSubmit = prompt.trim().length > 0 && !busy;
   const closing = commandState === "closing";
   const expanded = commandState === "expanded";
   const showingExpandedSurface = commandState === "expanded" || commandState === "collapsing" || (closing && closingFromExpanded);
@@ -206,9 +209,9 @@ export function AiCommandBar({
   }, [clearCollapseTimer, clearExitTimer, open, setCommandStateValue]);
 
   useEffect(() => {
-    if (previousSubmittingRef.current && !submitting) setActiveQuickActionIntent(null);
-    previousSubmittingRef.current = submitting;
-  }, [submitting]);
+    if (previousSubmittingRef.current && !busy) setActiveQuickActionIntent(null);
+    previousSubmittingRef.current = busy;
+  }, [busy]);
 
   useEffect(() => {
     if (supportsThinking) return;
@@ -324,7 +327,7 @@ export function AiCommandBar({
   };
 
   const handlePromptChange = (nextPrompt: string) => {
-    if (submitting) return;
+    if (busy) return;
     if (nextPrompt.trim().length > 0) {
       setActiveQuickActionIntent(null);
       setQuickActionsVisible(false);
@@ -333,7 +336,7 @@ export function AiCommandBar({
   };
 
   const insertPromptNewline = (input: HTMLTextAreaElement) => {
-    if (submitting) return;
+    if (busy) return;
 
     const start = input.selectionStart ?? prompt.length;
     const end = input.selectionEnd ?? start;
@@ -362,7 +365,7 @@ export function AiCommandBar({
   };
 
   const handleQuickAction = (action: AiCommandAction) => {
-    if (submitting) return;
+    if (busy) return;
 
     const quickPrompt = label(action.labelKey);
     setActiveQuickActionIntent(action.intent);
@@ -371,10 +374,10 @@ export function AiCommandBar({
     submitPromptOverride(quickPrompt, action.intent);
   };
 
-  const quickActionSubmitting = submitting && activeQuickActionIntent !== null;
-  const activeExpandedSurface = showingExpandedSurface || (submitting && !quickActionSubmitting);
+  const quickActionSubmitting = busy && activeQuickActionIntent !== null;
+  const activeExpandedSurface = showingExpandedSurface || (busy && !quickActionSubmitting);
   const unifiedExpandedSurface = quickActionSubmitting ? false : activeExpandedSurface || Boolean(aiResult);
-  const showQuickActions = showingExpandedSurface && !aiResult && quickActionsVisible && !submitting;
+  const showQuickActions = showingExpandedSurface && !aiResult && quickActionsVisible && !busy;
   const showExpandedInput = unifiedExpandedSurface;
   const showCompactLoading = quickActionSubmitting && !showExpandedInput;
   const commandWidthClassName = showExpandedInput ? "max-w-205" : "max-w-176";
@@ -389,7 +392,7 @@ export function AiCommandBar({
         ? label("app.aiCommandPlaceholder")
         : label("app.aiCommandCompactPlaceholder");
   const showModelSelector = showExpandedInput && availableModels.length > 1 && Boolean(onSelectModel);
-  const showAgentStatus = showExpandedInput && submitting;
+  const showAgentStatus = showExpandedInput && busy;
   const showThinkingToggle = showExpandedInput && supportsThinking;
   const compactLoadingText = activeQuickActionIntent
     ? label(aiCommandLoadingLabelKeys[activeQuickActionIntent])
@@ -397,12 +400,12 @@ export function AiCommandBar({
   const renderSubmitButton = (compactSize: boolean) => (
     <RoundIconButton
       size={compactSize ? "md" : "lg"}
-      type={submitting ? "button" : "submit"}
-      disabled={!submitting && !canSubmit}
-      label={submitting ? label("app.aiCommandStop") : label("app.aiCommandSend")}
-      onClick={submitting ? onInterrupt : undefined}
+      type={busy ? "button" : "submit"}
+      disabled={!busy && !canSubmit}
+      label={busy ? label("app.aiCommandStop") : label("app.aiCommandSend")}
+      onClick={busy ? onInterrupt : undefined}
     >
-      {submitting ? (
+      {busy ? (
         <span className="relative inline-flex items-center justify-center">
           <LoaderCircle aria-hidden="true" className="ai-command-loading-icon animate-spin" size={17} />
           <Square aria-hidden="true" className="absolute" size={7} fill="currentColor" strokeWidth={0} />
@@ -454,8 +457,8 @@ export function AiCommandBar({
             }
             value={prompt}
             placeholder={inputPlaceholder}
-            readOnly={submitting}
-            aria-busy={submitting}
+            readOnly={busy}
+            aria-busy={busy}
             rows={showExpandedInput ? 2 : 1}
             onClick={expandCommand}
             onChange={(event) => handlePromptChange(event.target.value)}
@@ -484,7 +487,7 @@ export function AiCommandBar({
               label={label("app.aiDeepThinking")}
               pressed={thinkingEnabled}
               size="sm"
-              disabled={submitting}
+              disabled={busy}
               onClick={() => setThinkingEnabled((enabled) => !enabled)}
             >
               <BrainCircuit aria-hidden="true" size={14} />
@@ -495,7 +498,7 @@ export function AiCommandBar({
             {showModelSelector ? (
               <AiModelPicker
                 ariaLabel={label("app.aiModelSelector")}
-                disabled={submitting}
+                disabled={busy}
                 models={availableModels}
                 selectedModelId={selectedModelId}
                 selectedProviderId={selectedProviderId}

--- a/apps/desktop/src/hooks/useNativeBindings.test.tsx
+++ b/apps/desktop/src/hooks/useNativeBindings.test.tsx
@@ -2,6 +2,15 @@ import { renderHook } from "@testing-library/react";
 import { useNativeMenuHandlers } from "./useNativeBindings";
 
 describe("useNativeMenuHandlers", () => {
+  const baseOptions = {
+    insertMarkdownSnippet: vi.fn(),
+    insertMarkdownTable: vi.fn(),
+    openDocument: vi.fn(),
+    runEditorShortcut: vi.fn(),
+    saveDocument: vi.fn(),
+    saveDocumentAs: vi.fn()
+  };
+
   it("routes the insert table menu command to the editor table insertion", () => {
     const insertMarkdownSnippet = vi.fn();
     const insertMarkdownTable = vi.fn();
@@ -20,5 +29,24 @@ describe("useNativeMenuHandlers", () => {
 
     expect(insertMarkdownTable).toHaveBeenCalledTimes(1);
     expect(insertMarkdownSnippet).not.toHaveBeenCalled();
+  });
+
+  it("routes native AI context menu commands to localized inline AI actions", () => {
+    const runAiQuickAction = vi.fn();
+    const { result } = renderHook(() =>
+      useNativeMenuHandlers({
+        ...baseOptions,
+        language: "zh-CN",
+        runAiQuickAction
+      })
+    );
+
+    result.current.aiPolish?.();
+    result.current.aiContinueWriting?.();
+    result.current.aiTranslate?.();
+
+    expect(runAiQuickAction).toHaveBeenNthCalledWith(1, "polish", "润色");
+    expect(runAiQuickAction).toHaveBeenNthCalledWith(2, "continue", "续写");
+    expect(runAiQuickAction).toHaveBeenNthCalledWith(3, "translate", "翻译");
   });
 });

--- a/apps/desktop/src/hooks/useNativeBindings.ts
+++ b/apps/desktop/src/hooks/useNativeBindings.ts
@@ -5,12 +5,17 @@ import {
   installNativeEditorContextMenu,
   type NativeMenuHandlers
 } from "../lib/tauri";
-import type { AppLanguage } from "@markra/shared";
+import type { AiEditIntent } from "@markra/ai";
+import { t, type AppLanguage, type I18nKey } from "@markra/shared";
+
+type NativeAiQuickActionIntent = Exclude<AiEditIntent, "custom">;
 
 type NativeMenuHandlerOptions = {
   insertMarkdownSnippet: (open: string, close: string, placeholder: string) => unknown;
   insertMarkdownTable: () => unknown;
+  language?: AppLanguage;
   openDocument: () => unknown | Promise<unknown>;
+  runAiQuickAction?: (intent: NativeAiQuickActionIntent, prompt: string) => unknown | Promise<unknown>;
   runEditorShortcut: (key: string, modifiers?: Pick<KeyboardEventInit, "altKey" | "shiftKey">) => unknown;
   saveDocument: () => unknown | Promise<unknown>;
   saveDocumentAs: () => unknown | Promise<unknown>;
@@ -26,7 +31,9 @@ type ApplicationShortcutOptions = {
 export function useNativeMenuHandlers({
   insertMarkdownSnippet,
   insertMarkdownTable,
+  language = "en",
   openDocument,
+  runAiQuickAction,
   runEditorShortcut,
   saveDocument,
   saveDocumentAs
@@ -50,10 +57,33 @@ export function useNativeMenuHandlers({
       formatCodeBlock: () => runEditorShortcut("c", { altKey: true }),
       insertLink: () => insertMarkdownSnippet("[", "](https://)", "text"),
       insertImage: () => insertMarkdownSnippet("![", "](https://)", "alt"),
-      insertTable: insertMarkdownTable
+      insertTable: insertMarkdownTable,
+      aiPolish: aiQuickAction(runAiQuickAction, "polish", "app.aiPolish", language),
+      aiRewrite: aiQuickAction(runAiQuickAction, "rewrite", "app.aiRewrite", language),
+      aiContinueWriting: aiQuickAction(runAiQuickAction, "continue", "app.aiContinueWriting", language),
+      aiSummarize: aiQuickAction(runAiQuickAction, "summarize", "app.aiSummarize", language),
+      aiTranslate: aiQuickAction(runAiQuickAction, "translate", "app.aiTranslate", language)
     }),
-    [insertMarkdownSnippet, insertMarkdownTable, openDocument, runEditorShortcut, saveDocument, saveDocumentAs]
+    [
+      insertMarkdownSnippet,
+      insertMarkdownTable,
+      language,
+      openDocument,
+      runAiQuickAction,
+      runEditorShortcut,
+      saveDocument,
+      saveDocumentAs
+    ]
   );
+}
+
+function aiQuickAction(
+  runAiQuickAction: NativeMenuHandlerOptions["runAiQuickAction"],
+  intent: NativeAiQuickActionIntent,
+  labelKey: I18nKey,
+  language: AppLanguage
+) {
+  return () => runAiQuickAction?.(intent, t(language, labelKey));
 }
 
 export function useNativeMarkdownDrop(onDrop: (target: NativeMarkdownDroppedTarget) => unknown | Promise<unknown>) {
@@ -77,7 +107,11 @@ export function useNativeMarkdownDrop(onDrop: (target: NativeMarkdownDroppedTarg
   }, [onDrop]);
 }
 
-export function useNativeMenus(handlers: NativeMenuHandlers, language: AppLanguage | null = "en") {
+export function useNativeMenus(
+  handlers: NativeMenuHandlers,
+  language: AppLanguage | null = "en",
+  options: { getAiCommandsAvailable?: () => boolean } = {}
+) {
   useEffect(() => {
     if (!language) return;
 
@@ -105,7 +139,9 @@ export function useNativeMenus(handlers: NativeMenuHandlers, language: AppLangua
     let active = true;
     let cleanup: (() => unknown) | null = null;
 
-    installNativeEditorContextMenu(globalThis.document, handlers, language).then((removeContextMenu) => {
+    installNativeEditorContextMenu(globalThis.document, handlers, language, {
+      getAiCommandsAvailable: options.getAiCommandsAvailable
+    }).then((removeContextMenu) => {
       if (!active) {
         removeContextMenu();
         return;
@@ -118,7 +154,7 @@ export function useNativeMenus(handlers: NativeMenuHandlers, language: AppLangua
       active = false;
       cleanup?.();
     };
-  }, [handlers, language]);
+  }, [handlers, language, options.getAiCommandsAvailable]);
 }
 
 export function useApplicationShortcuts({

--- a/apps/desktop/src/lib/tauri/menu.test.ts
+++ b/apps/desktop/src/lib/tauri/menu.test.ts
@@ -29,6 +29,7 @@ const mockedGetCurrentWindow = vi.mocked(getCurrentWindow);
 type TestMenuItem = NonNullable<MenuOptions["items"]>[number];
 type TestActionMenuItem = TestMenuItem & {
   action?: (id: string) => unknown;
+  icon?: unknown;
   id?: string;
 };
 
@@ -40,10 +41,27 @@ function latestMenuItems() {
 }
 
 function menuItemById(items: TestMenuItem[], id: string) {
-  const item = items.find((candidate) => "id" in candidate && candidate.id === id);
+  const item = findMenuItemById(items, id);
   if (!item) throw new Error(`Expected menu item ${id}.`);
 
   return item as TestActionMenuItem;
+}
+
+function findMenuItemById(items: TestMenuItem[], id: string): TestActionMenuItem | null {
+  for (const candidate of items) {
+    if ("id" in candidate && candidate.id === id) return candidate as TestActionMenuItem;
+    if ("items" in candidate && Array.isArray(candidate.items)) {
+      const child = findMenuItemById(candidate.items as TestMenuItem[], id);
+      if (child) return child;
+    }
+  }
+
+  return null;
+}
+
+async function flushNativeMenuPopup() {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("native menu", () => {
@@ -109,6 +127,9 @@ describe("native menu", () => {
         expect.objectContaining({ id: "markra:format" })
       ])
     });
+    expect(menuItemById(latestMenuItems(), "insertTable")).toMatchObject({
+      accelerator: "CmdOrCtrl+Alt+T"
+    });
     expect(setAsAppMenu).toHaveBeenCalledTimes(1);
   });
 
@@ -144,12 +165,16 @@ describe("native menu", () => {
     expect(popup).not.toHaveBeenCalled();
 
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await flushNativeMenuPopup();
 
     expect(mockedMenuNew).toHaveBeenCalledTimes(1);
     expect(popup).toHaveBeenCalledTimes(1);
 
     const table = menuItemById(latestMenuItems(), "markra:context:table");
-    expect(table).toMatchObject({ text: "Table" });
+    expect(table).toMatchObject({
+      accelerator: "CmdOrCtrl+Alt+T",
+      text: "Table"
+    });
 
     table.action?.("markra:context:table");
 
@@ -159,6 +184,102 @@ describe("native menu", () => {
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
 
     expect(popup).toHaveBeenCalledTimes(1);
+  });
+
+  it("groups richer editor formatting actions in the native context menu", async () => {
+    const target = document.createElement("main");
+    const paper = document.createElement("article");
+    const handlers: NativeMenuHandlers = {
+      formatBold: vi.fn(),
+      formatCodeBlock: vi.fn(),
+      formatHeading2: vi.fn(),
+      formatInlineCode: vi.fn(),
+      formatOrderedList: vi.fn(),
+      formatQuote: vi.fn(),
+      formatStrikethrough: vi.fn(),
+      insertImage: vi.fn(),
+      insertLink: vi.fn(),
+      insertTable: vi.fn()
+    };
+    paper.className = "markdown-paper";
+    target.append(paper);
+
+    await installNativeEditorContextMenu(target, handlers);
+
+    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await flushNativeMenuPopup();
+
+    const items = latestMenuItems();
+
+    expect(menuItemById(items, "markra:context:format")).toMatchObject({ text: "Format" });
+    expect(menuItemById(items, "markra:context:strikethrough")).toMatchObject({ text: "Strikethrough" });
+    expect(menuItemById(items, "markra:context:inline-code")).toMatchObject({ text: "Inline Code" });
+    expect(menuItemById(items, "markra:context:heading-2")).toMatchObject({ text: "Heading 2" });
+    expect(menuItemById(items, "markra:context:ordered-list")).toMatchObject({ text: "Ordered List" });
+    expect(menuItemById(items, "markra:context:quote")).toMatchObject({ text: "Quote" });
+    expect(menuItemById(items, "markra:context:code-block")).toMatchObject({ text: "Code Block" });
+    expect(menuItemById(items, "markra:context:image")).toMatchObject({ text: "Image" });
+
+    menuItemById(items, "markra:context:strikethrough").action?.("markra:context:strikethrough");
+    menuItemById(items, "markra:context:code-block").action?.("markra:context:code-block");
+    menuItemById(items, "markra:context:image").action?.("markra:context:image");
+
+    expect(handlers.formatStrikethrough).toHaveBeenCalledTimes(1);
+    expect(handlers.formatCodeBlock).toHaveBeenCalledTimes(1);
+    expect(handlers.insertImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows editor AI context actions only when an AI target is available", async () => {
+    const target = document.createElement("main");
+    const paper = document.createElement("article");
+    const aiPolish = vi.fn();
+    const aiTranslate = vi.fn();
+    let aiCommandsAvailable = false;
+    paper.className = "markdown-paper";
+    target.append(paper);
+
+    await installNativeEditorContextMenu(target, {
+      aiPolish,
+      aiTranslate
+    }, "en", {
+      getAiCommandsAvailable: () => aiCommandsAvailable
+    });
+
+    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await flushNativeMenuPopup();
+
+    expect(findMenuItemById(latestMenuItems(), "markra:context:ai")).toBeNull();
+
+    mockedMenuNew.mockClear();
+    aiCommandsAvailable = true;
+
+    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    await flushNativeMenuPopup();
+
+    const items = latestMenuItems();
+    const aiMenu = menuItemById(items, "markra:context:ai");
+    expect(aiMenu).toMatchObject({ text: "AI toolkit" });
+    expect(aiMenu).not.toHaveProperty("icon");
+    const aiActionItems = [
+      ["markra:context:ai-polish", "Polish"],
+      ["markra:context:ai-rewrite", "Rewrite"],
+      ["markra:context:ai-continue-writing", "Continue writing"],
+      ["markra:context:ai-summarize", "Summarize"],
+      ["markra:context:ai-translate", "Translate"]
+    ] as const;
+
+    for (const [id, text] of aiActionItems) {
+      const item = menuItemById(items, id);
+
+      expect(item).toMatchObject({ text });
+      expect(item).not.toHaveProperty("icon");
+    }
+
+    menuItemById(items, "markra:context:ai-polish").action?.("markra:context:ai-polish");
+    menuItemById(items, "markra:context:ai-translate").action?.("markra:context:ai-translate");
+
+    expect(aiPolish).toHaveBeenCalledTimes(1);
+    expect(aiTranslate).toHaveBeenCalledTimes(1);
   });
 
   it("shows native markdown file tree actions for a file target", async () => {

--- a/apps/desktop/src/lib/tauri/menu.ts
+++ b/apps/desktop/src/lib/tauri/menu.ts
@@ -19,6 +19,10 @@ export type NativeMarkdownFileTreeContextMenuHandlers = {
   renameFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
 };
 
+export type NativeEditorContextMenuOptions = {
+  getAiCommandsAvailable?: () => boolean;
+};
+
 export type NativeMenuCommand =
   | "openDocument"
   | "saveDocument"
@@ -37,7 +41,12 @@ export type NativeMenuCommand =
   | "formatCodeBlock"
   | "insertLink"
   | "insertImage"
-  | "insertTable";
+  | "insertTable"
+  | "aiPolish"
+  | "aiRewrite"
+  | "aiContinueWriting"
+  | "aiSummarize"
+  | "aiTranslate";
 
 type NativeMenuCommandPayload = {
   command: NativeMenuCommand;
@@ -89,6 +98,14 @@ function separator(): PredefinedMenuItemOptions {
 
 function predefined(item: PredefinedMenuItemOptions["item"], text?: string): PredefinedMenuItemOptions {
   return text ? { item, text } : { item };
+}
+
+function submenu(id: string, text: string, items: SubmenuOptions["items"]): SubmenuOptions {
+  return {
+    id,
+    items,
+    text
+  };
 }
 
 function menuLabel(language: AppLanguage, key: I18nKey) {
@@ -155,7 +172,7 @@ export function createNativeApplicationMenuItems(
   const codeBlock = customItem("formatCodeBlock", label("menu.codeBlock"), "CmdOrCtrl+Alt+C", handlers.formatCodeBlock);
   const link = customItem("insertLink", label("menu.link"), "CmdOrCtrl+K", handlers.insertLink);
   const image = customItem("insertImage", label("menu.image"), "CmdOrCtrl+Shift+I", handlers.insertImage);
-  const table = customItem("insertTable", label("menu.table"), undefined, handlers.insertTable);
+  const table = customItem("insertTable", label("menu.table"), "CmdOrCtrl+Alt+T", handlers.insertTable);
 
   return [
     {
@@ -246,47 +263,127 @@ export async function installNativeApplicationMenu(handlers: NativeMenuHandlers,
   return stopListening;
 }
 
-export function createNativeEditorContextMenuItems(handlers: NativeMenuHandlers, language: AppLanguage = "en") {
+export function createNativeEditorContextMenuItems(
+  handlers: NativeMenuHandlers,
+  language: AppLanguage = "en",
+  options: { aiCommandsAvailable?: boolean } = {}
+) {
   const label = (key: I18nKey) => menuLabel(language, key);
-
-  return [
+  const formatItems = [
+    customItem("markra:context:bold", label("menu.bold"), "CmdOrCtrl+B", handlers.formatBold),
+    customItem("markra:context:italic", label("menu.italic"), "CmdOrCtrl+I", handlers.formatItalic),
+    customItem(
+      "markra:context:strikethrough",
+      label("menu.strikethrough"),
+      "CmdOrCtrl+Shift+X",
+      handlers.formatStrikethrough
+    ),
+    customItem(
+      "markra:context:inline-code",
+      label("menu.inlineCode"),
+      "CmdOrCtrl+E",
+      handlers.formatInlineCode
+    ),
+    separator(),
+    customItem("markra:context:paragraph", label("menu.paragraph"), "CmdOrCtrl+Alt+0", handlers.formatParagraph),
+    customItem("markra:context:heading-1", label("menu.heading1"), "CmdOrCtrl+Alt+1", handlers.formatHeading1),
+    customItem("markra:context:heading-2", label("menu.heading2"), "CmdOrCtrl+Alt+2", handlers.formatHeading2),
+    customItem("markra:context:heading-3", label("menu.heading3"), "CmdOrCtrl+Alt+3", handlers.formatHeading3),
+    separator(),
+    customItem(
+      "markra:context:bullet-list",
+      label("menu.bulletList"),
+      "CmdOrCtrl+Shift+8",
+      handlers.formatBulletList
+    ),
+    customItem(
+      "markra:context:ordered-list",
+      label("menu.orderedList"),
+      "CmdOrCtrl+Shift+7",
+      handlers.formatOrderedList
+    ),
+    customItem("markra:context:quote", label("menu.quote"), "CmdOrCtrl+Shift+B", handlers.formatQuote),
+    customItem(
+      "markra:context:code-block",
+      label("menu.codeBlock"),
+      "CmdOrCtrl+Alt+C",
+      handlers.formatCodeBlock
+    )
+  ];
+  const items: Array<MenuItemOptions | PredefinedMenuItemOptions | SubmenuOptions> = [
     predefined("Cut", label("menu.cut")),
     predefined("Copy", label("menu.copy")),
     predefined("Paste", label("menu.paste")),
     predefined("SelectAll", label("menu.selectAll")),
     separator(),
-    customItem("markra:context:bold", label("menu.bold"), "CmdOrCtrl+B", handlers.formatBold),
-    customItem("markra:context:italic", label("menu.italic"), "CmdOrCtrl+I", handlers.formatItalic),
+    submenu("markra:context:format", label("menu.format"), formatItems),
+    separator(),
     customItem("markra:context:link", label("menu.link"), "CmdOrCtrl+K", handlers.insertLink),
-    customItem("markra:context:table", label("menu.table"), undefined, handlers.insertTable)
+    customItem("markra:context:image", label("menu.image"), "CmdOrCtrl+Shift+I", handlers.insertImage),
+    customItem("markra:context:table", label("menu.table"), "CmdOrCtrl+Alt+T", handlers.insertTable)
   ];
+
+  if (options.aiCommandsAvailable) {
+    items.push(
+      separator(),
+      submenu("markra:context:ai", label("app.aiToolkit"), [
+        customItem("markra:context:ai-polish", label("app.aiPolish"), undefined, handlers.aiPolish),
+        customItem("markra:context:ai-rewrite", label("app.aiRewrite"), undefined, handlers.aiRewrite),
+        customItem(
+          "markra:context:ai-continue-writing",
+          label("app.aiContinueWriting"),
+          undefined,
+          handlers.aiContinueWriting
+        ),
+        customItem("markra:context:ai-summarize", label("app.aiSummarize"), undefined, handlers.aiSummarize),
+        customItem("markra:context:ai-translate", label("app.aiTranslate"), undefined, handlers.aiTranslate)
+      ])
+    );
+  }
+
+  return items;
 }
 
 export async function installNativeEditorContextMenu(
   target: Pick<EventTarget, "addEventListener" | "removeEventListener">,
   handlers: NativeMenuHandlers,
-  language: AppLanguage = "en"
+  language: AppLanguage = "en",
+  options: NativeEditorContextMenuOptions = {}
 ) {
+  const handleContextMenu = (event: Event) => {
+    const element = event.target instanceof Element ? event.target : null;
+    if (!element?.closest(".markdown-paper")) return;
+
+    event.preventDefault();
+    showNativeEditorContextMenu(handlers, language, {
+      aiCommandsAvailable: readAiCommandsAvailable(options)
+    }).catch(() => {});
+  };
+
+  target.addEventListener("contextmenu", handleContextMenu);
+
+  return () => {
+    target.removeEventListener("contextmenu", handleContextMenu);
+  };
+}
+
+async function showNativeEditorContextMenu(
+  handlers: NativeMenuHandlers,
+  language: AppLanguage,
+  options: { aiCommandsAvailable?: boolean }
+) {
+  const menu = await Menu.new({
+    items: createNativeEditorContextMenuItems(handlers, language, options)
+  });
+
+  await menu.popup();
+}
+
+function readAiCommandsAvailable(options: NativeEditorContextMenuOptions) {
   try {
-    const menu = await Menu.new({
-      items: createNativeEditorContextMenuItems(handlers, language)
-    });
-
-    const handleContextMenu = (event: Event) => {
-      const element = event.target instanceof Element ? event.target : null;
-      if (!element?.closest(".markdown-paper")) return;
-
-      event.preventDefault();
-      menu.popup();
-    };
-
-    target.addEventListener("contextmenu", handleContextMenu);
-
-    return () => {
-      target.removeEventListener("contextmenu", handleContextMenu);
-    };
+    return Boolean(options.getAiCommandsAvailable?.());
   } catch {
-    return () => {};
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a richer native editor context menu with a Format submenu and insert actions.
- Show AI toolkit actions only for explicit text selections.
- Open the inline AI command bar immediately in a thinking state when launching AI from the native context menu.

## Validation
- `pnpm --filter @markra/desktop test -- src/App.test.tsx src/lib/tauri/menu.test.ts src/components/AiCommandBar.test.tsx src/hooks/useNativeBindings.test.tsx`
- `pnpm --filter @markra/desktop typecheck:test`
- `pnpm --filter @markra/desktop build`