### PR TITLE
feat(editor): add slash commands and improve quote behavior

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -108,6 +108,23 @@ function selectText(view: EditorView, from: number, to: number) {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
 }
 
+function findFirstTextBlockCursor(view: EditorView) {
+  let position: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (!node.isTextblock) return true;
+
+    position = nodePosition + 1;
+    return false;
+  });
+
+  if (position === null) {
+    throw new Error("Could not find text block in editor.");
+  }
+
+  return position;
+}
+
 function splitCurrentTextBlockDirectly(view: EditorView) {
   view.dispatch(view.state.tr.split(view.state.selection.from).scrollIntoView());
 }
@@ -172,6 +189,15 @@ function findNodeStartPosition(view: EditorView, typeName: string) {
 function pressEnter(view: EditorView) {
   const event = new KeyboardEvent("keydown", {
     key: "Enter",
+    bubbles: true,
+    cancelable: true
+  });
+  return view.someProp("handleKeyDown", (handler) => handler(view, event));
+}
+
+function pressBackspace(view: EditorView) {
+  const event = new KeyboardEvent("keydown", {
+    key: "Backspace",
     bubbles: true,
     cancelable: true
   });
@@ -2303,6 +2329,44 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("toggles quote formatting off without deleting the quoted text", async () => {
+    const { container, view } = await renderEditor();
+    typeText(view, "Quote");
+
+    expect(pressShortcut(view, "b", { metaKey: true, shiftKey: true })).toBe(true);
+    expect(container.querySelector(".ProseMirror blockquote")).toHaveTextContent("Quote");
+
+    expect(pressShortcut(view, "b", { metaKey: true, shiftKey: true })).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror p")).toHaveTextContent("Quote");
+    await settleMarkdownListener();
+  });
+
+  it("keeps empty quote formatting when pressing Enter", async () => {
+    const { container, view } = await renderEditor("> ");
+    moveCursor(view, findFirstTextBlockCursor(view));
+
+    expect(container.querySelector(".ProseMirror blockquote")).toBeInTheDocument();
+    expect(pressEnter(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("");
+    await settleMarkdownListener();
+  });
+
+  it("removes empty quote formatting when pressing Backspace", async () => {
+    const { container, view } = await renderEditor("> ");
+    moveCursor(view, findFirstTextBlockCursor(view));
+
+    expect(container.querySelector(".ProseMirror blockquote")).toBeInTheDocument();
+    expect(pressBackspace(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror p")).toHaveTextContent("");
+    await settleMarkdownListener();
+  });
+
   it("supports undo and redo shortcuts", async () => {
     const { container, view } = await renderEditor();
 
@@ -3058,6 +3122,52 @@ describe("MarkdownPaper editing", () => {
 
     expect(quote.container.querySelector(".ProseMirror blockquote")).toHaveTextContent("quote");
     expect(quote.container.querySelector(".ProseMirror")?.textContent).toBe("quote");
+    await settleMarkdownListener();
+  });
+
+  it("opens and dismisses the slash command menu from an empty block", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "/");
+
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Heading 1" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Code Block" })).toBeInTheDocument();
+
+    expect(pressShortcut(view, "Escape")).toBe(true);
+
+    await waitFor(() => expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("/");
+    await settleMarkdownListener();
+  });
+
+  it("filters slash commands and inserts a code block from the keyboard", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "/co");
+
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Code Block" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByRole("option", { name: "Heading 1" })).not.toBeInTheDocument();
+
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-code-block")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/co");
+    await settleMarkdownListener();
+  });
+
+  it("inserts a table from the slash command menu", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "/ta");
+
+    const tableOption = await screen.findByRole("option", { name: "Table" });
+    fireEvent.mouseDown(tableOption);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 1");
+    expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/ta");
     await settleMarkdownListener();
   });
 

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -34,6 +34,7 @@ import { markraRawHtmlPlugin } from "@markra/editor";
 import { serializeLinkImageLiveMarkdown } from "@markra/editor";
 import { markraMarkdownShortcuts } from "@markra/editor";
 import { normalizeMarkdownShortcuts } from "@markra/editor";
+import { markraSlashCommands } from "@markra/editor";
 import { markraMathPlugin } from "@markra/editor";
 import { markraMathRemarkPlugin } from "@markra/editor";
 import { markraMathSourcePlugin } from "@markra/editor";
@@ -41,6 +42,7 @@ import { markraTableControlsPlugin } from "@markra/editor";
 import { markraAiEditorPreviewPlugin } from "@markra/editor";
 import { markraAiSelectionHoldPlugin } from "@markra/editor";
 import type { MarkdownShortcutMap } from "@markra/editor";
+import type { SlashCommandLabels } from "@markra/editor";
 import type { AiSelectionContext } from "@markra/ai";
 import { t, type AppLanguage } from "@markra/shared";
 import {
@@ -284,6 +286,21 @@ function MilkdownSurface({
     tableColumns: t(language, "editor.table.columns"),
     tableRows: t(language, "editor.table.rows")
   };
+  const slashCommandLabels = useMemo<SlashCommandLabels>(() => ({
+    menu: t(language, "editor.slashCommands"),
+    noResults: t(language, "editor.slashCommandsNoResults"),
+    commands: {
+      bulletList: t(language, "menu.bulletList"),
+      codeBlock: t(language, "menu.codeBlock"),
+      heading1: t(language, "menu.heading1"),
+      heading2: t(language, "menu.heading2"),
+      heading3: t(language, "menu.heading3"),
+      orderedList: t(language, "menu.orderedList"),
+      paragraph: t(language, "menu.paragraph"),
+      quote: t(language, "menu.quote"),
+      table: t(language, "menu.table")
+    }
+  }), [language]);
 
   useEffect(() => {
     onSaveClipboardImageRef.current = onSaveClipboardImage;
@@ -334,6 +351,7 @@ function MilkdownSurface({
         .use(markraMathRemarkPlugin)
         .use(markraCommonmark)
         .use(markraGfm)
+        .use(markraSlashCommands(slashCommandLabels))
         .use(markraMathSourcePlugin)
         .use(markraMarkdownShortcuts(markdownShortcuts))
         .use(markraCodeBlockPlugin)
@@ -369,7 +387,7 @@ function MilkdownSurface({
 
       return editor;
     },
-    [language, markdownDocumentLabel, markdownShortcuts, onMarkdownChange, openExternalUrl, resolveImageSrc]
+    [language, markdownDocumentLabel, markdownShortcuts, onMarkdownChange, openExternalUrl, resolveImageSrc, slashCommandLabels]
   );
 
   useEditor(createEditor, [createEditor]);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -277,6 +277,24 @@
 }
 
 @layer components {
+  .markra-slash-menu {
+    @apply fixed z-[60] w-60 rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 text-(--text-primary);
+    box-shadow: var(--ai-command-popover-shadow);
+  }
+
+  .markra-slash-menu-option {
+    @apply flex h-8 w-full cursor-pointer items-center rounded-md border-0 bg-transparent px-2.5 text-left text-[13px] leading-5 font-[560] tracking-normal text-(--text-primary) outline-none transition-[background-color,color] duration-150 ease-out;
+  }
+
+  .markra-slash-menu-option:hover,
+  .markra-slash-menu-option[aria-selected="true"] {
+    @apply bg-(--bg-active) text-(--text-heading);
+  }
+
+  .markra-slash-menu-empty {
+    @apply px-2.5 py-2 text-[12px] leading-5 font-[560] text-(--text-secondary);
+  }
+
   .markdown-paper [data-milkdown-root],
   .markdown-paper .ProseMirror {
     @apply min-h-[calc(100vh-176px)] outline-none;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -8,4 +8,5 @@ export * from "./math.ts";
 export * from "./raw-html.ts";
 export * from "./selection-hold.ts";
 export * from "./shortcuts.ts";
+export * from "./slash-commands.ts";
 export * from "./table-controls.ts";

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -10,10 +10,10 @@ import {
   strongSchema
 } from "@milkdown/kit/preset/commonmark";
 import { strikethroughSchema } from "@milkdown/kit/preset/gfm";
-import { exitCode, setBlockType, toggleMark, wrapIn } from "@milkdown/kit/prose/commands";
+import { exitCode, lift, setBlockType, toggleMark, wrapIn } from "@milkdown/kit/prose/commands";
 import { redo, undo } from "@milkdown/kit/prose/history";
-import type { ResolvedPos } from "@milkdown/kit/prose/model";
-import type { Command } from "@milkdown/kit/prose/state";
+import type { NodeType, ResolvedPos } from "@milkdown/kit/prose/model";
+import type { Command, Selection } from "@milkdown/kit/prose/state";
 import { NodeSelection, Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { wrapInList } from "@milkdown/kit/prose/schema-list";
@@ -60,6 +60,44 @@ function runCommand(view: EditorView, command: Command) {
   }
 
   return handled;
+}
+
+function selectionIsInsideNodeType(
+  selection: Selection,
+  nodeType: NodeType
+) {
+  const positions = [selection.$from, selection.$to];
+
+  return positions.every(($pos) => {
+    for (let depth = $pos.depth; depth > 0; depth -= 1) {
+      if ($pos.node(depth).type === nodeType) return true;
+    }
+
+    return false;
+  });
+}
+
+function toggleBlockquote(blockquote: ReturnType<typeof blockquoteSchema.type>): Command {
+  return (state, dispatch, view) => {
+    if (selectionIsInsideNodeType(state.selection, blockquote)) {
+      return lift(state, dispatch, view);
+    }
+
+    return wrapIn(blockquote)(state, dispatch, view);
+  };
+}
+
+function selectionIsEmptyTextBlock(selection: Selection) {
+  return (
+    selection instanceof TextSelection &&
+    selection.empty &&
+    selection.$from.parent.isTextblock &&
+    selection.$from.parent.content.size === 0
+  );
+}
+
+function selectionIsEmptyBlockquote(selection: Selection, blockquote: NodeType) {
+  return selectionIsEmptyTextBlock(selection) && selectionIsInsideNodeType(selection, blockquote);
 }
 
 function isPlainParagraphNodeName(nodeName: string) {
@@ -141,7 +179,7 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
     italic: toggleMark(emphasis),
     orderedList: wrapInList(orderedList),
     paragraph: setBlockType(paragraph),
-    quote: wrapIn(blockquote),
+    quote: toggleBlockquote(blockquote),
     strikethrough: toggleMark(strikethrough)
   };
 
@@ -149,9 +187,20 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
     props: {
       handleKeyDown: (view, event) => {
         let command: Command | null = null;
+        const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
 
         // Support both Milkdown-style shortcuts and common document-editor aliases.
-        if (event.key === "Enter" && isKeyboardShortcutModKey(event) && !event.shiftKey && !event.altKey) {
+        if (event.key === "Enter" && !hasModifier && selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
+          event.preventDefault();
+          view.focus();
+          return true;
+        } else if (event.key === "Backspace" && !hasModifier && selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
+          const handled = runCommand(view, lift);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        } else if (event.key === "Enter" && isKeyboardShortcutModKey(event) && !event.shiftKey && !event.altKey) {
           const handled = runCommand(view, exitCode) || moveBelowTerminalBlock(view, paragraph);
           if (!handled) return false;
 

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -1,0 +1,534 @@
+import {
+  blockquoteSchema,
+  bulletListSchema,
+  codeBlockSchema,
+  headingSchema,
+  orderedListSchema,
+  paragraphSchema
+} from "@milkdown/kit/preset/commonmark";
+import {
+  tableCellSchema,
+  tableHeaderRowSchema,
+  tableHeaderSchema,
+  tableRowSchema,
+  tableSchema
+} from "@milkdown/kit/preset/gfm";
+import type { NodeType } from "@milkdown/kit/prose/model";
+import { setBlockType, wrapIn } from "@milkdown/kit/prose/commands";
+import { Plugin, PluginKey, TextSelection, type Command, type EditorState } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { wrapInList } from "@milkdown/kit/prose/schema-list";
+import { $prose } from "@milkdown/kit/utils";
+
+export type SlashCommandId =
+  | "paragraph"
+  | "heading1"
+  | "heading2"
+  | "heading3"
+  | "bulletList"
+  | "orderedList"
+  | "quote"
+  | "codeBlock"
+  | "table";
+
+export type SlashCommandLabels = {
+  menu: string;
+  noResults: string;
+  commands: Record<SlashCommandId, string>;
+};
+
+type SlashCommandRange = {
+  from: number;
+  query: string;
+  to: number;
+};
+
+type SuppressedSlashCommandRange = Pick<SlashCommandRange, "from" | "to">;
+
+type SlashCommandState = {
+  active: SlashCommandRange | null;
+  selectedIndex: number;
+  suppressed: SuppressedSlashCommandRange | null;
+};
+
+type SlashCommandMeta =
+  | {
+      type: "close";
+    }
+  | {
+      selectedIndex: number;
+      type: "select";
+    };
+
+type SlashCommandSpec = {
+  aliases: string[];
+  id: SlashCommandId;
+  label: string;
+  run: (view: EditorView, range: SlashCommandRange) => boolean;
+};
+
+const slashCommandsKey = new PluginKey<SlashCommandState>("markra-slash-commands");
+const emptySlashCommandState: SlashCommandState = {
+  active: null,
+  selectedIndex: 0,
+  suppressed: null
+};
+
+export const defaultSlashCommandLabels: SlashCommandLabels = {
+  menu: "Slash commands",
+  noResults: "No matching commands",
+  commands: {
+    bulletList: "Bullet List",
+    codeBlock: "Code Block",
+    heading1: "Heading 1",
+    heading2: "Heading 2",
+    heading3: "Heading 3",
+    orderedList: "Ordered List",
+    paragraph: "Paragraph",
+    quote: "Quote",
+    table: "Table"
+  }
+};
+
+function clampSelectedIndex(index: number, commandsLength: number) {
+  if (commandsLength <= 0) return 0;
+
+  return Math.max(0, Math.min(index, commandsLength - 1));
+}
+
+function sameRange(left: SuppressedSlashCommandRange | null, right: SuppressedSlashCommandRange | null) {
+  return Boolean(left && right && left.from === right.from && left.to === right.to);
+}
+
+function slashRangeFromState(state: EditorState): SlashCommandRange | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock || $from.parent.type.spec.code) return null;
+
+  const beforeCursor = $from.parent.textContent.slice(0, $from.parentOffset);
+  const afterCursor = $from.parent.textContent.slice($from.parentOffset);
+  if (afterCursor.length > 0) return null;
+
+  const match = beforeCursor.match(/^\/([^\s/]*)$/u);
+  if (!match) return null;
+
+  return {
+    from: selection.from - beforeCursor.length,
+    query: match[1] ?? "",
+    to: selection.from
+  };
+}
+
+function normalizedSearchText(value: string) {
+  return value.toLowerCase().replace(/\s+/gu, "");
+}
+
+function filterSlashCommands(commands: SlashCommandSpec[], query: string) {
+  const normalizedQuery = normalizedSearchText(query);
+  if (!normalizedQuery) return commands;
+
+  return commands.filter((command) => {
+    const haystacks = [command.id, command.label, ...command.aliases];
+
+    return haystacks.some((candidate) => normalizedSearchText(candidate).includes(normalizedQuery));
+  });
+}
+
+function runCommandAfterDeletingSlash(view: EditorView, range: SlashCommandRange, command: Command) {
+  let deleteTransaction = view.state.tr.delete(range.from, range.to);
+  deleteTransaction = deleteTransaction
+    .setSelection(TextSelection.create(deleteTransaction.doc, range.from))
+    .scrollIntoView();
+  view.dispatch(deleteTransaction);
+
+  const handled = command(view.state, view.dispatch, view);
+  if (handled) view.focus();
+
+  return handled;
+}
+
+function createTableCell(
+  view: EditorView,
+  cellType: NodeType,
+  paragraph: NodeType,
+  text = ""
+) {
+  const content = text ? paragraph.create(null, view.state.schema.text(text)) : paragraph.create();
+
+  return cellType.create(null, content);
+}
+
+function createDefaultTableNode(view: EditorView, commands: {
+  paragraph: NodeType;
+  table: NodeType;
+  tableCell: NodeType;
+  tableHeader: NodeType;
+  tableHeaderRow: NodeType;
+  tableRow: NodeType;
+}) {
+  const headerRow = commands.tableHeaderRow.create(null, [
+    createTableCell(view, commands.tableHeader, commands.paragraph, "Column 1"),
+    createTableCell(view, commands.tableHeader, commands.paragraph, "Column 2")
+  ]);
+  const bodyRow = commands.tableRow.create(null, [
+    createTableCell(view, commands.tableCell, commands.paragraph),
+    createTableCell(view, commands.tableCell, commands.paragraph)
+  ]);
+
+  return commands.table.create(null, [headerRow, bodyRow]);
+}
+
+function runTableCommand(view: EditorView, range: SlashCommandRange, commands: {
+  paragraph: NodeType;
+  table: NodeType;
+  tableCell: NodeType;
+  tableHeader: NodeType;
+  tableHeaderRow: NodeType;
+  tableRow: NodeType;
+}) {
+  const { state } = view;
+  const $from = state.doc.resolve(range.from);
+  if (!$from.parent.isTextblock || $from.depth < 1) return false;
+
+  const blockFrom = $from.before();
+  const blockTo = $from.after();
+  let transaction = state.tr.replaceWith(blockFrom, blockTo, createDefaultTableNode(view, commands));
+  const selectionPosition = Math.min(blockFrom + 3, transaction.doc.content.size);
+
+  transaction = transaction
+    .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition)))
+    .scrollIntoView();
+  view.dispatch(transaction);
+  view.focus();
+
+  return true;
+}
+
+function createSlashCommands(
+  labels: SlashCommandLabels,
+  commands: {
+    bulletList: ReturnType<typeof bulletListSchema.type>;
+    codeBlock: ReturnType<typeof codeBlockSchema.type>;
+    heading: ReturnType<typeof headingSchema.type>;
+    orderedList: ReturnType<typeof orderedListSchema.type>;
+    paragraph: ReturnType<typeof paragraphSchema.type>;
+    quote: ReturnType<typeof blockquoteSchema.type>;
+    table: ReturnType<typeof tableSchema.type>;
+    tableCell: ReturnType<typeof tableCellSchema.type>;
+    tableHeader: ReturnType<typeof tableHeaderSchema.type>;
+    tableHeaderRow: ReturnType<typeof tableHeaderRowSchema.type>;
+    tableRow: ReturnType<typeof tableRowSchema.type>;
+  }
+): SlashCommandSpec[] {
+  return [
+    {
+      aliases: ["text", "plain"],
+      id: "paragraph",
+      label: labels.commands.paragraph,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, setBlockType(commands.paragraph))
+    },
+    {
+      aliases: ["h1", "title", "heading"],
+      id: "heading1",
+      label: labels.commands.heading1,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, setBlockType(commands.heading, { level: 1 }))
+    },
+    {
+      aliases: ["h2", "subtitle", "heading"],
+      id: "heading2",
+      label: labels.commands.heading2,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, setBlockType(commands.heading, { level: 2 }))
+    },
+    {
+      aliases: ["h3", "subheading", "heading"],
+      id: "heading3",
+      label: labels.commands.heading3,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, setBlockType(commands.heading, { level: 3 }))
+    },
+    {
+      aliases: ["ul", "list", "unordered"],
+      id: "bulletList",
+      label: labels.commands.bulletList,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, wrapInList(commands.bulletList))
+    },
+    {
+      aliases: ["ol", "list", "numbered"],
+      id: "orderedList",
+      label: labels.commands.orderedList,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, wrapInList(commands.orderedList))
+    },
+    {
+      aliases: ["blockquote", "callout"],
+      id: "quote",
+      label: labels.commands.quote,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, wrapIn(commands.quote))
+    },
+    {
+      aliases: ["code", "pre", "fence"],
+      id: "codeBlock",
+      label: labels.commands.codeBlock,
+      run: (view, range) => runCommandAfterDeletingSlash(view, range, setBlockType(commands.codeBlock))
+    },
+    {
+      aliases: ["grid"],
+      id: "table",
+      label: labels.commands.table,
+      run: (view, range) => runTableCommand(view, range, commands)
+    }
+  ];
+}
+
+function dispatchSlashCommandSelection(view: EditorView, selectedIndex: number) {
+  view.dispatch(view.state.tr.setMeta(slashCommandsKey, {
+    selectedIndex,
+    type: "select"
+  } satisfies SlashCommandMeta));
+}
+
+function closeSlashCommandMenu(view: EditorView) {
+  view.dispatch(view.state.tr.setMeta(slashCommandsKey, {
+    type: "close"
+  } satisfies SlashCommandMeta));
+}
+
+function runSelectedSlashCommand(view: EditorView, commands: SlashCommandSpec[]) {
+  const state = slashCommandsKey.getState(view.state);
+  if (!state?.active) return false;
+
+  const filteredCommands = filterSlashCommands(commands, state.active.query);
+  const selectedCommand = filteredCommands[state.selectedIndex];
+  if (!selectedCommand) return false;
+
+  return selectedCommand.run(view, state.active);
+}
+
+function positionMenu(menu: HTMLElement, view: EditorView, range: SlashCommandRange) {
+  try {
+    const coords = view.coordsAtPos(range.to);
+    const margin = 10;
+    const width = menu.offsetWidth || 240;
+    const height = menu.offsetHeight || 220;
+    const left = Math.min(Math.max(coords.left, margin), Math.max(window.innerWidth - width - margin, margin));
+    const top = Math.min(coords.bottom + 8, Math.max(window.innerHeight - height - margin, margin));
+
+    menu.style.left = `${left}px`;
+    menu.style.top = `${top}px`;
+  } catch {
+    menu.style.left = "12px";
+    menu.style.top = "12px";
+  }
+}
+
+class SlashCommandMenuView {
+  private readonly menu: HTMLDivElement;
+  private view: EditorView;
+
+  constructor(
+    view: EditorView,
+    private readonly commands: SlashCommandSpec[],
+    private readonly labels: SlashCommandLabels
+  ) {
+    this.view = view;
+    this.menu = view.dom.ownerDocument.createElement("div");
+    this.menu.className = "markra-slash-menu";
+    this.menu.setAttribute("aria-label", labels.menu);
+    this.menu.setAttribute("role", "listbox");
+    this.menu.addEventListener("mousedown", this.handleMouseDown);
+    this.menu.addEventListener("mouseover", this.handleMouseOver);
+  }
+
+  update(view: EditorView) {
+    this.view = view;
+    const state = slashCommandsKey.getState(view.state);
+
+    if (!state?.active) {
+      this.detach();
+      return;
+    }
+
+    this.attach();
+    this.render(state);
+    positionMenu(this.menu, view, state.active);
+  }
+
+  destroy() {
+    this.menu.removeEventListener("mousedown", this.handleMouseDown);
+    this.menu.removeEventListener("mouseover", this.handleMouseOver);
+    this.detach();
+  }
+
+  private attach() {
+    if (this.menu.isConnected) return;
+
+    this.view.dom.ownerDocument.body.append(this.menu);
+  }
+
+  private detach() {
+    if (!this.menu.isConnected) return;
+
+    this.menu.remove();
+  }
+
+  private render(state: SlashCommandState) {
+    const filteredCommands = filterSlashCommands(this.commands, state.active?.query ?? "");
+    this.menu.textContent = "";
+
+    if (filteredCommands.length === 0) {
+      const empty = this.view.dom.ownerDocument.createElement("div");
+      empty.className = "markra-slash-menu-empty";
+      empty.textContent = this.labels.noResults;
+      this.menu.append(empty);
+      return;
+    }
+
+    filteredCommands.forEach((command, index) => {
+      const option = this.view.dom.ownerDocument.createElement("button");
+      option.className = "markra-slash-menu-option";
+      option.dataset.slashCommandId = command.id;
+      option.setAttribute("aria-selected", String(index === state.selectedIndex));
+      option.setAttribute("role", "option");
+      option.tabIndex = -1;
+      option.type = "button";
+      option.textContent = command.label;
+      this.menu.append(option);
+    });
+  }
+
+  private readonly handleMouseDown = (event: MouseEvent) => {
+    const target = event.target instanceof Element ? event.target : null;
+    const option = target?.closest<HTMLElement>("[data-slash-command-id]");
+    if (!option || !this.menu.contains(option)) return;
+
+    event.preventDefault();
+    const commandId = option.dataset.slashCommandId as SlashCommandId | undefined;
+    const state = slashCommandsKey.getState(this.view.state);
+    if (!state?.active || !commandId) return;
+
+    const command = this.commands.find((candidate) => candidate.id === commandId);
+    if (!command) return;
+
+    command.run(this.view, state.active);
+  };
+
+  private readonly handleMouseOver = (event: MouseEvent) => {
+    const target = event.target instanceof Element ? event.target : null;
+    const option = target?.closest<HTMLElement>("[data-slash-command-id]");
+    if (!option || !this.menu.contains(option)) return;
+
+    const options = Array.from(this.menu.querySelectorAll<HTMLElement>("[data-slash-command-id]"));
+    const selectedIndex = options.indexOf(option);
+    if (selectedIndex < 0) return;
+
+    dispatchSlashCommandSelection(this.view, selectedIndex);
+  };
+}
+
+export const markraSlashCommands = (labels: Partial<SlashCommandLabels> = {}) => $prose((ctx) => {
+  const resolvedLabels: SlashCommandLabels = {
+    menu: labels.menu ?? defaultSlashCommandLabels.menu,
+    noResults: labels.noResults ?? defaultSlashCommandLabels.noResults,
+    commands: {
+      ...defaultSlashCommandLabels.commands,
+      ...labels.commands
+    }
+  };
+  const commands = createSlashCommands(resolvedLabels, {
+    bulletList: bulletListSchema.type(ctx),
+    codeBlock: codeBlockSchema.type(ctx),
+    heading: headingSchema.type(ctx),
+    orderedList: orderedListSchema.type(ctx),
+    paragraph: paragraphSchema.type(ctx),
+    quote: blockquoteSchema.type(ctx),
+    table: tableSchema.type(ctx),
+    tableCell: tableCellSchema.type(ctx),
+    tableHeader: tableHeaderSchema.type(ctx),
+    tableHeaderRow: tableHeaderRowSchema.type(ctx),
+    tableRow: tableRowSchema.type(ctx)
+  });
+
+  return new Plugin<SlashCommandState>({
+    key: slashCommandsKey,
+    state: {
+      init: () => emptySlashCommandState,
+      apply(transaction, previousState, _oldState, newState) {
+        const meta = transaction.getMeta(slashCommandsKey) as SlashCommandMeta | undefined;
+        const activeRange = slashRangeFromState(newState);
+
+        if (meta?.type === "close") {
+          return {
+            active: null,
+            selectedIndex: 0,
+            suppressed: activeRange ? { from: activeRange.from, to: activeRange.to } : null
+          };
+        }
+
+        if (!activeRange) return emptySlashCommandState;
+        if (sameRange(activeRange, previousState.suppressed)) {
+          return {
+            active: null,
+            selectedIndex: 0,
+            suppressed: previousState.suppressed
+          };
+        }
+
+        const filteredCommands = filterSlashCommands(commands, activeRange.query);
+        const selectedIndex = meta?.type === "select"
+          ? meta.selectedIndex
+          : previousState.active?.query === activeRange.query
+            ? previousState.selectedIndex
+            : 0;
+
+        return {
+          active: activeRange,
+          selectedIndex: clampSelectedIndex(selectedIndex, filteredCommands.length),
+          suppressed: null
+        };
+      }
+    },
+    props: {
+      handleKeyDown(view, event) {
+        const state = slashCommandsKey.getState(view.state);
+        if (!state?.active) return false;
+
+        const filteredCommands = filterSlashCommands(commands, state.active.query);
+
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeSlashCommandMenu(view);
+          return true;
+        }
+
+        if (event.metaKey || event.ctrlKey || event.altKey) return false;
+
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          dispatchSlashCommandSelection(view, (state.selectedIndex + 1) % Math.max(filteredCommands.length, 1));
+          return true;
+        }
+
+        if (event.key === "ArrowUp") {
+          event.preventDefault();
+          dispatchSlashCommandSelection(
+            view,
+            (state.selectedIndex + Math.max(filteredCommands.length, 1) - 1) % Math.max(filteredCommands.length, 1)
+          );
+          return true;
+        }
+
+        if (event.key !== "Enter" && event.key !== "Tab") return false;
+        if (filteredCommands.length === 0) return false;
+
+        event.preventDefault();
+        return runSelectedSlashCommand(view, commands);
+      }
+    },
+    view: (view) => {
+      const menuView = new SlashCommandMenuView(view, commands, resolvedLabels);
+      menuView.update(view);
+
+      return menuView;
+    }
+  });
+});

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "Tabelle auf {columns} Spalten x {rows} Zeilen anpassen",
   "editor.table.columns": "Tabellenspalten",
   "editor.table.rows": "Tabellenzeilen",
+  "editor.slashCommands": "Slash-Befehle",
+  "editor.slashCommandsNoResults": "Keine passenden Befehle",
   "app.documentStatus": "Dokumentstatus",
   "app.words": "Wörter",
   "app.saved": "gespeichert",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -315,6 +315,8 @@ const messages: BaseLocaleMessages = {
   "editor.table.resizeTableTo": "Resize table to {columns} columns by {rows} rows",
   "editor.table.columns": "Table columns",
   "editor.table.rows": "Table rows",
+  "editor.slashCommands": "Slash commands",
+  "editor.slashCommandsNoResults": "No matching commands",
   "app.documentStatus": "Document status",
   "app.words": "words",
   "app.saved": "saved",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "Cambiar tabla a {columns} columnas x {rows} filas",
   "editor.table.columns": "Columnas de la tabla",
   "editor.table.rows": "Filas de la tabla",
+  "editor.slashCommands": "Comandos con barra",
+  "editor.slashCommandsNoResults": "No hay comandos coincidentes",
   "app.documentStatus": "Estado del documento",
   "app.words": "palabras",
   "app.saved": "guardado",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "Redimensionner le tableau en {columns} colonnes x {rows} lignes",
   "editor.table.columns": "Colonnes du tableau",
   "editor.table.rows": "Lignes du tableau",
+  "editor.slashCommands": "Commandes slash",
+  "editor.slashCommandsNoResults": "Aucune commande correspondante",
   "app.documentStatus": "État du document",
   "app.words": "mots",
   "app.saved": "enregistré",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "Ridimensiona tabella a {columns} colonne x {rows} righe",
   "editor.table.columns": "Colonne tabella",
   "editor.table.rows": "Righe tabella",
+  "editor.slashCommands": "Comandi slash",
+  "editor.slashCommandsNoResults": "Nessun comando corrispondente",
   "app.documentStatus": "Stato documento",
   "app.words": "parole",
   "app.saved": "salvato",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -215,6 +215,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "{columns} 列 x {rows} 行に変更",
   "editor.table.columns": "表の列数",
   "editor.table.rows": "表の行数",
+  "editor.slashCommands": "スラッシュコマンド",
+  "editor.slashCommandsNoResults": "一致するコマンドはありません",
   "app.documentStatus": "ドキュメント状態",
   "app.words": "語",
   "app.saved": "保存済み",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "표를 {columns}열 x {rows}행으로 변경",
   "editor.table.columns": "표 열 수",
   "editor.table.rows": "표 행 수",
+  "editor.slashCommands": "슬래시 명령",
+  "editor.slashCommandsNoResults": "일치하는 명령이 없습니다",
   "app.documentStatus": "문서 상태",
   "app.words": "단어",
   "app.saved": "저장됨",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "Redimensionar tabela para {columns} colunas x {rows} linhas",
   "editor.table.columns": "Colunas da tabela",
   "editor.table.rows": "Linhas da tabela",
+  "editor.slashCommands": "Comandos de barra",
+  "editor.slashCommandsNoResults": "Nenhum comando correspondente",
   "app.documentStatus": "Status do documento",
   "app.words": "palavras",
   "app.saved": "salvo",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -209,6 +209,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "Изменить таблицу до {columns} столбцов x {rows} строк",
   "editor.table.columns": "Столбцы таблицы",
   "editor.table.rows": "Строки таблицы",
+  "editor.slashCommands": "Slash-команды",
+  "editor.slashCommandsNoResults": "Нет подходящих команд",
   "app.documentStatus": "Состояние документа",
   "app.words": "слов",
   "app.saved": "сохранено",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -326,6 +326,8 @@ export type I18nKey =
   | "editor.table.resizeTableTo"
   | "editor.table.columns"
   | "editor.table.rows"
+  | "editor.slashCommands"
+  | "editor.slashCommandsNoResults"
   | "app.documentStatus"
   | "app.words"
   | "app.saved"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -315,6 +315,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "调整为 {columns} 列 x {rows} 行",
   "editor.table.columns": "表格列数",
   "editor.table.rows": "表格行数",
+  "editor.slashCommands": "斜杠命令",
+  "editor.slashCommandsNoResults": "没有匹配的命令",
   "app.documentStatus": "文档状态",
   "app.words": "个词",
   "app.saved": "已保存",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -215,6 +215,8 @@ const messages: LocaleMessages = {
   "editor.table.resizeTableTo": "調整為 {columns} 欄 x {rows} 列",
   "editor.table.columns": "表格欄數",
   "editor.table.rows": "表格列數",
+  "editor.slashCommands": "斜線命令",
+  "editor.slashCommandsNoResults": "沒有符合的命令",
   "app.documentStatus": "文件狀態",
   "app.words": "個字",
   "app.saved": "已儲存",


### PR DESCRIPTION
## Summary
- add a slash command menu to the Milkdown editor for paragraph, headings, lists, quote, code block, and table insertion
- wire localized labels and menu styling into the desktop editor surface
- make quote formatting toggle cleanly and fix empty-quote Enter/Backspace behavior

## Why
- implements the slash command editor workflow requested in #38
- removes a rough quote-block editing path discovered while testing the new editor interactions

## Validation
- `pnpm --filter @markra/desktop test -- MarkdownPaper.test.tsx` passed (`121 passed`) 
- `pnpm build` passed

## Risk
- browser QA was not run; editor behavior is covered by the updated MarkdownPaper tests

## Related Issues
- Closes #38
