### PR TITLE
fix: address markdown rendering and picker feedback

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,6 +39,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "6.0.0",
     "sonner": "^2.0.7"

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleAllowMixedLocalizations</key>
+  <true/>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleLocalizations</key>
+  <array>
+    <string>en</string>
+    <string>zh-Hans</string>
+    <string>zh-Hant</string>
+    <string>ja</string>
+    <string>ko</string>
+    <string>fr</string>
+    <string>de</string>
+    <string>es</string>
+    <string>pt-BR</string>
+    <string>it</string>
+    <string>ru</string>
+  </array>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/macos-locales/de.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/de.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/en.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/es.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/es.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/fr.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/fr.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/it.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/it.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/ja.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/ja.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/ko.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/ko.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/pt-BR.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/pt-BR.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/ru.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/ru.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/zh-Hans.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/macos-locales/zh-Hant.lproj/InfoPlist.strings
+++ b/apps/desktop/src-tauri/macos-locales/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Markra";
+"CFBundleName" = "Markra";

--- a/apps/desktop/src-tauri/src/language.rs
+++ b/apps/desktop/src-tauri/src/language.rs
@@ -193,6 +193,7 @@ fn read_settings_object(path: &Path) -> Map<String, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn stored_language_wins_over_system_locale() {
@@ -220,6 +221,61 @@ mod tests {
         let language = language_for_initial_launch(None, &["nl_NL", "ja_JP"]);
 
         assert_eq!(language, AppLanguage::Ja);
+    }
+
+    #[test]
+    fn macos_bundle_declares_all_supported_localizations() {
+        let expected_localizations = [
+            (AppLanguage::En, "en"),
+            (AppLanguage::ZhCn, "zh-Hans"),
+            (AppLanguage::ZhTw, "zh-Hant"),
+            (AppLanguage::Ja, "ja"),
+            (AppLanguage::Ko, "ko"),
+            (AppLanguage::Fr, "fr"),
+            (AppLanguage::De, "de"),
+            (AppLanguage::Es, "es"),
+            (AppLanguage::PtBr, "pt-BR"),
+            (AppLanguage::It, "it"),
+            (AppLanguage::Ru, "ru"),
+        ];
+        let info_plist = include_str!("../Info.plist");
+        let config: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
+            .expect("Tauri config should be valid JSON");
+        let bundled_files = config
+            .pointer("/bundle/macOS/files")
+            .and_then(serde_json::Value::as_object)
+            .expect("macOS bundle config should include localized resource files");
+        let resources_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("macos-locales");
+
+        for (language, macos_code) in expected_localizations {
+            assert!(
+                info_plist.contains(&format!("<string>{macos_code}</string>")),
+                "Info.plist should declare {} as {macos_code}",
+                language.as_code()
+            );
+
+            let source = format!("macos-locales/{macos_code}.lproj");
+            let destination = format!("Resources/{macos_code}.lproj");
+            assert_eq!(
+                bundled_files
+                    .get(&destination)
+                    .and_then(serde_json::Value::as_str),
+                Some(source.as_str()),
+                "missing bundle resource mapping for {}",
+                language.as_code()
+            );
+
+            let strings_path = resources_root
+                .join(format!("{macos_code}.lproj"))
+                .join("InfoPlist.strings");
+            let strings = fs::read_to_string(&strings_path)
+                .unwrap_or_else(|error| panic!("{}: {error}", strings_path.display()));
+            assert!(
+                strings.contains("CFBundleDisplayName"),
+                "{} should localize the bundle display name",
+                strings_path.display()
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/markdown_files.rs
+++ b/apps/desktop/src-tauri/src/markdown_files.rs
@@ -814,14 +814,24 @@ fn ensure_markdown_tree_parent(root: &Path, parent: &Path) -> Result<(), String>
     Ok(())
 }
 
+fn markdown_open_picker_title(title: Option<String>) -> String {
+    title
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "Open Markdown File or Folder".to_string())
+}
+
 #[cfg(target_os = "macos")]
 fn pick_markdown_path<R: tauri::Runtime>(
     _app: &tauri::AppHandle<R>,
+    title: Option<String>,
 ) -> Result<Option<PathBuf>, String> {
     use dispatch2::run_on_main;
     use objc2::rc::autoreleasepool;
     use objc2_app_kit::{NSModalResponseOK, NSOpenPanel};
     use objc2_foundation::{NSArray, NSString};
+
+    let panel_title = markdown_open_picker_title(title);
 
     Ok(autoreleasepool(|_| {
         run_on_main(|mtm| {
@@ -838,7 +848,7 @@ fn pick_markdown_path<R: tauri::Runtime>(
             panel.setCanChooseDirectories(true);
             panel.setAllowsMultipleSelection(false);
             panel.setCanCreateDirectories(false);
-            panel.setMessage(Some(&NSString::from_str("Open Markdown File or Folder")));
+            panel.setMessage(Some(&NSString::from_str(&panel_title)));
 
             #[allow(deprecated)]
             panel.setAllowedFileTypes(Some(&allowed_file_types));
@@ -857,12 +867,14 @@ fn pick_markdown_path<R: tauri::Runtime>(
 #[cfg(not(target_os = "macos"))]
 fn pick_markdown_path<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
+    title: Option<String>,
 ) -> Result<Option<PathBuf>, String> {
     use tauri_plugin_dialog::DialogExt;
 
     let Some(path) = app
         .dialog()
         .file()
+        .set_title(markdown_open_picker_title(title))
         .add_filter("Markdown", &["md", "markdown", "txt"])
         .blocking_pick_file()
     else {
@@ -891,8 +903,9 @@ pub(crate) fn read_markdown_file(
 #[tauri::command]
 pub(crate) fn open_markdown_path(
     app: tauri::AppHandle,
+    title: Option<String>,
 ) -> Result<Option<MarkdownOpenPath>, String> {
-    let Some(path) = pick_markdown_path(&app)? else {
+    let Some(path) = pick_markdown_path(&app, title)? else {
         return Ok(None);
     };
 
@@ -1271,6 +1284,22 @@ mod tests {
         assert!(markdown_open_path_for_path(&unsupported).is_err());
 
         fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn localizes_unified_open_picker_title() {
+        assert_eq!(
+            markdown_open_picker_title(Some(" 打开 Markdown 或文件夹 ".to_string())),
+            "打开 Markdown 或文件夹"
+        );
+        assert_eq!(
+            markdown_open_picker_title(Some("   ".to_string())),
+            "Open Markdown File or Folder"
+        );
+        assert_eq!(
+            markdown_open_picker_title(None),
+            "Open Markdown File or Folder"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -46,7 +46,22 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "files": {
+        "Resources/de.lproj": "macos-locales/de.lproj",
+        "Resources/en.lproj": "macos-locales/en.lproj",
+        "Resources/es.lproj": "macos-locales/es.lproj",
+        "Resources/fr.lproj": "macos-locales/fr.lproj",
+        "Resources/it.lproj": "macos-locales/it.lproj",
+        "Resources/ja.lproj": "macos-locales/ja.lproj",
+        "Resources/ko.lproj": "macos-locales/ko.lproj",
+        "Resources/pt-BR.lproj": "macos-locales/pt-BR.lproj",
+        "Resources/ru.lproj": "macos-locales/ru.lproj",
+        "Resources/zh-Hans.lproj": "macos-locales/zh-Hans.lproj",
+        "Resources/zh-Hant.lproj": "macos-locales/zh-Hant.lproj"
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -792,8 +792,10 @@ export default function App() {
   }, [openImageTab, openTreeMarkdownFile]);
   const handleOpenMarkdownFile = useCallback(async () => {
     setActiveImageFile(null);
-    await openMarkdownFile();
-  }, [openMarkdownFile]);
+    await openMarkdownFile({
+      pickerTitle: translate("app.openMarkdownOrFolder")
+    });
+  }, [openMarkdownFile, translate]);
   const handleCloseCurrentFile = useCallback(async () => {
     if (activeImageFile) {
       const closingTabId = imageDocumentTabId(activeImageFile.path);
@@ -889,12 +891,14 @@ export default function App() {
     const canDiscard = await confirmCanDiscardCurrentDocument();
     if (!canDiscard) return;
 
-    const folder = await openMarkdownFolder();
+    const folder = await openMarkdownFolder({
+      pickerTitle: translate("app.openFolder")
+    });
     if (folder) {
       setActiveImageFile(null);
       clearOpenDocument();
     }
-  }, [clearOpenDocument, confirmCanDiscardCurrentDocument, openMarkdownFolder]);
+  }, [clearOpenDocument, confirmCanDiscardCurrentDocument, openMarkdownFolder, translate]);
   const clearExportSnapshot = useCallback((id: number) => {
     setExportSnapshot((current) => current?.id === id ? null : current);
   }, []);

--- a/apps/desktop/src/components/MarkdownExportDocument.test.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.test.tsx
@@ -2,6 +2,29 @@ import { render, waitFor } from "@testing-library/react";
 import { MarkdownExportDocument } from "./MarkdownExportDocument";
 
 describe("MarkdownExportDocument", () => {
+  it("renders ordinary Markdown line breaks without explicit br tags", async () => {
+    const onRendered = vi.fn();
+
+    render(
+      <MarkdownExportDocument
+        onRendered={onRendered}
+        snapshot={{
+          id: 1,
+          kind: "html",
+          markdown: "First line\nSecond line",
+          title: "line-breaks.md"
+        }}
+      />
+    );
+
+    await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
+
+    const bodyHtml = onRendered.mock.calls[0]?.[0].bodyHtml as string;
+    expect(bodyHtml).toContain("First line<br");
+    expect(bodyHtml).toContain("Second line");
+    expect(bodyHtml).not.toContain("&lt;br");
+  });
+
   it("renders inline and display math before exporting HTML", async () => {
     const onRendered = vi.fn();
 

--- a/apps/desktop/src/components/MarkdownExportDocument.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.tsx
@@ -1,6 +1,7 @@
 import { Children, isValidElement, useEffect, useRef, type ReactNode } from "react";
 import { renderToString } from "katex";
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import type { ExportDocumentFormat } from "../lib/document-export";
@@ -80,7 +81,7 @@ export function MarkdownExportDocument({
     >
       <article className="markdown-paper markdown-export-paper" ref={articleRef}>
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkMath]}
+          remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
           components={{
             a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
             code: ({ node: _node, className, children, ...props }) => {

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -485,6 +485,120 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
   });
 
+  it("renders multiline display math without treating minus-led rows as lists", async () => {
+    const source = [
+      "$$",
+      String.raw`\begin{aligned}`,
+      String.raw`x &= a \\`,
+      String.raw`- y &= b`,
+      String.raw`\end{aligned}`,
+      "$$"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const hiddenMathSource = Array.from(container.querySelectorAll(".ProseMirror .markra-math-source-hidden"))
+      .map((node) => node.textContent)
+      .join("");
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-display .katex")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror ul")).not.toBeInTheDocument();
+    expect(hiddenMathSource).toContain("- y &= b");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+  });
+
+  it("creates a paragraph below a rendered display math block when pressing Enter after it", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, source.length + 1);
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "After formula");
+
+    expect(view.state.doc.child(0).textContent).toBe(source);
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).textContent).toBe("After formula");
+    expect(serializeMarkdown(view.state.doc)).toContain([source, "", "After formula"].join("\n"));
+  });
+
+  it("moves down from text to display math so Enter can create a paragraph below it", async () => {
+    const formula = String.raw`$$ E = mc^2 $$`;
+    const source = ["Before formula", "", formula].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Before formula", "Before formula".length));
+
+    expect(pressArrowDown(view)).toBe(true);
+    expect(view.state.selection.from).toBe(findTextPosition(view, formula, formula.length));
+    expect(container.querySelector(".ProseMirror .markra-math-edge-caret")).not.toBeInTheDocument();
+    const nativeCaretAnchor = container.querySelector<HTMLImageElement>(
+      ".ProseMirror img.ProseMirror-separator.markra-math-caret-anchor"
+    );
+    expect(nativeCaretAnchor).toBeInTheDocument();
+    expect(nativeCaretAnchor).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "After formula");
+
+    expect(view.state.doc.child(0).textContent).toBe("Before formula");
+    expect(view.state.doc.child(1).textContent).toBe(formula);
+    expect(view.state.doc.child(2).textContent).toBe("After formula");
+    expect(serializeMarkdown(view.state.doc)).toContain([formula, "", "After formula"].join("\n"));
+  });
+
+  it("keeps the native caret anchor when leaving display math source at the closing delimiter", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, view } = await renderEditor(source);
+    const blockFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-display");
+
+    fireEvent.mouseDown(blockFormula!);
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+    });
+
+    moveCursor(view, findTextPosition(view, source, source.length));
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
+    });
+
+    const nativeCaretAnchor = container.querySelector<HTMLImageElement>(
+      ".ProseMirror img.ProseMirror-separator.markra-math-caret-anchor"
+    );
+    const domSelection = container.ownerDocument.getSelection();
+    const selectionParent =
+      domSelection?.anchorNode instanceof HTMLElement
+        ? domSelection.anchorNode
+        : domSelection?.anchorNode?.parentElement ?? null;
+
+    expect(view.state.selection.from).toBe(findTextPosition(view, source, source.length));
+    expect(selectionParent).toHaveClass("markra-math-source-hidden-display");
+    expect(nativeCaretAnchor).toBeInTheDocument();
+    expect(nativeCaretAnchor).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
+  });
+
+  it("creates a paragraph below display math when confirming active formula editing", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const blockFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-display");
+
+    fireEvent.mouseDown(blockFormula!);
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+    });
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "After formula");
+
+    expect(view.state.doc.child(0).textContent).toBe(source);
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).textContent).toBe("After formula");
+    expect(serializeMarkdown(view.state.doc)).toContain([source, "", "After formula"].join("\n"));
+  });
+
   it("reveals math source for editing when a rendered formula is clicked", async () => {
     const source = "Where $A$ is the final amount.";
     const { container, view } = await renderEditor(source);

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -507,6 +507,17 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain(source);
   });
 
+  it("renders ordinary paragraph line breaks without requiring explicit br tags", async () => {
+    const source = ["First line", "Second line"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const paragraph = container.querySelector(".ProseMirror p");
+
+    expect(paragraph).toContainHTML("<br");
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+    expect(serializeMarkdown(view.state.doc)).not.toContain("<br");
+  });
+
   it("creates a paragraph below a rendered display math block when pressing Enter after it", async () => {
     const source = String.raw`$$ E = mc^2 $$`;
     const { container, editor, view } = await renderEditor(source);

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -35,6 +35,8 @@ import { serializeLinkImageLiveMarkdown } from "@markra/editor";
 import { markraMarkdownShortcuts } from "@markra/editor";
 import { normalizeMarkdownShortcuts } from "@markra/editor";
 import { markraMathPlugin } from "@markra/editor";
+import { markraMathRemarkPlugin } from "@markra/editor";
+import { markraMathSourcePlugin } from "@markra/editor";
 import { markraTableControlsPlugin } from "@markra/editor";
 import { markraAiEditorPreviewPlugin } from "@markra/editor";
 import { markraAiSelectionHoldPlugin } from "@markra/editor";
@@ -323,8 +325,10 @@ function MilkdownSurface({
         })
         .use(listener)
         .use(history)
+        .use(markraMathRemarkPlugin)
         .use(markraCommonmark)
         .use(markraGfm)
+        .use(markraMathSourcePlugin)
         .use(markraMarkdownShortcuts(markdownShortcuts))
         .use(markraCodeBlockPlugin)
         .use(markraMathPlugin)

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -139,6 +139,10 @@ type UseMarkdownDocumentOptions = {
   restoreWorkspaceOnStartup?: boolean;
 };
 
+type OpenMarkdownFileOptions = {
+  pickerTitle?: string;
+};
+
 function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState>[0]) {
   saveStoredWorkspaceState(patch).catch(() => {});
 }
@@ -433,8 +437,10 @@ export function useMarkdownDocument({
     [applyNativeMarkdownFile]
   );
 
-  const openMarkdownFile = useCallback(async () => {
-    const target = await openNativeMarkdownPath();
+  const openMarkdownFile = useCallback(async (options: OpenMarkdownFileOptions = {}) => {
+    const target = await openNativeMarkdownPath(
+      options.pickerTitle ? { title: options.pickerTitle } : undefined
+    );
     if (!target) return;
 
     if (target.kind === "folder") {

--- a/apps/desktop/src/hooks/useMarkdownFileTree.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownFileTree.test.tsx
@@ -44,7 +44,7 @@ function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) 
       <p data-testid="tree-resizing">{tree.resizing ? "resizing" : "idle"}</p>
       <p data-testid="layout-class">{tree.workspaceLayoutClassName}</p>
       <p data-testid="layout-columns">{tree.workspaceLayoutStyle.gridTemplateColumns}</p>
-      <button type="button" onClick={tree.openMarkdownFolder}>
+      <button type="button" onClick={() => tree.openMarkdownFolder()}>
         Open folder
       </button>
       <button type="button" onClick={() => tree.toggle(currentPath)}>

--- a/apps/desktop/src/hooks/useMarkdownFileTree.ts
+++ b/apps/desktop/src/hooks/useMarkdownFileTree.ts
@@ -23,6 +23,10 @@ type UseMarkdownFileTreeOptions = {
   onWorkspaceSessionChange?: (sessionId: string) => unknown;
 };
 
+type OpenMarkdownFolderOptions = {
+  pickerTitle?: string;
+};
+
 export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFileTreeOptions = {}) {
   const [files, setFiles] = useState<NativeMarkdownFolderFile[]>([]);
   const [rootName, setRootName] = useState("No folder");
@@ -92,8 +96,10 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     });
   }, [onWorkspaceSessionChange]);
 
-  const openMarkdownFolder = useCallback(async () => {
-    const folder = await openNativeMarkdownFolder();
+  const openMarkdownFolder = useCallback(async (options: OpenMarkdownFolderOptions = {}) => {
+    const folder = await openNativeMarkdownFolder(
+      options.pickerTitle ? { title: options.pickerTitle } : undefined
+    );
     if (!folder) return null;
 
     openFolderPath(folder.path, folder.name);

--- a/apps/desktop/src/lib/tauri/file.test.ts
+++ b/apps/desktop/src/lib/tauri/file.test.ts
@@ -95,6 +95,39 @@ describe("native file access", () => {
     });
   });
 
+  it("passes localized titles to native markdown pickers", async () => {
+    mockedOpen
+      .mockResolvedValueOnce(mockReadmePath)
+      .mockResolvedValueOnce(mockFolderPath);
+    mockedInvoke
+      .mockResolvedValueOnce({
+        path: mockReadmePath,
+        contents: "# Native"
+      })
+      .mockResolvedValueOnce({ kind: "folder", path: mockFolderPath });
+
+    await openNativeMarkdownFile({ title: "打开 Markdown 文件" });
+    await openNativeMarkdownFolder({ title: "打开文件夹" });
+    await openNativeMarkdownPath({ title: "打开 Markdown 或文件夹" });
+
+    expect(mockedOpen).toHaveBeenNthCalledWith(1, {
+      multiple: false,
+      fileAccessMode: "scoped",
+      filters: [{ name: "Markdown", extensions: ["md", "markdown", "txt"] }],
+      title: "打开 Markdown 文件"
+    });
+    expect(mockedOpen).toHaveBeenNthCalledWith(2, {
+      multiple: false,
+      directory: true,
+      recursive: true,
+      fileAccessMode: "scoped",
+      title: "打开文件夹"
+    });
+    expect(mockedInvoke).toHaveBeenNthCalledWith(2, "open_markdown_path", {
+      title: "打开 Markdown 或文件夹"
+    });
+  });
+
   it("does not read from disk when the native open dialog is canceled", async () => {
     mockedOpen.mockResolvedValue(null);
 

--- a/apps/desktop/src/lib/tauri/file.ts
+++ b/apps/desktop/src/lib/tauri/file.ts
@@ -102,6 +102,10 @@ export type SaveNativeClipboardImageInput = {
   image: File;
 };
 
+export type NativeMarkdownPickerLabels = {
+  title: string;
+};
+
 export type SavedNativeClipboardImage = {
   alt: string;
   src: string;
@@ -318,12 +322,18 @@ export async function openNativeMarkdownFolderInNewWindow(path: string) {
   await invoke("open_markdown_folder_in_new_window", { path });
 }
 
-export async function openNativeMarkdownFile(): Promise<NativeMarkdownFile | null> {
+function pickerTitleOption(labels: NativeMarkdownPickerLabels | undefined) {
+  const title = labels?.title.trim();
+  return title ? { title } : {};
+}
+
+export async function openNativeMarkdownFile(labels?: NativeMarkdownPickerLabels): Promise<NativeMarkdownFile | null> {
   // The native dialog gives us a real filesystem path; Rust owns the actual disk read.
   const selectedPath = await open({
     multiple: false,
     fileAccessMode: "scoped",
-    filters: markdownFilters
+    filters: markdownFilters,
+    ...pickerTitleOption(labels)
   });
 
   if (!selectedPath || Array.isArray(selectedPath)) return null;
@@ -331,8 +341,11 @@ export async function openNativeMarkdownFile(): Promise<NativeMarkdownFile | nul
   return readNativeMarkdownFile(selectedPath);
 }
 
-export async function openNativeMarkdownPath(): Promise<NativeMarkdownOpenTarget | null> {
-  const target = await invoke<MarkdownOpenPathResponse | null>("open_markdown_path");
+export async function openNativeMarkdownPath(labels?: NativeMarkdownPickerLabels): Promise<NativeMarkdownOpenTarget | null> {
+  const title = labels?.title.trim();
+  const target = title
+    ? await invoke<MarkdownOpenPathResponse | null>("open_markdown_path", { title })
+    : await invoke<MarkdownOpenPathResponse | null>("open_markdown_path");
   if (!target) return null;
 
   if (target.kind === "folder") {
@@ -379,12 +392,13 @@ async function firstDroppedMarkdownTarget(paths: string[]) {
   return null;
 }
 
-export async function openNativeMarkdownFolder(): Promise<NativeMarkdownFolder | null> {
+export async function openNativeMarkdownFolder(labels?: NativeMarkdownPickerLabels): Promise<NativeMarkdownFolder | null> {
   const selectedPath = await open({
     multiple: false,
     directory: true,
     recursive: true,
-    fileAccessMode: "scoped"
+    fileAccessMode: "scoped",
+    ...pickerTitleOption(labels)
   });
 
   if (!selectedPath || Array.isArray(selectedPath)) return null;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -809,6 +809,24 @@
     overflow-y: hidden;
   }
 
+  .markdown-paper p:has(.markra-math-caret-anchor) {
+    position: relative;
+  }
+
+  .markdown-paper img.ProseMirror-separator.markra-math-caret-anchor {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 1px !important;
+    height: 1.35em !important;
+    max-width: none;
+    margin: 0 !important;
+    padding: 0;
+    border: 0 !important;
+    pointer-events: none;
+    transform: translateY(-50%);
+  }
+
   .markdown-paper .markra-math-render-invalid {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     color: var(--text-secondary);
@@ -829,6 +847,25 @@
 
   .markdown-paper .markra-md-hidden-delimiter {
     @apply hidden;
+  }
+
+  .markdown-paper .markra-math-source-hidden-display.markra-md-hidden-delimiter {
+    display: inline-block;
+    position: absolute;
+    top: 50%;
+    right: 0;
+    z-index: 1;
+    width: max-content;
+    max-width: 100%;
+    height: 1.35em;
+    overflow: hidden;
+    color: transparent;
+    line-height: 1.35;
+    pointer-events: none;
+    white-space: pre;
+    transform: translateY(-50%);
+    -webkit-text-fill-color: transparent;
+    caret-color: var(--accent);
   }
 
   .markdown-paper .markra-live-mark-strong {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1008,6 +1008,8 @@
   .markdown-paper code {
     @apply rounded-[3px] border border-(--border-default) bg-(--bg-code) px-[0.28em] py-[0.12em] text-[0.88em] text-(--text-primary);
     font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    color: oklch(40% 0.13 247);
+    box-shadow: inset 0 -1px 0 color-mix(in srgb, oklch(69.6% 0.17 162.48) 28%, transparent);
   }
 
   .markdown-paper pre {
@@ -1016,6 +1018,8 @@
 
   .markdown-paper pre code {
     @apply border-0 bg-transparent p-0;
+    color: inherit;
+    box-shadow: none;
   }
 
   .markdown-paper .markra-code-block {
@@ -1070,7 +1074,8 @@
     color: var(--text-primary);
     font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
     line-height: 1.65;
-    white-space: pre;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
   }
 
   .markdown-paper .hljs-keyword,
@@ -1096,6 +1101,29 @@
   .markdown-paper .hljs-function,
   .markdown-paper .hljs-built_in {
     color: oklch(44% 0.15 247);
+  }
+
+  .markdown-paper .hljs-type,
+  .markdown-paper .hljs-class .hljs-title,
+  .markdown-paper .hljs-tag,
+  .markdown-paper .hljs-name {
+    color: oklch(39% 0.13 210);
+  }
+
+  .markdown-paper .hljs-meta,
+  .markdown-paper .hljs-doctag,
+  .markdown-paper .hljs-section {
+    color: oklch(44% 0.15 330);
+  }
+
+  .markdown-paper .hljs-symbol,
+  .markdown-paper .hljs-bullet,
+  .markdown-paper .hljs-link {
+    color: oklch(40% 0.12 190);
+  }
+
+  .markdown-paper .hljs-deletion {
+    color: oklch(45% 0.17 29);
   }
 
   .markdown-paper .hljs-comment,

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -133,6 +133,34 @@ describe("editor stylesheet", () => {
     expect(languageSelectStyles).toContain("border border-(--border-default)");
   });
 
+  it("wraps code block lines instead of forcing horizontal scrolling", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const codeStart = styles.indexOf(".markdown-paper .markra-code-block code {");
+    const codeEnd = styles.indexOf(".markdown-paper .hljs-keyword");
+    const codeStyles = styles.slice(codeStart, codeEnd);
+
+    expect(codeStyles).toContain("white-space: pre-wrap");
+    expect(codeStyles).toContain("overflow-wrap: anywhere");
+  });
+
+  it("uses a richer palette for inline code and syntax highlights", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const inlineCodeStart = styles.indexOf(".markdown-paper code {");
+    const inlineCodeEnd = styles.indexOf(".markdown-paper pre {");
+    const inlineCodeStyles = styles.slice(inlineCodeStart, inlineCodeEnd);
+    const preCodeStart = styles.indexOf(".markdown-paper pre code {");
+    const preCodeEnd = styles.indexOf(".markdown-paper .markra-code-block");
+    const preCodeStyles = styles.slice(preCodeStart, preCodeEnd);
+
+    expect(inlineCodeStyles).toContain("color: oklch");
+    expect(inlineCodeStyles).toContain("box-shadow");
+    expect(preCodeStyles).toContain("color: inherit");
+    expect(preCodeStyles).toContain("box-shadow: none");
+    expect(styles).toContain(".markdown-paper .hljs-meta");
+    expect(styles).toContain(".markdown-paper .hljs-symbol");
+    expect(styles).toContain(".markdown-paper .hljs-type");
+  });
+
   it("includes the inline AI loading shimmer used by compact quick actions", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -59,6 +59,32 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("font-synthesis: style");
   });
 
+  it("positions the native display math caret anchor at the formula block edge", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const anchorStart = styles.indexOf(".markdown-paper img.ProseMirror-separator.markra-math-caret-anchor {");
+    const anchorEnd = styles.indexOf(".markdown-paper .markra-math-render-invalid");
+    const anchorStyles = styles.slice(anchorStart, anchorEnd);
+
+    expect(styles).toContain(".markdown-paper p:has(.markra-math-caret-anchor)");
+    expect(anchorStyles).toContain("position: absolute");
+    expect(anchorStyles).toContain("right: 0");
+    expect(anchorStyles).toContain("width: 1px !important");
+    expect(anchorStyles).not.toContain("opacity: 0");
+  });
+
+  it("keeps hidden display math source available for the native caret", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const sourceStart = styles.indexOf(".markdown-paper .markra-math-source-hidden-display.markra-md-hidden-delimiter {");
+    const sourceEnd = styles.indexOf(".markdown-paper .markra-live-mark-strong");
+    const sourceStyles = styles.slice(sourceStart, sourceEnd);
+
+    expect(sourceStyles).toContain("display: inline-block");
+    expect(sourceStyles).toContain("position: absolute");
+    expect(sourceStyles).toContain("right: 0");
+    expect(sourceStyles).toContain("-webkit-text-fill-color: transparent");
+    expect(sourceStyles).not.toContain("@apply hidden");
+  });
+
   it("keeps AI diff action controls visually quiet until interaction", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,8 @@
     "@milkdown/kit": "^7.20.0",
     "katex": "0.16.45",
     "lowlight": "3.3.0",
-    "prosemirror-tables": "1.8.5"
+    "prosemirror-tables": "1.8.5",
+    "remark-math": "6.0.0"
   },
   "devDependencies": {
     "@types/node": "24.10.0",

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -1,8 +1,10 @@
 import type { Node as ProseNode } from "@milkdown/kit/prose/model";
 import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
-import { $prose } from "@milkdown/kit/utils";
+import type { MarkdownNode } from "@milkdown/kit/transformer";
+import { $prose, $remark } from "@milkdown/kit/utils";
 import { renderToString } from "katex";
+import remarkMath from "remark-math";
 
 type MathRangeKind = "display" | "inline";
 
@@ -29,6 +31,172 @@ type MathRenderMeta =
     };
 
 const mathRenderKey = new PluginKey<ActiveMathSource | null>("markra-math-render");
+const transparentCaretAnchorSrc =
+  "data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%221%22%20height=%221%22%20viewBox=%220%200%201%201%22/%3E";
+
+type MarkdownPosition = {
+  end?: {
+    offset?: number;
+  };
+  start?: {
+    offset?: number;
+  };
+};
+
+type MathMarkdownNode = MarkdownNode & {
+  position?: MarkdownPosition;
+  value?: string;
+};
+
+type MarkdownSerializerInfo = {
+  after?: string;
+  before?: string;
+};
+
+type MarkdownSerializerState = {
+  containerPhrasing: (node: MarkdownNode, info: MarkdownSerializerInfo) => string;
+  enter: (name: string) => () => unknown;
+};
+
+function mathSourceFromPosition(markdown: string, node: MathMarkdownNode, fallback: string) {
+  const start = node.position?.start?.offset;
+  const end = node.position?.end?.offset;
+  if (typeof start !== "number" || typeof end !== "number") return fallback;
+  if (start < 0 || end < start || end > markdown.length) return fallback;
+
+  const source = markdown.slice(start, end);
+  return source.trim() ? source : fallback;
+}
+
+function inlineMathFallback(value: string) {
+  return `$${value}$`;
+}
+
+function displayMathFallback(value: string) {
+  return value.includes("\n") ? `$$\n${value}\n$$` : `$$ ${value} $$`;
+}
+
+function sourceToInlineMarkdownNodes(source: string) {
+  const children: MarkdownNode[] = [];
+  const lines = source.split(/\r\n?|\n/u);
+
+  lines.forEach((line, index) => {
+    if (line.length > 0) {
+      children.push({
+        type: "text",
+        value: line
+      });
+    }
+
+    if (index < lines.length - 1) {
+      children.push({
+        data: {
+          isInline: true
+        },
+        type: "break"
+      });
+    }
+  });
+
+  return children;
+}
+
+function transformMathMarkdownSources(node: MarkdownNode, markdown: string) {
+  if (!Array.isArray(node.children)) return;
+
+  for (let index = 0; index < node.children.length; index += 1) {
+    const child = node.children[index] as MathMarkdownNode;
+
+    if (child.type === "math") {
+      const source = mathSourceFromPosition(markdown, child, displayMathFallback(child.value ?? ""));
+      node.children.splice(index, 1, {
+        children: sourceToInlineMarkdownNodes(source),
+        type: "paragraph"
+      });
+      continue;
+    }
+
+    if (child.type === "inlineMath") {
+      const source = mathSourceFromPosition(markdown, child, inlineMathFallback(child.value ?? ""));
+      const sourceNodes = sourceToInlineMarkdownNodes(source);
+      node.children.splice(index, 1, ...sourceNodes);
+      index += sourceNodes.length - 1;
+      continue;
+    }
+
+    transformMathMarkdownSources(child, markdown);
+  }
+}
+
+function markdownSourceFromInlineNodes(children: MarkdownNode[] | undefined) {
+  if (!children) return null;
+
+  let source = "";
+  for (const child of children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      source += child.value;
+      continue;
+    }
+
+    if (child.type === "break") {
+      source += "\n";
+      continue;
+    }
+
+    return null;
+  }
+
+  return source;
+}
+
+function isDisplayMathSource(source: string) {
+  const ranges = getMathRanges(source);
+  return ranges.length === 1 && ranges[0]?.kind === "display" && ranges[0].from === 0 && ranges[0].to === source.length;
+}
+
+function serializeMathAwareParagraph(
+  node: MarkdownNode,
+  _parent: MarkdownNode | undefined,
+  state: MarkdownSerializerState,
+  info: MarkdownSerializerInfo
+) {
+  const source = markdownSourceFromInlineNodes(node.children);
+  if (source !== null && isDisplayMathSource(source)) return source;
+
+  const exit = state.enter("paragraph");
+  const subexit = state.enter("phrasing");
+  const value = state.containerPhrasing(node, info);
+  subexit();
+  exit();
+  return value;
+}
+
+function remarkMathParseOnly(this: { data: () => { toMarkdownExtensions?: unknown[] } }) {
+  const dataBeforeMath = this.data();
+  const toMarkdownExtensionCount = dataBeforeMath.toMarkdownExtensions?.length ?? 0;
+
+  // Keep remark-math parsing so math blocks win over Markdown lists, but avoid its source-escaping stringifier.
+  remarkMath.call(this);
+
+  const dataAfterMath = this.data();
+  if (!Array.isArray(dataAfterMath.toMarkdownExtensions)) return;
+
+  dataAfterMath.toMarkdownExtensions.splice(toMarkdownExtensionCount);
+  dataAfterMath.toMarkdownExtensions.push({
+    handlers: {
+      paragraph: serializeMathAwareParagraph
+    }
+  });
+}
+
+export const markraMathRemarkPlugin = $remark<"markraMathRemark", undefined>(
+  "markraMathRemark",
+  () => remarkMathParseOnly
+);
+
+export const markraMathSourcePlugin = $remark("markraMathSource", () => () => (tree, file) => {
+  transformMathMarkdownSources(tree as MarkdownNode, String(file.value ?? ""));
+});
 
 function isEscaped(text: string, index: number) {
   let slashCount = 0;
@@ -199,6 +367,39 @@ function findAdjacentMathRange(state: EditorState, direction: "backward" | "forw
   return adjacentRange;
 }
 
+function displayMathRangeForWholeTextBlock(node: ProseNode, position: number): MathRange | null {
+  const relativeRanges = getMathRanges(node.textContent);
+  const range = relativeRanges.length === 1 ? relativeRanges[0] : null;
+  if (!range || range.kind !== "display") return null;
+  if (range.from !== 0 || range.to !== node.textContent.length) return null;
+
+  return makeAbsoluteRange(range, position + 1);
+}
+
+function findNextDisplayMathBlock(state: EditorState): MathRange | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+  if (getActiveMathSource(state)) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock || $from.parent.type.spec.code) return null;
+  if ($from.parentOffset !== $from.parent.content.size) return null;
+
+  const currentBlockEnd = $from.after();
+  let nextBlockMathRange: MathRange | null = null;
+
+  state.doc.descendants((node, position) => {
+    if (nextBlockMathRange) return false;
+    if (!node.isTextblock || node.type.spec.code) return true;
+    if (position < currentBlockEnd) return true;
+
+    nextBlockMathRange = displayMathRangeForWholeTextBlock(node, position);
+    return false;
+  });
+
+  return nextBlockMathRange;
+}
+
 function renderFormula(range: MathRange) {
   return renderToString(range.tex, {
     displayMode: range.kind === "display",
@@ -231,6 +432,16 @@ function revealMathSource(view: EditorView, range: MathRange) {
   view.focus();
 }
 
+function displayMathBlockInsertPosition(state: EditorState, range: MathRange) {
+  if (range.kind !== "display") return null;
+
+  const resolvedRangeStart = state.doc.resolve(range.from);
+  if (!resolvedRangeStart.parent.isTextblock) return null;
+  if (range.from !== resolvedRangeStart.start() || range.to !== resolvedRangeStart.end()) return null;
+
+  return resolvedRangeStart.after();
+}
+
 function closeActiveMathSource(view: EditorView, event: KeyboardEvent) {
   if (event.key !== "Enter" || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
 
@@ -238,14 +449,20 @@ function closeActiveMathSource(view: EditorView, event: KeyboardEvent) {
   if (!range) return false;
 
   event.preventDefault();
-  view.dispatch(
-    view.state.tr
-      .setMeta(mathRenderKey, {
-        type: "deactivate"
-      } satisfies MathRenderMeta)
-      .setSelection(TextSelection.create(view.state.doc, range.to))
-      .scrollIntoView()
-  );
+  let transaction = view.state.tr.setMeta(mathRenderKey, {
+    type: "deactivate"
+  } satisfies MathRenderMeta);
+  const insertPosition = displayMathBlockInsertPosition(view.state, range);
+  const paragraph = view.state.schema.nodes.paragraph;
+
+  if (insertPosition !== null && paragraph) {
+    transaction = transaction.insert(insertPosition, paragraph.create());
+    transaction = transaction.setSelection(TextSelection.create(transaction.doc, insertPosition + 1));
+  } else {
+    transaction = transaction.setSelection(TextSelection.create(transaction.doc, range.to));
+  }
+
+  view.dispatch(transaction.scrollIntoView());
   view.focus();
   return true;
 }
@@ -273,8 +490,20 @@ function deleteAdjacentMathSource(view: EditorView, event: KeyboardEvent) {
   return true;
 }
 
+function moveDownToDisplayMath(view: EditorView, event: KeyboardEvent) {
+  if (event.key !== "ArrowDown" || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+
+  const range = findNextDisplayMathBlock(view.state);
+  if (!range) return false;
+
+  event.preventDefault();
+  view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, range.to)).scrollIntoView());
+  view.focus();
+  return true;
+}
+
 function handleMathKeyDown(view: EditorView, event: KeyboardEvent) {
-  return closeActiveMathSource(view, event) || deleteAdjacentMathSource(view, event);
+  return moveDownToDisplayMath(view, event) || closeActiveMathSource(view, event) || deleteAdjacentMathSource(view, event);
 }
 
 function selectionIsInsideMathRange(state: EditorState, range: MathRange) {
@@ -297,6 +526,18 @@ function closeInactiveMathSource(state: EditorState) {
   return state.tr.setMeta(mathRenderKey, {
     type: "deactivate"
   } satisfies MathRenderMeta);
+}
+
+function createMathNativeCaretAnchor() {
+  return (view: EditorView) => {
+    const element = view.dom.ownerDocument.createElement("img");
+    element.className = "ProseMirror-separator markra-math-caret-anchor";
+    element.setAttribute("src", transparentCaretAnchorSrc);
+    element.setAttribute("alt", "");
+    element.setAttribute("aria-hidden", "true");
+    element.setAttribute("draggable", "false");
+    return element;
+  };
 }
 
 function createMathWidget(range: MathRange) {
@@ -337,7 +578,22 @@ function createMathWidget(range: MathRange) {
   };
 }
 
-function buildMathDecorations(doc: ProseNode, activeRange: MathRange | null) {
+function selectionIsAtMathRangeEnd(state: EditorState, range: MathRange) {
+  const { selection } = state;
+  return selection instanceof TextSelection && selection.empty && selection.from === range.to;
+}
+
+function createMathCaretAnchorDecoration(range: MathRange) {
+  return Decoration.widget(range.to, createMathNativeCaretAnchor(), {
+    key: `markra-math-caret-anchor-${range.to}`,
+    raw: true,
+    relaxedSide: true,
+    side: 1
+  });
+}
+
+function buildMathDecorations(state: EditorState, activeRange: MathRange | null) {
+  const { doc } = state;
   const decorations: Decoration[] = [];
 
   doc.descendants((node, position) => {
@@ -351,7 +607,14 @@ function buildMathDecorations(doc: ProseNode, activeRange: MathRange | null) {
         Decoration.inline(range.from, range.to, {
           class: isActive
             ? "markra-math-source markra-md-delimiter"
-            : "markra-math-source markra-math-source-hidden markra-md-hidden-delimiter"
+            : [
+                "markra-math-source",
+                "markra-math-source-hidden",
+                range.kind === "display" ? "markra-math-source-hidden-display" : "",
+                "markra-md-hidden-delimiter"
+              ]
+                .filter(Boolean)
+                .join(" ")
         })
       );
 
@@ -363,6 +626,10 @@ function buildMathDecorations(doc: ProseNode, activeRange: MathRange | null) {
             side: -1
           })
         );
+
+        if (range.kind === "display" && selectionIsAtMathRangeEnd(state, range)) {
+          decorations.push(createMathCaretAnchorDecoration(range));
+        }
       }
     }
   });
@@ -398,7 +665,7 @@ export const markraMathPlugin = $prose(() => {
     },
     appendTransaction: (_transactions, _oldState, newState) => closeInactiveMathSource(newState),
     props: {
-      decorations: (state) => buildMathDecorations(state.doc, getEditableMathRange(state)),
+      decorations: (state) => buildMathDecorations(state, getEditableMathRange(state)),
       handleKeyDown: handleMathKeyDown
     }
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       prosemirror-tables:
         specifier: 1.8.5
         version: 1.8.5
+      remark-math:
+        specifier: 6.0.0
+        version: 6.0.0
     devDependencies:
       '@types/node':
         specifier: 24.10.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.7)(react@19.2.5)
+      remark-breaks:
+        specifier: 4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2038,6 +2041,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -2335,6 +2341,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -5254,6 +5263,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -5737,6 +5751,12 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Parse display math before CommonMark so multiline formulas render correctly, including rows that start with `-`.
- Preserve math source serialization while improving display math caret flow: ArrowDown can land on a formula, Enter creates a paragraph below it, and the native caret remains visible after leaving source edit mode.
- Render ordinary Markdown soft line breaks as `<br>` in exported HTML/PDF output, without requiring users to write explicit `<br />` in source.
- Improve code readability by wrapping long code block lines, making inline code more distinct, and expanding syntax highlight color groups.
- Pass localized picker titles into Markdown file/folder dialogs.
- Add macOS bundle localization resources for every supported Markra language so packaged system Open Panel chrome can use localized AppKit strings like `取消`, `最近使用`, `下载`, and `搜索` when macOS selects that localization.

## Why
Issue #30 collected several editor/rendering rough edges from user feedback. The main root causes were Markdown parsing order for display math, export rendering treating soft line breaks as collapsible whitespace, code block CSS forcing horizontal scrolling, and missing macOS bundle localization resources for system picker chrome.

## Validation
- `pnpm --dir apps/desktop exec vitest run src/lib/tauri/file.test.ts src/App.test.tsx src/hooks/useMarkdownDocument.test.tsx src/hooks/useMarkdownFileTree.test.tsx` passed, 101 tests.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` passed, 58 tests.
- `pnpm --filter @markra/desktop build` passed.
- `pnpm --dir apps/desktop tauri build --debug --bundles app` passed and produced `Markra.app` with 11 localized `.lproj` resource folders.
- `plutil -lint apps/desktop/src-tauri/Info.plist` passed.
- `git diff --check` passed.

## Related Issues
- Refs #30