### PR TITLE
fix(editor): avoid false dirty state detection

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -779,6 +779,51 @@ describe("Markra workspace", () => {
     expect(mockedConfirmNativeUnsavedMarkdownDocumentDiscard).not.toHaveBeenCalled();
   });
 
+  it("switches away from a clean file with normalized markdown without asking to discard changes", async () => {
+    const guidePath = "/mock-files/vault/docs/guide.md";
+    const notesPath = "/mock-files/vault/docs/notes.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "guide.md", path: guidePath, relativePath: "docs/guide.md" },
+      { name: "notes.md", path: notesPath, relativePath: "docs/notes.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === guidePath) {
+        return {
+          content: "Guide\n=====\n\nRead-only content.",
+          name: "guide.md",
+          path: guidePath
+        };
+      }
+
+      return {
+        content: "# Notes\n\nSecond read-only content.",
+        name: "notes.md",
+        path: notesPath
+      };
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "docs/guide.md" }));
+    expect(await screen.findByText("Guide")).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs/notes.md" }));
+    expect(await screen.findByText("Notes")).toBeInTheDocument();
+
+    expect(mockedConfirmNativeUnsavedMarkdownDocumentDiscard).not.toHaveBeenCalled();
+  });
+
   it("clears a selected folder file after deleting it from the file tree", async () => {
     const test1Path = "/mock-files/vault/test1.md";
     const test2Path = "/mock-files/vault/test2.md";
@@ -1377,6 +1422,31 @@ describe("Markra workspace", () => {
     expect(await screen.findByText("Source edit")).toBeInTheDocument();
     expect(screen.getByText("Updated from source mode.")).toBeInTheDocument();
     expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
+  });
+
+  it("keeps a clean file unmodified when toggling markdown source mode without edits", async () => {
+    const originalContent = "Native file\n===========\n\nOpened from disk.";
+    mockOpenMarkdownFile({
+      content: originalContent,
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByText("Native file")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Unsaved changes")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveValue(originalContent);
+    expect(screen.queryByLabelText("Unsaved changes")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+
+    expect(await screen.findByText("Native file")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Unsaved changes")).not.toBeInTheDocument();
   });
 
   it("saves markdown source mode edits through the native file API", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -178,6 +178,7 @@ export default function App() {
   const markdownDocument = useMarkdownDocument({
     confirmDiscardUnsavedChanges,
     getCurrentMarkdown: editor.getCurrentMarkdown,
+    isCurrentMarkdownEquivalent: editor.isCurrentMarkdownEquivalent,
     onMarkdownTreeChange: refreshMarkdownFileTree,
     onTreeRootFromFolderPath: openFolderPath,
     onTreeRootFromFilePath: setRootFromMarkdownFilePath,
@@ -752,15 +753,11 @@ export default function App() {
       return;
     }
 
-    handleMarkdownChange(editor.getCurrentMarkdown(document.content));
     updateActiveAiSelection(null);
     handleAiCommandClose();
     setEditorMode("source");
   }, [
-    document.content,
-    editor,
     handleAiCommandClose,
-    handleMarkdownChange,
     sourceMode,
     sourceModeAvailable,
     updateActiveAiSelection

--- a/apps/desktop/src/hooks/useEditorController.ts
+++ b/apps/desktop/src/hooks/useEditorController.ts
@@ -25,6 +25,13 @@ const defaultMarkdownTable = [
   "|  |  |"
 ].join("\n");
 
+function comparableSerializedMarkdown(markdown: string) {
+  return markdown
+    .replace(/\r\n?/gu, "\n")
+    .replace(/[ \t]+$/gmu, "")
+    .trim();
+}
+
 type EditorReadyOptions = {
   autoFocus?: boolean;
 };
@@ -229,6 +236,24 @@ export function useEditorController() {
       }) ?? fallbackContent;
     } catch {
       return fallbackContent;
+    }
+  }, []);
+
+  const isCurrentMarkdownEquivalent = useCallback((markdown: string) => {
+    try {
+      return editorRef.current?.action((ctx) => {
+        const view = ctx.get(editorViewCtx);
+        const parseMarkdown = ctx.get(parserCtx);
+        const serializer = ctx.get(serializerCtx);
+        const link = linkSchema.type(ctx);
+        const image = imageSchema.type(ctx);
+        const currentMarkdown = serializeLinkImageLiveMarkdown(view.state.doc, serializer, link, image);
+        const parsedMarkdown = serializeLinkImageLiveMarkdown(parseMarkdown(markdown), serializer, link, image);
+
+        return comparableSerializedMarkdown(currentMarkdown) === comparableSerializedMarkdown(parsedMarkdown);
+      }) ?? true;
+    } catch {
+      return false;
     }
   }, []);
 
@@ -548,6 +573,7 @@ export function useEditorController() {
     getDocumentEndPosition,
     getHeadingAnchors,
     getCurrentMarkdown,
+    isCurrentMarkdownEquivalent,
     getSelection,
     getSectionAnchors,
     getTableAnchors,

--- a/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
@@ -132,6 +132,52 @@ describe("useMarkdownDocument", () => {
     expect(result.current.document.name).toBe("second.md");
   });
 
+  it("does not ask to discard a clean file only because the editor serialized markdown differently", async () => {
+    let editorMarkdown = "";
+    const confirmDiscardUnsavedChanges = vi.fn(() => true);
+    mockedOpenNativeMarkdownPath
+      .mockResolvedValueOnce({
+        kind: "file",
+        file: {
+          content: "First file\n==========\n\n- Clean content.",
+          name: "first.md",
+          path: "/mock-files/first.md"
+        }
+      })
+      .mockResolvedValueOnce({
+        kind: "file",
+        file: {
+          content: "# Second file\n\nClean content.",
+          name: "second.md",
+          path: "/mock-files/second.md"
+        }
+      });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: () => true,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openMarkdownFile();
+    });
+
+    editorMarkdown = "# First file\n\n* Clean content.";
+
+    await act(async () => {
+      await result.current.openMarkdownFile();
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(result.current.document.name).toBe("second.md");
+  });
+
   it("forwards native folder tree changes while watching an opened markdown file", async () => {
     const onMarkdownTreeChange = vi.fn();
     let emitTreeChange: (path: string) => unknown = () => {};

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -49,9 +49,49 @@ function isPristineUntitledDocument(document: DocumentState) {
   return document.open && document.path === null && document.content === "" && !document.dirty && document.revision === 0;
 }
 
+function normalizeComparableMarkdownHeadings(content: string) {
+  const lines = content.replace(/\r\n?/gu, "\n").split("\n");
+  const normalized: string[] = [];
+  let fencedMarker: "`" | "~" | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/u);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]!.startsWith("~") ? "~" : "`";
+      if (!fencedMarker) {
+        fencedMarker = marker;
+      } else if (fencedMarker === marker) {
+        fencedMarker = null;
+      }
+
+      normalized.push(line);
+      continue;
+    }
+
+    if (!fencedMarker) {
+      const atxHeadingMatch = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/u);
+      if (atxHeadingMatch) {
+        normalized.push(`${atxHeadingMatch[1]} ${atxHeadingMatch[2]!.trim()}`);
+        continue;
+      }
+
+      const setextHeadingMatch = line.match(/^\s*(=+|-+)\s*$/u);
+      const previousLine = normalized.at(-1);
+      if (setextHeadingMatch && previousLine?.trim()) {
+        const level = setextHeadingMatch[1]!.startsWith("=") ? 1 : 2;
+        normalized[normalized.length - 1] = `${"#".repeat(level)} ${previousLine.trim()}`;
+        continue;
+      }
+    }
+
+    normalized.push(line);
+  }
+
+  return normalized.join("\n");
+}
+
 function comparableMarkdown(content: string) {
-  return content
-    .replace(/\r\n?/gu, "\n")
+  return normalizeComparableMarkdownHeadings(content)
     .replace(/[ \t]+$/gmu, "")
     .trim();
 }
@@ -63,6 +103,7 @@ function isEquivalentEditorMarkdown(left: string, right: string) {
 type UseMarkdownDocumentOptions = {
   confirmDiscardUnsavedChanges?: (document: DocumentState) => boolean | Promise<boolean>;
   getCurrentMarkdown: (fallbackContent: string) => string;
+  isCurrentMarkdownEquivalent?: (markdown: string) => boolean;
   onMarkdownTreeChange?: (path: string) => unknown | Promise<unknown>;
   onTreeRootFromFolderPath: (path: string, name: string, sessionId?: string | null) => unknown;
   onTreeRootFromFilePath: (path: string) => unknown;
@@ -78,6 +119,7 @@ function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState
 export function useMarkdownDocument({
   confirmDiscardUnsavedChanges,
   getCurrentMarkdown,
+  isCurrentMarkdownEquivalent,
   onMarkdownTreeChange,
   onTreeRootFromFolderPath,
   onTreeRootFromFilePath,
@@ -133,14 +175,19 @@ export function useMarkdownDocument({
     if (!current.open) return false;
     if (current.path === null && current.content.trim().length === 0) return false;
 
-    const editorMarkdown = currentMarkdown();
     if (!current.dirty) {
+      const editorContentEquivalent = isCurrentMarkdownEquivalent?.(current.content);
+      if (editorContentEquivalent) return false;
+      if (editorContentEquivalent === false && current.path !== null) return true;
+
+      const editorMarkdown = currentMarkdown();
       return !isEquivalentEditorMarkdown(editorMarkdown, current.content) && (current.path !== null || editorMarkdown.trim().length > 0);
     }
     if (current.path) return true;
 
+    const editorMarkdown = currentMarkdown();
     return editorMarkdown.trim().length > 0;
-  }, [currentMarkdown]);
+  }, [currentMarkdown, isCurrentMarkdownEquivalent]);
 
   const confirmCanDiscardCurrentDocument = useCallback(() => {
     if (!hasDiscardableUnsavedChanges()) return true;


### PR DESCRIPTION
## Summary
- Stop entering source mode from reserializing clean visual editor content into document state.
- Compare clean editor content through Milkdown parser/serializer canonical Markdown before prompting to discard changes.
- Add regression coverage for both issue scenarios: source/visual toggling and switching files without edits.

## Why
- Fixes #14.
- Clean files could look dirty because source mode wrote normalized Markdown back to `document.content`.
- Switching files could also show a false discard prompt when Milkdown serialized equivalent Markdown differently from the original file text.

## Validation
- `pnpm --filter @markra/desktop test -- App.test.tsx -t "keeps a clean file unmodified"` passed.
- `pnpm --filter @markra/desktop test -- App.test.tsx -t "switches away from a clean file"` passed.
- `pnpm --filter @markra/desktop test -- App.test.tsx -t "keeps dirty editor content"` passed.
- `pnpm --filter @markra/desktop test -- useMarkdownDocument.test.tsx -t "serialized markdown differently"` passed.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Low. The discard prompt still appears for real editor content changes; clean documents now avoid false positives caused by equivalent Markdown serialization differences.
