### PR TITLE
fix(desktop): open associated markdown files

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod language;
 mod markdown_files;
 mod menu;
 mod menu_labels;
+mod opened_files;
 mod watcher;
 mod web_http;
 mod windows;
@@ -22,6 +23,10 @@ use menu::{
     is_native_new_window_command, is_native_settings_window_command, NativeMenuCommand,
     NATIVE_MENU_COMMAND_EVENT,
 };
+use opened_files::{
+    opened_markdown_paths_from_args, opened_markdown_paths_from_urls, queue_opened_markdown_paths,
+    take_opened_markdown_paths, OpenedMarkdownPathsState,
+};
 use tauri::Emitter;
 use watcher::{unwatch_markdown_file, watch_markdown_file, MarkdownWatcherState};
 use web_http::request_web_resource;
@@ -35,6 +40,7 @@ use windows::{
 pub fn run() {
     tauri::Builder::default()
         .manage(MarkdownWatcherState::default())
+        .manage(OpenedMarkdownPathsState::default())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
@@ -42,6 +48,8 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             apply_main_window_chrome(app);
+            let paths = opened_markdown_paths_from_args(std::env::args());
+            queue_opened_markdown_paths(&app.handle(), paths);
             Ok(())
         })
         .on_page_load(|webview, _| {
@@ -98,10 +106,17 @@ pub fn run() {
             write_markdown_file,
             export_pdf_file,
             watch_markdown_file,
-            unwatch_markdown_file
+            unwatch_markdown_file,
+            take_opened_markdown_paths
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running Markra");
+        .build(tauri::generate_context!())
+        .expect("error while building Markra")
+        .run(|app, event| {
+            #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
+            if let tauri::RunEvent::Opened { urls } = event {
+                queue_opened_markdown_paths(app, opened_markdown_paths_from_urls(&urls));
+            }
+        });
 }
 
 #[cfg(test)]
@@ -113,5 +128,38 @@ mod tests {
         assert!(crate::menu::is_native_settings_window_command(
             "openSettings"
         ));
+    }
+
+    #[test]
+    fn bundle_declares_markdown_file_associations() {
+        let config: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
+            .expect("Tauri config should be valid JSON");
+        let associations = config
+            .pointer("/bundle/fileAssociations")
+            .and_then(serde_json::Value::as_array)
+            .expect("bundle should declare file associations");
+        let markdown_association = associations
+            .iter()
+            .find(|association| {
+                association
+                    .pointer("/ext")
+                    .and_then(serde_json::Value::as_array)
+                    .is_some_and(|extensions| {
+                        extensions
+                            .iter()
+                            .any(|extension| extension.as_str() == Some("md"))
+                            && extensions
+                                .iter()
+                                .any(|extension| extension.as_str() == Some("markdown"))
+                    })
+            })
+            .expect("Markdown extensions should be associated with Markra");
+
+        assert_eq!(
+            markdown_association
+                .pointer("/role")
+                .and_then(serde_json::Value::as_str),
+            Some("Editor")
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/markdown_files.rs
+++ b/apps/desktop/src-tauri/src/markdown_files.rs
@@ -98,7 +98,7 @@ fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().to_string()
 }
 
-fn markdown_open_path_for_path(path: &Path) -> Result<MarkdownOpenPath, String> {
+pub(crate) fn markdown_open_path_for_path(path: &Path) -> Result<MarkdownOpenPath, String> {
     if path.is_dir() {
         return Ok(MarkdownOpenPath::Folder {
             path: path_to_string(path),

--- a/apps/desktop/src-tauri/src/opened_files.rs
+++ b/apps/desktop/src-tauri/src/opened_files.rs
@@ -1,0 +1,142 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use crate::markdown_files::markdown_open_path_for_path;
+use tauri::{Emitter, Manager, Url};
+
+pub(crate) const OPENED_MARKDOWN_PATHS_EVENT: &str = "markra://opened-markdown-paths";
+
+#[derive(Default)]
+pub(crate) struct OpenedMarkdownPathsState(Mutex<Vec<String>>);
+
+#[derive(Clone, serde::Serialize)]
+struct OpenedMarkdownPathsPayload {
+    paths: Vec<String>,
+}
+
+fn opened_markdown_path_from_path(path: PathBuf) -> Option<String> {
+    markdown_open_path_for_path(&path).ok()?;
+    Some(path.to_string_lossy().to_string())
+}
+
+pub(crate) fn opened_markdown_paths_from_args(
+    args: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    args.into_iter()
+        .skip(1)
+        .filter_map(|arg| {
+            let trimmed = arg.trim();
+            if trimmed.is_empty() || trimmed.starts_with('-') {
+                return None;
+            }
+
+            opened_markdown_path_from_path(PathBuf::from(trimmed))
+        })
+        .collect()
+}
+
+pub(crate) fn opened_markdown_paths_from_urls(urls: &[Url]) -> Vec<String> {
+    urls.iter()
+        .filter_map(|url| {
+            let path = url.to_file_path().ok()?;
+            opened_markdown_path_from_path(path)
+        })
+        .collect()
+}
+
+pub(crate) fn queue_opened_markdown_paths<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    paths: Vec<String>,
+) {
+    if paths.is_empty() {
+        return;
+    }
+
+    {
+        let state = app.state::<OpenedMarkdownPathsState>();
+        let mut pending_paths = state.0.lock().expect("opened Markdown paths lock poisoned");
+        pending_paths.extend(paths.clone());
+    }
+
+    let _ = app.emit(
+        OPENED_MARKDOWN_PATHS_EVENT,
+        OpenedMarkdownPathsPayload { paths },
+    );
+}
+
+#[tauri::command]
+pub(crate) fn take_opened_markdown_paths(app: tauri::AppHandle) -> Vec<String> {
+    let state = app.state::<OpenedMarkdownPathsState>();
+    let mut pending_paths = state.0.lock().expect("opened Markdown paths lock poisoned");
+
+    std::mem::take(&mut *pending_paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tauri::Url;
+
+    fn test_root(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "markra-opened-files-{name}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after epoch")
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn collects_supported_markdown_paths_from_launch_arguments() {
+        let root = test_root("args");
+        fs::create_dir_all(&root).expect("test folder should be created");
+        let markdown_file = root.join("readme.md");
+        let text_file = root.join("notes.txt");
+        let unsupported_file = root.join("image.png");
+        fs::write(&markdown_file, "# Readme").expect("markdown file should be created");
+        fs::write(&text_file, "Notes").expect("text file should be created");
+        fs::write(&unsupported_file, "png").expect("unsupported file should be created");
+
+        let paths = opened_markdown_paths_from_args([
+            "/Applications/Markra.app/Contents/MacOS/markra".to_string(),
+            "--ignored".to_string(),
+            markdown_file.to_string_lossy().to_string(),
+            unsupported_file.to_string_lossy().to_string(),
+            text_file.to_string_lossy().to_string(),
+        ]);
+
+        assert_eq!(
+            paths,
+            vec![
+                markdown_file.to_string_lossy().to_string(),
+                text_file.to_string_lossy().to_string()
+            ]
+        );
+
+        fs::remove_dir_all(root).expect("test folder should be removed");
+    }
+
+    #[test]
+    fn collects_supported_markdown_paths_from_opened_file_urls() {
+        let root = test_root("urls");
+        fs::create_dir_all(&root).expect("test folder should be created");
+        let markdown_file = root.join("readme.markdown");
+        let unsupported_file = root.join("image.png");
+        fs::write(&markdown_file, "# Readme").expect("markdown file should be created");
+        fs::write(&unsupported_file, "png").expect("unsupported file should be created");
+        let markdown_url =
+            Url::from_file_path(&markdown_file).expect("markdown file URL should be valid");
+        let unsupported_url =
+            Url::from_file_path(&unsupported_file).expect("unsupported file URL should be valid");
+        let remote_url =
+            Url::parse("https://example.com/readme.md").expect("remote URL should be valid");
+
+        let paths = opened_markdown_paths_from_urls(&[markdown_url, unsupported_url, remote_url]);
+
+        assert_eq!(paths, vec![markdown_file.to_string_lossy().to_string()]);
+
+        fs::remove_dir_all(root).expect("test folder should be removed");
+    }
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -47,6 +47,15 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "fileAssociations": [
+      {
+        "ext": ["md", "markdown"],
+        "name": "Markdown Document",
+        "description": "Markdown document",
+        "mimeType": "text/markdown",
+        "role": "Editor"
+      }
+    ],
     "macOS": {
       "files": {
         "Resources/de.lproj": "macos-locales/de.lproj",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -26,6 +26,7 @@ import {
   mockedInstallNativeEditorContextMenu,
   mockedInstallNativeMarkdownFileDrop,
   mockedListNativeMarkdownFilesForPath,
+  mockedListenNativeOpenedMarkdownPaths,
   mockedListenAppEditorPreferencesChanged,
   mockedListenAppLanguageChanged,
   mockedListenAppThemeChanged,
@@ -52,6 +53,7 @@ import {
   mockedSaveStoredTheme,
   mockedSaveStoredWorkspaceState,
   mockedShowNativeMarkdownFileTreeContextMenu,
+  mockedTakeNativeOpenedMarkdownPaths,
   mockedTestAiProviderConnection,
   mockedWatchNativeMarkdownFile,
   renderApp
@@ -1757,6 +1759,47 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("tab", { name: /dropped\.md/ })).toBeInTheDocument();
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(mockDroppedPath);
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("loads a markdown file when the operating system opens Markra with a file path", async () => {
+    mockedTakeNativeOpenedMarkdownPaths.mockResolvedValue([mockDroppedPath]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Opened from OS\n\nDouble-clicked from Finder or Explorer.",
+      name: "dropped.md",
+      path: mockDroppedPath
+    });
+
+    renderApp();
+
+    expect(await screen.findByText("Opened from OS")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /dropped\.md/ })).toBeInTheDocument();
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(mockDroppedPath);
+    expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("opens a markdown file when the operating system sends a file-open event while Markra is running", async () => {
+    let onOpenedPaths: ((paths: string[]) => unknown) | null = null;
+    mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
+    mockedListenNativeOpenedMarkdownPaths.mockImplementation(async (listener) => {
+      onOpenedPaths = listener;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Runtime file\n\nOpened while Markra was already running.",
+      name: "dropped.md",
+      path: mockDroppedPath
+    });
+
+    renderApp();
+    await screen.findByRole("textbox", { name: "Markdown document" });
+    await waitFor(() => expect(onOpenedPaths).not.toBeNull());
+
+    await act(async () => {
+      await onOpenedPaths?.([mockDroppedPath]);
+    });
+
+    expect(await screen.findByText("Runtime file")).toBeInTheDocument();
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(mockDroppedPath);
   });
 
   it("opens a markdown folder when a native folder window opens with an initial path", async () => {

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -12,7 +12,10 @@ import {
   openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
   readNativeMarkdownFile,
+  resolveNativeMarkdownPath,
   saveNativeMarkdownFile,
+  listenNativeOpenedMarkdownPaths,
+  takeNativeOpenedMarkdownPaths,
   watchNativeMarkdownFile,
   type NativeMarkdownDroppedTarget,
   type NativeMarkdownFile,
@@ -163,11 +166,13 @@ export function useMarkdownDocument({
   const [tabs, setTabs] = useState<MarkdownDocumentTab[]>(() => [createDocumentTab(createInitialDocumentState(), "untitled:0")]);
   const [activeTabId, setActiveTabId] = useState<string | null>("untitled:0");
   const [workspaceSessionId, setWorkspaceSessionId] = useState<string | null>(null);
+  const [nativeOpenedPathsReady, setNativeOpenedPathsReady] = useState(false);
   const documentRef = useRef(document);
   const tabsRef = useRef(tabs);
   const activeTabIdRef = useRef<string | null>(activeTabId);
   const untitledTabIndexRef = useRef(1);
   const workspaceSessionIdRef = useRef<string | null>(null);
+  const openedFromNativeRef = useRef(false);
   const outlineItems = useMemo(() => getMarkdownOutline(document.content), [document.content]);
   const wordCount = useMemo(() => getWordCount(document.content), [document.content]);
 
@@ -636,6 +641,25 @@ export function useMarkdownDocument({
     [clearOpenDocument, currentMarkdown, loadNativeMarkdownPath, onTreeRootFromFolderPath, resolveWorkspaceSessionId]
   );
 
+  const handleNativeOpenedMarkdownPaths = useCallback(async (paths: string[]) => {
+    if (paths.length === 0) return false;
+
+    let openedPath = false;
+
+    for (const path of paths) {
+      try {
+        const target = await resolveNativeMarkdownPath(path);
+        await handleDroppedMarkdownPath(target);
+        openedPath = true;
+      } catch {
+        // Unsupported or moved OS-opened paths should not block other files.
+      }
+    }
+
+    if (openedPath) openedFromNativeRef.current = true;
+    return openedPath;
+  }, [handleDroppedMarkdownPath]);
+
   useEffect(() => {
     const title = document.open && document.dirty ? `${document.name} *` : document.name;
     setNativeWindowTitle(title);
@@ -682,7 +706,54 @@ export function useMarkdownDocument({
   }, [clearOpenDocument, onTreeRootFromFolderPath, resolveWorkspaceSessionId]);
 
   useEffect(() => {
+    if (isBlankEditorWindow() || initialMarkdownFilePath() || initialMarkdownFolderPath()) {
+      setNativeOpenedPathsReady(true);
+      return;
+    }
+
+    let active = true;
+    let cleanupNativeListener: (() => unknown) | null = null;
+
+    (async () => {
+      try {
+        const paths = await takeNativeOpenedMarkdownPaths();
+        if (active) await handleNativeOpenedMarkdownPaths(paths);
+      } catch {
+        // Native launch state is opportunistic; the normal startup path remains available.
+      } finally {
+        if (active) setNativeOpenedPathsReady(true);
+      }
+
+      try {
+        const cleanup = await listenNativeOpenedMarkdownPaths((paths) => {
+          takeNativeOpenedMarkdownPaths()
+            .then((queuedPaths) => handleNativeOpenedMarkdownPaths(queuedPaths.length > 0 ? queuedPaths : paths))
+            .catch(() => handleNativeOpenedMarkdownPaths(paths));
+        });
+
+        if (!active) {
+          cleanup();
+          return;
+        }
+
+        cleanupNativeListener = cleanup;
+      } catch {
+        // If event registration fails, manual open and drag/drop still work.
+      }
+    })().catch(() => {
+      if (active) setNativeOpenedPathsReady(true);
+    });
+
+    return () => {
+      active = false;
+      cleanupNativeListener?.();
+    };
+  }, [handleNativeOpenedMarkdownPaths]);
+
+  useEffect(() => {
     if (isBlankEditorWindow() || initialMarkdownFilePath() || initialMarkdownFolderPath()) return;
+    if (!nativeOpenedPathsReady) return;
+    if (openedFromNativeRef.current) return;
     if (!preferencesReady) return;
 
     let active = true;
@@ -747,6 +818,7 @@ export function useMarkdownDocument({
     applyNativeMarkdownFile,
     assignWorkspaceSessionId,
     clearOpenDocument,
+    nativeOpenedPathsReady,
     onTreeRootFromFolderPath,
     preferencesReady,
     resolveWorkspaceSessionId,

--- a/apps/desktop/src/lib/tauri/file.test.ts
+++ b/apps/desktop/src/lib/tauri/file.test.ts
@@ -9,7 +9,9 @@ import {
   createNativeMarkdownTreeFolder,
   deleteNativeMarkdownTreeFile,
   installNativeMarkdownFileDrop,
+  listenNativeOpenedMarkdownPaths,
   listNativeMarkdownFilesForPath,
+  takeNativeOpenedMarkdownPaths,
   openNativeMarkdownFolder,
   openNativeMarkdownFile,
   openNativeMarkdownFolderInNewWindow,
@@ -93,6 +95,32 @@ describe("native file access", () => {
     expect(mockedInvoke).toHaveBeenCalledWith("read_markdown_file", {
       path: mockReadmePath
     });
+  });
+
+  it("takes markdown paths queued by native file-open requests", async () => {
+    mockedInvoke.mockResolvedValue([mockReadmePath, mockDraftPath]);
+
+    await expect(takeNativeOpenedMarkdownPaths()).resolves.toEqual([mockReadmePath, mockDraftPath]);
+
+    expect(mockedInvoke).toHaveBeenCalledWith("take_opened_markdown_paths");
+  });
+
+  it("listens for markdown paths opened by the operating system", async () => {
+    const unlisten = vi.fn();
+    const onPaths = vi.fn();
+    mockedListen.mockResolvedValue(unlisten);
+
+    const cleanup = await listenNativeOpenedMarkdownPaths(onPaths);
+    const listener = mockedListen.mock.calls[0]?.[1];
+
+    listener?.({ payload: { paths: [mockReadmePath] } } as Parameters<NonNullable<typeof listener>>[0]);
+    listener?.({ payload: { paths: [] } } as Parameters<NonNullable<typeof listener>>[0]);
+    cleanup();
+
+    expect(mockedListen).toHaveBeenCalledWith("markra://opened-markdown-paths", expect.any(Function));
+    expect(onPaths).toHaveBeenCalledTimes(1);
+    expect(onPaths).toHaveBeenCalledWith([mockReadmePath]);
+    expect(unlisten).toHaveBeenCalledTimes(1);
   });
 
   it("passes localized titles to native markdown pickers", async () => {

--- a/apps/desktop/src/lib/tauri/file.ts
+++ b/apps/desktop/src/lib/tauri/file.ts
@@ -146,8 +146,13 @@ type MarkdownImageFileResponse = {
   path: string;
 };
 
+type OpenedMarkdownPathsPayload = {
+  paths?: unknown;
+};
+
 const markdownFileChangedEvent = "markra://file-changed";
 const markdownTreeChangedEvent = "markra://tree-changed";
+const openedMarkdownPathsEvent = "markra://opened-markdown-paths";
 
 const markdownFilters = [
   {
@@ -178,10 +183,29 @@ function isMarkdownTreeAssetPath(path: string) {
   return /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i.test(path);
 }
 
+function normalizeOpenedMarkdownPaths(paths: unknown) {
+  if (!Array.isArray(paths)) return [];
+
+  return paths.filter((path): path is string => typeof path === "string" && path.trim().length > 0);
+}
+
 function parentPathFromPath(path: string) {
   const lastSeparatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   if (lastSeparatorIndex < 0) return ".";
   return path.slice(0, lastSeparatorIndex);
+}
+
+export async function takeNativeOpenedMarkdownPaths(): Promise<string[]> {
+  return normalizeOpenedMarkdownPaths(await invoke("take_opened_markdown_paths"));
+}
+
+export async function listenNativeOpenedMarkdownPaths(onPaths: (paths: string[]) => unknown | Promise<unknown>) {
+  return listen<OpenedMarkdownPathsPayload>(openedMarkdownPathsEvent, (event) => {
+    const paths = normalizeOpenedMarkdownPaths(event.payload?.paths);
+    if (paths.length === 0) return;
+
+    Promise.resolve(onPaths(paths)).catch(() => {});
+  });
 }
 
 export async function readNativeMarkdownFile(path: string): Promise<NativeMarkdownFile> {

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -10,14 +10,17 @@ import {
   openNativeMarkdownFolderInNewWindow,
   openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
+  listenNativeOpenedMarkdownPaths,
   readNativeMarkdownImageFile,
   readNativeMarkdownFile,
+  resolveNativeMarkdownPath,
   saveNativeHtmlFile,
   saveNativeMarkdownFile,
   saveNativePdfFile,
   showNativeMarkdownFileTreeContextMenu,
   installNativeMarkdownFileDrop,
   listNativeMarkdownFilesForPath,
+  takeNativeOpenedMarkdownPaths,
   renameNativeMarkdownTreeFile,
   watchNativeMarkdownFile
 } from "../lib/tauri";
@@ -82,12 +85,14 @@ vi.mock("../lib/tauri", () => ({
   openNativeMarkdownFolderInNewWindow: vi.fn(),
   openNativeMarkdownFileInNewWindow: vi.fn(),
   openNativeMarkdownPath: vi.fn(),
+  listenNativeOpenedMarkdownPaths: vi.fn(),
   readNativeMarkdownImageFile: vi.fn(),
   readNativeMarkdownFile: vi.fn(),
   requestNativeAiJson: vi.fn(),
   requestNativeChat: vi.fn(),
   requestNativeChatStream: vi.fn(),
   requestNativeWebResource: vi.fn(),
+  resolveNativeMarkdownPath: vi.fn(),
   renameNativeMarkdownTreeFile: vi.fn(),
   saveNativeClipboardImage: vi.fn(),
   saveNativeHtmlFile: vi.fn(),
@@ -96,6 +101,7 @@ vi.mock("../lib/tauri", () => ({
   showNativeMarkdownFileTreeContextMenu: vi.fn(),
   watchNativeMarkdownFile: vi.fn(),
   listNativeMarkdownFilesForPath: vi.fn(),
+  takeNativeOpenedMarkdownPaths: vi.fn(),
   installNativeApplicationMenu: vi.fn(),
   installNativeEditorContextMenu: vi.fn(),
   openNativeExternalUrl: vi.fn(),
@@ -326,14 +332,17 @@ export const mockedCreateNativeMarkdownTreeFile = vi.mocked(createNativeMarkdown
 export const mockedDeleteNativeMarkdownTreeFile = vi.mocked(deleteNativeMarkdownTreeFile);
 export const mockedOpenNativeMarkdownFileInNewWindow = vi.mocked(openNativeMarkdownFileInNewWindow);
 export const mockedOpenNativeMarkdownPath = vi.mocked(openNativeMarkdownPath);
+export const mockedListenNativeOpenedMarkdownPaths = vi.mocked(listenNativeOpenedMarkdownPaths);
 export const mockedReadNativeMarkdownImageFile = vi.mocked(readNativeMarkdownImageFile);
 export const mockedReadNativeMarkdownFile = vi.mocked(readNativeMarkdownFile);
+export const mockedResolveNativeMarkdownPath = vi.mocked(resolveNativeMarkdownPath);
 export const mockedSaveNativeHtmlFile = vi.mocked(saveNativeHtmlFile);
 export const mockedSaveNativeMarkdownFile = vi.mocked(saveNativeMarkdownFile);
 export const mockedSaveNativePdfFile = vi.mocked(saveNativePdfFile);
 export const mockedShowNativeMarkdownFileTreeContextMenu = vi.mocked(showNativeMarkdownFileTreeContextMenu);
 export const mockedInstallNativeMarkdownFileDrop = vi.mocked(installNativeMarkdownFileDrop);
 export const mockedListNativeMarkdownFilesForPath = vi.mocked(listNativeMarkdownFilesForPath);
+export const mockedTakeNativeOpenedMarkdownPaths = vi.mocked(takeNativeOpenedMarkdownPaths);
 export const mockedRenameNativeMarkdownTreeFile = vi.mocked(renameNativeMarkdownTreeFile);
 export const mockedWatchNativeMarkdownFile = vi.mocked(watchNativeMarkdownFile);
 export const mockedInstallNativeApplicationMenu = vi.mocked(installNativeApplicationMenu);
@@ -467,14 +476,17 @@ export function installAppTestHarness() {
     mockedOpenNativeMarkdownFolderInNewWindow.mockReset();
     mockedOpenNativeMarkdownFileInNewWindow.mockReset();
     mockedOpenNativeMarkdownPath.mockReset();
+    mockedListenNativeOpenedMarkdownPaths.mockReset();
     mockedReadNativeMarkdownImageFile.mockReset();
     mockedReadNativeMarkdownFile.mockReset();
+    mockedResolveNativeMarkdownPath.mockReset();
     mockedSaveNativeHtmlFile.mockReset();
     mockedSaveNativePdfFile.mockReset();
     mockedRenameNativeMarkdownTreeFile.mockReset();
     mockedSaveNativeMarkdownFile.mockReset();
     mockedShowNativeMarkdownFileTreeContextMenu.mockReset();
     mockedListNativeMarkdownFilesForPath.mockReset();
+    mockedTakeNativeOpenedMarkdownPaths.mockReset();
     mockedWatchNativeMarkdownFile.mockReset();
     mockedInstallNativeApplicationMenu.mockReset();
     mockedInstallNativeEditorContextMenu.mockReset();
@@ -521,7 +533,9 @@ export function installAppTestHarness() {
     document.documentElement.removeAttribute("data-window");
     mockedWatchNativeMarkdownFile.mockResolvedValue(() => {});
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([]);
+    mockedTakeNativeOpenedMarkdownPaths.mockResolvedValue([]);
     mockedInstallNativeMarkdownFileDrop.mockResolvedValue(() => {});
+    mockedListenNativeOpenedMarkdownPaths.mockResolvedValue(() => {});
     mockedInstallNativeApplicationMenu.mockResolvedValue(() => {});
     mockedInstallNativeEditorContextMenu.mockResolvedValue(() => {});
     mockedOpenNativeExternalUrl.mockResolvedValue(undefined);
@@ -534,6 +548,11 @@ export function installAppTestHarness() {
       path: "/mock-files/assets/image.png",
       src: "assets/image.png"
     });
+    mockedResolveNativeMarkdownPath.mockImplementation(async (path) => ({
+      kind: path === mockFolderPath ? "folder" : "file",
+      name: path === mockFolderPath ? "vault" : path.split("/").pop() ?? path,
+      path
+    }));
     mockedSaveStoredEditorPreferences.mockResolvedValue(undefined);
     mockedSaveStoredExportSettings.mockResolvedValue(undefined);
     mockedSaveNativeHtmlFile.mockResolvedValue({


### PR DESCRIPTION
## Summary
- Register Markra as an editor for `.md` and `.markdown` files in the Tauri bundle.
- Capture OS file-open requests from launch args and Tauri opened-file events, then queue them for the frontend.
- Have the desktop editor consume queued/runtime opened paths through the existing markdown file/folder open flow.

## Why
- Double-clicking a Markdown file after setting Markra as the default app launched or focused Markra without opening the file.
- The bundle did not declare Markdown file associations, and the app did not bridge OS-opened file paths into the editor startup/runtime flow.

## Validation
- `cargo test` passed: 62 tests.
- `pnpm --filter @markra/desktop test -- file.test.ts App.test.tsx` passed: 36 files / 494 tests.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed; Vite reported the existing chunk-size/browser-externalization warnings.

Closes #51
