### PR TITLE
feat(editor): add block drag sorting

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -293,6 +293,213 @@ function dropImage(view: EditorView, image: File) {
   return view.someProp("handleDrop", (handler) => handler(view, event, view.state.selection.content(), false));
 }
 
+function createDragDataTransfer() {
+  const data = new Map<string, string>();
+
+  return {
+    clearData: () => data.clear(),
+    dropEffect: "move",
+    effectAllowed: "copyMove",
+    getData: (type: string) => data.get(type) ?? "",
+    setData: (type: string, value: string) => data.set(type, value),
+    setDragImage: vi.fn()
+  } as unknown as DataTransfer;
+}
+
+function dispatchDragEvent(
+  target: Element,
+  type: string,
+  options: { clientX: number; clientY: number; dataTransfer: DataTransfer }
+) {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true
+  }) as DragEvent;
+
+  Object.defineProperty(event, "clientX", { value: options.clientX });
+  Object.defineProperty(event, "clientY", { value: options.clientY });
+  Object.defineProperty(event, "dataTransfer", { value: options.dataTransfer });
+  target.dispatchEvent(event);
+
+  return event;
+}
+
+function topLevelBlockPositions(view: EditorView) {
+  const positions: number[] = [];
+
+  view.state.doc.forEach((_node, offset) => {
+    positions.push(offset);
+  });
+
+  return positions;
+}
+
+function nodePositionsByType(view: EditorView, typeName: string) {
+  const positions: number[] = [];
+
+  view.state.doc.descendants((node, position) => {
+    if (node.type.name === typeName) positions.push(position);
+  });
+
+  return positions;
+}
+
+function positionWithAncestorExcluding(view: EditorView, typeName: string, excludedTypeName: string) {
+  for (let position = 0; position <= view.state.doc.content.size; position += 1) {
+    const $position = view.state.doc.resolve(position);
+    let hasType = false;
+    let hasExcludedType = false;
+
+    for (let depth = $position.depth; depth > 0; depth -= 1) {
+      const nodeTypeName = $position.node(depth).type.name;
+      if (nodeTypeName === typeName) hasType = true;
+      if (nodeTypeName === excludedTypeName) hasExcludedType = true;
+    }
+
+    if (hasType && !hasExcludedType) return position;
+  }
+
+  return null;
+}
+
+function mockBlockDragLayout(view: EditorView, blocks: HTMLElement[], positions: number[]) {
+  const blockRects = blocks.map((_block, index) => {
+    const top = 100 + index * 40;
+    return {
+      bottom: top + 28,
+      height: 28,
+      left: 160,
+      right: 640,
+      top,
+      width: 480,
+      x: 160,
+      y: top,
+      toJSON: () => ({})
+    } as DOMRect;
+  });
+  const originalPosAtCoords = view.posAtCoords.bind(view);
+
+  for (const [index, block] of blocks.entries()) {
+    block.getBoundingClientRect = vi.fn(() => blockRects[index]);
+  }
+
+  view.dom.getBoundingClientRect = vi.fn(() => ({
+    bottom: 260,
+    height: 180,
+    left: 160,
+    right: 640,
+    top: 90,
+    width: 480,
+    x: 160,
+    y: 90,
+    toJSON: () => ({})
+  } as DOMRect));
+
+  Object.defineProperty(view, "posAtCoords", {
+    configurable: true,
+    value: ({ left, top }: { left: number; top: number }) => {
+      if (left < 160 || left > 640) return null;
+
+      const index = blockRects.findIndex((rect) => top >= rect.top && top <= rect.bottom);
+      let blockIndex = index;
+
+      if (blockIndex === -1) {
+        blockIndex = 0;
+        for (const [rectIndex, rect] of blockRects.entries()) {
+          if (top > rect.bottom) blockIndex = rectIndex;
+        }
+      }
+
+      const normalizedIndex = Math.max(0, Math.min(positions.length - 1, blockIndex));
+      const position = positions[normalizedIndex];
+
+      return { inside: position, pos: position + 1 };
+    }
+  });
+
+  return () => {
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: originalPosAtCoords
+    });
+  };
+}
+
+function mockTopLevelBlockDragLayout(view: EditorView, container: HTMLElement) {
+  return mockBlockDragLayout(
+    view,
+    Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > *")),
+    topLevelBlockPositions(view)
+  );
+}
+
+function mockListItemBlockDragLayout(view: EditorView, container: HTMLElement) {
+  return mockBlockDragLayout(
+    view,
+    Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror li")),
+    nodePositionsByType(view, "list_item")
+  );
+}
+
+function mockTopLevelBlockDragLayoutByCurrentDomOrder(view: EditorView, container: HTMLElement) {
+  const surface = container.querySelector<HTMLElement>(".ProseMirror");
+  if (!surface) throw new Error("Could not find editor surface.");
+
+  const blocks = Array.from(surface.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
+  const positions = topLevelBlockPositions(view);
+  const originalPosAtCoords = view.posAtCoords.bind(view);
+
+  const rectForIndex = (index: number) => {
+    const top = 100 + index * 40;
+    return {
+      bottom: top + 28,
+      height: 28,
+      left: 160,
+      right: 640,
+      top,
+      width: 480,
+      x: 160,
+      y: top,
+      toJSON: () => ({})
+    } as DOMRect;
+  };
+
+  for (const block of blocks) {
+    block.getBoundingClientRect = vi.fn(() => rectForIndex(Array.from(surface.children).indexOf(block)));
+  }
+
+  view.dom.getBoundingClientRect = vi.fn(() => ({
+    bottom: 260,
+    height: 180,
+    left: 160,
+    right: 640,
+    top: 90,
+    width: 480,
+    x: 160,
+    y: 90,
+    toJSON: () => ({})
+  } as DOMRect));
+
+  Object.defineProperty(view, "posAtCoords", {
+    configurable: true,
+    value: ({ left, top }: { left: number; top: number }) => {
+      if (left < 160 || left > 640) return null;
+
+      const blockIndex = Math.max(0, Math.min(positions.length - 1, Math.floor((top - 100) / 40)));
+      const position = positions[blockIndex];
+
+      return { inside: position, pos: position + 1 };
+    }
+  });
+
+  return () => {
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: originalPosAtCoords
+    });
+  };
+}
+
 function expectLiveMark(container: HTMLElement, kind: string, text: string) {
   expect(container.querySelector(`.ProseMirror .markra-live-mark-${kind}`)).toHaveTextContent(text);
 }
@@ -868,6 +1075,715 @@ describe("MarkdownPaper editing", () => {
     });
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain("![Diagram](https://cdn.example.com/notes/diagram.png)");
+  });
+
+  it("reorders top-level blocks from the hover drag handle", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const editorRoot = surface?.parentElement;
+    expect(surface).toBeInTheDocument();
+    expect(editorRoot).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+    const dataTransfer = createDragDataTransfer();
+
+    dispatchDragEvent(handle, "dragstart", {
+      clientX: 136,
+      clientY: 112,
+      dataTransfer
+    });
+    dispatchDragEvent(editorRoot!, "dragover", {
+      clientX: 136,
+      clientY: 160,
+      dataTransfer
+    });
+    dispatchDragEvent(editorRoot!, "drop", {
+      clientX: 136,
+      clientY: 160,
+      dataTransfer
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
+    expect(view.state.selection).not.toBeInstanceOf(NodeSelection);
+    expect(container.querySelector(".ProseMirror-selectednode")).not.toBeInTheDocument();
+    restoreLayout();
+  });
+
+  it("reveals the block drag handle from the editor gutter and reorders blocks there", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    fireEvent.pointerMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+    const dataTransfer = createDragDataTransfer();
+
+    dispatchDragEvent(handle, "dragstart", {
+      clientX: 136,
+      clientY: 112,
+      dataTransfer
+    });
+    dispatchDragEvent(paper!, "dragover", {
+      clientX: 136,
+      clientY: 160,
+      dataTransfer
+    });
+    dispatchDragEvent(paper!, "drop", {
+      clientX: 136,
+      clientY: 160,
+      dataTransfer
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
+    restoreLayout();
+  });
+
+  it("reorders blocks with pointer dragging from the gutter handle", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    fireEvent.pointerMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112,
+      pointerId: 7
+    });
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 160,
+      pointerId: 7
+    });
+    fireEvent.pointerUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 160,
+      pointerId: 7
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
+    restoreLayout();
+  });
+
+  it("reorders blocks with mouse dragging from the gutter handle", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    fireEvent.mouseMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+    expect(handle.closest(".markra-block-toolbar")).toHaveAttribute("data-show", "true");
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 160
+    });
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 160
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
+    restoreLayout();
+  });
+
+  it("shows a lightweight drag ghost while dragging a block", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    fireEvent.mouseMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 160
+    });
+
+    const ghost = paper!.querySelector<HTMLElement>(".markra-block-drag-ghost");
+    expect(ghost).toBeInTheDocument();
+    expect(ghost).toHaveAttribute("data-show", "true");
+    expect(ghost).toHaveTextContent("First");
+    expect(ghost?.style.left).toBe("0px");
+    expect(ghost?.style.top).toBe("0px");
+    expect(ghost?.style.transform).toBe("translate(148px, 170px)");
+
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 160
+    });
+
+    expect(ghost).toHaveAttribute("data-show", "false");
+    restoreLayout();
+  });
+
+  it("keeps the drop indicator close to the content width", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    const secondBlock = surface?.children.item(1) as HTMLElement | null;
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+    expect(secondBlock).toBeInstanceOf(HTMLElement);
+
+    secondBlock!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 168,
+          height: 28,
+          left: 160,
+          right: 1160,
+          top: 140,
+          width: 1000,
+          x: 160,
+          y: 140,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+
+    fireEvent.mouseMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 160
+    });
+
+    const indicator = paper!.querySelector<HTMLElement>(".markra-block-drop-indicator");
+    expect(indicator).toHaveAttribute("data-show", "true");
+    expect(indicator?.style.left).toBe("162px");
+    expect(indicator?.style.width).toBe("640px");
+
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 160
+    });
+    restoreLayout();
+  });
+
+  it("scrolls the editor edge while dragging a block near the viewport boundary", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    const paperScroll = surface?.closest<HTMLElement>(".paper-scroll");
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+    expect(paperScroll).toBeInTheDocument();
+
+    paperScroll!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 200,
+          height: 200,
+          left: 0,
+          right: 900,
+          top: 0,
+          width: 900,
+          x: 0,
+          y: 0,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+    const scrollBy = vi.fn();
+    paperScroll!.scrollBy = scrollBy;
+
+    fireEvent.mouseMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 188
+    });
+
+    const scrollOptions = scrollBy.mock.calls[0]?.[0] as ScrollToOptions | undefined;
+    expect(scrollOptions?.top).toBeGreaterThan(0);
+
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 188
+    });
+    restoreLayout();
+  });
+
+  it("prevents native text selection while dragging a block", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    const firstText = surface?.querySelector("p")?.firstChild;
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+    expect(firstText).toBeInstanceOf(Text);
+
+    const selection = window.getSelection();
+    const selectionRange = document.createRange();
+    selectionRange.selectNodeContents(firstText!);
+    selection?.removeAllRanges();
+    selection?.addRange(selectionRange);
+    expect(selection?.toString()).toBe("First");
+
+    fireEvent.mouseMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 160
+    });
+
+    expect(document.documentElement).toHaveAttribute("data-markra-block-dragging", "true");
+    expect(paper).toHaveAttribute("data-block-dragging", "true");
+    expect(selection?.toString()).toBe("");
+
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 160
+    });
+
+    expect(document.documentElement).not.toHaveAttribute("data-markra-block-dragging");
+    expect(paper).not.toHaveAttribute("data-block-dragging");
+    restoreLayout();
+  });
+
+  it("animates blocks into their reordered positions", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayoutByCurrentDomOrder(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    const originalAnimate = HTMLElement.prototype.animate;
+    const animate = vi.fn(() => ({
+      addEventListener: vi.fn(),
+      finished: Promise.resolve()
+    } as unknown as Animation));
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      value: animate
+    });
+
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    fireEvent.mouseMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 160
+    });
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 160
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
+    expect(animate).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ transform: expect.stringContaining("translate") }),
+        { transform: "translate(0, 0)" }
+      ],
+      expect.objectContaining({
+        duration: expect.any(Number),
+        easing: expect.stringContaining("cubic-bezier")
+      })
+    );
+
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      value: originalAnimate
+    });
+    restoreLayout();
+  });
+
+  it("reorders list items from the hover drag handle", async () => {
+    const { container, editor, view } = await renderEditor("- First\n- Second\n- Third");
+    const restoreLayout = mockListItemBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+    const dataTransfer = createDragDataTransfer();
+
+    dispatchDragEvent(handle, "dragstart", {
+      clientX: 136,
+      clientY: 112,
+      dataTransfer
+    });
+    dispatchDragEvent(surface!, "dragover", {
+      clientX: 170,
+      clientY: 160,
+      dataTransfer
+    });
+    dispatchDragEvent(surface!, "drop", {
+      clientX: 170,
+      clientY: 160,
+      dataTransfer
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("* Second\n\n* First\n\n* Third\n");
+    restoreLayout();
+  });
+
+  it("does not show a separate drag handle for the whole list container", async () => {
+    const { container, view } = await renderEditor("- First\n- Second\n- Third");
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const originalPosAtCoords = view.posAtCoords.bind(view);
+    const listContainerPosition = positionWithAncestorExcluding(view, "bullet_list", "list_item");
+    expect(surface).toBeInTheDocument();
+    expect(listContainerPosition).not.toBeNull();
+
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: () => ({ inside: listContainerPosition, pos: listContainerPosition })
+    });
+
+    fireEvent.mouseMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    expect(container.querySelector(".markra-block-toolbar")).toHaveAttribute("data-show", "false");
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: originalPosAtCoords
+    });
+  });
+
+  it("keeps the list block toolbar anchored while hovering its drag handle", async () => {
+    const { container, view } = await renderEditor("- First\n- Second\n- Third");
+    const restoreLayout = mockListItemBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.mouseMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+    const toolbar = handle.closest<HTMLElement>(".markra-block-toolbar");
+    expect(toolbar).toBeInTheDocument();
+    const anchoredTop = toolbar!.style.top;
+
+    fireEvent.mouseMove(handle, {
+      clientX: 136,
+      clientY: 160
+    });
+
+    expect(toolbar!.style.top).toBe(anchoredTop);
+    restoreLayout();
+  });
+
+  it("moves a list item outside its list near another top-level block", async () => {
+    const { container, editor, view } = await renderEditor("Intro\n\n- First\n- Second\n\nOutro");
+    const paragraphs = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > p"));
+    const listItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror li"));
+    const topLevelPositions = topLevelBlockPositions(view);
+    const listItemPositions = nodePositionsByType(view, "list_item");
+    const restoreLayout = mockBlockDragLayout(view, [listItems[0], listItems[1], paragraphs[1]], [
+      listItemPositions[0],
+      listItemPositions[1],
+      topLevelPositions[2]
+    ]);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.mouseMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 152
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 240,
+      clientY: 200
+    });
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 240,
+      clientY: 200
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("Intro\n\n* First\n\nOutro\n\n* Second\n");
+    restoreLayout();
+  });
+
+  it("moves a paragraph into a list as a list item", async () => {
+    const { container, editor, view } = await renderEditor("Intro\n\n- First\n- Second");
+    const intro = container.querySelector<HTMLElement>(".ProseMirror > p");
+    const listItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror li"));
+    const restoreLayout = mockBlockDragLayout(view, [intro!, listItems[0], listItems[1]], [
+      topLevelBlockPositions(view)[0],
+      ...nodePositionsByType(view, "list_item")
+    ]);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+    expect(intro).toBeInTheDocument();
+
+    fireEvent.mouseMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 170,
+      clientY: 160
+    });
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 170,
+      clientY: 160
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n* Intro\n\n* Second\n");
+    restoreLayout();
+  });
+
+  it("nests a paragraph when dragged rightward into a list", async () => {
+    const { container, editor, view } = await renderEditor("Intro\n\n- First\n- Second");
+    const intro = container.querySelector<HTMLElement>(".ProseMirror > p");
+    const listItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror li"));
+    const restoreLayout = mockBlockDragLayout(view, [intro!, listItems[0], listItems[1]], [
+      topLevelBlockPositions(view)[0],
+      ...nodePositionsByType(view, "list_item")
+    ]);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+    expect(intro).toBeInTheDocument();
+
+    fireEvent.mouseMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 112
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 240,
+      clientY: 160
+    });
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 240,
+      clientY: 160
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n  * Intro\n\n* Second\n");
+    restoreLayout();
+  });
+
+  it("nests a list item when dragged with a rightward offset", async () => {
+    const { container, editor, view } = await renderEditor("- First\n- Second\n- Third");
+    const restoreLayout = mockListItemBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.mouseMove(surface!, {
+      clientX: 240,
+      clientY: 192
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+
+    fireEvent.mouseDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 192
+    });
+    fireEvent.mouseMove(document, {
+      buttons: 1,
+      clientX: 220,
+      clientY: 112
+    });
+    fireEvent.mouseUp(document, {
+      button: 0,
+      clientX: 220,
+      clientY: 112
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n  * Third\n\n* Second\n");
+    restoreLayout();
+  });
+
+  it("adds a paragraph below the hovered block from the side toolbar", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+    typeText(view, "Inserted");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("First\n\nSecond\n\nInserted\n\nThird\n");
+    restoreLayout();
+  });
+
+  it("adds a list item below the hovered list item from the side toolbar", async () => {
+    const { container, editor, view } = await renderEditor("- First\n- Second");
+    const restoreLayout = mockListItemBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+    typeText(view, "Inserted");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n* Inserted\n\n* Second\n");
+    restoreLayout();
   });
 
   it("adds table rows and columns from the hover controls", async () => {

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -45,6 +45,7 @@ import { markraMathSourcePlugin } from "@markra/editor";
 import { markraTableControlsPlugin } from "@markra/editor";
 import { markraAiEditorPreviewPlugin } from "@markra/editor";
 import { markraAiSelectionHoldPlugin } from "@markra/editor";
+import { markraBlockDragPlugin } from "@markra/editor";
 import type { MarkdownShortcutMap } from "@markra/editor";
 import type { SlashCommandLabels } from "@markra/editor";
 import type { AiSelectionContext } from "@markra/ai";
@@ -294,6 +295,10 @@ function MilkdownSurface({
     tableColumns: t(language, "editor.table.columns"),
     tableRows: t(language, "editor.table.rows")
   };
+  const blockDragLabels = {
+    addBlock: t(language, "editor.blockAdd"),
+    dragBlock: t(language, "editor.blockDrag")
+  };
   const slashCommandLabels = useMemo<SlashCommandLabels>(() => ({
     menu: t(language, "editor.slashCommands"),
     noResults: t(language, "editor.slashCommandsNoResults"),
@@ -370,6 +375,7 @@ function MilkdownSurface({
         .use(markraMathPlugin)
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)
+        .use(markraBlockDragPlugin(blockDragLabels))
         .use(
           markraTextSelectionObserverPlugin((selection) => {
             onTextSelectionChangeRef.current?.(selection);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -308,6 +308,123 @@
     @apply outline-none;
   }
 
+  .markdown-paper .markra-block-toolbar {
+    @apply fixed z-50 flex h-6 items-center gap-0 rounded-md border border-transparent bg-transparent p-0 text-(--text-secondary) outline-none transition-[opacity,color,background-color,border-color,box-shadow] duration-150 ease-out;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+  }
+
+  .markdown-paper .markra-block-toolbar[data-show="true"] {
+    opacity: 0.58;
+    pointer-events: auto;
+  }
+
+  .markdown-paper .markra-block-toolbar:hover,
+  .markdown-paper .markra-block-toolbar:focus-within,
+  .markdown-paper .markra-block-toolbar[data-dragging="true"] {
+    @apply bg-(--bg-hover) text-(--text-heading);
+    opacity: 1;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+  }
+
+  .markdown-paper .markra-block-tool-button {
+    @apply grid h-5 w-5 cursor-pointer place-content-center rounded-sm border-0 bg-transparent p-0 text-(--text-secondary) outline-none transition-[color,background-color] duration-150 ease-out hover:bg-(--bg-active) hover:text-(--text-heading) focus-visible:bg-(--bg-active) focus-visible:text-(--text-heading);
+  }
+
+  .markdown-paper .markra-block-add-button {
+    @apply relative;
+  }
+
+  .markdown-paper .markra-block-add-button::before,
+  .markdown-paper .markra-block-add-button::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 8px;
+    height: 1.25px;
+    border-radius: 999px;
+    background: currentColor;
+    transform: translate(-50%, -50%);
+  }
+
+  .markdown-paper .markra-block-add-button::after {
+    transform: translate(-50%, -50%) rotate(90deg);
+  }
+
+  .markdown-paper .markra-block-drag-handle {
+    @apply cursor-grab;
+    grid-template-columns: repeat(2, 2.5px);
+    column-gap: 4px;
+    row-gap: 3px;
+  }
+
+  .markdown-paper .markra-block-drag-handle[data-dragging="true"] {
+    @apply cursor-grabbing;
+  }
+
+  .markdown-paper .markra-block-drag-dot {
+    @apply block rounded-full bg-current;
+    width: 2.5px;
+    height: 2.5px;
+    opacity: 0.78;
+  }
+
+  .markdown-paper .markra-block-drag-source {
+    opacity: 0.42;
+    transition: opacity 120ms ease-out;
+  }
+
+  .markdown-paper .markra-block-drop-indicator {
+    @apply fixed z-40 h-0.5 rounded-full bg-(--accent);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-50%) scaleX(0.98);
+    transform-origin: center;
+    transition:
+      opacity 120ms ease-out,
+      transform 120ms ease-out;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
+  .markdown-paper .markra-block-drop-indicator[data-show="true"] {
+    opacity: 1;
+    transform: translateY(-50%) scaleX(1);
+  }
+
+  .markdown-paper .markra-block-drag-ghost {
+    @apply fixed z-50 max-w-80 truncate rounded-sm border border-(--border-default) bg-(--bg-primary) px-2 py-1 text-sm leading-5 text-(--text-heading);
+    left: 0;
+    opacity: 0;
+    pointer-events: none;
+    top: 0;
+    transform: translate(-9999px, -9999px);
+    transition: opacity 90ms ease-out;
+    white-space: nowrap;
+    box-shadow:
+      0 10px 24px rgba(15, 23, 42, 0.12),
+      0 1px 3px rgba(15, 23, 42, 0.1);
+    will-change: transform;
+  }
+
+  .markdown-paper .markra-block-drag-ghost[data-show="true"] {
+    opacity: 0.94;
+  }
+
+  .markdown-paper .ProseMirror[data-dragging="true"] {
+    cursor: grabbing;
+  }
+
+  html[data-markra-block-dragging="true"],
+  html[data-markra-block-dragging="true"] body,
+  .markdown-paper[data-block-dragging="true"],
+  .markdown-paper[data-block-dragging="true"] * {
+    cursor: grabbing;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   .markdown-source-highlight code {
     font-family: inherit;
   }

--- a/packages/editor/src/block-drag.ts
+++ b/packages/editor/src/block-drag.ts
@@ -1,0 +1,1042 @@
+import type { Node as ProseNode, ResolvedPos } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+export type BlockDragLabels = {
+  addBlock: string;
+  dragBlock: string;
+};
+
+type BlockDragRange = {
+  depth: number;
+  node: ProseNode;
+  parentStart: number;
+  parentTypeName: string;
+  pos: number;
+};
+
+type BlockDropTarget = {
+  placement: "nested" | "sibling";
+  range: BlockDragRange;
+  side: "before" | "after";
+};
+
+type PointerDragState = {
+  pointerId: number;
+  range: BlockDragRange;
+  startLeft: number;
+  startTop: number;
+};
+
+type MouseDragState = {
+  range: BlockDragRange;
+  startLeft: number;
+  startTop: number;
+};
+
+const blockDragKey = new PluginKey("markra-block-drag");
+const markraBlockDragMime = "application/x-markra-block";
+const movableNodeNames = new Set([
+  "blockquote",
+  "code_block",
+  "heading",
+  "horizontal_rule",
+  "list_item",
+  "paragraph"
+]);
+const listNodeNames = new Set(["bullet_list", "ordered_list"]);
+const priorityNodeNames = ["list_item", "blockquote"];
+const tableNodeNames = new Set(["table", "table_cell", "table_header", "table_row"]);
+
+const defaultBlockDragLabels: BlockDragLabels = {
+  addBlock: "Add block below",
+  dragBlock: "Drag block"
+};
+const blockMoveAnimation = {
+  duration: 180,
+  easing: "cubic-bezier(0.16, 1, 0.3, 1)"
+};
+const dragGhostOffset = {
+  left: 12,
+  top: 10
+};
+const dragGhostTextLimit = 96;
+const dropIndicatorInset = 2;
+const dropIndicatorMaxWidth = 640;
+const edgeScrollMaxStep = 28;
+const edgeScrollThreshold = 72;
+const listNestOffset = 36;
+
+function normalizeBlockDragLabels(labels: Partial<BlockDragLabels> | undefined): BlockDragLabels {
+  return {
+    ...defaultBlockDragLabels,
+    ...labels
+  };
+}
+
+function clampedDocumentPosition(state: EditorState, position: number) {
+  return Math.max(0, Math.min(position, state.doc.content.size));
+}
+
+function hasTableAncestor($pos: ResolvedPos) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    if (tableNodeNames.has($pos.node(depth).type.name)) return true;
+  }
+
+  return false;
+}
+
+function blockRangeAtDepth($pos: ResolvedPos, depth: number): BlockDragRange {
+  const parentDepth = depth - 1;
+  const parent = $pos.node(parentDepth);
+
+  return {
+    depth,
+    node: $pos.node(depth),
+    parentStart: parentDepth === 0 ? 0 : $pos.before(parentDepth),
+    parentTypeName: parent.type.name,
+    pos: $pos.before(depth)
+  };
+}
+
+function findAncestorRangeByName($pos: ResolvedPos, nodeName: string) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (node.type.name === nodeName) return blockRangeAtDepth($pos, depth);
+  }
+
+  return null;
+}
+
+function findMovableBlockAtPosition(state: EditorState, position: number): BlockDragRange | null {
+  const $pos = state.doc.resolve(clampedDocumentPosition(state, position));
+  if (hasTableAncestor($pos)) return null;
+
+  for (const nodeName of priorityNodeNames) {
+    const priorityRange = findAncestorRangeByName($pos, nodeName);
+    if (priorityRange) return priorityRange;
+  }
+
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (!movableNodeNames.has(node.type.name)) continue;
+
+    return blockRangeAtDepth($pos, depth);
+  }
+
+  return null;
+}
+
+function sameParentBlock(source: BlockDragRange, target: BlockDragRange) {
+  return source.parentStart === target.parentStart && source.parentTypeName === target.parentTypeName;
+}
+
+function isListItem(range: BlockDragRange) {
+  return range.node.type.name === "list_item";
+}
+
+function parentNodeForRange(state: EditorState, range: BlockDragRange) {
+  return range.parentTypeName === "doc" ? state.doc : state.doc.nodeAt(range.parentStart);
+}
+
+function listItemFromBlock(source: BlockDragRange, target: BlockDropTarget) {
+  if (isListItem(source)) return source.node;
+
+  return target.range.node.type.createAndFill(null, source.node);
+}
+
+function dropBoundary(target: BlockDropTarget) {
+  return target.side === "before" ? target.range.pos : target.range.pos + target.range.node.nodeSize;
+}
+
+function targetInsideSource(source: BlockDragRange, target: BlockDropTarget) {
+  const sourceEnd = source.pos + source.node.nodeSize;
+  return target.range.pos >= source.pos && target.range.pos < sourceEnd;
+}
+
+function canMoveListItem(state: EditorState, source: BlockDragRange, target: BlockDropTarget) {
+  if (targetInsideSource(source, target)) return false;
+  if (target.placement === "nested") return isListItem(target.range);
+
+  const sourceParent = parentNodeForRange(state, source);
+  if (!sourceParent || !listNodeNames.has(sourceParent.type.name)) return false;
+  if (isListItem(target.range)) return true;
+
+  return true;
+}
+
+function canMoveBlockIntoList(state: EditorState, source: BlockDragRange, target: BlockDropTarget) {
+  if (targetInsideSource(source, target)) return false;
+  if (!isListItem(target.range)) return false;
+
+  const targetParent = parentNodeForRange(state, target.range);
+  if (!targetParent || !listNodeNames.has(targetParent.type.name)) return false;
+
+  return listItemFromBlock(source, target) !== null;
+}
+
+function canMoveBlock(state: EditorState, source: BlockDragRange, target: BlockDropTarget) {
+  if (isListItem(source)) return canMoveListItem(state, source, target);
+  if (canMoveBlockIntoList(state, source, target)) return true;
+
+  if (!sameParentBlock(source, target.range)) return false;
+  if (targetInsideSource(source, target)) return false;
+
+  const sourceEnd = source.pos + source.node.nodeSize;
+  const boundary = dropBoundary(target);
+  return boundary < source.pos || boundary > sourceEnd;
+}
+
+function siblingBlockElements(view: EditorView, range: BlockDragRange) {
+  const element = targetFromEventTarget(view.nodeDOM(range.pos));
+  const parent = element?.parentElement;
+  if (!parent) return [];
+
+  return Array.from(parent.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
+}
+
+function snapshotBlockRects(elements: HTMLElement[]) {
+  const rects = new Map<HTMLElement, DOMRect>();
+  for (const element of elements) {
+    rects.set(element, element.getBoundingClientRect());
+  }
+
+  return rects;
+}
+
+function animateBlockMoves(elements: HTMLElement[], beforeRects: Map<HTMLElement, DOMRect>) {
+  for (const element of elements) {
+    const before = beforeRects.get(element);
+    if (!before || typeof element.animate !== "function") continue;
+
+    const after = element.getBoundingClientRect();
+    const deltaX = before.left - after.left;
+    const deltaY = before.top - after.top;
+    if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) continue;
+
+    const animation = element.animate(
+      [
+        { transform: `translate(${Math.round(deltaX)}px, ${Math.round(deltaY)}px)` },
+        { transform: "translate(0, 0)" }
+      ],
+      blockMoveAnimation
+    );
+    animation.finished?.catch(() => {});
+  }
+}
+
+function listItemDeleteRange(state: EditorState, source: BlockDragRange, target: BlockDropTarget) {
+  const sourceParent = parentNodeForRange(state, source);
+  if (
+    sourceParent &&
+    listNodeNames.has(sourceParent.type.name) &&
+    sourceParent.childCount === 1 &&
+    !sameParentBlock(source, target.range)
+  ) {
+    return {
+      from: source.parentStart,
+      to: source.parentStart + sourceParent.nodeSize
+    };
+  }
+
+  return {
+    from: source.pos,
+    to: source.pos + source.node.nodeSize
+  };
+}
+
+function dispatchBlockMove(
+  view: EditorView,
+  source: BlockDragRange,
+  target: BlockDropTarget,
+  insertPos: number,
+  insertNode: ProseNode
+) {
+  const currentNode = view.state.doc.nodeAt(source.pos);
+  if (!currentNode || !currentNode.eq(source.node)) return false;
+
+  const animatedElements = siblingBlockElements(view, source);
+  const beforeRects = snapshotBlockRects(animatedElements);
+  const deleteRange = isListItem(source)
+    ? listItemDeleteRange(view.state, source, target)
+    : { from: source.pos, to: source.pos + source.node.nodeSize };
+  const insertAssoc = insertPos > deleteRange.from ? -1 : 1;
+
+  try {
+    const tr = view.state.tr.delete(deleteRange.from, deleteRange.to);
+    const mappedInsertPos = tr.mapping.map(insertPos, insertAssoc);
+    tr.insert(mappedInsertPos, insertNode);
+    const selectionPosition = Math.min(mappedInsertPos + 1, tr.doc.content.size);
+    const selection = TextSelection.near(tr.doc.resolve(selectionPosition), 1);
+
+    view.dispatch(tr.setSelection(selection).scrollIntoView());
+    animateBlockMoves(animatedElements, beforeRects);
+    view.focus();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function moveListItemAsSibling(view: EditorView, source: BlockDragRange, target: BlockDropTarget) {
+  return dispatchBlockMove(view, source, target, dropBoundary(target), source.node);
+}
+
+function moveListItemOutsideList(view: EditorView, source: BlockDragRange, target: BlockDropTarget) {
+  const sourceParent = parentNodeForRange(view.state, source);
+  if (!sourceParent || !listNodeNames.has(sourceParent.type.name)) return false;
+
+  const wrapperList = sourceParent.type.create(sourceParent.attrs, source.node);
+  return dispatchBlockMove(view, source, target, dropBoundary(target), wrapperList);
+}
+
+function findNestedListInTarget(
+  target: BlockDropTarget,
+  listType: ProseNode["type"]
+): { node: ProseNode; pos: number } | null {
+  let existingList: { node: ProseNode; pos: number } | null = null;
+
+  target.range.node.forEach((child, offset) => {
+    if (existingList || child.type !== listType) return;
+    existingList = {
+      node: child,
+      pos: target.range.pos + 1 + offset
+    };
+  });
+
+  return existingList;
+}
+
+function nestedListInsertion(listItem: ProseNode, listType: ProseNode["type"], target: BlockDropTarget) {
+  if (!listNodeNames.has(listType.name)) return null;
+
+  const existingList = findNestedListInTarget(target, listType);
+
+  if (existingList) {
+    return {
+      insertNode: listItem,
+      insertPos: existingList.pos + existingList.node.nodeSize - 1
+    };
+  }
+
+  return {
+    insertNode: listType.create(null, listItem),
+    insertPos: target.range.pos + target.range.node.nodeSize - 1
+  };
+}
+
+function moveListItemNested(view: EditorView, source: BlockDragRange, target: BlockDropTarget) {
+  const sourceParent = parentNodeForRange(view.state, source);
+  if (!sourceParent || !listNodeNames.has(sourceParent.type.name)) return false;
+
+  const insertion = nestedListInsertion(source.node, sourceParent.type, target);
+  if (!insertion) return false;
+
+  return dispatchBlockMove(view, source, target, insertion.insertPos, insertion.insertNode);
+}
+
+function moveListItem(view: EditorView, source: BlockDragRange, target: BlockDropTarget) {
+  if (target.placement === "nested") return moveListItemNested(view, source, target);
+  if (isListItem(target.range)) return moveListItemAsSibling(view, source, target);
+
+  return moveListItemOutsideList(view, source, target);
+}
+
+function moveBlockIntoList(view: EditorView, source: BlockDragRange, target: BlockDropTarget) {
+  const listItem = listItemFromBlock(source, target);
+  const targetParent = parentNodeForRange(view.state, target.range);
+  if (!listItem || !targetParent || !listNodeNames.has(targetParent.type.name)) return false;
+
+  if (target.placement === "nested") {
+    const insertion = nestedListInsertion(listItem, targetParent.type, target);
+    if (!insertion) return false;
+
+    return dispatchBlockMove(view, source, target, insertion.insertPos, insertion.insertNode);
+  }
+
+  return dispatchBlockMove(view, source, target, dropBoundary(target), listItem);
+}
+
+function moveBlock(view: EditorView, source: BlockDragRange, target: BlockDropTarget) {
+  if (!canMoveBlock(view.state, source, target)) return false;
+  if (isListItem(source)) return moveListItem(view, source, target);
+  if (canMoveBlockIntoList(view.state, source, target)) return moveBlockIntoList(view, source, target);
+
+  const currentNode = view.state.doc.nodeAt(source.pos);
+  if (!currentNode || !currentNode.eq(source.node)) return false;
+
+  const animatedElements = siblingBlockElements(view, source);
+  const beforeRects = snapshotBlockRects(animatedElements);
+  const sourceEnd = source.pos + source.node.nodeSize;
+  const boundary = dropBoundary(target);
+  let insertPos = boundary;
+  if (boundary > source.pos) insertPos -= source.node.nodeSize;
+
+  try {
+    const tr = view.state.tr.delete(source.pos, sourceEnd).insert(insertPos, source.node);
+    const selection = TextSelection.near(tr.doc.resolve(Math.min(insertPos + 1, tr.doc.content.size)), 1);
+
+    view.dispatch(tr.setSelection(selection).scrollIntoView());
+    animateBlockMoves(animatedElements, beforeRects);
+    view.focus();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function blockToInsertAfter(view: EditorView, range: BlockDragRange) {
+  if (range.node.type.name === "list_item") {
+    return range.node.type.createAndFill();
+  }
+
+  const paragraph = view.state.schema.nodes.paragraph;
+  return paragraph?.create() ?? null;
+}
+
+function insertBlockAfter(view: EditorView, range: BlockDragRange) {
+  const block = blockToInsertAfter(view, range);
+  if (!block) return false;
+
+  const insertPos = range.pos + range.node.nodeSize;
+
+  try {
+    const tr = view.state.tr.insert(insertPos, block);
+    const selection = TextSelection.near(tr.doc.resolve(insertPos + 1), 1);
+    view.dispatch(tr.setSelection(selection).scrollIntoView());
+    view.focus();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function targetFromEventTarget(target: EventTarget | null) {
+  return target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+}
+
+function clearTimeoutIfNeeded(timeout: ReturnType<typeof setTimeout> | null) {
+  if (timeout !== null) clearTimeout(timeout);
+}
+
+function clearNativeSelection(ownerDocument: Document) {
+  const selection = ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+
+  selection.removeAllRanges();
+}
+
+function dragGhostText(range: BlockDragRange) {
+  const text = range.node.textContent.trim().replace(/\s+/g, " ");
+  const label = text.length > 0 ? text : range.node.type.name.replace(/_/g, " ");
+  if (label.length <= dragGhostTextLimit) return label;
+
+  return `${label.slice(0, dragGhostTextLimit - 3)}...`;
+}
+
+function scrollContainerFor(viewDom: HTMLElement, ownerDocument: Document) {
+  const paperScroll = viewDom.closest<HTMLElement>(".paper-scroll");
+  if (paperScroll) return paperScroll;
+
+  const scrollingElement = ownerDocument.scrollingElement;
+  return scrollingElement instanceof HTMLElement ? scrollingElement : null;
+}
+
+class MarkraBlockDragView {
+  private activeRange: BlockDragRange | null = null;
+  private dragSourceElement: Element | null = null;
+  private draggingRange: BlockDragRange | null = null;
+  private dropTarget: BlockDropTarget | null = null;
+  private readonly ghost: HTMLElement;
+  private hideTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly addButton: HTMLButtonElement;
+  private readonly handle: HTMLButtonElement;
+  private readonly indicator: HTMLElement;
+  private mouseDrag: MouseDragState | null = null;
+  private nativeDragActive = false;
+  private readonly ownerDocument: Document;
+  private pointerDrag: PointerDragState | null = null;
+  private readonly root: HTMLElement;
+  private readonly scrollContainer: HTMLElement | null;
+  private readonly toolbar: HTMLElement;
+
+  constructor(
+    private readonly view: EditorView,
+    labels: BlockDragLabels
+  ) {
+    const ownerDocument = view.dom.ownerDocument;
+    this.ownerDocument = ownerDocument;
+    this.root = view.dom.closest<HTMLElement>(".markdown-paper") ?? view.dom.parentElement ?? view.dom;
+    this.toolbar = ownerDocument.createElement("div");
+    this.addButton = ownerDocument.createElement("button");
+    this.handle = ownerDocument.createElement("button");
+    this.indicator = ownerDocument.createElement("div");
+    this.ghost = ownerDocument.createElement("div");
+    this.scrollContainer = scrollContainerFor(view.dom, ownerDocument);
+
+    this.toolbar.className = "markra-block-toolbar";
+    this.toolbar.contentEditable = "false";
+    this.toolbar.dataset.show = "false";
+
+    this.addButton.type = "button";
+    this.addButton.className = "markra-block-tool-button markra-block-add-button";
+    this.addButton.title = labels.addBlock;
+    this.addButton.ariaLabel = labels.addBlock;
+    this.addButton.contentEditable = "false";
+    this.addButton.draggable = false;
+
+    this.handle.type = "button";
+    this.handle.className = "markra-block-tool-button markra-block-drag-handle";
+    this.handle.title = labels.dragBlock;
+    this.handle.ariaLabel = labels.dragBlock;
+    this.handle.contentEditable = "false";
+    this.handle.draggable = false;
+
+    for (let index = 0; index < 4; index += 1) {
+      const dot = ownerDocument.createElement("span");
+      dot.className = "markra-block-drag-dot";
+      this.handle.append(dot);
+    }
+
+    this.indicator.className = "markra-block-drop-indicator";
+    this.indicator.ariaHidden = "true";
+    this.indicator.dataset.show = "false";
+
+    this.ghost.className = "markra-block-drag-ghost";
+    this.ghost.ariaHidden = "true";
+    this.ghost.contentEditable = "false";
+    this.ghost.dataset.show = "false";
+    this.ghost.style.left = "0px";
+    this.ghost.style.top = "0px";
+
+    this.toolbar.append(this.addButton, this.handle);
+    this.root.append(this.toolbar, this.indicator, this.ghost);
+
+    this.root.addEventListener("pointermove", this.handleHoverMove);
+    this.root.addEventListener("pointerleave", this.handleHoverLeave);
+    this.root.addEventListener("mousemove", this.handleHoverMove);
+    this.root.addEventListener("mouseleave", this.handleHoverLeave);
+    this.root.addEventListener("dragover", this.handleDragOver, true);
+    this.root.addEventListener("drop", this.handleDrop, true);
+    this.root.addEventListener("dragend", this.handleDragEnd, true);
+    this.toolbar.addEventListener("pointerenter", this.handlePointerEnter);
+    this.addButton.addEventListener("mousedown", this.handleAddMouseDown);
+    this.addButton.addEventListener("click", this.handleAddClick);
+    this.handle.addEventListener("pointerdown", this.handlePointerDown);
+    this.handle.addEventListener("mousedown", this.handleMouseDown);
+    this.handle.addEventListener("click", this.handleClick);
+    this.handle.addEventListener("dragstart", this.handleDragStart);
+    this.handle.addEventListener("dragend", this.handleDragEnd);
+  }
+
+  update(view: EditorView, previousState: EditorState) {
+    if (!view.state.doc.eq(previousState.doc) && !this.draggingRange) {
+      this.hideHandle();
+    }
+  }
+
+  destroy() {
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.root.removeEventListener("pointermove", this.handleHoverMove);
+    this.root.removeEventListener("pointerleave", this.handleHoverLeave);
+    this.root.removeEventListener("mousemove", this.handleHoverMove);
+    this.root.removeEventListener("mouseleave", this.handleHoverLeave);
+    this.root.removeEventListener("dragover", this.handleDragOver, true);
+    this.root.removeEventListener("drop", this.handleDrop, true);
+    this.root.removeEventListener("dragend", this.handleDragEnd, true);
+    this.toolbar.removeEventListener("pointerenter", this.handlePointerEnter);
+    this.addButton.removeEventListener("mousedown", this.handleAddMouseDown);
+    this.addButton.removeEventListener("click", this.handleAddClick);
+    this.handle.removeEventListener("pointerdown", this.handlePointerDown);
+    this.handle.removeEventListener("mousedown", this.handleMouseDown);
+    this.handle.removeEventListener("click", this.handleClick);
+    this.handle.removeEventListener("dragstart", this.handleDragStart);
+    this.handle.removeEventListener("dragend", this.handleDragEnd);
+    this.clearMouseDrag();
+    this.clearPointerDrag();
+    this.clearDragSource();
+    this.endNativeDragInteraction();
+    this.toolbar.remove();
+    this.indicator.remove();
+    this.ghost.remove();
+  }
+
+  private readonly handleHoverMove = (event: PointerEvent | MouseEvent) => {
+    if (this.mouseDrag || this.pointerDrag || this.draggingRange || !this.view.editable) return;
+    if (this.toolbar.contains(targetFromEventTarget(event.target))) return;
+
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.hideTimer = null;
+
+    const range = this.rangeFromPoint(event.clientX, event.clientY);
+    if (!range) {
+      this.hideHandle();
+      return;
+    }
+
+    this.activeRange = range;
+    this.positionToolbar(range);
+  };
+
+  private readonly handleHoverLeave = () => {
+    if (this.mouseDrag || this.pointerDrag || this.draggingRange) return;
+
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.hideTimer = setTimeout(() => {
+      this.hideHandle();
+    }, 120);
+  };
+
+  private readonly handlePointerEnter = () => {
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.hideTimer = null;
+  };
+
+  private readonly handleAddMouseDown = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  private readonly handleAddClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const range = this.activeRange ?? this.rangeFromPoint(event.clientX, event.clientY);
+    if (!range || !insertBlockAfter(this.view, range)) return;
+
+    this.hideHandle();
+  };
+
+  private readonly handlePointerDown = (event: PointerEvent) => {
+    if (event.button !== 0) return;
+
+    const range = this.activeRange ?? this.rangeFromPoint(event.clientX, event.clientY);
+    if (!range) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.hideTimer = null;
+    this.beginNativeDragInteraction();
+    this.pointerDrag = {
+      pointerId: event.pointerId,
+      range,
+      startLeft: event.clientX,
+      startTop: event.clientY
+    };
+    this.ownerDocument.addEventListener("pointermove", this.handlePointerDragMove);
+    this.ownerDocument.addEventListener("pointerup", this.handlePointerDragEnd);
+    this.ownerDocument.addEventListener("pointercancel", this.handlePointerDragCancel);
+
+    try {
+      this.handle.setPointerCapture(event.pointerId);
+    } catch {
+      // Some test and WebView environments do not expose pointer capture for detached drags.
+    }
+  };
+
+  private readonly handleMouseDown = (event: MouseEvent) => {
+    if (this.pointerDrag) return;
+    if (event.button !== 0) return;
+
+    const range = this.activeRange ?? this.rangeFromPoint(event.clientX, event.clientY);
+    if (!range) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.hideTimer = null;
+    this.beginNativeDragInteraction();
+    this.mouseDrag = {
+      range,
+      startLeft: event.clientX,
+      startTop: event.clientY
+    };
+    this.ownerDocument.addEventListener("mousemove", this.handleMouseDragMove);
+    this.ownerDocument.addEventListener("mouseup", this.handleMouseDragEnd);
+  };
+
+  private readonly handleClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  private readonly handleDragStart = (event: DragEvent) => {
+    if (!this.activeRange || !event.dataTransfer) {
+      event.preventDefault();
+      return;
+    }
+
+    const range = this.activeRange;
+    const blockDom = this.blockDom(range);
+    clearTimeoutIfNeeded(this.hideTimer);
+    this.hideTimer = null;
+    this.beginNativeDragInteraction();
+    this.beginDrag(range);
+    this.positionGhost(event.clientX, event.clientY);
+
+    event.dataTransfer.clearData();
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData(markraBlockDragMime, "true");
+    event.dataTransfer.setData("text/plain", range.node.textContent);
+    if (blockDom) event.dataTransfer.setDragImage(blockDom, 0, 0);
+  };
+
+  private readonly handleDragOver = (event: DragEvent) => {
+    if (!this.draggingRange) return;
+
+    this.positionGhost(event.clientX, event.clientY);
+    this.autoScrollAtPoint(event.clientY);
+    if (!this.updateDropTarget(event.clientX, event.clientY)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+  };
+
+  private readonly handleDrop = (event: DragEvent) => {
+    if (!this.draggingRange) return;
+
+    const target = this.dropTarget ?? this.dropTargetFromPoint(event.clientX, event.clientY);
+    event.preventDefault();
+    event.stopPropagation();
+    if (target) moveBlock(this.view, this.draggingRange, target);
+
+    this.endDrag();
+  };
+
+  private readonly handleDragEnd = () => {
+    this.clearPointerDrag();
+    this.endDrag();
+  };
+
+  private readonly handlePointerDragMove = (event: PointerEvent) => {
+    const pointerDrag = this.pointerDrag;
+    if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return;
+
+    const distance = Math.abs(event.clientX - pointerDrag.startLeft) + Math.abs(event.clientY - pointerDrag.startTop);
+    if (!this.draggingRange) {
+      if (distance < 4) return;
+      this.beginDrag(pointerDrag.range);
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.clearNativeSelection();
+    this.positionGhost(event.clientX, event.clientY);
+    this.autoScrollAtPoint(event.clientY);
+    this.updateDropTarget(event.clientX, event.clientY);
+  };
+
+  private readonly handlePointerDragEnd = (event: PointerEvent) => {
+    const pointerDrag = this.pointerDrag;
+    if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = this.draggingRange
+      ? this.dropTarget ?? this.dropTargetFromPoint(event.clientX, event.clientY)
+      : null;
+    if (this.draggingRange && target) moveBlock(this.view, this.draggingRange, target);
+
+    this.clearPointerDrag();
+    this.endDrag();
+  };
+
+  private readonly handlePointerDragCancel = (event: PointerEvent) => {
+    const pointerDrag = this.pointerDrag;
+    if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return;
+
+    this.clearPointerDrag();
+    this.endDrag();
+  };
+
+  private readonly handleMouseDragMove = (event: MouseEvent) => {
+    const mouseDrag = this.mouseDrag;
+    if (!mouseDrag) return;
+
+    const distance = Math.abs(event.clientX - mouseDrag.startLeft) + Math.abs(event.clientY - mouseDrag.startTop);
+    if (!this.draggingRange) {
+      if (distance < 4) return;
+      this.beginDrag(mouseDrag.range);
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.clearNativeSelection();
+    this.positionGhost(event.clientX, event.clientY);
+    this.autoScrollAtPoint(event.clientY);
+    this.updateDropTarget(event.clientX, event.clientY);
+  };
+
+  private readonly handleMouseDragEnd = (event: MouseEvent) => {
+    if (!this.mouseDrag) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = this.draggingRange
+      ? this.dropTarget ?? this.dropTargetFromPoint(event.clientX, event.clientY)
+      : null;
+    if (this.draggingRange && target) moveBlock(this.view, this.draggingRange, target);
+
+    this.clearMouseDrag();
+    this.endDrag();
+  };
+
+  private rangeFromPoint(left: number, top: number) {
+    let position: ReturnType<EditorView["posAtCoords"]>;
+    try {
+      position = this.view.posAtCoords({
+        left: this.documentProbeLeft(left),
+        top
+      });
+    } catch {
+      return null;
+    }
+
+    if (!position) return null;
+
+    return findMovableBlockAtPosition(this.view.state, position.pos);
+  }
+
+  private documentProbeLeft(left: number) {
+    const rect = this.view.dom.getBoundingClientRect();
+    if (left >= rect.left && left <= rect.right) return left;
+
+    return rect.left + rect.width / 2;
+  }
+
+  private dropTargetFromPoint(left: number, top: number): BlockDropTarget | null {
+    const range = this.rangeFromPoint(left, top);
+    if (!range) return null;
+
+    const dom = this.blockDom(range);
+    const rect = dom?.getBoundingClientRect();
+    const placement = this.dropPlacementFromPoint(range, rect, left);
+    const side = placement === "nested" || (rect && top > rect.top + rect.height / 2) ? "after" : "before";
+
+    return { placement, range, side };
+  }
+
+  private dropPlacementFromPoint(
+    range: BlockDragRange,
+    rect: DOMRect | undefined,
+    left: number
+  ): BlockDropTarget["placement"] {
+    if (!this.draggingRange || !isListItem(range) || !rect) return "sibling";
+    if (left < rect.left + listNestOffset) return "sibling";
+
+    return "nested";
+  }
+
+  private beginDrag(range: BlockDragRange) {
+    this.draggingRange = range;
+    this.beginNativeDragInteraction();
+    this.markDragSource(range);
+    this.showGhost(range);
+    this.toolbar.dataset.dragging = "true";
+    this.handle.dataset.dragging = "true";
+    this.view.dom.dataset.dragging = "true";
+  }
+
+  private updateDropTarget(left: number, top: number) {
+    if (!this.draggingRange) return false;
+
+    const target = this.dropTargetFromPoint(left, top);
+    if (!target || !canMoveBlock(this.view.state, this.draggingRange, target)) {
+      this.dropTarget = null;
+      this.hideIndicator();
+      return false;
+    }
+
+    this.dropTarget = target;
+    this.positionIndicator(target);
+    this.clearNativeSelection();
+    return true;
+  }
+
+  private blockDom(range: BlockDragRange) {
+    const dom = this.view.nodeDOM(range.pos);
+    return targetFromEventTarget(dom);
+  }
+
+  private positionToolbar(range: BlockDragRange) {
+    const dom = this.blockDom(range);
+    const rect = dom?.getBoundingClientRect();
+    const editorRect = this.view.dom.getBoundingClientRect();
+    if (!rect) {
+      this.hideHandle();
+      return;
+    }
+
+    const left = Math.max(8, editorRect.left - 30);
+    const top = rect.top + Math.min(rect.height / 2, 18);
+
+    this.toolbar.style.left = `${Math.round(left)}px`;
+    this.toolbar.style.top = `${Math.round(top)}px`;
+    this.toolbar.dataset.show = "true";
+  }
+
+  private hideHandle() {
+    this.activeRange = null;
+    this.toolbar.dataset.show = "false";
+  }
+
+  private markDragSource(range: BlockDragRange) {
+    this.clearDragSource();
+    this.dragSourceElement = this.blockDom(range);
+    this.dragSourceElement?.classList.add("markra-block-drag-source");
+  }
+
+  private clearDragSource() {
+    this.dragSourceElement?.classList.remove("markra-block-drag-source");
+    this.dragSourceElement = null;
+  }
+
+  private clearMouseDrag() {
+    this.mouseDrag = null;
+    this.ownerDocument.removeEventListener("mousemove", this.handleMouseDragMove);
+    this.ownerDocument.removeEventListener("mouseup", this.handleMouseDragEnd);
+  }
+
+  private clearPointerDrag() {
+    const pointerDrag = this.pointerDrag;
+    if (pointerDrag) {
+      try {
+        this.handle.releasePointerCapture(pointerDrag.pointerId);
+      } catch {
+        // Pointer capture may already be released when the native WebView cancels a drag.
+      }
+    }
+
+    this.pointerDrag = null;
+    this.ownerDocument.removeEventListener("pointermove", this.handlePointerDragMove);
+    this.ownerDocument.removeEventListener("pointerup", this.handlePointerDragEnd);
+    this.ownerDocument.removeEventListener("pointercancel", this.handlePointerDragCancel);
+  }
+
+  private beginNativeDragInteraction() {
+    if (!this.nativeDragActive) {
+      this.nativeDragActive = true;
+      this.root.dataset.blockDragging = "true";
+      this.ownerDocument.documentElement.dataset.markraBlockDragging = "true";
+      this.ownerDocument.body.classList.add("markra-block-dragging");
+    }
+
+    this.clearNativeSelection();
+  }
+
+  private endNativeDragInteraction() {
+    if (!this.nativeDragActive) return;
+
+    this.nativeDragActive = false;
+    delete this.root.dataset.blockDragging;
+    delete this.ownerDocument.documentElement.dataset.markraBlockDragging;
+    this.ownerDocument.body.classList.remove("markra-block-dragging");
+    this.clearNativeSelection();
+  }
+
+  private clearNativeSelection() {
+    clearNativeSelection(this.ownerDocument);
+  }
+
+  private positionIndicator(target: BlockDropTarget) {
+    const dom = this.blockDom(target.range);
+    const rect = dom?.getBoundingClientRect();
+    if (!rect) {
+      this.hideIndicator();
+      return;
+    }
+
+    const top = target.side === "before" ? rect.top : rect.bottom;
+    const left = target.placement === "nested" ? rect.left + listNestOffset : rect.left + dropIndicatorInset;
+    const rawWidth =
+      target.placement === "nested" ? rect.width - listNestOffset - dropIndicatorInset : rect.width - dropIndicatorInset * 2;
+    const indicatorWidth = Math.max(24, Math.min(rawWidth, dropIndicatorMaxWidth));
+
+    this.indicator.style.left = `${Math.round(left)}px`;
+    this.indicator.style.top = `${Math.round(top)}px`;
+    this.indicator.style.width = `${Math.round(indicatorWidth)}px`;
+    this.indicator.dataset.show = "true";
+  }
+
+  private hideIndicator() {
+    this.indicator.dataset.show = "false";
+  }
+
+  private showGhost(range: BlockDragRange) {
+    this.ghost.textContent = dragGhostText(range);
+    this.ghost.dataset.show = "true";
+  }
+
+  private positionGhost(left: number, top: number) {
+    if (this.ghost.dataset.show !== "true") return;
+
+    this.ghost.style.transform = `translate(${Math.round(left + dragGhostOffset.left)}px, ${Math.round(
+      top + dragGhostOffset.top
+    )}px)`;
+  }
+
+  private hideGhost() {
+    this.ghost.dataset.show = "false";
+    this.ghost.textContent = "";
+    this.ghost.style.transform = "translate(-9999px, -9999px)";
+  }
+
+  private autoScrollAtPoint(top: number) {
+    const scrollContainer = this.scrollContainer;
+    if (!scrollContainer) return;
+
+    const rect = scrollContainer.getBoundingClientRect();
+    const threshold = Math.min(edgeScrollThreshold, rect.height / 2);
+    if (threshold < 1) return;
+
+    const topDistance = top - rect.top;
+    const bottomDistance = rect.bottom - top;
+    let scrollTopDelta = 0;
+
+    if (topDistance < threshold) {
+      const pressure = (threshold - topDistance) / threshold;
+      scrollTopDelta = -Math.ceil(edgeScrollMaxStep * Math.max(0, pressure));
+    } else if (bottomDistance < threshold) {
+      const pressure = (threshold - bottomDistance) / threshold;
+      scrollTopDelta = Math.ceil(edgeScrollMaxStep * Math.max(0, pressure));
+    }
+
+    if (scrollTopDelta === 0) return;
+
+    if (typeof scrollContainer.scrollBy === "function") {
+      scrollContainer.scrollBy({ left: 0, top: scrollTopDelta });
+      return;
+    }
+
+    scrollContainer.scrollTop += scrollTopDelta;
+  }
+
+  private endDrag() {
+    this.draggingRange = null;
+    this.dropTarget = null;
+    this.clearDragSource();
+    delete this.toolbar.dataset.dragging;
+    delete this.handle.dataset.dragging;
+    this.view.dom.dataset.dragging = "false";
+    this.endNativeDragInteraction();
+    this.hideHandle();
+    this.hideIndicator();
+    this.hideGhost();
+  }
+}
+
+export function markraBlockDragPlugin(labels?: Partial<BlockDragLabels>) {
+  const normalizedLabels = normalizeBlockDragLabels(labels);
+
+  return $prose(() => {
+    return new Plugin({
+      key: blockDragKey,
+      view: (view) => new MarkraBlockDragView(view, normalizedLabels)
+    });
+  });
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ai-preview.ts";
+export * from "./block-drag.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
 export * from "./heading-source.ts";

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Markdown-Editor",
   "app.markdownSource": "Markdown-Quelle",
   "app.markdownDocument": "Markdown-Dokument",
+  "editor.blockAdd": "Block darunter hinzufügen",
+  "editor.blockDrag": "Block ziehen",
   "editor.htmlSource": "HTML-Quelle",
   "editor.htmlSourceApply": "HTML-Quelle anwenden",
   "editor.table.addColumnRight": "Spalte rechts hinzufügen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -302,6 +302,8 @@ const messages: BaseLocaleMessages = {
   "app.markdownEditor": "Markdown editor",
   "app.markdownSource": "Markdown source",
   "app.markdownDocument": "Markdown document",
+  "editor.blockAdd": "Add block below",
+  "editor.blockDrag": "Drag block",
   "editor.htmlSource": "HTML source",
   "editor.htmlSourceApply": "Apply HTML source",
   "editor.table.addColumnRight": "Add column to the right",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Editor Markdown",
   "app.markdownSource": "Código fuente Markdown",
   "app.markdownDocument": "Documento Markdown",
+  "editor.blockAdd": "Añadir bloque debajo",
+  "editor.blockDrag": "Arrastrar bloque",
   "editor.htmlSource": "Código fuente HTML",
   "editor.htmlSourceApply": "Aplicar código fuente HTML",
   "editor.table.addColumnRight": "Añadir columna a la derecha",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Éditeur Markdown",
   "app.markdownSource": "Source Markdown",
   "app.markdownDocument": "Document Markdown",
+  "editor.blockAdd": "Ajouter un bloc en dessous",
+  "editor.blockDrag": "Faire glisser le bloc",
   "editor.htmlSource": "Source HTML",
   "editor.htmlSourceApply": "Appliquer la source HTML",
   "editor.table.addColumnRight": "Ajouter une colonne à droite",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Editor Markdown",
   "app.markdownSource": "Sorgente Markdown",
   "app.markdownDocument": "Documento Markdown",
+  "editor.blockAdd": "Aggiungi blocco sotto",
+  "editor.blockDrag": "Trascina blocco",
   "editor.htmlSource": "Sorgente HTML",
   "editor.htmlSourceApply": "Applica sorgente HTML",
   "editor.table.addColumnRight": "Aggiungi colonna a destra",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -202,6 +202,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Markdown エディター",
   "app.markdownSource": "Markdown ソース",
   "app.markdownDocument": "Markdown ドキュメント",
+  "editor.blockAdd": "下にブロックを追加",
+  "editor.blockDrag": "ブロックをドラッグ",
   "editor.htmlSource": "HTML ソース",
   "editor.htmlSourceApply": "HTML ソースを適用",
   "editor.table.addColumnRight": "右に列を追加",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Markdown 편집기",
   "app.markdownSource": "Markdown 소스",
   "app.markdownDocument": "Markdown 문서",
+  "editor.blockAdd": "아래에 블록 추가",
+  "editor.blockDrag": "블록 드래그",
   "editor.htmlSource": "HTML 소스",
   "editor.htmlSourceApply": "HTML 소스 적용",
   "editor.table.addColumnRight": "오른쪽에 열 추가",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Editor Markdown",
   "app.markdownSource": "Fonte Markdown",
   "app.markdownDocument": "Documento Markdown",
+  "editor.blockAdd": "Adicionar bloco abaixo",
+  "editor.blockDrag": "Arrastar bloco",
   "editor.htmlSource": "Código-fonte HTML",
   "editor.htmlSourceApply": "Aplicar código-fonte HTML",
   "editor.table.addColumnRight": "Adicionar coluna à direita",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -196,6 +196,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Редактор Markdown",
   "app.markdownSource": "Исходник Markdown",
   "app.markdownDocument": "Документ Markdown",
+  "editor.blockAdd": "Добавить блок ниже",
+  "editor.blockDrag": "Перетащить блок",
   "editor.htmlSource": "HTML-исходник",
   "editor.htmlSourceApply": "Применить HTML-исходник",
   "editor.table.addColumnRight": "Добавить столбец справа",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -313,6 +313,8 @@ export type I18nKey =
   | "app.markdownEditor"
   | "app.markdownSource"
   | "app.markdownDocument"
+  | "editor.blockAdd"
+  | "editor.blockDrag"
   | "editor.htmlSource"
   | "editor.htmlSourceApply"
   | "editor.table.addColumnRight"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -302,6 +302,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Markdown 编辑器",
   "app.markdownSource": "Markdown 源码",
   "app.markdownDocument": "Markdown 文档",
+  "editor.blockAdd": "在下方新增块",
+  "editor.blockDrag": "拖拽块",
   "editor.htmlSource": "HTML 源码",
   "editor.htmlSourceApply": "应用 HTML 源码",
   "editor.table.addColumnRight": "在右侧新增列",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -202,6 +202,8 @@ const messages: LocaleMessages = {
   "app.markdownEditor": "Markdown 編輯器",
   "app.markdownSource": "Markdown 原始碼",
   "app.markdownDocument": "Markdown 文件",
+  "editor.blockAdd": "在下方新增區塊",
+  "editor.blockDrag": "拖曳區塊",
   "editor.htmlSource": "HTML 原始碼",
   "editor.htmlSourceApply": "套用 HTML 原始碼",
   "editor.table.addColumnRight": "在右側新增欄",


### PR DESCRIPTION
## Summary
- Add a ProseMirror block drag plugin with gutter add/drag controls, block reordering, a lightweight drag ghost, precise drop indicator, and edge auto-scroll.
- Match Notion-style list behavior: no separate whole-list drag handle, list items can move within/out of lists, ordinary blocks can move into lists, and rightward drags can nest both list items and ordinary blocks into child lists.
- Wire the block drag labels through shared i18n across all supported locales.
- Add focused MarkdownPaper coverage for native, pointer, and mouse dragging, list item movement, list nesting, ordinary block-to-list conversion/nesting, selection prevention, move animation, drag ghost, drop indicator width, and edge scrolling.

## Why
- Closes #39.
- Moves editor block interactions closer to a Notion-like drag sorting experience, including cross-boundary list interactions.

## Validation
- `pnpm --filter @markra/shared build`
- `pnpm --filter @markra/editor build`
- `pnpm --filter @markra/desktop typecheck:test`
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "whole list container|outside its list|paragraph into a list|paragraph when dragged rightward|rightward offset|reorders list items|list block toolbar"`
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "reorders|reveals the block drag handle|prevents native text selection|animates blocks|adds a paragraph below|adds a list item below|drag ghost|drop indicator|editor edge|list block toolbar|whole list container|outside its list|paragraph into a list|rightward offset"`
- `pnpm --filter @markra/desktop build` passed with existing Vite chunk / node externalization warnings.

## Risk
- Drag positioning depends on editor DOM geometry, so browser/WebView QA is still useful before marking ready.