### PR TITLE
feat(desktop): add about metadata and update menu

### DIFF
--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -9,6 +9,8 @@ pub(crate) const NATIVE_MENU_COMMAND_EVENT: &str = "markra://menu-command";
 
 const NEW_DOCUMENT_COMMAND: &str = "newDocument";
 const SETTINGS_WINDOW_COMMAND: &str = "openSettings";
+const CHECK_FOR_UPDATES_COMMAND: &str = "checkForUpdates";
+const MARKRA_GITHUB_URL: &str = "https://github.com/murongg/markra";
 
 #[derive(Clone, serde::Serialize)]
 pub(crate) struct NativeMenuCommand {
@@ -24,6 +26,25 @@ fn app_menu_item<R: tauri::Runtime, M: Manager<R>>(
     MenuItemBuilder::with_id(id, text)
         .accelerator(accelerator)
         .build(manager)
+}
+
+fn app_menu_item_without_accelerator<R: tauri::Runtime, M: Manager<R>>(
+    manager: &M,
+    id: &str,
+    text: &str,
+) -> tauri::Result<tauri::menu::MenuItem<R>> {
+    MenuItemBuilder::with_id(id, text).build(manager)
+}
+
+fn application_about_metadata() -> AboutMetadata<'static> {
+    AboutMetadata {
+        name: Some("Markra".into()),
+        version: Some(env!("CARGO_PKG_VERSION").into()),
+        website: Some(MARKRA_GITHUB_URL.into()),
+        website_label: Some("GitHub".into()),
+        credits: Some(format!("GitHub: {MARKRA_GITHUB_URL}")),
+        ..Default::default()
+    }
 }
 
 pub(crate) fn create_application_menu<R: tauri::Runtime>(
@@ -62,6 +83,8 @@ fn create_application_menu_for_language<R: tauri::Runtime>(
         .items(&[&export_pdf, &export_html])
         .build()?;
     let settings = app_menu_item(app, SETTINGS_WINDOW_COMMAND, labels.settings, "CmdOrCtrl+,")?;
+    let check_updates =
+        app_menu_item_without_accelerator(app, CHECK_FOR_UPDATES_COMMAND, labels.check_updates)?;
 
     let bold = app_menu_item(
         app,
@@ -179,12 +202,9 @@ fn create_application_menu_for_language<R: tauri::Runtime>(
     )?;
 
     let app_menu = SubmenuBuilder::with_id(app, "markra:app", "Markra")
-        .about(Some(AboutMetadata {
-            name: Some("Markra".into()),
-            ..Default::default()
-        }))
+        .about(Some(application_about_metadata()))
         .separator()
-        .items(&[&settings])
+        .items(&[&settings, &check_updates])
         .separator()
         .hide_with_text(labels.hide)
         .hide_others_with_text(labels.hide_others)
@@ -276,7 +296,8 @@ pub(crate) fn is_native_settings_window_command(command: &str) -> bool {
 pub(crate) fn is_frontend_menu_command(command: &str) -> bool {
     matches!(
         command,
-        "openDocument"
+        CHECK_FOR_UPDATES_COMMAND
+            | "openDocument"
             | "openFolder"
             | "closeDocument"
             | "saveDocument"
@@ -322,6 +343,7 @@ mod tests {
     #[test]
     fn recognizes_frontend_menu_commands() {
         assert!(!is_frontend_menu_command("newDocument"));
+        assert!(is_frontend_menu_command("checkForUpdates"));
         assert!(is_frontend_menu_command("openDocument"));
         assert!(is_frontend_menu_command("openFolder"));
         assert!(is_frontend_menu_command("closeDocument"));
@@ -337,6 +359,23 @@ mod tests {
         assert!(is_frontend_menu_command("toggleSourceMode"));
         assert!(!is_frontend_menu_command("markra:file"));
         assert!(!is_frontend_menu_command("copy"));
+    }
+
+    #[test]
+    fn about_metadata_includes_version_and_github_link() {
+        let metadata = application_about_metadata();
+
+        assert_eq!(metadata.name.as_deref(), Some("Markra"));
+        assert_eq!(metadata.version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            metadata.website.as_deref(),
+            Some("https://github.com/murongg/markra")
+        );
+        assert_eq!(metadata.website_label.as_deref(), Some("GitHub"));
+        assert!(metadata
+            .credits
+            .as_deref()
+            .is_some_and(|credits| credits.contains("https://github.com/murongg/markra")));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/menu_labels/de.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/de.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "PDF exportieren",
     export_html: "HTML exportieren",
     settings: "Einstellungen...",
+    check_updates: "Nach Updates suchen",
     undo: "Rückgängig",
     redo: "Wiederholen",
     cut: "Ausschneiden",

--- a/apps/desktop/src-tauri/src/menu_labels/en.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/en.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "Export PDF",
     export_html: "Export HTML",
     settings: "Settings...",
+    check_updates: "Check for Updates",
     undo: "Undo",
     redo: "Redo",
     cut: "Cut",

--- a/apps/desktop/src-tauri/src/menu_labels/es.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/es.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "Exportar PDF",
     export_html: "Exportar HTML",
     settings: "Ajustes...",
+    check_updates: "Buscar actualizaciones",
     undo: "Deshacer",
     redo: "Rehacer",
     cut: "Cortar",

--- a/apps/desktop/src-tauri/src/menu_labels/fr.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/fr.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "Exporter en PDF",
     export_html: "Exporter en HTML",
     settings: "Réglages...",
+    check_updates: "Rechercher des mises à jour",
     undo: "Annuler",
     redo: "Rétablir",
     cut: "Couper",

--- a/apps/desktop/src-tauri/src/menu_labels/it.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/it.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "Esporta PDF",
     export_html: "Esporta HTML",
     settings: "Impostazioni...",
+    check_updates: "Controlla aggiornamenti",
     undo: "Annulla",
     redo: "Ripeti",
     cut: "Taglia",

--- a/apps/desktop/src-tauri/src/menu_labels/ja.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/ja.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "PDF に書き出す",
     export_html: "HTML に書き出す",
     settings: "設定...",
+    check_updates: "アップデートを確認",
     undo: "取り消す",
     redo: "やり直す",
     cut: "カット",

--- a/apps/desktop/src-tauri/src/menu_labels/ko.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/ko.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "PDF 내보내기",
     export_html: "HTML 내보내기",
     settings: "설정...",
+    check_updates: "업데이트 확인",
     undo: "실행 취소",
     redo: "다시 실행",
     cut: "잘라내기",

--- a/apps/desktop/src-tauri/src/menu_labels/mod.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/mod.rs
@@ -28,6 +28,7 @@ pub(crate) struct MenuLabels {
     pub(crate) export_pdf: &'static str,
     pub(crate) export_html: &'static str,
     pub(crate) settings: &'static str,
+    pub(crate) check_updates: &'static str,
     pub(crate) undo: &'static str,
     pub(crate) redo: &'static str,
     pub(crate) cut: &'static str,

--- a/apps/desktop/src-tauri/src/menu_labels/pt_br.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/pt_br.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "Exportar PDF",
     export_html: "Exportar HTML",
     settings: "Configurações...",
+    check_updates: "Verificar atualizações",
     undo: "Desfazer",
     redo: "Refazer",
     cut: "Recortar",

--- a/apps/desktop/src-tauri/src/menu_labels/ru.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/ru.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "Экспорт PDF",
     export_html: "Экспорт HTML",
     settings: "Настройки...",
+    check_updates: "Проверить обновления",
     undo: "Отменить",
     redo: "Повторить",
     cut: "Вырезать",

--- a/apps/desktop/src-tauri/src/menu_labels/zh_cn.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/zh_cn.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "导出 PDF",
     export_html: "导出 HTML",
     settings: "设置...",
+    check_updates: "检查更新",
     undo: "撤销",
     redo: "重做",
     cut: "剪切",

--- a/apps/desktop/src-tauri/src/menu_labels/zh_tw.rs
+++ b/apps/desktop/src-tauri/src/menu_labels/zh_tw.rs
@@ -15,6 +15,7 @@ pub(super) const LABELS: MenuLabels = MenuLabels {
     export_pdf: "匯出 PDF",
     export_html: "匯出 HTML",
     settings: "設定...",
+    check_updates: "檢查更新",
     undo: "復原",
     redo: "重做",
     cut: "剪下",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -564,6 +564,22 @@ describe("Markra workspace", () => {
     await waitFor(() => expect(document.querySelector(".app-toast")).toHaveTextContent("Markra is up to date."));
   });
 
+  it("checks for updates from the native application menu", async () => {
+    renderApp();
+
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockedCheckNativeAppUpdate).toHaveBeenCalledTimes(1));
+    mockedCheckNativeAppUpdate.mockClear();
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls[0]?.[0] as NativeMenuHandlers;
+
+    await act(async () => {
+      await menuHandlers.checkForUpdates?.();
+    });
+
+    expect(mockedCheckNativeAppUpdate).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(document.querySelector(".app-toast")).toHaveTextContent("Markra is up to date."));
+  });
+
   it("opens a folder markdown tree from the lower-left file list button", async () => {
     mockOpenMarkdownFile({
       content: "# Native file\n\nOpened from disk.",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -975,7 +975,11 @@ export default function App() {
     editor,
     outlineItems.length
   ]);
+  const appUpdater = useAutoUpdater(appLanguage.language, appLanguage.ready, {
+    confirmRestart: confirmCanDiscardCurrentDocument
+  });
   const nativeMenuHandlers = useNativeMenuHandlers({
+    checkForUpdates: appUpdater.checkForUpdates,
     closeDocument: handleCloseCurrentFile,
     exportHtml: exportHtmlDocument,
     exportPdf: exportPdfDocument,
@@ -999,9 +1003,6 @@ export default function App() {
   useNativeMenus(nativeMenuHandlers, appLanguage.ready ? appLanguage.language : null, {
     getAiCommandsAvailable: getAiContextMenuAvailable,
     markdownShortcuts: editorPreferences.preferences.markdownShortcuts
-  });
-  useAutoUpdater(appLanguage.language, appLanguage.ready, {
-    confirmRestart: confirmCanDiscardCurrentDocument
   });
   useApplicationShortcuts({
     closeDocument: handleCloseCurrentFile,

--- a/apps/desktop/src/hooks/useNativeBindings.test.tsx
+++ b/apps/desktop/src/hooks/useNativeBindings.test.tsx
@@ -74,6 +74,7 @@ describe("useNativeMenuHandlers", () => {
 
   it("routes native application commands to app toggles", () => {
     const closeDocument = vi.fn();
+    const checkForUpdates = vi.fn();
     const toggleAiAgent = vi.fn();
     const toggleAiCommand = vi.fn();
     const toggleMarkdownFiles = vi.fn();
@@ -81,6 +82,7 @@ describe("useNativeMenuHandlers", () => {
     const { result } = renderHook(() =>
       useNativeMenuHandlers({
         ...baseOptions,
+        checkForUpdates,
         closeDocument,
         toggleAiAgent,
         toggleAiCommand,
@@ -90,12 +92,14 @@ describe("useNativeMenuHandlers", () => {
     );
 
     result.current.closeDocument?.();
+    result.current.checkForUpdates?.();
     result.current.toggleMarkdownFiles?.();
     result.current.toggleAiAgent?.();
     result.current.toggleAiCommand?.();
     result.current.toggleSourceMode?.();
 
     expect(closeDocument).toHaveBeenCalledTimes(1);
+    expect(checkForUpdates).toHaveBeenCalledTimes(1);
     expect(toggleMarkdownFiles).toHaveBeenCalledTimes(1);
     expect(toggleAiAgent).toHaveBeenCalledTimes(1);
     expect(toggleAiCommand).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/hooks/useNativeBindings.ts
+++ b/apps/desktop/src/hooks/useNativeBindings.ts
@@ -18,6 +18,7 @@ import { matchesKeyboardShortcutEvent, t, type AppLanguage, type I18nKey } from 
 type NativeAiQuickActionIntent = Exclude<AiEditIntent, "custom">;
 
 type NativeMenuHandlerOptions = {
+  checkForUpdates?: () => unknown | Promise<unknown>;
   closeDocument?: () => unknown | Promise<unknown>;
   exportHtml?: () => unknown | Promise<unknown>;
   exportPdf?: () => unknown | Promise<unknown>;
@@ -53,6 +54,7 @@ type ApplicationShortcutOptions = {
 };
 
 export function useNativeMenuHandlers({
+  checkForUpdates,
   closeDocument,
   exportHtml,
   exportPdf,
@@ -76,6 +78,7 @@ export function useNativeMenuHandlers({
     [markdownShortcuts]
   );
   const latestOptionsRef = useRef({
+    checkForUpdates,
     exportHtml,
     exportPdf,
     closeDocument,
@@ -95,6 +98,7 @@ export function useNativeMenuHandlers({
     toggleSourceMode
   });
   latestOptionsRef.current = {
+    checkForUpdates,
     exportHtml,
     exportPdf,
     closeDocument,
@@ -118,6 +122,7 @@ export function useNativeMenuHandlers({
     () => ({
       openDocument: () => latestOptionsRef.current.openDocument(),
       openFolder: () => latestOptionsRef.current.openFolder(),
+      checkForUpdates: () => latestOptionsRef.current.checkForUpdates?.(),
       closeDocument: () => latestOptionsRef.current.closeDocument?.(),
       saveDocument: () => latestOptionsRef.current.saveDocument(),
       saveDocumentAs: () => latestOptionsRef.current.saveDocumentAs(),

--- a/apps/desktop/src/lib/tauri/menu.ts
+++ b/apps/desktop/src/lib/tauri/menu.ts
@@ -32,6 +32,7 @@ export type NativeEditorContextMenuOptions = {
 };
 
 export type NativeMenuCommand =
+  | "checkForUpdates"
   | "openDocument"
   | "openFolder"
   | "closeDocument"


### PR DESCRIPTION
## Summary
- Add version and GitHub metadata to the native About panel.
- Add a localized Markra > Check for Updates menu item and route it to the existing updater flow.
- Cover the native menu handler and Rust menu metadata behavior with tests.

## Validation
- `pnpm --filter @markra/desktop test -- src/hooks/useNativeBindings.test.tsx src/App.test.tsx --runInBand`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml menu::tests`
- `pnpm --filter @markra/desktop build`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`

Closes #36