### PR TITLE
fix(editor): avoid covering code with language selector

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -332,6 +332,15 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain(["```json", "const answer = 42;", "```"].join("\n"));
   });
 
+  it("places the code block language selector after the code content", async () => {
+    const source = ["```bash", "echo hello", "```"].join("\n");
+    const { container } = await renderEditor(source);
+    const codeBlock = container.querySelector<HTMLElement>(".ProseMirror .markra-code-block");
+    const languageControl = container.querySelector<HTMLElement>(".ProseMirror .markra-code-language-control");
+
+    expect(codeBlock?.lastElementChild).toBe(languageControl);
+  });
+
   it("keeps uncommon code block languages available in the inline selector", async () => {
     const source = ["```custom-lang", "alpha", "```"].join("\n");
     const { container } = await renderEditor(source);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -982,16 +982,26 @@
   }
 
   .markdown-paper .markra-code-block {
-    @apply relative mt-5 mb-7 grid overflow-hidden rounded border border-(--border-default) bg-(--bg-code);
+    @apply relative mt-5 mb-7 grid overflow-visible rounded border border-(--border-default) bg-(--bg-code);
     grid-template-columns: auto minmax(0, 1fr);
   }
 
   .markdown-paper .markra-code-language-control {
-    @apply absolute top-2 right-2 z-[1] flex items-center;
+    @apply absolute right-0 z-[2] flex items-center justify-end pt-1.5 transition-[opacity,transform] duration-150 ease-out;
+    top: 100%;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-0.125rem);
+  }
+
+  .markdown-paper .markra-code-block:hover .markra-code-language-control {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
   }
 
   .markdown-paper .markra-code-language-select {
-    @apply h-9 min-w-40 rounded-md border border-(--border-default) bg-(--bg-primary)/96 px-3 text-[0.82rem] font-medium text-(--text-secondary) outline-none transition-[border-color,color,background-color,box-shadow];
+    @apply h-8 min-w-40 cursor-pointer rounded-md border border-(--border-default) bg-(--bg-primary)/96 px-3 text-[0.82rem] font-medium text-(--text-secondary) shadow-sm outline-none transition-[border-color,color,background-color,box-shadow];
     max-width: min(18rem, calc(100vw - 4rem));
     font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
     line-height: 1;
@@ -1003,7 +1013,7 @@
   }
 
   .markdown-paper .markra-code-line-numbers {
-    @apply border-r border-(--border-default) px-3 py-4 text-right text-[0.9em] leading-[1.65] text-(--text-secondary);
+    @apply rounded-l border-r border-(--border-default) px-3 py-4 text-right text-[0.9em] leading-[1.65] text-(--text-secondary);
     background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-code));
     font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
     user-select: none;

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -77,6 +77,36 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("z-index: 60");
   });
 
+  it("reveals the code block language selector below the block without taking layout space", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const codeBlockStart = styles.indexOf(".markdown-paper .markra-code-block {");
+    const codeBlockEnd = styles.indexOf(".markdown-paper .markra-code-language-control");
+    const codeBlockStyles = styles.slice(codeBlockStart, codeBlockEnd);
+    const languageControlStart = styles.indexOf(".markdown-paper .markra-code-language-control {");
+    const languageControlEnd = styles.indexOf(".markdown-paper .markra-code-language-select");
+    const languageControlStyles = styles.slice(languageControlStart, languageControlEnd);
+    const languageRevealStart = styles.indexOf(".markdown-paper .markra-code-block:hover .markra-code-language-control");
+    const languageRevealEnd = styles.indexOf(".markdown-paper .markra-code-language-select");
+    const languageRevealStyles = styles.slice(languageRevealStart, languageRevealEnd);
+    const languageSelectStart = styles.indexOf(".markdown-paper .markra-code-language-select {");
+    const languageSelectEnd = styles.indexOf(".markdown-paper .markra-code-language-select:focus");
+    const languageSelectStyles = styles.slice(languageSelectStart, languageSelectEnd);
+
+    expect(codeBlockStyles).toContain("overflow-visible");
+    expect(languageControlStyles).toContain("absolute");
+    expect(languageControlStyles).toContain("top: 100%");
+    expect(languageControlStyles).toContain("pt-1.5");
+    expect(languageControlStyles).toContain("justify-end");
+    expect(languageControlStyles).toContain("opacity: 0");
+    expect(languageControlStyles).toContain("pointer-events: none");
+    expect(languageControlStyles).not.toContain("border-t");
+    expect(languageControlStyles).not.toContain("grid-column");
+    expect(languageRevealStyles).not.toContain(":focus-within");
+    expect(languageRevealStyles).toContain("opacity: 1");
+    expect(languageRevealStyles).toContain("pointer-events: auto");
+    expect(languageSelectStyles).toContain("border border-(--border-default)");
+  });
+
   it("includes the inline AI loading shimmer used by compact quick actions", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/editor/src/code-block.ts
+++ b/packages/editor/src/code-block.ts
@@ -338,7 +338,7 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.languageSelect.addEventListener("change", this.handleLanguageChange);
     this.languageControl.append(this.languageSelect);
     pre.append(this.code);
-    this.dom.append(this.languageControl, this.lineNumbers, pre);
+    this.dom.append(this.lineNumbers, pre, this.languageControl);
     this.syncLanguage();
     this.syncLineNumbers();
   }


### PR DESCRIPTION
## Summary
- Move the code block language selector after the code content in the node view.
- Show the selector below the code block only while hovering the block, without taking layout space.
- Keep the selector bordered and add regression coverage for hover-only reveal behavior.

## Why
- The previous inline selector could cover long code lines.
- A fixed bottom row avoided overlap but changed document layout.
- The hover reveal now sits below the block with a continuous hover path into the selector.

## Validation
- `pnpm --filter @markra/desktop test -- styles.test.ts MarkdownPaper.test.tsx -t "code block language|reveals the code block language selector"` passed
- `pnpm --filter @markra/desktop build` passed