### PR TITLE
fix(editor): delete image when source markdown is cleared

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -2887,6 +2887,27 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("![Edited screenshot](assets/edited.png)");
   });
 
+  it("deletes a finalized image when its markdown source is cleared", async () => {
+    const { container, editor, view } = await renderEditor("Intro\n\n![Screenshot](assets/pasted-image.png)");
+
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+    expect(image).toBeInTheDocument();
+
+    expect(fireEvent.mouseDown(image!)).toBe(false);
+
+    const source = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
+    expect(source).toHaveValue("![Screenshot](assets/pasted-image.png)");
+
+    fireEvent.change(source!, { target: { value: "" } });
+
+    expect(
+      container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]')
+    ).not.toBeInTheDocument();
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).not.toContain("![Screenshot](assets/pasted-image.png)");
+  });
+
   it("hides finalized image markdown source when another editor area is pressed", async () => {
     const { container } = await renderEditor("Intro\n\n![Screenshot](assets/pasted-image.png)");
 

--- a/packages/editor/src/link-image/images.ts
+++ b/packages/editor/src/link-image/images.ts
@@ -159,6 +159,14 @@ export function createFinalizedImageNodeView(
   };
 
   const syncSource = () => {
+    const position = typeof getPos === "function" ? getPos() : undefined;
+    if (source.value.trim().length === 0) {
+      if (typeof position !== "number") return;
+
+      view.dispatch(view.state.tr.delete(position, position + currentNode.nodeSize).scrollIntoView());
+      return;
+    }
+
     const parsed = parseImageMarkdownSource(source.value);
     if (!parsed) {
       dom.classList.add("markra-image-node-source-invalid");
@@ -166,7 +174,6 @@ export function createFinalizedImageNodeView(
     }
 
     dom.classList.remove("markra-image-node-source-invalid");
-    const position = typeof getPos === "function" ? getPos() : undefined;
     if (typeof position !== "number") return;
 
     view.dispatch(


### PR DESCRIPTION
## Summary
- Delete finalized image nodes when their markdown source input is cleared.
- Add regression coverage for clearing a pasted image markdown reference.

## Why
- Fixes #34, where deleting `![image](...)` source text left the rendered image in the editor.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "deletes a finalized image when its markdown source is cleared"` passed (36 files, 476 tests).
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/editor build` passed.

## Risk
- Low: scoped to finalized image source editing; malformed non-empty source still keeps the existing invalid-source behavior.

Closes #34