### PR TITLE
fix(release): avoid caching cargo shims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.DESKTOP_DIR }}/src-tauri -> target
+          cache-bin: false
 
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
## Summary
- Disable `swatinem/rust-cache` binary caching in the release workflow.
- Prevent restored `~/.cargo/bin` contents from overwriting the Rust toolchain `cargo` shim installed earlier in the job.

## Why
- The v0.1.3 release run failed in `Build macOS (Apple Silicon)` during `tauri build` because `cargo metadata` invoked `rustup-init` instead of Cargo.
- The release job log shows Rust cache restore included cargo binaries before the build step.

## Validation
- Inspected failed job log: https://github.com/murongg/markra/actions/runs/25841615688/job/75927946258
- `git diff --check` passed.
- Verified `.github/workflows/release.yml` contains `cache-bin: false`.

## Follow-up
- After this lands on `main`, rerun the Release workflow for `v0.1.3` with `workflow_dispatch` so it uses the fixed workflow while building the existing tag.