### PR TITLE
fix(desktop): stabilize native menu commands

### DIFF
--- a/apps/desktop/src-tauri/src/language.rs
+++ b/apps/desktop/src-tauri/src/language.rs
@@ -40,7 +40,7 @@ impl AppLanguage {
         }
     }
 
-    fn from_code(value: &str) -> Option<Self> {
+    pub(crate) fn from_code(value: &str) -> Option<Self> {
         match value {
             "en" => Some(Self::En),
             "zh-CN" => Some(Self::ZhCn),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,8 +18,9 @@ use markdown_files::{
     save_clipboard_image, write_markdown_file,
 };
 use menu::{
-    create_application_menu, is_frontend_menu_command, is_native_new_window_command,
-    is_native_settings_window_command, NativeMenuCommand, NATIVE_MENU_COMMAND_EVENT,
+    create_application_menu, install_application_menu, is_frontend_menu_command,
+    is_native_new_window_command, is_native_settings_window_command, NativeMenuCommand,
+    NATIVE_MENU_COMMAND_EVENT,
 };
 use tauri::Emitter;
 use watcher::{unwatch_markdown_file, watch_markdown_file, MarkdownWatcherState};
@@ -77,6 +78,7 @@ pub fn run() {
             list_markdown_files_for_path,
             create_markdown_tree_file,
             create_markdown_tree_folder,
+            install_application_menu,
             rename_markdown_tree_file,
             delete_markdown_tree_file,
             open_markdown_file_in_new_window,

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -1,4 +1,4 @@
-use crate::language::resolve_startup_language;
+use crate::language::{resolve_startup_language, AppLanguage};
 use tauri::{
     menu::{AboutMetadata, Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
     Manager,
@@ -29,6 +29,13 @@ pub(crate) fn create_application_menu<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> tauri::Result<Menu<R>> {
     let language = resolve_startup_language(&app.config().identifier);
+    create_application_menu_for_language(app, language)
+}
+
+fn create_application_menu_for_language<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    language: AppLanguage,
+) -> tauri::Result<Menu<R>> {
     let labels = crate::menu_labels::for_language(language);
 
     let new = app_menu_item(
@@ -81,6 +88,7 @@ pub(crate) fn create_application_menu<R: tauri::Runtime>(
     let code_block = app_menu_item(app, "formatCodeBlock", labels.code_block, "CmdOrCtrl+Alt+C")?;
     let link = app_menu_item(app, "insertLink", labels.link, "CmdOrCtrl+K")?;
     let image = app_menu_item(app, "insertImage", labels.image, "CmdOrCtrl+Shift+I")?;
+    let table = app_menu_item(app, "insertTable", labels.table, "CmdOrCtrl+Alt+T")?;
 
     let app_menu = SubmenuBuilder::with_id(app, "markra:app", "Markra")
         .about(Some(AboutMetadata {
@@ -124,7 +132,7 @@ pub(crate) fn create_application_menu<R: tauri::Runtime>(
         .separator()
         .items(&[&bullet_list, &ordered_list, &quote, &code_block])
         .separator()
-        .items(&[&link, &image])
+        .items(&[&link, &image, &table])
         .build()?;
 
     let view_menu = SubmenuBuilder::with_id(app, "markra:view", labels.view)
@@ -134,6 +142,21 @@ pub(crate) fn create_application_menu<R: tauri::Runtime>(
     MenuBuilder::new(app)
         .items(&[&app_menu, &file_menu, &edit_menu, &format_menu, &view_menu])
         .build()
+}
+
+#[tauri::command]
+pub(crate) fn install_application_menu(
+    app: tauri::AppHandle,
+    language: String,
+) -> Result<(), String> {
+    let language = AppLanguage::from_code(&language)
+        .ok_or_else(|| format!("Unsupported application menu language: {language}"))?;
+    let menu =
+        create_application_menu_for_language(&app, language).map_err(|error| error.to_string())?;
+
+    app.set_menu(menu)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }
 
 pub(crate) fn is_native_new_window_command(command: &str) -> bool {
@@ -166,6 +189,7 @@ pub(crate) fn is_frontend_menu_command(command: &str) -> bool {
             | "formatCodeBlock"
             | "insertLink"
             | "insertImage"
+            | "insertTable"
     )
 }
 
@@ -193,6 +217,7 @@ mod tests {
         assert!(is_frontend_menu_command("exportHtml"));
         assert!(is_frontend_menu_command("formatBold"));
         assert!(is_frontend_menu_command("insertImage"));
+        assert!(is_frontend_menu_command("insertTable"));
         assert!(!is_frontend_menu_command("markra:file"));
         assert!(!is_frontend_menu_command("copy"));
     }

--- a/apps/desktop/src-tauri/src/menu_labels/de.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/de.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Codeblock",
     link: "Link",
     image: "Bild",
+    table: "Tabelle",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/en.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/en.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Code Block",
     link: "Link",
     image: "Image",
+    table: "Table",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/es.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/es.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Bloque de código",
     link: "Enlace",
     image: "Imagen",
+    table: "Tabla",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/fr.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/fr.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Bloc de code",
     link: "Lien",
     image: "Image",
+    table: "Tableau",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/it.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/it.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Blocco di codice",
     link: "Link",
     image: "Immagine",
+    table: "Tabella",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/ja.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/ja.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "コードブロック",
     link: "リンク",
     image: "画像",
+    table: "表",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/ko.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/ko.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "코드 블록",
     link: "링크",
     image: "이미지",
+    table: "표",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/mod.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/mod.rs
@@ -52,6 +52,7 @@ pub(crate) struct MenuLabels {
     pub(crate) code_block: &'static str,
     pub(crate) link: &'static str,
     pub(crate) image: &'static str,
+    pub(crate) table: &'static str,
 }
 
 pub(crate) fn for_language(language: AppLanguage) -> MenuLabels {

--- a/apps/desktop/src-tauri/src/menu_labels/pt_br.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/pt_br.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Bloco de código",
     link: "Link",
     image: "Imagem",
+    table: "Tabela",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/ru.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/ru.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "Блок кода",
     link: "Ссылка",
     image: "Изображение",
+    table: "Таблица",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/zh_cn.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/zh_cn.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "代码块",
     link: "链接",
     image: "图片",
+    table: "表格",
 };

--- a/apps/desktop/src-tauri/src/menu_labels/zh_tw.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/zh_tw.rs
@@ -39,4 +39,5 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     code_block: "程式碼區塊",
     link: "連結",
     image: "圖片",
+    table: "表格",
 };

--- a/apps/desktop/src/lib/tauri/menu.test.ts
+++ b/apps/desktop/src/lib/tauri/menu.test.ts
@@ -1,4 +1,5 @@
 import { Menu, type MenuOptions } from "@tauri-apps/api/menu";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -15,6 +16,10 @@ vi.mock("@tauri-apps/api/menu", () => ({
   }
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn()
+}));
+
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn()
 }));
@@ -24,6 +29,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 }));
 
 const mockedMenuNew = vi.mocked(Menu.new);
+const mockedInvoke = vi.mocked(invoke);
 const mockedListen = vi.mocked(listen);
 const mockedGetCurrentWindow = vi.mocked(getCurrentWindow);
 type TestMenuItem = NonNullable<MenuOptions["items"]>[number];
@@ -80,6 +86,7 @@ describe("native menu", () => {
 
   beforeEach(() => {
     mockedMenuNew.mockReset();
+    mockedInvoke.mockReset();
     mockedListen.mockReset();
     mockedGetCurrentWindow.mockReset();
     setAsAppMenu.mockReset();
@@ -90,6 +97,7 @@ describe("native menu", () => {
       popup,
       setAsAppMenu
     } as unknown as Awaited<ReturnType<typeof Menu.new>>);
+    mockedInvoke.mockResolvedValue(undefined);
     mockedListen.mockResolvedValue(unlisten);
     mockedGetCurrentWindow.mockReturnValue({
       isFocused
@@ -121,7 +129,7 @@ describe("native menu", () => {
     expect(unlisten).toHaveBeenCalledTimes(1);
   });
 
-  it("installs the application menu while keeping command listeners", async () => {
+  it("asks Rust to install the application menu while keeping command listeners", async () => {
     const handlers: NativeMenuHandlers = {
       saveDocument: vi.fn()
     };
@@ -129,28 +137,25 @@ describe("native menu", () => {
     await installNativeApplicationMenu(handlers, "fr");
 
     expect(mockedListen).toHaveBeenCalledWith("markra://menu-command", expect.any(Function));
-    expect(mockedMenuNew).toHaveBeenCalledWith({
-      items: expect.arrayContaining([
-        expect.objectContaining({ id: "markra:file" }),
-        expect.objectContaining({ id: "markra:format" })
-      ])
+    expect(mockedInvoke).toHaveBeenCalledWith("install_application_menu", {
+      language: "fr"
     });
-    expect(menuItemById(latestMenuItems(), "insertTable")).toMatchObject({
-      accelerator: "CmdOrCtrl+Alt+T"
-    });
-    const exportMenu = menuItemById(latestMenuItems(), "markra:file:export");
-    expect(exportMenu).toMatchObject({
-      text: "Exporter"
-    });
-    expect(menuItemById(menuItemChildren(exportMenu), "exportPdf")).toMatchObject({
-      accelerator: "CmdOrCtrl+P",
-      text: "Exporter en PDF"
-    });
-    expect(menuItemById(menuItemChildren(exportMenu), "exportHtml")).toMatchObject({
-      accelerator: "CmdOrCtrl+Shift+E",
-      text: "Exporter en HTML"
-    });
-    expect(setAsAppMenu).toHaveBeenCalledTimes(1);
+    expect(mockedMenuNew).not.toHaveBeenCalled();
+    expect(setAsAppMenu).not.toHaveBeenCalled();
+  });
+
+  it("routes Rust application menu commands once after Rust installs the menu", async () => {
+    const handlers: NativeMenuHandlers = {
+      openDocument: vi.fn()
+    };
+
+    await installNativeApplicationMenu(handlers, "en");
+    const listener = mockedListen.mock.calls[0]?.[1];
+
+    await listener?.({ payload: { command: "openDocument" } } as Parameters<NonNullable<typeof listener>>[0]);
+
+    expect(mockedMenuNew).not.toHaveBeenCalled();
+    expect(handlers.openDocument).toHaveBeenCalledTimes(1);
   });
 
   it("ignores native application menu commands in unfocused windows", async () => {

--- a/apps/desktop/src/lib/tauri/menu.ts
+++ b/apps/desktop/src/lib/tauri/menu.ts
@@ -60,10 +60,6 @@ function runNativeMenuAction(handler: (() => unknown | Promise<unknown>) | undef
   Promise.resolve(handler()).catch(() => {});
 }
 
-function invokeNativeWindowCommand(command: "open_blank_editor_window" | "open_settings_window") {
-  invoke(command).catch(() => {});
-}
-
 function customItem(
   id: string,
   text: string,
@@ -75,20 +71,6 @@ function customItem(
     text,
     accelerator,
     action: () => runNativeMenuAction(handler)
-  };
-}
-
-function commandItem(
-  id: string,
-  text: string,
-  accelerator: string | undefined,
-  command: "open_blank_editor_window" | "open_settings_window"
-): MenuItemOptions {
-  return {
-    id,
-    text,
-    accelerator,
-    action: () => invokeNativeWindowCommand(command)
   };
 }
 
@@ -130,141 +112,13 @@ export async function listenNativeApplicationMenuCommands(handlers: NativeMenuHa
   });
 }
 
-export function createNativeApplicationMenuItems(
-  handlers: NativeMenuHandlers,
-  language: AppLanguage = "en"
-): SubmenuOptions[] {
-  const label = (key: I18nKey) => menuLabel(language, key);
-  const newDocument = commandItem("newDocument", label("menu.newDocument"), "CmdOrCtrl+N", "open_blank_editor_window");
-  const openDocument = customItem("openDocument", label("menu.openDocument"), "CmdOrCtrl+O", handlers.openDocument);
-  const saveDocument = customItem("saveDocument", label("menu.saveDocument"), "CmdOrCtrl+S", handlers.saveDocument);
-  const saveDocumentAs = customItem(
-    "saveDocumentAs",
-    label("menu.saveDocumentAs"),
-    "CmdOrCtrl+Shift+S",
-    handlers.saveDocumentAs
-  );
-  const exportPdf = customItem("exportPdf", label("menu.exportPdf"), "CmdOrCtrl+P", handlers.exportPdf);
-  const exportHtml = customItem("exportHtml", label("menu.exportHtml"), "CmdOrCtrl+Shift+E", handlers.exportHtml);
-  const exportMenu = submenu("markra:file:export", label("menu.export"), [exportPdf, exportHtml]);
-  const settings = commandItem("openSettings", label("menu.settings"), "CmdOrCtrl+,", "open_settings_window");
-  const bold = customItem("formatBold", label("menu.bold"), "CmdOrCtrl+B", handlers.formatBold);
-  const italic = customItem("formatItalic", label("menu.italic"), "CmdOrCtrl+I", handlers.formatItalic);
-  const strikethrough = customItem(
-    "formatStrikethrough",
-    label("menu.strikethrough"),
-    "CmdOrCtrl+Shift+X",
-    handlers.formatStrikethrough
-  );
-  const inlineCode = customItem("formatInlineCode", label("menu.inlineCode"), "CmdOrCtrl+E", handlers.formatInlineCode);
-  const paragraph = customItem("formatParagraph", label("menu.paragraph"), "CmdOrCtrl+Alt+0", handlers.formatParagraph);
-  const heading1 = customItem("formatHeading1", label("menu.heading1"), "CmdOrCtrl+Alt+1", handlers.formatHeading1);
-  const heading2 = customItem("formatHeading2", label("menu.heading2"), "CmdOrCtrl+Alt+2", handlers.formatHeading2);
-  const heading3 = customItem("formatHeading3", label("menu.heading3"), "CmdOrCtrl+Alt+3", handlers.formatHeading3);
-  const bulletList = customItem(
-    "formatBulletList",
-    label("menu.bulletList"),
-    "CmdOrCtrl+Shift+8",
-    handlers.formatBulletList
-  );
-  const orderedList = customItem(
-    "formatOrderedList",
-    label("menu.orderedList"),
-    "CmdOrCtrl+Shift+7",
-    handlers.formatOrderedList
-  );
-  const quote = customItem("formatQuote", label("menu.quote"), "CmdOrCtrl+Shift+B", handlers.formatQuote);
-  const codeBlock = customItem("formatCodeBlock", label("menu.codeBlock"), "CmdOrCtrl+Alt+C", handlers.formatCodeBlock);
-  const link = customItem("insertLink", label("menu.link"), "CmdOrCtrl+K", handlers.insertLink);
-  const image = customItem("insertImage", label("menu.image"), "CmdOrCtrl+Shift+I", handlers.insertImage);
-  const table = customItem("insertTable", label("menu.table"), "CmdOrCtrl+Alt+T", handlers.insertTable);
-
-  return [
-    {
-      id: "markra:app",
-      text: "Markra",
-      items: [
-        predefined({ About: { name: "Markra" } }),
-        separator(),
-        settings,
-        separator(),
-        predefined("Hide", label("menu.hide")),
-        predefined("HideOthers", label("menu.hideOthers")),
-        predefined("ShowAll", label("menu.showAll")),
-        separator(),
-        predefined("Quit", label("menu.quit"))
-      ]
-    },
-    {
-      id: "markra:file",
-      text: label("menu.file"),
-      items: [
-        newDocument,
-        openDocument,
-        separator(),
-        saveDocument,
-        saveDocumentAs,
-        separator(),
-        exportMenu,
-        separator(),
-        predefined("CloseWindow", label("menu.closeWindow"))
-      ]
-    },
-    {
-      id: "markra:edit",
-      text: label("menu.edit"),
-      items: [
-        predefined("Undo", label("menu.undo")),
-        predefined("Redo", label("menu.redo")),
-        separator(),
-        predefined("Cut", label("menu.cut")),
-        predefined("Copy", label("menu.copy")),
-        predefined("Paste", label("menu.paste")),
-        predefined("SelectAll", label("menu.selectAll"))
-      ]
-    },
-    {
-      id: "markra:format",
-      text: label("menu.format"),
-      items: [
-        bold,
-        italic,
-        strikethrough,
-        inlineCode,
-        separator(),
-        paragraph,
-        heading1,
-        heading2,
-        heading3,
-        separator(),
-        bulletList,
-        orderedList,
-        quote,
-        codeBlock,
-        separator(),
-        link,
-        image,
-        table
-      ]
-    },
-    {
-      id: "markra:view",
-      text: label("menu.view"),
-      items: [predefined("Fullscreen", label("menu.fullscreen"))]
-    }
-  ];
-}
-
 export async function installNativeApplicationMenu(handlers: NativeMenuHandlers, language: AppLanguage = "en") {
   const stopListening = await listenNativeApplicationMenuCommands(handlers);
 
   try {
-    const menu = await Menu.new({
-      items: createNativeApplicationMenuItems(handlers, language)
-    });
-    await menu.setAsAppMenu();
+    await invoke("install_application_menu", { language });
   } catch {
-    // Keep the Rust-installed startup menu working if the JS menu API is unavailable.
+    // Keep the Rust-installed startup menu working if runtime menu refresh is unavailable.
   }
 
   return stopListening;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -818,6 +818,11 @@
     @apply text-(--text-heading) font-[760];
   }
 
+  .markdown-paper em {
+    @apply italic;
+    font-synthesis: style;
+  }
+
   .markdown-paper .markra-md-delimiter {
     @apply text-(--text-md-char);
   }

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -51,6 +51,14 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("font-weight: inherit");
   });
 
+  it("styles finalized emphasis marks in the editor", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).toContain(".markdown-paper em");
+    expect(styles).toContain("@apply italic");
+    expect(styles).toContain("font-synthesis: style");
+  });
+
   it("keeps AI diff action controls visually quiet until interaction", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 


### PR DESCRIPTION
## Summary
- Move application menu registration back to Rust and refresh it through a Rust command when the frontend language changes.
- Keep frontend app menu handling limited to listening for `markra://menu-command` and running editor/app handlers.
- Add the missing Rust `insertTable` menu item and localized table labels.
- Restore scoped editor styling for finalized emphasis marks and allow style synthesis so Chinese text visibly slants when italic is applied.
- Keep regression coverage for Rust app-menu installation and editor emphasis styling.

## Why
Tauri app menu items already flow through Rust `on_menu_event`. Creating the app menu again from JavaScript with item actions gave the same command two possible dispatch paths, which could queue duplicate native open panels on macOS.

The editor already turns menu formatting into Markdown/emphasis marks. For Chinese text, the active system font may not provide a real italic face; the app globally disables font synthesis, so `font-style: italic` could compute without any visible slant. The emphasis rule now opts back into style synthesis only for rendered emphasis.

## Validation
- `pnpm --filter @markra/desktop test -- src/lib/tauri/menu.test.ts` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `cargo test menu::tests` passed
- `cargo test language::tests` passed
- `cargo fmt --check` passed
- `cargo check` passed
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "supports inline markdown formatting shortcuts"` passed
- `pnpm --filter @markra/desktop test -- src/styles.test.ts -t "styles finalized emphasis marks"` passed
- `pnpm --filter @markra/desktop build` passed

## Risk
- Low. App menu ownership moves to Rust; context menus still use the existing JS menu action path. The emphasis change is scoped to Markdown paper rendering.

Closes #13