### PR TITLE
feat(editor): transfer pasted web images

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ use opened_files::{
 };
 use tauri::Emitter;
 use watcher::{unwatch_markdown_file, watch_markdown_file, MarkdownWatcherState};
-use web_http::request_web_resource;
+use web_http::{download_web_image, request_web_resource};
 use windows::{
     apply_main_window_chrome, apply_webview_window_chrome, apply_window_event_chrome,
     open_blank_editor_window, open_settings_window, spawn_blank_editor_window,
@@ -105,6 +105,7 @@ pub fn run() {
             request_native_chat,
             request_native_chat_stream,
             request_web_resource,
+            download_web_image,
             upload_s3_image,
             upload_webdav_image,
             write_markdown_file,

--- a/apps/desktop/src-tauri/src/markdown_files.rs
+++ b/apps/desktop/src-tauri/src/markdown_files.rs
@@ -145,6 +145,7 @@ fn clipboard_image_extension(mime_type: &str) -> Result<&'static str, String> {
         "image/webp" => Ok("webp"),
         "image/avif" => Ok("avif"),
         "image/bmp" => Ok("bmp"),
+        "image/svg+xml" => Ok("svg"),
         _ => Err("Clipboard image type is not supported".to_string()),
     }
 }
@@ -1620,6 +1621,14 @@ mod tests {
         );
 
         fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn saves_svg_clipboard_images_with_svg_extension() {
+        assert_eq!(
+            clipboard_image_extension("image/svg+xml").expect("SVG images should be supported"),
+            "svg"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/web_http.rs
+++ b/apps/desktop/src-tauri/src/web_http.rs
@@ -2,13 +2,14 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE, LOCATION};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 use reqwest::redirect::Policy;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
 const WEB_RESOURCE_MAX_REDIRECTS: usize = 5;
 const WEB_RESOURCE_REQUEST_TIMEOUT_SECS: u64 = 30;
+const WEB_IMAGE_MAX_BYTES: u64 = 25 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -28,11 +29,32 @@ pub(crate) struct WebResourceResponse {
     status: u16,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WebImageDownloadRequest {
+    url: String,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WebImageDownloadResponse {
+    bytes: Vec<u8>,
+    file_name: String,
+    mime_type: String,
+}
+
 #[tauri::command]
 pub(crate) async fn request_web_resource(
     request: WebResourceRequest,
 ) -> Result<WebResourceResponse, String> {
     execute_web_resource_request(request).await
+}
+
+#[tauri::command]
+pub(crate) async fn download_web_image(
+    request: WebImageDownloadRequest,
+) -> Result<WebImageDownloadResponse, String> {
+    execute_web_image_download(request).await
 }
 
 async fn execute_web_resource_request(
@@ -87,7 +109,73 @@ async fn execute_web_resource_request(
     Err("Web resource request followed too many redirects.".to_string())
 }
 
-fn validated_web_resource_url(value: &str, allow_localhost: bool) -> Result<Url, String> {
+async fn execute_web_image_download(
+    request: WebImageDownloadRequest,
+) -> Result<WebImageDownloadResponse, String> {
+    let mut url = validated_web_resource_url(&request.url, false)?;
+    let client = reqwest::Client::builder()
+        .redirect(Policy::none())
+        .timeout(Duration::from_secs(WEB_RESOURCE_REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|error| error.to_string())?;
+
+    for _ in 0..=WEB_RESOURCE_MAX_REDIRECTS {
+        let response = client
+            .get(url.clone())
+            .send()
+            .await
+            .map_err(|error| error.to_string())?;
+        let status = response.status();
+
+        if status.is_redirection() {
+            let location = response
+                .headers()
+                .get(LOCATION)
+                .ok_or_else(|| "Web image redirect did not include a location.".to_string())?;
+            let location = location.to_str().map_err(|error| error.to_string())?;
+            let next_url = url.join(location).map_err(|error| error.to_string())?;
+            url = validated_web_resource_url(next_url.as_str(), false)?;
+            continue;
+        }
+
+        if !status.is_success() {
+            return Err(format!(
+                "Web image download failed: HTTP {}",
+                status.as_u16()
+            ));
+        }
+
+        if let Some(content_length) = response.headers().get(CONTENT_LENGTH) {
+            let content_length = content_length
+                .to_str()
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok());
+            if content_length.is_some_and(|length| length > WEB_IMAGE_MAX_BYTES) {
+                return Err("Web image is too large to paste into the document.".to_string());
+            }
+        }
+
+        let mime_type = web_image_mime_type(response.headers().get(CONTENT_TYPE), &url)?;
+        let file_name = web_image_file_name(&url, &mime_type);
+        let bytes = response.bytes().await.map_err(|error| error.to_string())?;
+        if bytes.len() as u64 > WEB_IMAGE_MAX_BYTES {
+            return Err("Web image is too large to paste into the document.".to_string());
+        }
+
+        return Ok(WebImageDownloadResponse {
+            bytes: bytes.to_vec(),
+            file_name,
+            mime_type,
+        });
+    }
+
+    Err("Web image download followed too many redirects.".to_string())
+}
+
+pub(crate) fn validated_web_resource_url(
+    value: &str,
+    allow_localhost: bool,
+) -> Result<Url, String> {
     let url = Url::parse(value).map_err(|error| error.to_string())?;
     if !matches!(url.scheme(), "http" | "https") {
         return Err("Only HTTP and HTTPS web resource URLs are supported.".to_string());
@@ -100,6 +188,96 @@ fn validated_web_resource_url(value: &str, allow_localhost: bool) -> Result<Url,
     }
 
     Ok(url)
+}
+
+fn web_image_mime_type(content_type: Option<&HeaderValue>, url: &Url) -> Result<String, String> {
+    let normalized_content_type = content_type
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .filter(|value| !value.is_empty());
+
+    if let Some(mime_type) = normalized_content_type {
+        if mime_type.starts_with("image/") {
+            return Ok(mime_type);
+        }
+
+        if mime_type != "application/octet-stream" {
+            return Err("Downloaded web resource is not an image.".to_string());
+        }
+    }
+
+    image_mime_type_from_url(url)
+        .map(str::to_string)
+        .ok_or_else(|| "Downloaded web resource is not a supported image.".to_string())
+}
+
+fn web_image_file_name(url: &Url, mime_type: &str) -> String {
+    let file_name = url
+        .path_segments()
+        .and_then(|segments| segments.filter(|segment| !segment.is_empty()).last())
+        .filter(|segment| !segment.trim().is_empty())
+        .unwrap_or("web-image");
+
+    if image_extension_from_file_name(file_name).is_some() {
+        return file_name.to_string();
+    }
+
+    format!(
+        "{}.{}",
+        file_name,
+        image_extension_from_mime_type(mime_type)
+    )
+}
+
+fn image_mime_type_from_url(url: &Url) -> Option<&'static str> {
+    let file_name = url
+        .path_segments()
+        .and_then(|segments| segments.filter(|segment| !segment.is_empty()).last())?;
+    let extension = image_extension_from_file_name(file_name)?;
+    image_mime_type_from_extension(extension)
+}
+
+fn image_extension_from_file_name(file_name: &str) -> Option<&str> {
+    let extension = file_name.rsplit_once('.')?.1;
+    if is_supported_image_extension(extension) {
+        Some(extension)
+    } else {
+        None
+    }
+}
+
+fn is_supported_image_extension(extension: &str) -> bool {
+    matches!(
+        extension.to_ascii_lowercase().as_str(),
+        "avif" | "bmp" | "gif" | "jpeg" | "jpg" | "png" | "svg" | "webp"
+    )
+}
+
+fn image_mime_type_from_extension(extension: &str) -> Option<&'static str> {
+    match extension.to_ascii_lowercase().as_str() {
+        "avif" => Some("image/avif"),
+        "bmp" => Some("image/bmp"),
+        "gif" => Some("image/gif"),
+        "jpeg" | "jpg" => Some("image/jpeg"),
+        "png" => Some("image/png"),
+        "svg" => Some("image/svg+xml"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+fn image_extension_from_mime_type(mime_type: &str) -> &'static str {
+    match mime_type {
+        "image/avif" => "avif",
+        "image/bmp" => "bmp",
+        "image/gif" => "gif",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/svg+xml" => "svg",
+        "image/webp" => "webp",
+        _ => "png",
+    }
 }
 
 fn is_local_or_private_host(url: &Url) -> bool {
@@ -201,6 +379,42 @@ mod tests {
             .expect("localhost should be allowed when explicitly requested");
 
         assert_eq!(url.as_str(), "http://localhost:8888/search?q=markra");
+    }
+
+    #[test]
+    fn accepts_image_content_types_for_web_image_downloads() {
+        let url = Url::parse("https://example.com/assets/kitten").expect("URL should parse");
+        let content_type = HeaderValue::from_static("image/png; charset=binary");
+
+        assert_eq!(
+            web_image_mime_type(Some(&content_type), &url).expect("image content type should pass"),
+            "image/png"
+        );
+        assert_eq!(web_image_file_name(&url, "image/png"), "kitten.png");
+    }
+
+    #[test]
+    fn infers_web_image_mime_type_from_url_for_octet_streams() {
+        let url = Url::parse("https://cdn.example.com/assets/logo.svg?version=1")
+            .expect("URL should parse");
+        let content_type = HeaderValue::from_static("application/octet-stream");
+
+        assert_eq!(
+            web_image_mime_type(Some(&content_type), &url)
+                .expect("octet stream image URLs should infer a MIME type"),
+            "image/svg+xml"
+        );
+        assert_eq!(web_image_file_name(&url, "image/svg+xml"), "logo.svg");
+    }
+
+    #[test]
+    fn rejects_non_image_content_types_for_web_image_downloads() {
+        let url = Url::parse("https://example.com/page.html").expect("URL should parse");
+        let content_type = HeaderValue::from_static("text/html");
+        let error = web_image_mime_type(Some(&content_type), &url)
+            .expect_err("non-image content type should be rejected");
+
+        assert!(error.contains("not an image"));
     }
 
     #[test]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -54,7 +54,8 @@ import {
   AI_EDITOR_PREVIEW_RESTORE_EVENT,
   type AiEditorPreviewAppliedDetail,
   type AiEditorPreviewActionDetail,
-  type AiEditorPreviewRestoreDetail
+  type AiEditorPreviewRestoreDetail,
+  type RemoteClipboardImage
 } from "@markra/editor";
 import { aiAgentWebSearchAvailable } from "@markra/ai";
 import {
@@ -69,6 +70,7 @@ import { notifyAppEditorPreferencesChanged } from "./lib/settings/settings-event
 import {
   confirmNativeMarkdownFileDelete,
   confirmNativeUnsavedMarkdownDocumentDiscard,
+  downloadNativeWebImage,
   readNativeMarkdownImageFile,
   readNativeMarkdownFile,
   saveNativeHtmlFile,
@@ -749,6 +751,19 @@ export default function App() {
     return result.image;
   }, [document.path, editorPreferences.preferences, refreshMarkdownFileTree, translate]);
 
+  const handleSaveRemoteClipboardImage = useCallback(async (image: RemoteClipboardImage) => {
+    const downloadedImage = await downloadNativeWebImage({ src: image.src }).catch(() => null);
+    if (!downloadedImage) {
+      showAppToast({
+        message: translate("app.clipboardImageSaveFailed"),
+        status: "error"
+      });
+      return null;
+    }
+
+    return handleSaveClipboardImage(downloadedImage);
+  }, [handleSaveClipboardImage, translate]);
+
   useEffect(() => {
     const storedWidth = editorPreferences.preferences.contentWidthPx ?? null;
     setEditorContentWidth(editorPreferences.preferences.contentWidth);
@@ -1337,6 +1352,7 @@ export default function App() {
                       onContentWidthChange={handleEditorContentWidthChange}
                       onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                       onSaveClipboardImage={handleSaveClipboardImage}
+                      onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
                       openExternalUrl={openNativeExternalUrl}
                       onTextSelectionChange={handleTextSelectionChange}
                       resolveImageSrc={resolveImageSrc}

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { Editor } from "@milkdown/kit/core";
 import { editorViewCtx, parserCtx, serializerCtx } from "@milkdown/kit/core";
+import { Slice } from "@milkdown/kit/prose/model";
 import { NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { MarkdownPaper } from "./MarkdownPaper";
@@ -10,6 +11,7 @@ import {
   AI_EDITOR_PREVIEW_RESTORE_EVENT,
   type AiEditorPreviewAppliedDetail,
   type AiEditorPreviewActionDetail,
+  type RemoteClipboardImage,
   applyAiEditorResult,
   clearAiEditorPreview,
   confirmAiEditorResultApplied,
@@ -29,6 +31,7 @@ async function renderEditor(
   options: {
     onMarkdownChange?: (content: string) => unknown;
     onSaveClipboardImage?: (image: File) => Promise<{ alt: string; src: string } | null>;
+    onSaveRemoteClipboardImage?: (image: RemoteClipboardImage) => Promise<{ alt: string; src: string } | null>;
     openExternalUrl?: (url: string) => unknown;
     onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
     resolveImageSrc?: (src: string) => string;
@@ -45,6 +48,7 @@ async function renderEditor(
       markdownShortcuts={options.markdownShortcuts}
       onMarkdownChange={options.onMarkdownChange ?? (() => {})}
       onSaveClipboardImage={options.onSaveClipboardImage}
+      onSaveRemoteClipboardImage={options.onSaveRemoteClipboardImage}
       openExternalUrl={options.openExternalUrl}
       onTextSelectionChange={options.onTextSelectionChange}
       resolveImageSrc={options.resolveImageSrc}
@@ -258,6 +262,21 @@ function pasteImage(view: EditorView, image: File) {
   });
 
   return view.someProp("handlePaste", (handler) => handler(view, event, view.state.selection.content()));
+}
+
+function pasteHtml(view: EditorView, html: string, slice: Slice) {
+  const event = new Event("paste", {
+    bubbles: true,
+    cancelable: true
+  }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [],
+      getData: (type: string) => type === "text/html" ? html : ""
+    }
+  });
+
+  return view.someProp("handlePaste", (handler) => handler(view, event, slice));
 }
 
 function dropImage(view: EditorView, image: File) {
@@ -770,6 +789,64 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("![Screenshot](assets/pasted-image.png)");
     expect(serializeMarkdown(view.state.doc)).not.toContain("!\\[Screenshot\\]\\(assets/pasted-image.png\\)");
     await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining("![Screenshot](assets/pasted-image.png)")));
+  });
+
+  it("transfers remote images from pasted web HTML through the image save pipeline", async () => {
+    const onMarkdownChange = vi.fn();
+    const onSaveRemoteClipboardImage = vi.fn().mockResolvedValue({
+      alt: "Kitten",
+      src: "assets/kitten.png"
+    });
+    const { container, editor, view } = await renderEditor("", {
+      onMarkdownChange,
+      onSaveRemoteClipboardImage
+    });
+    const parseMarkdown = editor.action((ctx) => ctx.get(parserCtx));
+    const pastedDocument = parseMarkdown("Intro\n\n![Kitten](https://images.example.com/kitten.png)\n\nOutro");
+
+    expect(pasteHtml(
+      view,
+      '<p>Intro</p><img src="https://images.example.com/kitten.png" alt="Kitten"><p>Outro</p>',
+      new Slice(pastedDocument.content, 0, 0)
+    )).toBe(true);
+
+    await waitFor(() => {
+      expect(onSaveRemoteClipboardImage).toHaveBeenCalledWith({
+        alt: "Kitten",
+        src: "https://images.example.com/kitten.png",
+        title: ""
+      });
+    });
+    await waitFor(() => {
+      expect(container.querySelector<HTMLImageElement>('img[src="assets/kitten.png"]')).toHaveAttribute(
+        "alt",
+        "Kitten"
+      );
+    });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("![Kitten](assets/kitten.png)");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining("![Kitten](assets/kitten.png)")));
+  });
+
+  it("keeps pasted web image URLs when remote image transfer is skipped", async () => {
+    const onSaveRemoteClipboardImage = vi.fn().mockResolvedValue(null);
+    const { container, editor, view } = await renderEditor("", { onSaveRemoteClipboardImage });
+    const parseMarkdown = editor.action((ctx) => ctx.get(parserCtx));
+    const pastedDocument = parseMarkdown("![Logo](https://images.example.com/logo.png)");
+
+    expect(pasteHtml(
+      view,
+      '<img src="https://images.example.com/logo.png" alt="Logo">',
+      new Slice(pastedDocument.content, 0, 0)
+    )).toBe(true);
+
+    await waitFor(() => expect(onSaveRemoteClipboardImage).toHaveBeenCalled());
+    expect(container.querySelector<HTMLImageElement>('img[src="https://images.example.com/logo.png"]')).toHaveAttribute(
+      "alt",
+      "Logo"
+    );
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("![Logo](https://images.example.com/logo.png)");
   });
 
   it("saves dropped image files and inserts markdown image references", async () => {

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -25,7 +25,11 @@ import { Milkdown, MilkdownProvider, useEditor, useInstance } from "@milkdown/re
 import { Plugin } from "@milkdown/kit/prose/state";
 import { $prose } from "@milkdown/kit/utils";
 import { markraLiveMarkdownPlugin } from "@markra/editor";
-import { markraClipboardImagePlugin, type SaveClipboardImage } from "@markra/editor";
+import {
+  markraClipboardImagePluginWithOptions,
+  type SaveClipboardImage,
+  type SaveRemoteClipboardImage
+} from "@markra/editor";
 import { markraCodeBlockPlugin } from "@markra/editor";
 import { markraHeadingSourcePlugin } from "@markra/editor";
 import { normalizeHeadingSourceDocument } from "@markra/editor";
@@ -92,6 +96,7 @@ type MarkdownPaperProps = {
   onContentWidthResizeEnd?: () => unknown;
   onContentWidthResizeStart?: () => unknown;
   onSaveClipboardImage?: SaveClipboardImage;
+  onSaveRemoteClipboardImage?: SaveRemoteClipboardImage;
   openExternalUrl?: (url: string) => unknown;
   onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
   resolveImageSrc?: (src: string) => string;
@@ -106,6 +111,7 @@ type MilkdownSurfaceProps = {
   onEditorReady: MarkdownPaperProps["onEditorReady"];
   onMarkdownChange: (content: string) => unknown;
   onSaveClipboardImage?: MarkdownPaperProps["onSaveClipboardImage"];
+  onSaveRemoteClipboardImage?: MarkdownPaperProps["onSaveRemoteClipboardImage"];
   openExternalUrl?: MarkdownPaperProps["openExternalUrl"];
   onTextSelectionChange?: MarkdownPaperProps["onTextSelectionChange"];
   resolveImageSrc?: MarkdownPaperProps["resolveImageSrc"];
@@ -264,6 +270,7 @@ function MilkdownSurface({
   onEditorReady,
   onMarkdownChange,
   onSaveClipboardImage,
+  onSaveRemoteClipboardImage,
   openExternalUrl,
   onTextSelectionChange,
   resolveImageSrc,
@@ -271,6 +278,7 @@ function MilkdownSurface({
 }: MilkdownSurfaceProps) {
   const initialContentRef = useRef(initialContent);
   const onSaveClipboardImageRef = useRef(onSaveClipboardImage);
+  const onSaveRemoteClipboardImageRef = useRef(onSaveRemoteClipboardImage);
   const onTextSelectionChangeRef = useRef(onTextSelectionChange);
   const markdownDocumentLabel = t(language, "app.markdownDocument");
   const tableControlLabels = {
@@ -305,6 +313,10 @@ function MilkdownSurface({
   useEffect(() => {
     onSaveClipboardImageRef.current = onSaveClipboardImage;
   }, [onSaveClipboardImage]);
+
+  useEffect(() => {
+    onSaveRemoteClipboardImageRef.current = onSaveRemoteClipboardImage;
+  }, [onSaveRemoteClipboardImage]);
 
   useEffect(() => {
     onTextSelectionChangeRef.current = onTextSelectionChange;
@@ -379,9 +391,14 @@ function MilkdownSurface({
         editor.use(markraExternalLinkClickPlugin(openExternalUrl));
       }
 
-      if (onSaveClipboardImageRef.current) {
+      if (onSaveClipboardImageRef.current || onSaveRemoteClipboardImageRef.current) {
         editor.use(
-          markraClipboardImagePlugin((image) => onSaveClipboardImageRef.current?.(image) ?? Promise.resolve(null))
+          markraClipboardImagePluginWithOptions(
+            (image) => onSaveClipboardImageRef.current?.(image) ?? Promise.resolve(null),
+            {
+              saveRemoteImage: (image) => onSaveRemoteClipboardImageRef.current?.(image) ?? Promise.resolve(null)
+            }
+          )
         );
       }
 
@@ -417,6 +434,7 @@ export function MarkdownPaper({
   onContentWidthResizeEnd,
   onContentWidthResizeStart,
   onSaveClipboardImage,
+  onSaveRemoteClipboardImage,
   openExternalUrl,
   onTextSelectionChange,
   resolveImageSrc,
@@ -466,6 +484,7 @@ export function MarkdownPaper({
             onEditorReady={onEditorReady}
             onMarkdownChange={onMarkdownChange}
             onSaveClipboardImage={onSaveClipboardImage}
+            onSaveRemoteClipboardImage={onSaveRemoteClipboardImage}
             openExternalUrl={openExternalUrl}
             onTextSelectionChange={onTextSelectionChange}
             resolveImageSrc={resolveImageSrc}

--- a/apps/desktop/src/lib/image-upload.test.ts
+++ b/apps/desktop/src/lib/image-upload.test.ts
@@ -19,6 +19,14 @@ describe("save editor image", () => {
     })).toBe("My-Diagram.1700000000000.png");
   });
 
+  it("keeps SVG image extensions when creating upload file names", () => {
+    const image = new File([new Uint8Array([1, 2, 3])], "Logo.svg", { type: "image/svg+xml" });
+
+    expect(createImageUploadFileName(image, "{name}-{timestamp}", {
+      timestamp: () => "1700000000000"
+    })).toBe("Logo-1700000000000.svg");
+  });
+
   it("uses the local clipboard image folder and reports that the file tree should refresh", async () => {
     const image = new File([new Uint8Array([1, 2, 3])], "Screenshot.png", { type: "image/png" });
     const saveLocalImage = vi.fn().mockResolvedValue({

--- a/apps/desktop/src/lib/image-upload.ts
+++ b/apps/desktop/src/lib/image-upload.ts
@@ -51,6 +51,7 @@ const imageMimeExtensions: Record<string, string> = {
   "image/jpeg": "jpg",
   "image/jpg": "jpg",
   "image/png": "png",
+  "image/svg+xml": "svg",
   "image/webp": "webp"
 };
 
@@ -156,7 +157,7 @@ function imageExtensionFromFile(image: File) {
     .pop()
     ?.trim()
     .toLowerCase();
-  if (nameExtension && ["avif", "bmp", "gif", "jpg", "jpeg", "png", "webp"].includes(nameExtension)) {
+  if (nameExtension && ["avif", "bmp", "gif", "jpg", "jpeg", "png", "svg", "webp"].includes(nameExtension)) {
     return nameExtension === "jpeg" ? "jpg" : nameExtension;
   }
 

--- a/apps/desktop/src/lib/tauri/file.test.ts
+++ b/apps/desktop/src/lib/tauri/file.test.ts
@@ -8,6 +8,7 @@ import {
   createNativeMarkdownTreeFile,
   createNativeMarkdownTreeFolder,
   deleteNativeMarkdownTreeFile,
+  downloadNativeWebImage,
   installNativeMarkdownFileDrop,
   listenNativeOpenedMarkdownPaths,
   listNativeMarkdownFilesForPath,
@@ -542,6 +543,26 @@ describe("native file access", () => {
       fileName: "custom-image.png",
       folder: "assets",
       mimeType: "image/png"
+    });
+  });
+
+  it("downloads a web image through Tauri and returns a File", async () => {
+    mockedInvoke.mockResolvedValue({
+      bytes: [1, 2, 3],
+      fileName: "kitten.png",
+      mimeType: "image/png"
+    });
+
+    const image = await downloadNativeWebImage({ src: "https://images.example.com/kitten.png" });
+
+    expect(image).toBeInstanceOf(File);
+    expect(image.name).toBe("kitten.png");
+    expect(image.type).toBe("image/png");
+    await expect(image.arrayBuffer()).resolves.toEqual(new Uint8Array([1, 2, 3]).buffer);
+    expect(mockedInvoke).toHaveBeenCalledWith("download_web_image", {
+      request: {
+        url: "https://images.example.com/kitten.png"
+      }
     });
   });
 

--- a/apps/desktop/src/lib/tauri/file.ts
+++ b/apps/desktop/src/lib/tauri/file.ts
@@ -104,6 +104,10 @@ export type SaveNativeClipboardImageInput = {
   image: File;
 };
 
+export type DownloadNativeWebImageInput = {
+  src: string;
+};
+
 export type UploadNativeWebDavImageInput = {
   fileName: string;
   image: File;
@@ -152,6 +156,12 @@ type MarkdownTreeChangedPayload = {
 
 type ClipboardImageFileResponse = {
   relativePath: string;
+};
+
+type WebImageDownloadResponse = {
+  bytes: number[];
+  fileName: string;
+  mimeType: string;
 };
 
 type RemoteImageUploadResponse = {
@@ -558,6 +568,18 @@ export async function saveNativeClipboardImage({
     alt: imageAltFromFileName(image.name),
     src: encodeMarkdownRelativePath(savedImage.relativePath)
   };
+}
+
+export async function downloadNativeWebImage({ src }: DownloadNativeWebImageInput): Promise<File> {
+  const downloadedImage = await invoke<WebImageDownloadResponse>("download_web_image", {
+    request: {
+      url: src
+    }
+  });
+
+  return new File([new Uint8Array(downloadedImage.bytes)], downloadedImage.fileName, {
+    type: downloadedImage.mimeType
+  });
 }
 
 export async function uploadNativeWebDavImage({

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -6,6 +6,7 @@ import {
   confirmNativeUnsavedMarkdownDocumentDiscard,
   createNativeMarkdownTreeFile,
   deleteNativeMarkdownTreeFile,
+  downloadNativeWebImage,
   openNativeMarkdownFolder,
   openNativeMarkdownFolderInNewWindow,
   openNativeMarkdownFileInNewWindow,
@@ -80,6 +81,7 @@ vi.mock("../lib/tauri", () => ({
   confirmNativeUnsavedMarkdownDocumentDiscard: vi.fn(),
   createNativeMarkdownTreeFile: vi.fn(),
   deleteNativeMarkdownTreeFile: vi.fn(),
+  downloadNativeWebImage: vi.fn(),
   installNativeMarkdownFileDrop: vi.fn(),
   openNativeMarkdownFolder: vi.fn(),
   openNativeMarkdownFolderInNewWindow: vi.fn(),
@@ -372,6 +374,7 @@ export const mockedConfirmNativeMarkdownFileDelete = vi.mocked(confirmNativeMark
 export const mockedConfirmNativeUnsavedMarkdownDocumentDiscard = vi.mocked(confirmNativeUnsavedMarkdownDocumentDiscard);
 export const mockedCreateNativeMarkdownTreeFile = vi.mocked(createNativeMarkdownTreeFile);
 export const mockedDeleteNativeMarkdownTreeFile = vi.mocked(deleteNativeMarkdownTreeFile);
+export const mockedDownloadNativeWebImage = vi.mocked(downloadNativeWebImage);
 export const mockedOpenNativeMarkdownFileInNewWindow = vi.mocked(openNativeMarkdownFileInNewWindow);
 export const mockedOpenNativeMarkdownPath = vi.mocked(openNativeMarkdownPath);
 export const mockedListenNativeOpenedMarkdownPaths = vi.mocked(listenNativeOpenedMarkdownPaths);
@@ -571,6 +574,7 @@ export function installAppTestHarness() {
     mockedTestAiProviderConnection.mockReset();
     mockedChatCompletion.mockReset();
     mockedGenerateAiAgentSessionTitle.mockReset();
+    mockedDownloadNativeWebImage.mockReset();
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-window");
     mockedWatchNativeMarkdownFile.mockResolvedValue(() => {});
@@ -581,6 +585,9 @@ export function installAppTestHarness() {
     mockedInstallNativeApplicationMenu.mockResolvedValue(() => {});
     mockedInstallNativeEditorContextMenu.mockResolvedValue(() => {});
     mockedOpenNativeExternalUrl.mockResolvedValue(undefined);
+    mockedDownloadNativeWebImage.mockResolvedValue(new File([new Uint8Array([1, 2, 3])], "web-image.png", {
+      type: "image/png"
+    }));
     mockedCheckNativeAppUpdate.mockResolvedValue(null);
     mockedResolveDesktopPlatform.mockReturnValue("macos");
     mockedOpenSettingsWindow.mockResolvedValue(undefined);

--- a/packages/editor/src/clipboard-images.ts
+++ b/packages/editor/src/clipboard-images.ts
@@ -1,5 +1,5 @@
 import { imageSchema } from "@milkdown/kit/preset/commonmark";
-import { Fragment, type NodeType } from "@milkdown/kit/prose/model";
+import { Fragment, type Node as ProseNode, type NodeType, type Slice } from "@milkdown/kit/prose/model";
 import { Plugin, Selection, type SelectionBookmark } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
@@ -10,6 +10,27 @@ export type SavedClipboardImage = {
 };
 
 export type SaveClipboardImage = (image: File) => Promise<SavedClipboardImage | null>;
+
+export type RemoteClipboardImage = {
+  alt: string;
+  src: string;
+  title: string;
+};
+
+export type SaveRemoteClipboardImage = (image: RemoteClipboardImage) => Promise<SavedClipboardImage | null>;
+
+export type ClipboardImagePluginOptions = {
+  saveRemoteImage?: SaveRemoteClipboardImage;
+};
+
+type InsertedRange = {
+  from: number;
+  to: number;
+};
+
+type PendingRemoteImage = RemoteClipboardImage & {
+  position: number;
+};
 
 function dataTransferImageFiles(dataTransfer: DataTransfer | null | undefined) {
   const files = dataTransfer?.files as (ArrayLike<File> & { item?: (index: number) => File | null }) | undefined;
@@ -26,6 +47,10 @@ function dataTransferImageFiles(dataTransfer: DataTransfer | null | undefined) {
 
 function clipboardImageFiles(event: ClipboardEvent) {
   return dataTransferImageFiles(event.clipboardData);
+}
+
+function clipboardHtml(event: ClipboardEvent) {
+  return event.clipboardData?.getData("text/html") ?? "";
 }
 
 function droppedImageFiles(event: DragEvent) {
@@ -57,6 +82,134 @@ function createImageFragment(images: SavedClipboardImage[], image: NodeType) {
   );
 }
 
+function isRemoteImageSrc(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function remoteClipboardImageFromNode(node: ProseNode): RemoteClipboardImage | null {
+  const { alt, src, title } = node.attrs;
+  if (!isRemoteImageSrc(src)) return null;
+
+  return {
+    alt: typeof alt === "string" ? alt : "",
+    src,
+    title: typeof title === "string" ? title : ""
+  };
+}
+
+function remoteImagesInSlice(slice: Slice, image: NodeType) {
+  const remoteImages: RemoteClipboardImage[] = [];
+
+  slice.content.descendants((node) => {
+    if (node.type !== image) return;
+
+    const remoteImage = remoteClipboardImageFromNode(node);
+    if (remoteImage) remoteImages.push(remoteImage);
+  });
+
+  return remoteImages;
+}
+
+function insertedRangesFromTransactionMaps(
+  maps: readonly {
+    forEach: (callback: (oldStart: number, oldEnd: number, newStart: number, newEnd: number) => unknown) => unknown;
+  }[]
+) {
+  const ranges: InsertedRange[] = [];
+
+  for (const map of maps) {
+    map.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+      if (newEnd > newStart) ranges.push({ from: newStart, to: newEnd });
+    });
+  }
+
+  return ranges;
+}
+
+function collectInsertedRemoteImages(
+  view: EditorView,
+  ranges: InsertedRange[],
+  image: NodeType,
+  pastedImages: RemoteClipboardImage[]
+) {
+  const pastedSources = new Set(pastedImages.map((pastedImage) => pastedImage.src));
+  const pendingImages: PendingRemoteImage[] = [];
+  const seenPositions = new Set<number>();
+
+  for (const range of ranges) {
+    const from = Math.max(0, range.from);
+    const to = Math.min(view.state.doc.content.size, range.to);
+    if (to < from) continue;
+
+    view.state.doc.nodesBetween(from, to, (node, position) => {
+      if (node.type !== image || seenPositions.has(position)) return;
+
+      const remoteImage = remoteClipboardImageFromNode(node);
+      if (!remoteImage || !pastedSources.has(remoteImage.src)) return;
+
+      seenPositions.add(position);
+      pendingImages.push({
+        ...remoteImage,
+        position
+      });
+    });
+  }
+
+  return pendingImages;
+}
+
+function replaceRemoteImage(
+  view: EditorView,
+  image: NodeType,
+  pendingImage: PendingRemoteImage,
+  savedImage: SavedClipboardImage
+) {
+  const currentNode = view.state.doc.nodeAt(pendingImage.position);
+  if (!currentNode || currentNode.type !== image || currentNode.attrs.src !== pendingImage.src) return;
+
+  const transaction = view.state.tr.setNodeMarkup(pendingImage.position, undefined, {
+    ...currentNode.attrs,
+    alt: pendingImage.alt || savedImage.alt || "image",
+    src: savedImage.src,
+    title: pendingImage.title
+  });
+  view.dispatch(transaction);
+}
+
+async function saveAndReplaceRemoteImages(
+  view: EditorView,
+  pendingImages: PendingRemoteImage[],
+  saveRemoteImage: SaveRemoteClipboardImage,
+  image: NodeType
+) {
+  const savedBySource = new Map<string, Promise<SavedClipboardImage | null>>();
+
+  for (const pendingImage of pendingImages) {
+    let savedImagePromise = savedBySource.get(pendingImage.src);
+    if (!savedImagePromise) {
+      savedImagePromise = saveRemoteImage({
+        alt: pendingImage.alt,
+        src: pendingImage.src,
+        title: pendingImage.title
+      });
+      savedBySource.set(pendingImage.src, savedImagePromise);
+    }
+
+    const savedImage = await savedImagePromise.catch((error: unknown) => {
+      console.error("[markra-clipboard-images] failed to save remote pasted image", error);
+      return null;
+    });
+    if (savedImage) replaceRemoteImage(view, image, pendingImage, savedImage);
+  }
+}
+
 async function saveAndInsertClipboardImages(
   view: EditorView,
   files: File[],
@@ -84,19 +237,48 @@ async function saveAndInsertClipboardImages(
 }
 
 export function markraClipboardImagePlugin(saveClipboardImage: SaveClipboardImage) {
+  return markraClipboardImagePluginWithOptions(saveClipboardImage);
+}
+
+export function markraClipboardImagePluginWithOptions(
+  saveClipboardImage: SaveClipboardImage,
+  options: ClipboardImagePluginOptions = {}
+) {
   return $prose((ctx) => {
     const image = imageSchema.type(ctx);
 
     return new Plugin({
       props: {
-        handlePaste: (view, event) => {
+        handlePaste: (view, event, slice) => {
           const files = clipboardImageFiles(event);
-          if (!files.length) return false;
+          if (files.length) {
+            event.preventDefault();
+            saveAndInsertClipboardImages(view, files, saveClipboardImage, image).catch((error: unknown) => {
+              console.error("[markra-clipboard-images] failed to insert pasted image", error);
+            });
+            return true;
+          }
+
+          const saveRemoteImage = options.saveRemoteImage;
+          const html = clipboardHtml(event);
+          if (!saveRemoteImage || !html || !/<img[\s>]/iu.test(html)) return false;
+
+          const pastedRemoteImages = remoteImagesInSlice(slice, image);
+          if (!pastedRemoteImages.length) return false;
 
           event.preventDefault();
-          saveAndInsertClipboardImages(view, files, saveClipboardImage, image).catch((error: unknown) => {
-            console.error("[markra-clipboard-images] failed to insert pasted image", error);
-          });
+          const transaction = view.state.tr.replaceSelection(slice).scrollIntoView();
+          const insertedRanges = insertedRangesFromTransactionMaps(transaction.mapping.maps);
+          view.dispatch(transaction);
+          view.focus();
+
+          const pendingRemoteImages = collectInsertedRemoteImages(view, insertedRanges, image, pastedRemoteImages);
+          if (pendingRemoteImages.length) {
+            saveAndReplaceRemoteImages(view, pendingRemoteImages, saveRemoteImage, image).catch((error: unknown) => {
+              console.error("[markra-clipboard-images] failed to replace remote pasted images", error);
+            });
+          }
+
           return true;
         },
         handleDrop: (view, event) => {


### PR DESCRIPTION
## Summary
- Transfer remote images found in pasted web HTML through the existing image save pipeline.
- Reuse the current image upload settings, so pasted web images can land in local assets, WebDAV, or S3.
- Add a native web image download command with HTTP(S), private-network, content type, redirect, and size guards.
- Add SVG handling for downloaded/pasted image assets.

## Validation
- `pnpm --filter @markra/desktop test` passed: 37 files / 520 tests.
- `pnpm --filter @markra/desktop build` passed; Vite still emitted existing chunk-size and node:fs externalization warnings.
- `pnpm --filter @markra/editor build` passed.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` passed: 69 tests.

## Risk
- Some remote images can still fail to transfer when the source requires cookies, blocks server-side downloads, or exceeds the download size limit; in those cases the original web image URL is preserved.