### PR TITLE
feat(editor): add slash menu block insertion

### DIFF
--- a/apps/desktop/src/components/NativeTitleBar.test.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.test.tsx
@@ -122,7 +122,7 @@ describe("NativeTitleBar", () => {
     });
   });
 
-  it("keeps Windows titlebar tabs out of the markdown files sidebar", () => {
+  it("keeps Windows titlebar tabs beside the markdown files sidebar without covering it", () => {
     const { container } = render(
       <NativeTitleBar
         aiAgentOpen={false}
@@ -147,9 +147,9 @@ describe("NativeTitleBar", () => {
 
     expect(screen.getByRole("tablist", { name: "Open documents" })).toBeInTheDocument();
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "220px minmax(0,1fr) 164px"
+      left: "220px"
     });
-    expect(container.querySelector(".native-titlebar-sidebar-spacer")).toBeInTheDocument();
+    expect(container.querySelector(".native-titlebar-sidebar-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".native-title-slot")).not.toHaveStyle({ paddingLeft: "232px" });
   });
 

--- a/apps/desktop/src/components/NativeTitleBar.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.tsx
@@ -422,8 +422,7 @@ export function NativeTitleBar({
   if (platform === "windows") {
     if (titleContent) {
       const windowsTitlebarStyle: CSSProperties | undefined = {
-        ...titlebarSurfaceStyle,
-        ...(markdownFilesOpen ? { gridTemplateColumns: `${markdownFilesWidth}px minmax(0,1fr) 164px` } : {})
+        ...(markdownFilesOpen ? { left: markdownFilesWidth } : {})
       };
 
       return (
@@ -433,14 +432,6 @@ export function NativeTitleBar({
           aria-label={label("app.windowDragRegion")}
           data-tauri-drag-region
         >
-          {renderMarkdownFilesDivider()}
-          {markdownFilesOpen ? (
-            <span
-              aria-hidden="true"
-              className="native-titlebar-sidebar-spacer h-10"
-              data-tauri-drag-region
-            />
-          ) : null}
           {renderTitleContent("native-title-slot min-w-0 h-10 px-3")}
           {renderDocumentActions(
             "document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 transition-[opacity,background-color,color] duration-150 ease-out hover:opacity-100 focus-within:opacity-100"


### PR DESCRIPTION
## Summary
- Open the slash command menu after adding a block and keep command clicks working through the block-add flow.
- Preserve slash menu option clicks when hovering or clicking option text.
- Keep Windows titlebar tabs beside the file tree so the sidebar no longer gets a blank top spacer.

## Why
- Adding a new editor block should let users immediately choose a slash command without focus or click regressions.
- On Windows, native chrome already owns the top menu area, so the web titlebar layer should not cover the file tree.

## Validation
- `pnpm --filter @markra/desktop test -- MarkdownPaper.test.tsx NativeTitleBar.test.tsx` passed.
- `pnpm --filter @markra/desktop build` passed.

## Risk
- Draft until the Windows portable build is checked visually on a Windows machine.