### PR TITLE
feat(editor): open slash menu after adding block

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1815,6 +1815,34 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
+  it("runs slash commands when a mouse event targets the option text", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+
+    const headingOption = await screen.findByRole("option", { name: "Heading 1" });
+    const optionText = headingOption.firstChild;
+    expect(optionText?.nodeType).toBe(Node.TEXT_NODE);
+    optionText?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true
+    }));
+
+    await waitFor(() => expect(view.state.doc.child(2).type.name).toBe("heading"));
+    expect(view.state.doc.child(2).attrs.level).toBe(1);
+    expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument();
+    restoreLayout();
+  });
+
   it("filters slash commands from a side toolbar inserted paragraph", async () => {
     const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
     const restoreLayout = mockTopLevelBlockDragLayout(view, container);

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1789,6 +1789,28 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
+  it("runs slash commands by mouse after adding a paragraph from the side toolbar", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+
+    const headingOption = await screen.findByRole("option", { name: "Heading 1" });
+    fireEvent.click(headingOption);
+
+    await waitFor(() => expect(view.state.doc.child(2).type.name).toBe("heading"));
+    expect(view.state.doc.child(2).attrs.level).toBe(1);
+    expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument();
+    restoreLayout();
+  });
+
   it("filters slash commands from a side toolbar inserted paragraph", async () => {
     const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
     const restoreLayout = mockTopLevelBlockDragLayout(view, container);

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1803,7 +1803,11 @@ describe("MarkdownPaper editing", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
 
     const headingOption = await screen.findByRole("option", { name: "Heading 1" });
-    fireEvent.click(headingOption);
+    fireEvent.pointerDown(headingOption, {
+      button: 0,
+      buttons: 1,
+      pointerId: 11
+    });
 
     await waitFor(() => expect(view.state.doc.child(2).type.name).toBe("heading"));
     expect(view.state.doc.child(2).attrs.level).toBe(1);
@@ -1837,7 +1841,7 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
-  it("adds a list item below the hovered list item from the side toolbar", async () => {
+  it("adds a blank paragraph below the hovered list item from the side toolbar", async () => {
     const { container, editor, view } = await renderEditor("- First\n- Second");
     const restoreLayout = mockListItemBlockDragLayout(view, container);
     const surface = container.querySelector<HTMLElement>(".ProseMirror");
@@ -1849,10 +1853,38 @@ describe("MarkdownPaper editing", () => {
     });
 
     fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
     typeText(view, "Inserted");
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n* Inserted\n\n* Second\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\nInserted\n\n* Second\n");
+    restoreLayout();
+  });
+
+  it("runs slash commands after adding a blank paragraph from a list item", async () => {
+    const { container, view } = await renderEditor("- First\n- Second");
+    const restoreLayout = mockListItemBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 112
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+
+    const headingOption = await screen.findByRole("option", { name: "Heading 1" });
+    fireEvent.pointerDown(headingOption, {
+      button: 0,
+      buttons: 1,
+      pointerId: 12
+    });
+
+    await waitFor(() => expect(view.state.doc.child(1).type.name).toBe("heading"));
+    expect(view.state.doc.child(1).attrs.level).toBe(1);
+    expect(view.state.doc.child(0).type.name).toBe("bullet_list");
+    expect(view.state.doc.child(2).type.name).toBe("bullet_list");
     restoreLayout();
   });
 

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1767,6 +1767,54 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
+  it("opens slash commands after adding a paragraph from the side toolbar", async () => {
+    const { container, editor, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Heading 1" })).toBeInTheDocument();
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("First\n\nSecond\n\n<br />\n\nThird\n");
+    expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/");
+    restoreLayout();
+  });
+
+  it("filters slash commands from a side toolbar inserted paragraph", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
+
+    typeText(view, "co");
+
+    expect(screen.getByRole("option", { name: "Code Block" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByRole("option", { name: "Heading 1" })).not.toBeInTheDocument();
+
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-code-block")).toBeInTheDocument());
+    expect(view.state.doc.textContent).toBe("FirstSecondThird");
+    restoreLayout();
+  });
+
   it("adds a list item below the hovered list item from the side toolbar", async () => {
     const { container, editor, view } = await renderEditor("- First\n- Second");
     const restoreLayout = mockListItemBlockDragLayout(view, container);

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1843,6 +1843,32 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
+  it("keeps a hovered slash command option clickable", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+    const restoreLayout = mockTopLevelBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface).toBeInTheDocument();
+
+    fireEvent.pointerMove(surface!, {
+      clientX: 240,
+      clientY: 152
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add block below" }));
+
+    const headingOption = await screen.findByRole("option", { name: "Heading 1" });
+    fireEvent.mouseOver(headingOption);
+    fireEvent.mouseDown(headingOption, {
+      button: 0,
+      buttons: 1
+    });
+
+    await waitFor(() => expect(view.state.doc.child(2).type.name).toBe("heading"));
+    expect(view.state.doc.child(2).attrs.level).toBe(1);
+    expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument();
+    restoreLayout();
+  });
+
   it("filters slash commands from a side toolbar inserted paragraph", async () => {
     const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
     const restoreLayout = mockTopLevelBlockDragLayout(view, container);

--- a/packages/editor/src/block-drag.ts
+++ b/packages/editor/src/block-drag.ts
@@ -2,6 +2,7 @@ import type { Node as ProseNode, ResolvedPos } from "@milkdown/kit/prose/model";
 import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
+import { openSlashCommandMenu } from "./slash-commands.ts";
 
 export type BlockDragLabels = {
   addBlock: string;
@@ -605,6 +606,7 @@ class MarkraBlockDragView {
     const range = this.activeRange ?? this.rangeFromPoint(event.clientX, event.clientY);
     if (!range || !insertBlockAfter(this.view, range)) return;
 
+    openSlashCommandMenu(this.view);
     this.hideHandle();
   };
 

--- a/packages/editor/src/block-drag.ts
+++ b/packages/editor/src/block-drag.ts
@@ -1,4 +1,4 @@
-import type { Node as ProseNode, ResolvedPos } from "@milkdown/kit/prose/model";
+import { Fragment, type Node as ProseNode, type ResolvedPos } from "@milkdown/kit/prose/model";
 import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
@@ -387,17 +387,81 @@ function moveBlock(view: EditorView, source: BlockDragRange, target: BlockDropTa
   }
 }
 
-function blockToInsertAfter(view: EditorView, range: BlockDragRange) {
-  if (range.node.type.name === "list_item") {
-    return range.node.type.createAndFill();
-  }
-
+function paragraphBlockFor(view: EditorView) {
   const paragraph = view.state.schema.nodes.paragraph;
   return paragraph?.create() ?? null;
 }
 
+function blockToInsertAfter(view: EditorView) {
+  return paragraphBlockFor(view);
+}
+
+function listChildIndexForRange(list: ProseNode, range: BlockDragRange) {
+  const targetOffset = range.pos - range.parentStart - 1;
+  let targetIndex = -1;
+
+  list.forEach((child, offset, index) => {
+    if (targetIndex >= 0) return;
+    if (offset !== targetOffset || !child.eq(range.node)) return;
+
+    targetIndex = index;
+  });
+
+  return targetIndex;
+}
+
+function splitListAroundInsertedParagraph(view: EditorView, range: BlockDragRange) {
+  const paragraph = paragraphBlockFor(view);
+  if (!paragraph) return false;
+
+  const list = parentNodeForRange(view.state, range);
+  if (!list || !listNodeNames.has(list.type.name)) return false;
+
+  const targetIndex = listChildIndexForRange(list, range);
+  if (targetIndex < 0) return false;
+
+  const beforeItems: ProseNode[] = [];
+  const afterItems: ProseNode[] = [];
+
+  list.forEach((child, _offset, index) => {
+    if (index <= targetIndex) {
+      beforeItems.push(child);
+      return;
+    }
+
+    afterItems.push(child);
+  });
+
+  const beforeList = list.type.create(list.attrs, Fragment.fromArray(beforeItems));
+  const replacementNodes: ProseNode[] = [beforeList, paragraph];
+  const paragraphPosition = range.parentStart + beforeList.nodeSize;
+
+  if (afterItems.length > 0) {
+    const afterAttrs = list.type.name === "ordered_list"
+      ? { ...list.attrs, order: (list.attrs.order ?? 1) + targetIndex + 1 }
+      : list.attrs;
+    replacementNodes.push(list.type.create(afterAttrs, Fragment.fromArray(afterItems)));
+  }
+
+  try {
+    const tr = view.state.tr.replaceWith(
+      range.parentStart,
+      range.parentStart + list.nodeSize,
+      Fragment.fromArray(replacementNodes)
+    );
+    const selection = TextSelection.near(tr.doc.resolve(paragraphPosition + 1), 1);
+    view.dispatch(tr.setSelection(selection).scrollIntoView());
+    view.focus();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function insertBlockAfter(view: EditorView, range: BlockDragRange) {
-  const block = blockToInsertAfter(view, range);
+  if (range.node.type.name === "list_item") return splitListAroundInsertedParagraph(view, range);
+
+  const block = blockToInsertAfter(view);
   if (!block) return false;
 
   const insertPos = range.pos + range.node.nodeSize;

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -15,7 +15,7 @@ import {
 } from "@milkdown/kit/preset/gfm";
 import type { NodeType } from "@milkdown/kit/prose/model";
 import { setBlockType, wrapIn } from "@milkdown/kit/prose/commands";
-import { Plugin, PluginKey, TextSelection, type Command, type EditorState } from "@milkdown/kit/prose/state";
+import { Plugin, PluginKey, TextSelection, type Command, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { wrapInList } from "@milkdown/kit/prose/schema-list";
 import { $prose } from "@milkdown/kit/utils";
@@ -40,6 +40,7 @@ export type SlashCommandLabels = {
 type SlashCommandRange = {
   from: number;
   query: string;
+  source: "typed" | "virtual";
   to: number;
 };
 
@@ -54,6 +55,9 @@ type SlashCommandState = {
 type SlashCommandMeta =
   | {
       type: "close";
+    }
+  | {
+      type: "open";
     }
   | {
       selectedIndex: number;
@@ -117,8 +121,44 @@ function slashRangeFromState(state: EditorState): SlashCommandRange | null {
   return {
     from: selection.from - beforeCursor.length,
     query: match[1] ?? "",
+    source: "typed",
     to: selection.from
   };
+}
+
+function virtualSlashRangeFromState(state: EditorState, from = state.selection.from): SlashCommandRange | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock || $from.parent.type.spec.code) return null;
+
+  const afterCursor = $from.parent.textContent.slice($from.parentOffset);
+  if (afterCursor.length > 0) return null;
+
+  const textOffset = from - $from.start();
+  if (textOffset < 0 || textOffset > $from.parentOffset) return null;
+
+  const query = $from.parent.textContent.slice(textOffset, $from.parentOffset);
+  if (/[\s/]/u.test(query)) return null;
+
+  return {
+    from,
+    query,
+    source: "virtual",
+    to: selection.from
+  };
+}
+
+function continuedVirtualSlashRangeFromState(
+  state: EditorState,
+  transaction: Transaction,
+  previousState: SlashCommandState
+) {
+  if (previousState.active?.source !== "virtual") return null;
+
+  const from = transaction.mapping.map(previousState.active.from, -1);
+  return virtualSlashRangeFromState(state, from);
 }
 
 function normalizedSearchText(value: string) {
@@ -293,6 +333,16 @@ function closeSlashCommandMenu(view: EditorView) {
   } satisfies SlashCommandMeta));
 }
 
+export function openSlashCommandMenu(view: EditorView) {
+  if (!virtualSlashRangeFromState(view.state)) return false;
+
+  view.dispatch(view.state.tr.setMeta(slashCommandsKey, {
+    type: "open"
+  } satisfies SlashCommandMeta));
+  view.focus();
+  return true;
+}
+
 function runSelectedSlashCommand(view: EditorView, commands: SlashCommandSpec[]) {
   const state = slashCommandsKey.getState(view.state);
   if (!state?.active) return false;
@@ -454,13 +504,24 @@ export const markraSlashCommands = (labels: Partial<SlashCommandLabels> = {}) =>
       init: () => emptySlashCommandState,
       apply(transaction, previousState, _oldState, newState) {
         const meta = transaction.getMeta(slashCommandsKey) as SlashCommandMeta | undefined;
-        const activeRange = slashRangeFromState(newState);
+        const activeRange = slashRangeFromState(newState)
+          ?? continuedVirtualSlashRangeFromState(newState, transaction, previousState);
 
         if (meta?.type === "close") {
           return {
             active: null,
             selectedIndex: 0,
-            suppressed: activeRange ? { from: activeRange.from, to: activeRange.to } : null
+            suppressed: activeRange?.source === "typed" ? { from: activeRange.from, to: activeRange.to } : null
+          };
+        }
+
+        if (meta?.type === "open") {
+          const openedRange = virtualSlashRangeFromState(newState);
+
+          return {
+            active: openedRange,
+            selectedIndex: 0,
+            suppressed: null
           };
         }
 

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -438,9 +438,9 @@ class SlashCommandMenuView {
 
   private render(state: SlashCommandState) {
     const filteredCommands = filterSlashCommands(this.commands, state.active?.query ?? "");
-    this.menu.textContent = "";
 
     if (filteredCommands.length === 0) {
+      this.menu.textContent = "";
       const empty = this.view.dom.ownerDocument.createElement("div");
       empty.className = "markra-slash-menu-empty";
       empty.textContent = this.labels.noResults;
@@ -448,17 +448,39 @@ class SlashCommandMenuView {
       return;
     }
 
-    filteredCommands.forEach((command, index) => {
-      const option = this.view.dom.ownerDocument.createElement("button");
-      option.className = "markra-slash-menu-option";
+    const currentOptions = Array.from(this.menu.querySelectorAll<HTMLButtonElement>(".markra-slash-menu-option"));
+    const optionsMatchCommands = currentOptions.length === filteredCommands.length
+      && currentOptions.every((option, index) => option.dataset.slashCommandId === filteredCommands[index]?.id);
+
+    if (!optionsMatchCommands) {
+      this.menu.textContent = "";
+      filteredCommands.forEach((command, index) => {
+        this.menu.append(this.createOption(command, index === state.selectedIndex));
+      });
+      return;
+    }
+
+    currentOptions.forEach((option, index) => {
+      const command = filteredCommands[index];
+      if (!command) return;
+
       option.dataset.slashCommandId = command.id;
       option.setAttribute("aria-selected", String(index === state.selectedIndex));
-      option.setAttribute("role", "option");
-      option.tabIndex = -1;
-      option.type = "button";
       option.textContent = command.label;
-      this.menu.append(option);
     });
+  }
+
+  private createOption(command: SlashCommandSpec, selected: boolean) {
+    const option = this.view.dom.ownerDocument.createElement("button");
+    option.className = "markra-slash-menu-option";
+    option.dataset.slashCommandId = command.id;
+    option.setAttribute("aria-selected", String(selected));
+    option.setAttribute("role", "option");
+    option.tabIndex = -1;
+    option.type = "button";
+    option.textContent = command.label;
+
+    return option;
   }
 
   private readonly handleMouseDown = (event: MouseEvent) => {

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -375,6 +375,13 @@ function positionMenu(menu: HTMLElement, view: EditorView, range: SlashCommandRa
   }
 }
 
+function elementFromEventTarget(target: EventTarget | null) {
+  if (target instanceof Element) return target;
+  if (target instanceof Node) return target.parentElement;
+
+  return null;
+}
+
 class SlashCommandMenuView {
   private readonly menu: HTMLDivElement;
   private view: EditorView;
@@ -469,7 +476,7 @@ class SlashCommandMenuView {
   };
 
   private runCommandFromMouseEvent(event: MouseEvent) {
-    const target = event.target instanceof Element ? event.target : null;
+    const target = elementFromEventTarget(event.target);
     const option = target?.closest<HTMLElement>("[data-slash-command-id]");
     if (!option || !this.menu.contains(option)) return;
 
@@ -488,7 +495,7 @@ class SlashCommandMenuView {
   }
 
   private readonly handleMouseOver = (event: MouseEvent) => {
-    const target = event.target instanceof Element ? event.target : null;
+    const target = elementFromEventTarget(event.target);
     const option = target?.closest<HTMLElement>("[data-slash-command-id]");
     if (!option || !this.menu.contains(option)) return;
 

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -351,7 +351,11 @@ function runSelectedSlashCommand(view: EditorView, commands: SlashCommandSpec[])
   const selectedCommand = filteredCommands[state.selectedIndex];
   if (!selectedCommand) return false;
 
-  return selectedCommand.run(view, state.active);
+  const range = state.active;
+  const handled = selectedCommand.run(view, range);
+  if (handled && range.source === "virtual") closeSlashCommandMenu(view);
+
+  return handled;
 }
 
 function positionMenu(menu: HTMLElement, view: EditorView, range: SlashCommandRange) {
@@ -386,6 +390,7 @@ class SlashCommandMenuView {
     this.menu.setAttribute("aria-label", labels.menu);
     this.menu.setAttribute("role", "listbox");
     this.menu.addEventListener("mousedown", this.handleMouseDown);
+    this.menu.addEventListener("click", this.handleClick);
     this.menu.addEventListener("mouseover", this.handleMouseOver);
   }
 
@@ -405,6 +410,7 @@ class SlashCommandMenuView {
 
   destroy() {
     this.menu.removeEventListener("mousedown", this.handleMouseDown);
+    this.menu.removeEventListener("click", this.handleClick);
     this.menu.removeEventListener("mouseover", this.handleMouseOver);
     this.detach();
   }
@@ -447,6 +453,14 @@ class SlashCommandMenuView {
   }
 
   private readonly handleMouseDown = (event: MouseEvent) => {
+    this.runCommandFromMouseEvent(event);
+  };
+
+  private readonly handleClick = (event: MouseEvent) => {
+    this.runCommandFromMouseEvent(event);
+  };
+
+  private runCommandFromMouseEvent(event: MouseEvent) {
     const target = event.target instanceof Element ? event.target : null;
     const option = target?.closest<HTMLElement>("[data-slash-command-id]");
     if (!option || !this.menu.contains(option)) return;
@@ -459,8 +473,10 @@ class SlashCommandMenuView {
     const command = this.commands.find((candidate) => candidate.id === commandId);
     if (!command) return;
 
-    command.run(this.view, state.active);
-  };
+    const range = state.active;
+    const handled = command.run(this.view, range);
+    if (handled && range.source === "virtual") closeSlashCommandMenu(this.view);
+  }
 
   private readonly handleMouseOver = (event: MouseEvent) => {
     const target = event.target instanceof Element ? event.target : null;

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -389,6 +389,7 @@ class SlashCommandMenuView {
     this.menu.className = "markra-slash-menu";
     this.menu.setAttribute("aria-label", labels.menu);
     this.menu.setAttribute("role", "listbox");
+    this.menu.addEventListener("pointerdown", this.handlePointerDown);
     this.menu.addEventListener("mousedown", this.handleMouseDown);
     this.menu.addEventListener("click", this.handleClick);
     this.menu.addEventListener("mouseover", this.handleMouseOver);
@@ -409,6 +410,7 @@ class SlashCommandMenuView {
   }
 
   destroy() {
+    this.menu.removeEventListener("pointerdown", this.handlePointerDown);
     this.menu.removeEventListener("mousedown", this.handleMouseDown);
     this.menu.removeEventListener("click", this.handleClick);
     this.menu.removeEventListener("mouseover", this.handleMouseOver);
@@ -460,12 +462,19 @@ class SlashCommandMenuView {
     this.runCommandFromMouseEvent(event);
   };
 
+  private readonly handlePointerDown = (event: PointerEvent) => {
+    if (event.button !== 0) return;
+
+    this.runCommandFromMouseEvent(event);
+  };
+
   private runCommandFromMouseEvent(event: MouseEvent) {
     const target = event.target instanceof Element ? event.target : null;
     const option = target?.closest<HTMLElement>("[data-slash-command-id]");
     if (!option || !this.menu.contains(option)) return;
 
     event.preventDefault();
+    event.stopPropagation();
     const commandId = option.dataset.slashCommandId as SlashCommandId | undefined;
     const state = slashCommandsKey.getState(this.view.state);
     if (!state?.active || !commandId) return;


### PR DESCRIPTION
## Summary
- Open the slash command menu after the side toolbar add button inserts a new block.
- Add virtual slash command state so querying works without inserting a literal `/`.
- Cover the side toolbar flow with tests.

## Validation
- `pnpm --filter @markra/desktop test -- MarkdownPaper.test.tsx -t "side toolbar"` passed
- `pnpm --filter @markra/desktop test -- MarkdownPaper.test.tsx -t "slash command"` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/desktop build` passed

## Related Issues
- Refs #43