### PR TITLE
fix(editor): expand headings to markdown source

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -520,7 +520,7 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.selection.from).toBeLessThan(source.indexOf("$$", 2) + 1);
   });
 
-  it("keeps math source visible after moving past the closing delimiter until Enter", async () => {
+  it("folds math source when the cursor leaves the formula", async () => {
     const source = String.raw`$$ E = mc^2 $$`;
     const { container, view } = await renderEditor(source);
     const blockFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-display");
@@ -532,11 +532,6 @@ describe("MarkdownPaper editing", () => {
     });
 
     moveCursor(view, source.length + 1);
-
-    expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
-    expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
-
-    expect(pressEnter(view)).toBe(true);
 
     await waitFor(() => {
       expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
@@ -2486,6 +2481,57 @@ describe("MarkdownPaper editing", () => {
 
     expect(container.querySelector(".ProseMirror h2")).toHaveTextContent("Title");
     expect(container.querySelector(".ProseMirror")?.textContent).toBe("Title");
+    await settleMarkdownListener();
+  });
+
+  it("expands a rendered heading back to editable markdown source when clicked", async () => {
+    const { container, editor, view } = await renderEditor("## Title");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    const heading = container.querySelector<HTMLElement>(".ProseMirror h2");
+    expect(heading).toHaveTextContent("Title");
+
+    fireEvent.click(heading!);
+
+    expect(container.querySelector(".ProseMirror h2")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("## Title");
+
+    view.dispatch(view.state.tr.delete(1, view.state.doc.content.size - 1).insertText("### Revised", 1));
+
+    expect(pressEnter(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror h3")).toHaveTextContent("Revised");
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("Revised");
+    expect(serializeMarkdown(view.state.doc)).toContain("### Revised");
+    await settleMarkdownListener();
+  });
+
+  it("preserves inline markdown when expanding and finalizing a rendered heading", async () => {
+    const { container, view } = await renderEditor("## **Bold**");
+
+    fireEvent.click(container.querySelector<HTMLElement>(".ProseMirror h2")!);
+
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("## **Bold**");
+
+    expect(pressEnter(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror h2 strong")).toHaveTextContent("Bold");
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("Bold");
+    await settleMarkdownListener();
+  });
+
+  it("finalizes expanded heading source when the cursor leaves the source", async () => {
+    const { container, view } = await renderEditor("## Title\n\nTail");
+
+    fireEvent.click(container.querySelector<HTMLElement>(".ProseMirror h2")!);
+
+    expect(container.querySelector(".ProseMirror h2")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("## TitleTail");
+
+    moveCursor(view, findTextPosition(view, "Tail"));
+
+    expect(container.querySelector(".ProseMirror h2")).toHaveTextContent("Title");
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("TitleTail");
     await settleMarkdownListener();
   });
 

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -25,6 +25,7 @@ import { $prose } from "@milkdown/kit/utils";
 import { markraLiveMarkdownPlugin } from "@markra/editor";
 import { markraClipboardImagePlugin, type SaveClipboardImage } from "@markra/editor";
 import { markraCodeBlockPlugin } from "@markra/editor";
+import { markraHeadingSourcePlugin } from "@markra/editor";
 import { markraLinkImageLivePlugin } from "@markra/editor";
 import { markraRawHtmlPlugin } from "@markra/editor";
 import { serializeLinkImageLiveMarkdown } from "@markra/editor";
@@ -325,6 +326,7 @@ function MilkdownSurface({
         )
         .use(markraTableControlsPlugin(tableControlLabels))
         .use(markraLinkImageLivePlugin(resolveImageSrc))
+        .use(markraHeadingSourcePlugin)
         .use(
           markraRawHtmlPlugin({
             htmlSourceApplyLabel: t(language, "editor.htmlSourceApply"),

--- a/packages/editor/src/heading-source.ts
+++ b/packages/editor/src/heading-source.ts
@@ -1,0 +1,366 @@
+import { parserCtx, serializerCtx } from "@milkdown/kit/core";
+import { headingSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode, NodeType } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, TextSelection, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+type ActiveHeadingSource = {
+  from: number;
+  to: number;
+};
+
+type HeadingRange = {
+  from: number;
+  node: ProseNode;
+  to: number;
+};
+
+type ParsedHeadingSource = {
+  from: number;
+  level: number;
+  markdown: string;
+  text: string;
+  to: number;
+};
+
+type HeadingSourceMeta =
+  | {
+      range: ActiveHeadingSource;
+      type: "activate";
+    }
+  | {
+      type: "deactivate";
+    };
+
+const headingSourceKey = new PluginKey<ActiveHeadingSource | null>("markra-heading-source");
+
+function clampPosition(position: number, docSize: number) {
+  return Math.max(0, Math.min(position, docSize));
+}
+
+function headingLevel(node: ProseNode) {
+  const level = Number(node.attrs.level ?? 1);
+  if (!Number.isFinite(level)) return 1;
+
+  return Math.max(1, Math.min(6, Math.trunc(level)));
+}
+
+function fallbackHeadingMarkdownSource(node: ProseNode) {
+  return `${"#".repeat(headingLevel(node))} ${node.textContent}`;
+}
+
+function headingMarkdownSource(
+  node: ProseNode,
+  doc: NodeType,
+  serializeMarkdown: (content: ProseNode) => string
+) {
+  try {
+    const serialized = serializeMarkdown(doc.create(null, node)).trim();
+    return serialized || fallbackHeadingMarkdownSource(node);
+  } catch {
+    return fallbackHeadingMarkdownSource(node);
+  }
+}
+
+function headingElementFromEventTarget(target: EventTarget | null, root: HTMLElement) {
+  const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+  const headingElement = element?.closest<HTMLElement>("h1,h2,h3,h4,h5,h6") ?? null;
+  if (!headingElement || !root.contains(headingElement)) return null;
+
+  return headingElement;
+}
+
+function findHeadingRangeAtPosition(state: EditorState, heading: NodeType, position: number): HeadingRange | null {
+  const safePosition = clampPosition(position, state.doc.content.size);
+  const $position = state.doc.resolve(safePosition);
+
+  for (let depth = $position.depth; depth > 0; depth -= 1) {
+    const node = $position.node(depth);
+    if (node.type !== heading) continue;
+
+    return {
+      from: $position.before(depth),
+      node,
+      to: $position.after(depth)
+    };
+  }
+
+  const nodeAfter = $position.nodeAfter;
+  if (nodeAfter?.type === heading) {
+    return {
+      from: safePosition,
+      node: nodeAfter,
+      to: safePosition + nodeAfter.nodeSize
+    };
+  }
+
+  const nodeBefore = $position.nodeBefore;
+  if (nodeBefore?.type === heading) {
+    return {
+      from: safePosition - nodeBefore.nodeSize,
+      node: nodeBefore,
+      to: safePosition
+    };
+  }
+
+  return null;
+}
+
+function headingSourceCursor(range: HeadingRange, source: string, selectionFrom: number) {
+  const level = headingLevel(range.node);
+  const contentStart = range.from + 1;
+  const contentEnd = range.to - 1;
+  const contentOffset =
+    contentStart <= selectionFrom && selectionFrom <= contentEnd ? selectionFrom - contentStart : 0;
+  const sourceContentStart = range.from + 1 + level + 1;
+
+  return Math.min(range.from + 1 + source.length, sourceContentStart + contentOffset);
+}
+
+function expandHeadingSource(
+  view: EditorView,
+  paragraph: NodeType,
+  range: HeadingRange,
+  serializeMarkdown: (content: ProseNode) => string
+) {
+  const source = headingMarkdownSource(range.node, view.state.schema.topNodeType, serializeMarkdown);
+  const cursor = headingSourceCursor(range, source, view.state.selection.from);
+  const paragraphNode = paragraph.create(null, view.state.schema.text(source));
+  const activeSource = {
+    from: range.from,
+    to: range.from + paragraphNode.nodeSize
+  } satisfies ActiveHeadingSource;
+  const tr = view.state.tr.replaceWith(range.from, range.to, paragraphNode);
+
+  view.dispatch(
+    tr
+      .setMeta(headingSourceKey, {
+        range: activeSource,
+        type: "activate"
+      } satisfies HeadingSourceMeta)
+      .setSelection(TextSelection.create(tr.doc, cursor))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
+function headingPositionFromElement(view: EditorView, element: HTMLElement) {
+  try {
+    return view.posAtDOM(element, 0);
+  } catch {
+    return null;
+  }
+}
+
+function parseHeadingSource(text: string) {
+  const match = /^(#{1,6})(?:[ \t]+|$)(.*)$/u.exec(text);
+  if (!match) return null;
+
+  const marker = match[1] ?? "";
+  const rawText = match[2] ?? "";
+
+  return {
+    level: marker.length,
+    markdown: text,
+    text: rawText.replace(/[ \t]+#+[ \t]*$/u, "").trim()
+  };
+}
+
+function findActiveHeadingSource(
+  state: EditorState,
+  paragraph: NodeType,
+  heading: NodeType
+): ParsedHeadingSource | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  if ($from.parent.type !== paragraph) return null;
+
+  const parsed = parseHeadingSource($from.parent.textContent);
+  if (!parsed) return null;
+
+  const parentDepth = $from.depth - 1;
+  const parent = $from.node(parentDepth);
+  const index = $from.index(parentDepth);
+  if (!parent.canReplaceWith(index, index + 1, heading)) return null;
+
+  return {
+    from: $from.before($from.depth),
+    level: parsed.level,
+    markdown: parsed.markdown,
+    text: parsed.text,
+    to: $from.after($from.depth)
+  };
+}
+
+function findHeadingSourceByRange(
+  state: EditorState,
+  paragraph: NodeType,
+  heading: NodeType,
+  range: ActiveHeadingSource
+): ParsedHeadingSource | null {
+  const node = state.doc.nodeAt(range.from);
+  if (!node || node.type !== paragraph) return null;
+
+  const parsed = parseHeadingSource(node.textContent);
+  if (!parsed) return null;
+
+  const $from = state.doc.resolve(range.from);
+  const parentDepth = Math.max(0, $from.depth - 1);
+  const parent = $from.node(parentDepth);
+  const index = $from.index(parentDepth);
+  if (!parent.canReplaceWith(index, index + 1, heading)) return null;
+
+  return {
+    from: range.from,
+    level: parsed.level,
+    markdown: parsed.markdown,
+    text: parsed.text,
+    to: range.from + node.nodeSize
+  };
+}
+
+function parseHeadingSourceNode(
+  parseMarkdown: (markdown: string) => ProseNode,
+  heading: NodeType,
+  source: ParsedHeadingSource
+) {
+  try {
+    const parsedDocument = parseMarkdown(source.markdown);
+    let parsedHeading: ProseNode | null = null;
+
+    parsedDocument.forEach((node) => {
+      if (!parsedHeading && node.type === heading) {
+        parsedHeading = node;
+      }
+    });
+
+    return parsedHeading;
+  } catch {
+    return null;
+  }
+}
+
+function fallbackHeadingNode(view: EditorView, heading: NodeType, source: ParsedHeadingSource) {
+  return heading.create({ level: source.level }, source.text ? view.state.schema.text(source.text) : null);
+}
+
+function fallbackHeadingNodeFromState(state: EditorState, heading: NodeType, source: ParsedHeadingSource) {
+  return heading.create({ level: source.level }, source.text ? state.schema.text(source.text) : null);
+}
+
+function headingNodeFromSource(
+  state: EditorState,
+  heading: NodeType,
+  source: ParsedHeadingSource,
+  parseMarkdown: (markdown: string) => ProseNode
+) {
+  return parseHeadingSourceNode(parseMarkdown, heading, source) ?? fallbackHeadingNodeFromState(state, heading, source);
+}
+
+function finalizeHeadingSource(
+  view: EditorView,
+  heading: NodeType,
+  source: ParsedHeadingSource,
+  parseMarkdown: (markdown: string) => ProseNode
+) {
+  const headingNode =
+    parseHeadingSourceNode(parseMarkdown, heading, source) ?? fallbackHeadingNode(view, heading, source);
+  const tr = view.state.tr.replaceWith(source.from, source.to, headingNode);
+  const cursor = source.from + 1 + headingNode.textContent.length;
+
+  view.dispatch(tr.setSelection(TextSelection.create(tr.doc, cursor)).scrollIntoView());
+  view.focus();
+  return true;
+}
+
+function selectionIsInsideHeadingSource(state: EditorState, source: ActiveHeadingSource) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection)) return false;
+
+  return source.from < selection.from && selection.to < source.to;
+}
+
+function finalizeInactiveHeadingSource(
+  state: EditorState,
+  paragraph: NodeType,
+  heading: NodeType,
+  source: ActiveHeadingSource,
+  parseMarkdown: (markdown: string) => ProseNode
+): Transaction | null {
+  if (selectionIsInsideHeadingSource(state, source)) return null;
+
+  const tr = state.tr.setMeta(headingSourceKey, {
+    type: "deactivate"
+  } satisfies HeadingSourceMeta);
+  const parsedSource = findHeadingSourceByRange(state, paragraph, heading, source);
+  if (!parsedSource) return tr;
+
+  const headingNode = headingNodeFromSource(state, heading, parsedSource, parseMarkdown);
+  return tr.replaceWith(parsedSource.from, parsedSource.to, headingNode);
+}
+
+export const markraHeadingSourcePlugin = $prose((ctx) => {
+  const paragraph = paragraphSchema.type(ctx);
+  const heading = headingSchema.type(ctx);
+  const parseMarkdown = ctx.use(parserCtx);
+  const serializeMarkdown = ctx.use(serializerCtx);
+
+  return new Plugin({
+    key: headingSourceKey,
+    state: {
+      init: (): ActiveHeadingSource | null => null,
+      apply(transaction, activeSource: ActiveHeadingSource | null): ActiveHeadingSource | null {
+        const meta = transaction.getMeta(headingSourceKey) as HeadingSourceMeta | undefined;
+        if (meta?.type === "deactivate") return null;
+        if (meta?.type === "activate") return meta.range;
+        if (!activeSource) return null;
+
+        const mappedSource = {
+          from: transaction.mapping.map(activeSource.from, 1),
+          to: transaction.mapping.map(activeSource.to, -1)
+        } satisfies ActiveHeadingSource;
+        if (mappedSource.from >= mappedSource.to) return null;
+
+        return mappedSource;
+      }
+    },
+    appendTransaction: (_transactions, _oldState, newState) => {
+      const activeSource = headingSourceKey.getState(newState);
+      if (!activeSource) return null;
+
+      return finalizeInactiveHeadingSource(newState, paragraph, heading, activeSource, parseMarkdown.get());
+    },
+    props: {
+      handleDOMEvents: {
+        click: (view, event) => {
+          if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+
+          const headingElement = headingElementFromEventTarget(event.target, view.dom);
+          if (!headingElement) return false;
+
+          const position = headingPositionFromElement(view, headingElement);
+          if (position === null) return false;
+
+          const range = findHeadingRangeAtPosition(view.state, heading, position);
+          if (!range) return false;
+
+          event.preventDefault();
+          return expandHeadingSource(view, paragraph, range, serializeMarkdown.get());
+        }
+      },
+      handleKeyDown: (view, event) => {
+        if (event.key !== "Enter" || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+
+        const source = findActiveHeadingSource(view.state, paragraph, heading);
+        if (!source) return false;
+
+        event.preventDefault();
+        return finalizeHeadingSource(view, heading, source, parseMarkdown.get());
+      }
+    }
+  });
+});

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./ai-preview.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
+export * from "./heading-source.ts";
 export * from "./input-rules.ts";
 export * from "./link-image-rules.ts";
 export * from "./math.ts";

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -277,6 +277,28 @@ function handleMathKeyDown(view: EditorView, event: KeyboardEvent) {
   return closeActiveMathSource(view, event) || deleteAdjacentMathSource(view, event);
 }
 
+function selectionIsInsideMathRange(state: EditorState, range: MathRange) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection)) return false;
+
+  const from = Math.min(selection.from, selection.to);
+  const to = Math.max(selection.from, selection.to);
+
+  return selection.empty ? range.from < from && from < range.to : range.from <= from && to <= range.to;
+}
+
+function closeInactiveMathSource(state: EditorState) {
+  const activeSource = mathRenderKey.getState(state) as ActiveMathSource | null;
+  if (!activeSource) return null;
+
+  const activeRange = findMathRangeByBounds(state.doc, activeSource);
+  if (activeRange && selectionIsInsideMathRange(state, activeRange)) return null;
+
+  return state.tr.setMeta(mathRenderKey, {
+    type: "deactivate"
+  } satisfies MathRenderMeta);
+}
+
 function createMathWidget(range: MathRange) {
   return (view: EditorView) => {
     const element = view.dom.ownerDocument.createElement("span");
@@ -374,6 +396,7 @@ export const markraMathPlugin = $prose(() => {
         return findMathRangeByBounds(newState.doc, mappedSource) ? mappedSource : null;
       }
     },
+    appendTransaction: (_transactions, _oldState, newState) => closeInactiveMathSource(newState),
     props: {
       decorations: (state) => buildMathDecorations(state.doc, getEditableMathRange(state)),
       handleKeyDown: handleMathKeyDown


### PR DESCRIPTION
## Summary
- Add a Milkdown editor plugin that expands rendered headings into editable Markdown source on click.
- Re-finalize heading source with Enter or when the cursor leaves the source, preserving inline Markdown like `## **Bold**`.
- Fold active math formula source when the cursor leaves the formula instead of requiring Enter.
- Wire the heading plugin into the desktop Markdown editor and cover the source-session behavior with regression tests.

## Why
- Users could type `## Heading` and see it rendered, but could not directly click the rendered heading to edit the original Markdown syntax.
- Source editing states also should not linger forever after focus/selection moves away.

## Validation
- `pnpm --filter @markra/desktop exec vitest run src/components/MarkdownPaper.test.tsx` passed: 107 tests.
- `pnpm --filter @markra/desktop test` passed: 447 tests across 36 files.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification.

## Risk
- Limited to rendered heading source sessions and active math formula source sessions in the Milkdown editor.

Closes #18