### PR TITLE
feat(editor): add resizable writing width

### DIFF
--- a/apps/desktop/src/App.ai.test.tsx
+++ b/apps/desktop/src/App.ai.test.tsx
@@ -86,6 +86,7 @@ describe("Markra AI workspace", () => {
     renderApp();
 
     await screen.findByText("Welcome to Markra");
+    await screen.findByRole("textbox", { name: "Markdown document" });
 
     fireEvent.keyDown(window, { key: "j", metaKey: true, shiftKey: true });
 

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import {
   dispatchAiEditorPreviewAction,
@@ -339,6 +339,7 @@ describe("Markra workspace", () => {
       clipboardImageFolder: "assets",
       closeAiCommandOnAgentPanelOpen: false,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: {
         ...defaultMarkdownShortcuts,
@@ -633,6 +634,58 @@ describe("Markra workspace", () => {
     expect(resizeHandle).toHaveAttribute("aria-valuemin", "220");
     expect(resizeHandle).toHaveAttribute("aria-valuemax", "440");
     expect(resizeHandle).toHaveAttribute("aria-valuenow", "220");
+  });
+
+  it("resizes the editor writing column and persists the custom width", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+      maxWidth: "860px"
+    });
+
+    const resizeHandle = await screen.findByRole("separator", { name: "Resize editor width" });
+
+    fireEvent.pointerDown(resizeHandle, { clientX: 860, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 980 });
+    fireEvent.pointerUp(window);
+
+    expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+      maxWidth: "980px"
+    });
+    await waitFor(() => expect(mockedSaveStoredEditorPreferences).toHaveBeenCalledWith(expect.objectContaining({
+      contentWidth: "default",
+      contentWidthPx: 980
+    })));
+    await waitFor(() => expect(mockedNotifyAppEditorPreferencesChanged).toHaveBeenCalledWith(expect.objectContaining({
+      contentWidth: "default",
+      contentWidthPx: 980
+    })));
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "source");
+    expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+      maxWidth: "980px"
+    });
+    expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "980");
+  });
+
+  it("keeps editor writing width controls out of the titlebar", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+      maxWidth: "860px"
+    });
+
+    const resizeHandle = screen.getByRole("separator", { name: "Resize editor width" });
+
+    expect(container.querySelector(".editor-width-resizer-indicator")).not.toHaveClass("rounded-full");
+    expect(resizeHandle.closest(".editor-width-resizer-shell")?.querySelector(".editor-width-menu-popover")).not.toBeInTheDocument();
+    expect(container.querySelector(".document-actions")?.querySelector('[data-icon^="editor-width-"]')).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Content width:/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Content width" })).not.toBeInTheDocument();
   });
 
   it("removes the markdown file tree hit area when the sidebar is collapsed", async () => {
@@ -1217,6 +1270,7 @@ describe("Markra workspace", () => {
       clipboardImageFolder: "assets",
       closeAiCommandOnAgentPanelOpen: false,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: defaultMarkdownShortcuts,
       restoreWorkspaceOnStartup: true,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -44,6 +44,7 @@ import { aiTranslationLanguageName, t, type I18nKey } from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
+import type { EditorContentWidth } from "./lib/editor-width";
 import { openNativeExternalUrl, openSettingsWindow } from "./lib/tauri";
 import type { AiDiffResult, AiEditIntent, AiSelectionContext } from "@markra/ai";
 import {
@@ -58,9 +59,11 @@ import { aiAgentWebSearchAvailable } from "@markra/ai";
 import {
   deleteStoredAiAgentSession,
   initializeStoredAiAgentSession,
+  saveStoredEditorPreferences,
   saveStoredAiAgentSessionTitle,
   setStoredAiAgentSessionArchived
 } from "./lib/settings/app-settings";
+import { notifyAppEditorPreferencesChanged } from "./lib/settings/settings-events";
 import {
   confirmNativeMarkdownFileDelete,
   confirmNativeUnsavedMarkdownDocumentDiscard,
@@ -153,6 +156,8 @@ export default function App() {
   const [aiAgentOpen, setAiAgentOpen] = useState(false);
   const [aiAgentPanelWidth, setAiAgentPanelWidth] = useState(aiAgentPanelDefaultWidth);
   const [aiAgentPanelResizing, setAiAgentPanelResizing] = useState(false);
+  const [editorContentWidth, setEditorContentWidth] = useState<EditorContentWidth>("default");
+  const [editorContentWidthPx, setEditorContentWidthPx] = useState<number | null>(null);
   const [aiResults, setAiResults] = useState<AiDiffResult[]>([]);
   const [activeImageFile, setActiveImageFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [imageTabs, setImageTabs] = useState<ImageDocumentTab[]>([]);
@@ -166,6 +171,7 @@ export default function App() {
   const activeAiSelectionRef = useRef<AiSelectionContext | null>(null);
   const aiContextMenuActionIdRef = useRef(0);
   const exportRequestIdRef = useRef(0);
+  const pendingEditorContentWidthPxRef = useRef<number | null>(null);
   const exportContextRef = useRef({
     activeImageFile: false,
     content: "",
@@ -245,8 +251,11 @@ export default function App() {
     wordCount
   } = markdownDocument;
   const workspaceKey = document.path ?? fileTree.sourcePath ?? null;
+  const hasOpenDocument = document.open;
   const activeAiAgentSessionId = workspaceSessionId ?? aiAgentSessionId;
   const aiResult = aiResults.at(-1) ?? null;
+  const activeEditorContentWidth = editorContentWidth;
+  const activeEditorContentWidthPx = editorContentWidthPx ?? editorPreferences.preferences.contentWidthPx ?? null;
   const resolveImageSrc = useMemo(() => createMarkdownImageSrcResolver(document.path), [document.path]);
   const resolveExportImageSrc = useMemo(
     () => createMarkdownImageSrcResolver(document.path, { convertFileSrc: localFileUrlFromPath }),
@@ -720,6 +729,33 @@ export default function App() {
       return null;
     }
   }, [document.path, editorPreferences.preferences.clipboardImageFolder, refreshMarkdownFileTree, translate]);
+
+  useEffect(() => {
+    const storedWidth = editorPreferences.preferences.contentWidthPx ?? null;
+    setEditorContentWidth(editorPreferences.preferences.contentWidth);
+    setEditorContentWidthPx(storedWidth);
+    pendingEditorContentWidthPxRef.current = storedWidth;
+  }, [editorPreferences.preferences.contentWidth, editorPreferences.preferences.contentWidthPx]);
+
+  const handleEditorContentWidthChange = useCallback((width: number) => {
+    pendingEditorContentWidthPxRef.current = width;
+    setEditorContentWidthPx(width);
+  }, []);
+
+  const handleEditorContentWidthResizeEnd = useCallback(() => {
+    const nextWidth = pendingEditorContentWidthPxRef.current;
+    if (nextWidth === null) return;
+
+    const nextPreferences = {
+      ...editorPreferences.preferences,
+      contentWidth: activeEditorContentWidth,
+      contentWidthPx: nextWidth
+    };
+
+    saveStoredEditorPreferences(nextPreferences)
+      .then(() => notifyAppEditorPreferencesChanged(nextPreferences))
+      .catch(() => {});
+  }, [activeEditorContentWidth, editorPreferences.preferences]);
   const handleCreateMarkdownTreeFile = useCallback(async (fileName: string) => {
     try {
       const file = await createMarkdownTreeFile(fileName);
@@ -842,7 +878,6 @@ export default function App() {
       : rawFileTreeRootName === "Files"
         ? translate("app.files")
         : rawFileTreeRootName;
-  const hasOpenDocument = document.open;
   const titlebarTabs = useMemo<MarkdownTabsBarItem[]>(() => [
     ...documentTabs,
     ...imageTabs.map((tab) => ({
@@ -1246,23 +1281,29 @@ export default function App() {
                       autoFocus
                       bodyFontSize={editorPreferences.preferences.bodyFontSize}
                       content={document.content}
-                      contentWidth={editorPreferences.preferences.contentWidth}
+                      contentWidth={activeEditorContentWidth}
+                      contentWidthPx={activeEditorContentWidthPx}
                       language={appLanguage.language}
                       lineHeight={editorPreferences.preferences.lineHeight}
                       onChange={handleMarkdownChange}
+                      onContentWidthChange={handleEditorContentWidthChange}
+                      onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                       topInset="titlebar"
                     />
                   ) : (
                     <MarkdownPaper
                       autoFocus={shouldFocusEditorOnReady(document.content)}
                       bodyFontSize={editorPreferences.preferences.bodyFontSize}
-                      contentWidth={editorPreferences.preferences.contentWidth}
+                      contentWidth={activeEditorContentWidth}
+                      contentWidthPx={activeEditorContentWidthPx}
                       initialContent={document.content}
                       language={appLanguage.language}
                       lineHeight={editorPreferences.preferences.lineHeight}
                       markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
                       onEditorReady={editor.handleEditorReady}
                       onMarkdownChange={handleMarkdownChange}
+                      onContentWidthChange={handleEditorContentWidthChange}
+                      onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                       onSaveClipboardImage={handleSaveClipboardImage}
                       openExternalUrl={openNativeExternalUrl}
                       onTextSelectionChange={handleTextSelectionChange}

--- a/apps/desktop/src/components/EditorWidthResizer.tsx
+++ b/apps/desktop/src/components/EditorWidthResizer.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { clampNumber, t, type AppLanguage } from "@markra/shared";
+
+type EditorWidthResizerProps = {
+  language?: AppLanguage;
+  maxWidth: number;
+  minWidth: number;
+  width: number;
+  onResize?: (width: number) => unknown;
+  onResizeEnd?: () => unknown;
+  onResizeStart?: () => unknown;
+};
+
+export function EditorWidthResizer({
+  language = "en",
+  maxWidth,
+  minWidth,
+  width,
+  onResize,
+  onResizeEnd,
+  onResizeStart
+}: EditorWidthResizerProps) {
+  const resizeCleanupRef = useRef<(() => unknown) | null>(null);
+  const resolvedMinWidth = Math.max(480, minWidth);
+  const resolvedMaxWidth = Math.max(resolvedMinWidth, maxWidth);
+  const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
+
+  useEffect(() => {
+    return () => {
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
+    };
+  }, []);
+
+  if (!onResize || resolvedWidth === null) return null;
+
+  const resizeEditor = (nextWidth: number | null) => {
+    if (nextWidth === null) return;
+    onResize(nextWidth);
+  };
+
+  const handleResizePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+
+    const startX = event.clientX;
+    const startWidth = resolvedWidth;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    onResizeStart?.();
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      resizeEditor(clampNumber(startWidth + moveEvent.clientX - startX, resolvedMinWidth, resolvedMaxWidth));
+    };
+
+    const cleanup = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      resizeCleanupRef.current = null;
+      onResizeEnd?.();
+    };
+
+    const handlePointerUp = () => {
+      cleanup();
+    };
+
+    resizeCleanupRef.current?.();
+    resizeCleanupRef.current = cleanup;
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+  };
+
+  const handleResizeKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      resizeEditor(clampNumber(resolvedWidth - 24, resolvedMinWidth, resolvedMaxWidth));
+      onResizeEnd?.();
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      resizeEditor(clampNumber(resolvedWidth + 24, resolvedMinWidth, resolvedMaxWidth));
+      onResizeEnd?.();
+      return;
+    }
+
+    if (event.key === "Home") {
+      event.preventDefault();
+      resizeEditor(resolvedMinWidth);
+      onResizeEnd?.();
+      return;
+    }
+
+    if (event.key === "End") {
+      event.preventDefault();
+      resizeEditor(resolvedMaxWidth);
+      onResizeEnd?.();
+    }
+  };
+
+  return (
+    <div className="editor-width-resizer-shell group/width-resizer absolute top-8 right-0 bottom-8 z-20 w-2 translate-x-1/2">
+      <div
+        className="editor-width-resizer absolute inset-0 cursor-col-resize touch-none outline-none"
+        role="separator"
+        tabIndex={0}
+        aria-label={t(language, "app.resizeEditorWidth")}
+        aria-orientation="vertical"
+        aria-valuemin={resolvedMinWidth}
+        aria-valuemax={resolvedMaxWidth}
+        aria-valuenow={resolvedWidth}
+        onKeyDown={handleResizeKeyDown}
+        onPointerDown={handleResizePointerDown}
+      >
+        <span
+          className="editor-width-resizer-indicator pointer-events-none absolute top-2 right-0 bottom-2 w-px bg-transparent transition-colors duration-150 ease-out group-hover/width-resizer:bg-(--border-strong) group-focus-within/width-resizer:bg-(--accent)"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -43,8 +43,14 @@ import { markraAiSelectionHoldPlugin } from "@markra/editor";
 import type { MarkdownShortcutMap } from "@markra/editor";
 import type { AiSelectionContext } from "@markra/ai";
 import { t, type AppLanguage } from "@markra/shared";
-import type { EditorContentWidth } from "../lib/settings/app-settings";
+import {
+  editorContentWidthPixels,
+  editorCustomContentWidthMax,
+  editorCustomContentWidthMin,
+  type EditorContentWidth
+} from "../lib/editor-width";
 import { readAiSelectionContextFromView } from "../hooks/useEditorController";
+import { EditorWidthResizer } from "./EditorWidthResizer";
 
 const markraCommonmark = [
   commonmarkSchema,
@@ -71,24 +77,24 @@ type MarkdownPaperProps = {
   autoFocus?: boolean;
   bodyFontSize?: number;
   contentWidth?: EditorContentWidth;
+  contentWidthMax?: number;
+  contentWidthMin?: number;
+  contentWidthPx?: number | null;
   initialContent: string;
   language?: AppLanguage;
   lineHeight?: number;
   markdownShortcuts?: MarkdownShortcutMap;
   onEditorReady: (editor: Editor | null, options?: { autoFocus?: boolean }) => unknown;
   onMarkdownChange: (content: string) => unknown;
+  onContentWidthChange?: (width: number) => unknown;
+  onContentWidthResizeEnd?: () => unknown;
+  onContentWidthResizeStart?: () => unknown;
   onSaveClipboardImage?: SaveClipboardImage;
   openExternalUrl?: (url: string) => unknown;
   onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
   resolveImageSrc?: (src: string) => string;
   revision: number;
   topInset?: "tabs" | "titlebar";
-};
-
-export const editorContentWidths: Record<EditorContentWidth, string> = {
-  default: "860px",
-  narrow: "720px",
-  wide: "1040px"
 };
 
 type MilkdownSurfaceProps = {
@@ -380,12 +386,18 @@ export function MarkdownPaper({
   autoFocus = false,
   bodyFontSize = 16,
   contentWidth = "default",
+  contentWidthMax = editorCustomContentWidthMax,
+  contentWidthMin = editorCustomContentWidthMin,
+  contentWidthPx = null,
   initialContent,
   language = "en",
   lineHeight = 1.65,
   markdownShortcuts,
   onEditorReady,
   onMarkdownChange,
+  onContentWidthChange,
+  onContentWidthResizeEnd,
+  onContentWidthResizeStart,
   onSaveClipboardImage,
   openExternalUrl,
   onTextSelectionChange,
@@ -393,10 +405,11 @@ export function MarkdownPaper({
   revision,
   topInset = "titlebar"
 }: MarkdownPaperProps) {
+  const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const paperStyle = {
     fontSize: `${bodyFontSize}px`,
     lineHeight,
-    maxWidth: editorContentWidths[contentWidth]
+    maxWidth: `${resolvedContentWidth}px`
   } satisfies CSSProperties;
   const shortcutsSignature = markdownShortcutSignature(markdownShortcuts);
   const normalizedMarkdownShortcuts = useMemo(
@@ -412,11 +425,20 @@ export function MarkdownPaper({
     >
       <article
         key={revision}
-        className={`markdown-paper mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
+        className={`markdown-paper relative mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
         style={paperStyle}
         aria-label={t(language, "app.markdownEditor")}
         data-editor-engine="milkdown"
       >
+        <EditorWidthResizer
+          language={language}
+          maxWidth={contentWidthMax}
+          minWidth={contentWidthMin}
+          width={resolvedContentWidth}
+          onResize={onContentWidthChange}
+          onResizeEnd={onContentWidthResizeEnd}
+          onResizeStart={onContentWidthResizeStart}
+        />
         <MilkdownProvider>
           <MilkdownSurface
             autoFocus={autoFocus}

--- a/apps/desktop/src/components/MarkdownSourceEditor.tsx
+++ b/apps/desktop/src/components/MarkdownSourceEditor.tsx
@@ -1,16 +1,27 @@
 import { Fragment, type CSSProperties, type ChangeEvent, type ReactNode } from "react";
 import { t, type AppLanguage } from "@markra/shared";
-import type { EditorContentWidth } from "../lib/settings/app-settings";
-import { editorContentWidths } from "./MarkdownPaper";
+import {
+  editorContentWidthPixels,
+  editorCustomContentWidthMax,
+  editorCustomContentWidthMin,
+  type EditorContentWidth
+} from "../lib/editor-width";
+import { EditorWidthResizer } from "./EditorWidthResizer";
 
 type MarkdownSourceEditorProps = {
   autoFocus?: boolean;
   bodyFontSize?: number;
   content: string;
   contentWidth?: EditorContentWidth;
+  contentWidthMax?: number;
+  contentWidthMin?: number;
+  contentWidthPx?: number | null;
   language?: AppLanguage;
   lineHeight?: number;
   onChange: (content: string) => unknown;
+  onContentWidthChange?: (width: number) => unknown;
+  onContentWidthResizeEnd?: () => unknown;
+  onContentWidthResizeStart?: () => unknown;
   topInset?: "tabs" | "titlebar";
 };
 
@@ -131,15 +142,22 @@ export function MarkdownSourceEditor({
   bodyFontSize = 16,
   content,
   contentWidth = "default",
+  contentWidthMax = editorCustomContentWidthMax,
+  contentWidthMin = editorCustomContentWidthMin,
+  contentWidthPx = null,
   language = "en",
   lineHeight = 1.65,
   onChange,
+  onContentWidthChange,
+  onContentWidthResizeEnd,
+  onContentWidthResizeStart,
   topInset = "titlebar"
 }: MarkdownSourceEditorProps) {
+  const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const paperStyle = {
     fontSize: `${bodyFontSize}px`,
     lineHeight,
-    maxWidth: editorContentWidths[contentWidth]
+    maxWidth: `${resolvedContentWidth}px`
   } satisfies CSSProperties;
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     onChange(event.currentTarget.value);
@@ -152,11 +170,20 @@ export function MarkdownSourceEditor({
       aria-label={t(language, "app.writingSurface")}
     >
       <article
-        className={`markdown-source-paper mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
+        className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
         style={paperStyle}
         aria-label={t(language, "app.markdownEditor")}
         data-editor-engine="source"
       >
+        <EditorWidthResizer
+          language={language}
+          maxWidth={contentWidthMax}
+          minWidth={contentWidthMin}
+          width={resolvedContentWidth}
+          onResize={onContentWidthChange}
+          onResizeEnd={onContentWidthResizeEnd}
+          onResizeStart={onContentWidthResizeStart}
+        />
         <div className="markdown-source-layer relative min-h-[calc(100vh-176px)]">
           <pre
             className="markdown-source-highlight pointer-events-none m-0 min-h-[calc(100vh-176px)] whitespace-pre-wrap wrap-break-word border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal"

--- a/apps/desktop/src/components/NativeTitleBar.test.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.test.tsx
@@ -149,6 +149,29 @@ describe("NativeTitleBar", () => {
     expect(sourceModeCase.container.querySelector(".lucide-code-xml")).not.toBeInTheDocument();
   });
 
+  it("keeps editor width controls out of the titlebar when unavailable", () => {
+    const { container } = render(
+      <NativeTitleBar
+        aiAgentOpen={false}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen={false}
+        theme="light"
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".document-actions")).not.toContainElement(
+      container.querySelector('[data-icon^="editor-width-"]')
+    );
+    expect(screen.queryByRole("button", { name: /Content width:/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Content width" })).not.toBeInTheDocument();
+  });
+
   it("centers the document title inside the editor area when the Markra AI panel is open", () => {
     const { container } = render(
       <NativeTitleBar
@@ -312,7 +335,7 @@ describe("NativeTitleBar", () => {
     expect(screen.getByLabelText("Window drag region")).toBeInTheDocument();
     expect(titlebar).toHaveClass("fixed", "right-3.5", "w-auto");
     expect(titlebar).not.toHaveClass("inset-x-0");
-    expect(titlebar).not.toHaveClass("grid-cols-[164px_minmax(0,1fr)_164px]");
+    expect(titlebar).not.toHaveClass("grid-cols-[240px_minmax(0,1fr)_240px]");
     expect(container.querySelector(".mac-window-controls")).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Draft.md" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Toggle file list" })).not.toBeInTheDocument();

--- a/apps/desktop/src/components/SettingsSections.test.tsx
+++ b/apps/desktop/src/components/SettingsSections.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import { t } from "@markra/shared";
 import { defaultEditorPreferences, type EditorPreferences } from "../lib/settings/app-settings";
@@ -40,6 +40,75 @@ describe("EditorSettings", () => {
     expect(onUpdatePreferences).toHaveBeenCalledWith({
       ...defaultEditorPreferences,
       showDocumentTabs: false
+    });
+  });
+
+  it("edits content width as a percentage with a reset button", () => {
+    const onUpdatePreferences = vi.fn();
+
+    render(
+      <EditorSettings
+        preferences={{
+          ...defaultEditorPreferences,
+          contentWidth: "default",
+          contentWidthPx: 980
+        }}
+        translate={translate}
+        onUpdatePreferences={onUpdatePreferences}
+      />
+    );
+
+    const widthInput = screen.getByRole("textbox", { name: "Content width" });
+    const resetButton = screen.getByRole("button", { name: "Content width Reset" });
+
+    expect(screen.queryByRole("group", { name: "Content width" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Narrow" })).not.toBeInTheDocument();
+    expect(widthInput).toHaveAttribute("inputmode", "numeric");
+    expect(widthInput).toHaveAttribute("min", "0");
+    expect(widthInput).toHaveAttribute("max", "100");
+    expect(widthInput).toHaveValue("53");
+    expect(screen.getByText("%")).toBeInTheDocument();
+    expect(resetButton.querySelector(".lucide-rotate-ccw")).toBeInTheDocument();
+
+    fireEvent.change(widthInput, { target: { value: "0100" } });
+
+    expect(widthInput).toHaveValue("100");
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      contentWidth: "default",
+      contentWidthPx: 1280
+    });
+
+    fireEvent.change(widthInput, { target: { value: "80" } });
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      contentWidth: "default",
+      contentWidthPx: 1152
+    });
+
+    fireEvent.change(widthInput, { target: { value: "0" } });
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      contentWidth: "default",
+      contentWidthPx: 640
+    });
+
+    fireEvent.change(widthInput, { target: { value: "200" } });
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      contentWidth: "default",
+      contentWidthPx: 1280
+    });
+
+    fireEvent.click(resetButton);
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      contentWidth: "default",
+      contentWidthPx: null
     });
   });
 });

--- a/apps/desktop/src/components/SettingsSections.tsx
+++ b/apps/desktop/src/components/SettingsSections.tsx
@@ -19,7 +19,6 @@ import {
 } from "@markra/editor";
 import type {
   AppTheme,
-  EditorContentWidth,
   EditorPreferences,
   ExportSettings as ExportSettingsValue,
   PdfMarginPreset,
@@ -28,7 +27,13 @@ import type {
   WebSearchSettings
 } from "../lib/settings/app-settings";
 import type { DesktopPlatform } from "../lib/platform";
-import { supportedLanguages, type AppLanguage, type I18nKey } from "@markra/shared";
+import { clampNumber, supportedLanguages, type AppLanguage, type I18nKey } from "@markra/shared";
+import {
+  editorContentWidthPixels,
+  editorCustomContentWidthMax,
+  editorCustomContentWidthMin,
+  normalizeEditorContentWidthPx
+} from "../lib/editor-width";
 
 type Translate = (key: I18nKey) => string;
 
@@ -59,7 +64,9 @@ const themeOptions: Array<{
 ];
 
 const bodyFontSizeOptions = [14, 15, 16, 17, 18, 20];
-const contentWidthOptions: EditorContentWidth[] = ["narrow", "default", "wide"];
+const contentWidthRatioSpanPx = editorCustomContentWidthMax - editorCustomContentWidthMin;
+const contentWidthRatioMin = 0;
+const contentWidthRatioMax = 100;
 const exportMarginPresetOptions: PdfMarginPreset[] = ["default", "none", "narrow", "normal", "wide", "custom"];
 const exportPageSizeOptions: PdfPageSize[] = ["default", "a4", "letter", "custom"];
 const lineHeightOptions = [1.5, 1.65, 1.8];
@@ -297,6 +304,107 @@ function SettingsNumberInput({
           {unit}
         </span>
       ) : null}
+    </div>
+  );
+}
+
+function contentWidthRatioValue(preferences: EditorPreferences) {
+  const contentWidthPx = preferences.contentWidthPx ?? editorContentWidthPixels[preferences.contentWidth];
+
+  return Math.round(((contentWidthPx - editorCustomContentWidthMin) / contentWidthRatioSpanPx) * 100);
+}
+
+function contentWidthPxFromRatio(value: number) {
+  const ratio = clampNumber(value, contentWidthRatioMin, contentWidthRatioMax);
+  if (ratio === null) return null;
+
+  return normalizeEditorContentWidthPx(Math.round(editorCustomContentWidthMin + (contentWidthRatioSpanPx * ratio) / 100));
+}
+
+function SettingsContentWidthInput({
+  label,
+  onUpdatePreferences,
+  preferences,
+  resetLabel
+}: {
+  label: string;
+  onUpdatePreferences: (preferences: EditorPreferences) => unknown;
+  preferences: EditorPreferences;
+  resetLabel: string;
+}) {
+  const ratio = contentWidthRatioValue(preferences);
+  const [draftRatio, setDraftRatio] = useState(String(ratio));
+
+  useEffect(() => {
+    setDraftRatio(String(ratio));
+  }, [ratio]);
+
+  return (
+    <div className="content-width-ratio-control inline-flex h-8 items-center overflow-hidden rounded-md border border-(--border-default) bg-(--bg-primary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) focus-within:ring-2 focus-within:ring-(--accent)">
+      <div className="relative inline-flex h-full items-center">
+        <input
+          className="h-full w-18 border-0 bg-transparent py-0 pr-7 pl-3 text-[12px] leading-5 font-[560] text-(--text-heading) outline-none"
+          type="text"
+          aria-label={label}
+          inputMode="numeric"
+          min={contentWidthRatioMin}
+          max={contentWidthRatioMax}
+          pattern="[0-9]*"
+          value={draftRatio}
+          onChange={(event) => {
+            const digits = event.currentTarget.value.replace(/\D/g, "");
+            if (!digits) {
+              setDraftRatio("");
+              return;
+            }
+
+            const normalizedDigits = digits.replace(/^0+(?=\d)/, "");
+            const nextRatio = Number(normalizedDigits);
+            if (!Number.isFinite(nextRatio)) return;
+
+            const nextContentWidthPx = contentWidthPxFromRatio(nextRatio);
+            if (nextContentWidthPx === null) return;
+
+            setDraftRatio(String(clampNumber(nextRatio, contentWidthRatioMin, contentWidthRatioMax) ?? ratio));
+            onUpdatePreferences({
+              ...preferences,
+              contentWidth: "default",
+              contentWidthPx: nextContentWidthPx
+            });
+          }}
+          onBlur={() => {
+            if (draftRatio) return;
+
+            setDraftRatio(String(ratio));
+          }}
+        />
+        <span
+          className="pointer-events-none absolute right-2.5 text-[12px] leading-5 font-[560] text-(--text-secondary)"
+          aria-hidden="true"
+        >
+          %
+        </span>
+      </div>
+      <button
+        className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center border-0 border-l border-(--border-default) bg-transparent text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+        type="button"
+        aria-label={resetLabel}
+        title={resetLabel}
+        onClick={() => {
+          setDraftRatio(String(contentWidthRatioValue({
+            ...preferences,
+            contentWidth: "default",
+            contentWidthPx: null
+          })));
+          onUpdatePreferences({
+            ...preferences,
+            contentWidth: "default",
+            contentWidthPx: null
+          });
+        }}
+      >
+        <RotateCcw aria-hidden="true" size={13} />
+      </button>
     </div>
   );
 }
@@ -742,19 +850,11 @@ export function EditorSettings({
           title={translate("settings.editor.contentWidth")}
           description={translate("settings.editor.contentWidthDescription")}
           action={
-            <SettingsSelect
+            <SettingsContentWidthInput
               label={translate("settings.editor.contentWidth")}
-              value={preferences.contentWidth}
-              options={contentWidthOptions.map((width) => ({
-                label: translate(`settings.editor.contentWidth.${width}` as I18nKey),
-                value: width
-              }))}
-              onChange={(value) =>
-                onUpdatePreferences({
-                  ...preferences,
-                  contentWidth: value as EditorContentWidth
-                })
-              }
+              preferences={preferences}
+              resetLabel={`${translate("settings.editor.contentWidth")} ${translate("settings.editor.shortcutsReset")}`}
+              onUpdatePreferences={onUpdatePreferences}
             />
           }
         />

--- a/apps/desktop/src/hooks/useEditorPreferences.test.tsx
+++ b/apps/desktop/src/hooks/useEditorPreferences.test.tsx
@@ -10,6 +10,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     clipboardImageFolder: "assets",
     closeAiCommandOnAgentPanelOpen: false,
     contentWidth: "default",
+    contentWidthPx: null,
     lineHeight: 1.65,
     markdownShortcuts: {
       bold: "Mod+B",
@@ -61,6 +62,7 @@ describe("useEditorPreferences", () => {
       clipboardImageFolder: "assets",
       closeAiCommandOnAgentPanelOpen: false,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: {
         bold: "Mod+B",
@@ -105,6 +107,7 @@ describe("useEditorPreferences", () => {
         clipboardImageFolder: "images",
         closeAiCommandOnAgentPanelOpen: true,
         contentWidth: "wide",
+        contentWidthPx: 1120,
         lineHeight: 1.8,
         markdownShortcuts: {
           bold: "Mod+Alt+B",

--- a/apps/desktop/src/lib/editor-width.ts
+++ b/apps/desktop/src/lib/editor-width.ts
@@ -1,0 +1,20 @@
+import { clampNumber } from "@markra/shared";
+
+export type EditorContentWidth = "narrow" | "default" | "wide";
+
+export const editorContentWidthOptions: EditorContentWidth[] = ["narrow", "default", "wide"];
+
+export const editorContentWidthPixels = {
+  default: 860,
+  narrow: 720,
+  wide: 1040
+} satisfies Record<EditorContentWidth, number>;
+
+export const editorCustomContentWidthMin = 640;
+export const editorCustomContentWidthMax = 1280;
+
+export function normalizeEditorContentWidthPx(value: unknown) {
+  const width = clampNumber(value, editorCustomContentWidthMin, editorCustomContentWidthMax);
+
+  return width === null ? null : Math.round(width);
+}

--- a/apps/desktop/src/lib/settings/app-settings.test.ts
+++ b/apps/desktop/src/lib/settings/app-settings.test.ts
@@ -138,6 +138,7 @@ describe("app settings", () => {
       clipboardImageFolder: "assets",
       closeAiCommandOnAgentPanelOpen: false,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: defaultMarkdownShortcuts,
       restoreWorkspaceOnStartup: true,
@@ -330,6 +331,7 @@ describe("app settings", () => {
       clipboardImageFolder: "media/screenshots",
       closeAiCommandOnAgentPanelOpen: true,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: {
         ...defaultMarkdownShortcuts,
@@ -355,6 +357,13 @@ describe("app settings", () => {
       bold: "Mod+Alt+B",
       strikethrough: "Mod+Shift+X"
     });
+  });
+
+  it("normalizes custom editor content width pixels", () => {
+    expect(normalizeEditorPreferences({ contentWidthPx: 1120 }).contentWidthPx).toBe(1120);
+    expect(normalizeEditorPreferences({ contentWidthPx: 320 }).contentWidthPx).toBe(640);
+    expect(normalizeEditorPreferences({ contentWidthPx: 2000 }).contentWidthPx).toBe(1280);
+    expect(normalizeEditorPreferences({ contentWidthPx: "wide" }).contentWidthPx).toBeNull();
   });
 
   it("migrates previous app shortcut defaults to the current defaults", () => {
@@ -396,6 +405,7 @@ describe("app settings", () => {
       clipboardImageFolder: "assets",
       closeAiCommandOnAgentPanelOpen: false,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: defaultMarkdownShortcuts,
       restoreWorkspaceOnStartup: true,
@@ -411,6 +421,7 @@ describe("app settings", () => {
       clipboardImageFolder: "images",
       closeAiCommandOnAgentPanelOpen: true,
       contentWidth: "wide",
+      contentWidthPx: 1120,
       lineHeight: 1.8,
       markdownShortcuts: {
         ...defaultMarkdownShortcuts,
@@ -427,6 +438,7 @@ describe("app settings", () => {
       clipboardImageFolder: "images",
       closeAiCommandOnAgentPanelOpen: true,
       contentWidth: "wide",
+      contentWidthPx: 1120,
       lineHeight: 1.8,
       markdownShortcuts: {
         ...defaultMarkdownShortcuts,

--- a/apps/desktop/src/lib/settings/app-settings.ts
+++ b/apps/desktop/src/lib/settings/app-settings.ts
@@ -15,6 +15,11 @@ import { createDefaultAiSettings, normalizeAiSettings, type AiProviderSettings }
 import { isAppLanguage, type AppLanguage } from "@markra/shared";
 import { normalizeNullableString } from "@markra/shared";
 import { type WebSearchProviderId, type WebSearchSettings } from "@markra/ai";
+import {
+  editorContentWidthOptions,
+  normalizeEditorContentWidthPx,
+  type EditorContentWidth
+} from "../editor-width";
 
 const settingsStorePath = "settings.json";
 const aiAgentSessionIndexStorePath = "ai-agent-sessions/index.json";
@@ -33,7 +38,6 @@ const workspaceKey = "workspace";
 
 export type AppTheme = "light" | "dark" | "system";
 export type ResolvedAppTheme = "light" | "dark";
-export type EditorContentWidth = "narrow" | "default" | "wide";
 export type PdfMarginPreset = "custom" | "default" | "narrow" | "none" | "normal" | "wide";
 export type PdfPageSize = "a4" | "custom" | "default" | "letter";
 export type AiAgentPreferences = {
@@ -46,6 +50,7 @@ export type EditorPreferences = {
   clipboardImageFolder: string;
   closeAiCommandOnAgentPanelOpen: boolean;
   contentWidth: EditorContentWidth;
+  contentWidthPx: number | null;
   lineHeight: number;
   markdownShortcuts: MarkdownShortcutBindings;
   restoreWorkspaceOnStartup: boolean;
@@ -71,6 +76,7 @@ export type StoredWorkspaceState = {
   folderPath: string | null;
 };
 export type { AppLanguage };
+export type { EditorContentWidth };
 export type { WebSearchProviderId, WebSearchSettings };
 
 export const defaultEditorPreferences: EditorPreferences = {
@@ -79,6 +85,7 @@ export const defaultEditorPreferences: EditorPreferences = {
   clipboardImageFolder: "assets",
   closeAiCommandOnAgentPanelOpen: false,
   contentWidth: "default",
+  contentWidthPx: null,
   lineHeight: 1.65,
   markdownShortcuts: defaultMarkdownShortcuts,
   restoreWorkspaceOnStartup: true,
@@ -112,7 +119,6 @@ export const defaultWebSearchSettings: WebSearchSettings = {
 };
 
 const editorBodyFontSizeOptions = [14, 15, 16, 17, 18, 20] as const;
-const editorContentWidthOptions: EditorContentWidth[] = ["narrow", "default", "wide"];
 const editorLineHeightOptions = [1.5, 1.65, 1.8] as const;
 const exportPageSizeOptions: PdfPageSize[] = ["default", "a4", "letter", "custom"];
 const exportMarginPresetOptions: PdfMarginPreset[] = ["default", "none", "narrow", "normal", "wide", "custom"];
@@ -511,6 +517,7 @@ export function normalizeEditorPreferences(value: unknown): EditorPreferences {
     contentWidth: editorContentWidthOptions.includes(preferences.contentWidth as EditorContentWidth)
       ? (preferences.contentWidth as EditorContentWidth)
       : defaultEditorPreferences.contentWidth,
+    contentWidthPx: normalizeEditorContentWidthPx(preferences.contentWidthPx),
     lineHeight: editorLineHeightOptions.includes(preferences.lineHeight as typeof editorLineHeightOptions[number])
       ? Number(preferences.lineHeight)
       : defaultEditorPreferences.lineHeight,

--- a/apps/desktop/src/lib/settings/settings-events.test.ts
+++ b/apps/desktop/src/lib/settings/settings-events.test.ts
@@ -93,6 +93,7 @@ describe("settings events", () => {
       clipboardImageFolder: "images",
       closeAiCommandOnAgentPanelOpen: true,
       contentWidth: "wide" as const,
+      contentWidthPx: 1120,
       lineHeight: 1.8,
       markdownShortcuts: defaultMarkdownShortcuts,
       restoreWorkspaceOnStartup: false,

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -126,6 +126,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     clipboardImageFolder: "assets",
     closeAiCommandOnAgentPanelOpen: false,
     contentWidth: "default",
+    contentWidthPx: null,
     lineHeight: 1.65,
     markdownShortcuts: {
       bold: "Mod+B",
@@ -181,6 +182,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     clipboardImageFolder: "assets",
     closeAiCommandOnAgentPanelOpen: false,
     contentWidth: "default",
+    contentWidthPx: null,
     lineHeight: 1.65,
     markdownShortcuts: {
       bold: "Mod+B",
@@ -543,6 +545,7 @@ export function installAppTestHarness() {
       clipboardImageFolder: "assets",
       closeAiCommandOnAgentPanelOpen: false,
       contentWidth: "default",
+      contentWidthPx: null,
       lineHeight: 1.65,
       markdownShortcuts: defaultMarkdownShortcuts,
       restoreWorkspaceOnStartup: true,

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Markra AI einklappen",
   "app.closeAiAgent": "Markra AI schließen",
   "app.resizeAiAgent": "Markra AI-Breite ändern",
+  "app.resizeEditorWidth": "Editorbreite ändern",
   "app.resizeMarkdownFiles": "Markdown-Dateibereich in der Breite ändern",
   "app.aiAgentSessions": "Sitzungen",
   "app.aiAgentNewSession": "Neue Sitzung",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -191,6 +191,7 @@ const messages: BaseLocaleMessages = {
   "app.collapseAiAgent": "Collapse Markra AI",
   "app.closeAiAgent": "Close Markra AI",
   "app.resizeAiAgent": "Resize Markra AI",
+  "app.resizeEditorWidth": "Resize editor width",
   "app.resizeMarkdownFiles": "Resize Markdown files",
   "app.aiAgentSessions": "Sessions",
   "app.aiAgentNewSession": "New session",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Contraer Markra AI",
   "app.closeAiAgent": "Cerrar Markra AI",
   "app.resizeAiAgent": "Cambiar ancho de Markra AI",
+  "app.resizeEditorWidth": "Cambiar ancho del editor",
   "app.resizeMarkdownFiles": "Cambiar ancho del panel de archivos Markdown",
   "app.aiAgentSessions": "Sesiones",
   "app.aiAgentNewSession": "Nueva sesión",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Replier Markra AI",
   "app.closeAiAgent": "Fermer Markra AI",
   "app.resizeAiAgent": "Redimensionner Markra AI",
+  "app.resizeEditorWidth": "Redimensionner l’éditeur",
   "app.resizeMarkdownFiles": "Redimensionner le panneau des fichiers Markdown",
   "app.aiAgentSessions": "Sessions",
   "app.aiAgentNewSession": "Nouvelle session",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Comprimi Markra AI",
   "app.closeAiAgent": "Chiudi Markra AI",
   "app.resizeAiAgent": "Ridimensiona Markra AI",
+  "app.resizeEditorWidth": "Ridimensiona editor",
   "app.resizeMarkdownFiles": "Ridimensiona pannello file Markdown",
   "app.aiAgentSessions": "Sessioni",
   "app.aiAgentNewSession": "Nuova sessione",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -133,6 +133,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Markra AI を折りたたむ",
   "app.closeAiAgent": "Markra AI を閉じる",
   "app.resizeAiAgent": "Markra AI の幅を変更",
+  "app.resizeEditorWidth": "エディター幅を変更",
   "app.resizeMarkdownFiles": "Markdown ファイル欄の幅を変更",
   "app.aiAgentSessions": "セッション",
   "app.aiAgentNewSession": "新しいセッション",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Markra AI 접기",
   "app.closeAiAgent": "Markra AI 닫기",
   "app.resizeAiAgent": "Markra AI 너비 조정",
+  "app.resizeEditorWidth": "편집기 너비 조정",
   "app.resizeMarkdownFiles": "Markdown 파일 패널 너비 조정",
   "app.aiAgentSessions": "세션",
   "app.aiAgentNewSession": "새 세션",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Recolher Markra AI",
   "app.closeAiAgent": "Fechar Markra AI",
   "app.resizeAiAgent": "Redimensionar Markra AI",
+  "app.resizeEditorWidth": "Redimensionar editor",
   "app.resizeMarkdownFiles": "Redimensionar painel de arquivos Markdown",
   "app.aiAgentSessions": "Sessões",
   "app.aiAgentNewSession": "Nova sessão",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -127,6 +127,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "Свернуть Markra AI",
   "app.closeAiAgent": "Закрыть Markra AI",
   "app.resizeAiAgent": "Изменить ширину Markra AI",
+  "app.resizeEditorWidth": "Изменить ширину редактора",
   "app.resizeMarkdownFiles": "Изменить ширину панели файлов Markdown",
   "app.aiAgentSessions": "Сессии",
   "app.aiAgentNewSession": "Новая сессия",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -202,6 +202,7 @@ export type I18nKey =
   | "app.collapseAiAgent"
   | "app.closeAiAgent"
   | "app.resizeAiAgent"
+  | "app.resizeEditorWidth"
   | "app.resizeMarkdownFiles"
   | "app.aiAgentSessions"
   | "app.aiAgentNewSession"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -191,6 +191,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "折叠 Markra AI",
   "app.closeAiAgent": "关闭 Markra AI",
   "app.resizeAiAgent": "调整 Markra AI 宽度",
+  "app.resizeEditorWidth": "调整编辑器宽度",
   "app.resizeMarkdownFiles": "调整 Markdown 文件栏宽度",
   "app.aiAgentSessions": "会话列表",
   "app.aiAgentNewSession": "新建会话",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -133,6 +133,7 @@ const messages: LocaleMessages = {
   "app.collapseAiAgent": "摺疊 Markra AI",
   "app.closeAiAgent": "關閉 Markra AI",
   "app.resizeAiAgent": "調整 Markra AI 寬度",
+  "app.resizeEditorWidth": "調整編輯器寬度",
   "app.resizeMarkdownFiles": "調整 Markdown 檔案欄寬度",
   "app.aiAgentSessions": "會話列表",
   "app.aiAgentNewSession": "新增會話",


### PR DESCRIPTION
## Summary
- Add a keyboard-accessible resize handle for the visual and source editor writing column.
- Persist custom editor widths as a normalized pixel preference.
- Move narrow/default/wide preset controls out of the titlebar and into the editor width resize handle hover/focus affordance.
- Keep the Settings editor width control as three shared icons with a clear selected state.

## Why
- Closes #32 by letting users manually adjust the editor area width and keep the last width while keeping the titlebar quieter.

## Validation
- `pnpm --filter @markra/desktop exec vitest run src/components/SettingsSections.test.tsx src/components/NativeTitleBar.test.tsx src/App.test.tsx -t "shows content width as three icon presets|keeps editor width controls|selects the editor writing|resizes the editor writing"` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm test` passed
- `pnpm build` passed
- Browser DOM check passed: titlebar has no content-width icon/button, resize handle owns the three preset buttons, and the preset popover reveals on keyboard focus
- GitHub CI passed: `Frontend` and `Tauri Rust`

## Risk
- Low. Custom width remains a nullable override on top of the existing preset setting, and preset changes reset the override.