### PR TITLE
feat(editor): add standard markdown document links

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -39,6 +39,7 @@ import {
   mockedOpenNativeMarkdownFolder,
   mockedOpenNativeMarkdownFolderInNewWindow,
   mockedOpenNativeMarkdownPath,
+  mockedOpenNativeExternalUrl,
   mockedOpenSettingsWindow,
   mockedReadNativeMarkdownFile,
   mockedResetWelcomeDocumentState,
@@ -2167,6 +2168,34 @@ describe("Markra workspace", () => {
     expect(savedContents).toContain("[关于我们](https://m.techflowpost.com/article/9424)");
     expect(savedContents).not.toContain("\\[关于我们\\]");
     expect(savedContents).not.toContain("\\(https\\://m.techflowpost.com/article/9424\\)");
+  });
+
+  it("opens relative markdown links inside the current folder workspace", async () => {
+    const guidePath = "/mock-files/docs/guide.md";
+    mockOpenMarkdownFile({
+      content: "[Guide](./docs/guide.md)",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "native.md", path: mockNativePath, relativePath: "native.md" },
+      { name: "guide.md", path: guidePath, relativePath: "docs/guide.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nOpened through a document link.",
+      name: "guide.md",
+      path: guidePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    const link = await screen.findByText("Guide");
+    link.closest("a")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true }));
+
+    expect(await screen.findByText("Opened through a document link.")).toBeInTheDocument();
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
+    expect(mockedOpenNativeExternalUrl).not.toHaveBeenCalled();
   });
 
   it("wires native menu file actions to the current document commands", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -46,6 +46,7 @@ import { aiTranslationLanguageName, t, type I18nKey } from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
+import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
 import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
@@ -291,6 +292,16 @@ export default function App() {
       src
     });
   }, [document.path]);
+  const handleOpenEditorLink = useCallback(async (href: string) => {
+    const linkedFile = resolveMarkdownDocumentLinkFile(href, document.path, fileTreeFiles);
+    if (linkedFile) {
+      setActiveImageFile(null);
+      await openTreeMarkdownFile(linkedFile);
+      return;
+    }
+
+    await openNativeExternalUrl(href);
+  }, [document.path, fileTreeFiles, openTreeMarkdownFile]);
   const getActiveAiSelection = useCallback(() => activeAiSelectionRef.current, []);
   const updateActiveAiSelection = useCallback((selection: AiSelectionContext | null) => {
     activeAiSelectionRef.current = selection;
@@ -1410,6 +1421,7 @@ export default function App() {
                       bodyFontSize={editorPreferences.preferences.bodyFontSize}
                       contentWidth={activeEditorContentWidth}
                       contentWidthPx={activeEditorContentWidthPx}
+                      documentPath={document.path}
                       initialContent={document.content}
                       language={appLanguage.language}
                       lineHeight={editorPreferences.preferences.lineHeight}
@@ -1420,11 +1432,12 @@ export default function App() {
                       onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                       onSaveClipboardImage={handleSaveClipboardImage}
                       onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
-                      openExternalUrl={openNativeExternalUrl}
+                      openExternalUrl={handleOpenEditorLink}
                       onTextSelectionChange={handleTextSelectionChange}
                       resolveImageSrc={resolveImageSrc}
                       revision={document.revision}
                       topInset="titlebar"
+                      workspaceFiles={fileTreeFiles}
                     />
                   )}
                   <QuietStatus

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -29,6 +29,7 @@ import { clearAiSelectionHold, defaultMarkdownShortcuts, showAiSelectionHold, ty
 async function renderEditor(
   initialContent = "",
   options: {
+    documentPath?: string | null;
     onMarkdownChange?: (content: string) => unknown;
     onSaveClipboardImage?: (image: File) => Promise<{ alt: string; src: string } | null>;
     onSaveRemoteClipboardImage?: (image: RemoteClipboardImage) => Promise<{ alt: string; src: string } | null>;
@@ -36,11 +37,18 @@ async function renderEditor(
     onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
     resolveImageSrc?: (src: string) => string;
     markdownShortcuts?: MarkdownShortcutMap;
+    workspaceFiles?: Array<{
+      kind?: "asset" | "folder";
+      name: string;
+      path: string;
+      relativePath: string;
+    }>;
   } = {}
 ) {
   let editor: Editor | null = null;
   const result = render(
     <MarkdownPaper
+      documentPath={options.documentPath}
       initialContent={initialContent}
       onEditorReady={(instance) => {
         editor = instance;
@@ -53,6 +61,7 @@ async function renderEditor(
       onTextSelectionChange={options.onTextSelectionChange}
       resolveImageSrc={options.resolveImageSrc}
       revision={0}
+      workspaceFiles={options.workspaceFiles}
     />
   );
 
@@ -4092,6 +4101,38 @@ describe("MarkdownPaper editing", () => {
     expect(editCase.container.querySelector(".ProseMirror")?.textContent).toBe("[Markra](https://example.com)");
     expectActiveSourceLinkLabel(editCase.container, "Markra");
     expect(editCase.container.querySelector(".ProseMirror .markra-live-link-mark-source-text")).not.toBeInTheDocument();
+  });
+
+  it("inserts a standard markdown document link from double-bracket completion", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", {
+      documentPath: "/mock-files/vault/index.md",
+      onMarkdownChange,
+      workspaceFiles: [
+        { name: "index.md", path: "/mock-files/vault/index.md", relativePath: "index.md" },
+        { name: "Guide Notes.md", path: "/mock-files/vault/docs/Guide Notes.md", relativePath: "docs/Guide Notes.md" },
+        { kind: "asset", name: "cover.png", path: "/mock-files/vault/cover.png", relativePath: "cover.png" }
+      ]
+    });
+
+    typeText(view, "[[guide");
+
+    expect(await screen.findByRole("listbox", { name: "Document links" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Guide Notes docs/Guide Notes.md" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+
+    expect(pressEnter(view)).toBe(true);
+    expect(screen.queryByRole("listbox", { name: "Document links" })).not.toBeInTheDocument();
+    expect(container.querySelector<HTMLAnchorElement>('.ProseMirror a[href="./docs/Guide%20Notes.md"]')).toHaveTextContent(
+      "Guide Notes"
+    );
+
+    await settleMarkdownListener();
+    const changedMarkdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "");
+    expect(changedMarkdown).toContain("[Guide Notes](./docs/Guide%20Notes.md)");
+    expect(changedMarkdown).not.toContain("[[guide");
   });
 
   it("expands finalized links into editable markdown source", async () => {

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -58,6 +58,8 @@ import {
   type EditorContentWidth
 } from "../lib/editor-width";
 import { readAiSelectionContextFromView } from "../hooks/useEditorController";
+import type { MarkdownDocumentLinkFile } from "../lib/document-links";
+import { markraDocumentLinkCompletionPlugin } from "./document-link-completion";
 import { EditorWidthResizer } from "./EditorWidthResizer";
 
 const markraCommonmark = [
@@ -89,6 +91,7 @@ type MarkdownPaperProps = {
   contentWidthMax?: number;
   contentWidthMin?: number;
   contentWidthPx?: number | null;
+  documentPath?: string | null;
   initialContent: string;
   language?: AppLanguage;
   lineHeight?: number;
@@ -105,10 +108,12 @@ type MarkdownPaperProps = {
   resolveImageSrc?: (src: string) => string;
   revision: number;
   topInset?: "tabs" | "titlebar";
+  workspaceFiles?: MarkdownDocumentLinkFile[];
 };
 
 type MilkdownSurfaceProps = {
   autoFocus: boolean;
+  documentPath?: MarkdownPaperProps["documentPath"];
   initialContent: string;
   language: AppLanguage;
   onEditorReady: MarkdownPaperProps["onEditorReady"];
@@ -119,6 +124,7 @@ type MilkdownSurfaceProps = {
   onTextSelectionChange?: MarkdownPaperProps["onTextSelectionChange"];
   resolveImageSrc?: MarkdownPaperProps["resolveImageSrc"];
   markdownShortcuts?: MarkdownPaperProps["markdownShortcuts"];
+  workspaceFiles?: MarkdownPaperProps["workspaceFiles"];
 };
 
 function markraTextSelectionObserverPlugin(
@@ -312,6 +318,7 @@ function MilkdownInstanceBridge({ autoFocus, onEditorReady }: Pick<MilkdownSurfa
 
 function MilkdownSurface({
   autoFocus,
+  documentPath,
   initialContent,
   language,
   onEditorReady,
@@ -321,12 +328,17 @@ function MilkdownSurface({
   openExternalUrl,
   onTextSelectionChange,
   resolveImageSrc,
-  markdownShortcuts
+  markdownShortcuts,
+  workspaceFiles
 }: MilkdownSurfaceProps) {
   const initialContentRef = useRef(initialContent);
+  const documentPathRef = useRef(documentPath);
+  const openExternalUrlRef = useRef(openExternalUrl);
   const onSaveClipboardImageRef = useRef(onSaveClipboardImage);
   const onSaveRemoteClipboardImageRef = useRef(onSaveRemoteClipboardImage);
   const onTextSelectionChangeRef = useRef(onTextSelectionChange);
+  const workspaceFilesRef = useRef(workspaceFiles ?? []);
+  const externalLinkOpeningEnabled = Boolean(openExternalUrl);
   const markdownDocumentLabel = t(language, "app.markdownDocument");
   const tableControlLabels = {
     addColumnRight: t(language, "editor.table.addColumnRight"),
@@ -366,12 +378,24 @@ function MilkdownSurface({
   }, [onSaveClipboardImage]);
 
   useEffect(() => {
+    documentPathRef.current = documentPath;
+  }, [documentPath]);
+
+  useEffect(() => {
+    openExternalUrlRef.current = openExternalUrl;
+  }, [openExternalUrl]);
+
+  useEffect(() => {
     onSaveRemoteClipboardImageRef.current = onSaveRemoteClipboardImage;
   }, [onSaveRemoteClipboardImage]);
 
   useEffect(() => {
     onTextSelectionChangeRef.current = onTextSelectionChange;
   }, [onTextSelectionChange]);
+
+  useEffect(() => {
+    workspaceFilesRef.current = workspaceFiles ?? [];
+  }, [workspaceFiles]);
 
   const createEditor = useCallback(
     (root: HTMLElement) => {
@@ -423,6 +447,12 @@ function MilkdownSurface({
         .use(markraAiEditorPreviewPlugin)
         .use(markraBlockDragPlugin(blockDragLabels))
         .use(
+          markraDocumentLinkCompletionPlugin({
+            getDocumentPath: () => documentPathRef.current,
+            getWorkspaceFiles: () => workspaceFilesRef.current
+          })
+        )
+        .use(
           markraTextSelectionObserverPlugin((selection) => {
             onTextSelectionChangeRef.current?.(selection);
           })
@@ -439,8 +469,12 @@ function MilkdownSurface({
         )
         .use(markraLiveMarkdownPlugin);
 
-      if (openExternalUrl) {
-        editor.use(markraExternalLinkClickPlugin(openExternalUrl));
+      if (externalLinkOpeningEnabled) {
+        editor.use(
+          markraExternalLinkClickPlugin((url) => {
+            return openExternalUrlRef.current?.(url);
+          })
+        );
       }
 
       if (onSaveClipboardImageRef.current || onSaveRemoteClipboardImageRef.current) {
@@ -456,7 +490,7 @@ function MilkdownSurface({
 
       return editor;
     },
-    [language, markdownDocumentLabel, markdownShortcuts, onMarkdownChange, openExternalUrl, resolveImageSrc, slashCommandLabels]
+    [externalLinkOpeningEnabled, language, markdownDocumentLabel, markdownShortcuts, onMarkdownChange, resolveImageSrc, slashCommandLabels]
   );
 
   useEditor(createEditor, [createEditor]);
@@ -477,6 +511,7 @@ export function MarkdownPaper({
   contentWidthMax = editorCustomContentWidthMax,
   contentWidthMin = editorCustomContentWidthMin,
   contentWidthPx = null,
+  documentPath,
   initialContent,
   language = "en",
   lineHeight = 1.65,
@@ -492,7 +527,8 @@ export function MarkdownPaper({
   onTextSelectionChange,
   resolveImageSrc,
   revision,
-  topInset = "titlebar"
+  topInset = "titlebar",
+  workspaceFiles
 }: MarkdownPaperProps) {
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const paperStyle = {
@@ -532,6 +568,7 @@ export function MarkdownPaper({
         <MilkdownProvider>
           <MilkdownSurface
             autoFocus={autoFocus}
+            documentPath={documentPath}
             initialContent={initialContent}
             language={language}
             markdownShortcuts={normalizedMarkdownShortcuts}
@@ -542,6 +579,7 @@ export function MarkdownPaper({
             openExternalUrl={openExternalUrl}
             onTextSelectionChange={onTextSelectionChange}
             resolveImageSrc={resolveImageSrc}
+            workspaceFiles={workspaceFiles}
           />
         </MilkdownProvider>
       </article>

--- a/apps/desktop/src/components/document-link-completion.ts
+++ b/apps/desktop/src/components/document-link-completion.ts
@@ -1,0 +1,257 @@
+import { Plugin, PluginKey, type EditorState } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+import {
+  documentLinkCompletionFiles,
+  markdownDocumentLinkHrefForFile,
+  markdownDocumentLinkForFile,
+  markdownDocumentLinkTitle,
+  type MarkdownDocumentLinkFile
+} from "../lib/document-links";
+
+type DocumentLinkCompletionOptions = {
+  getDocumentPath: () => string | null | undefined;
+  getWorkspaceFiles: () => MarkdownDocumentLinkFile[];
+};
+
+type ActiveCompletion = {
+  from: number;
+  query: string;
+  to: number;
+};
+
+type CompletionState = {
+  active: ActiveCompletion | null;
+  selectedIndex: number;
+};
+
+type CompletionMeta =
+  | {
+      type: "close";
+    }
+  | {
+      selectedIndex: number;
+      type: "move";
+    };
+
+const completionKey = new PluginKey<CompletionState>("markra-document-link-completion");
+const completionOptionAttribute = "data-markra-document-link-index";
+
+function activeDocumentLinkCompletion(state: EditorState): ActiveCompletion | null {
+  const { selection } = state;
+  if (!selection.empty) return null;
+
+  const $cursor = selection.$from;
+  if (!$cursor.parent.isTextblock) return null;
+
+  const textBeforeCursor = $cursor.parent.textBetween(0, $cursor.parentOffset, "\n", "\n");
+  const match = /\[\[([^\]\n]*)$/u.exec(textBeforeCursor);
+  if (!match) return null;
+
+  const typed = match[0] ?? "";
+  return {
+    from: selection.from - typed.length,
+    query: match[1] ?? "",
+    to: selection.from
+  };
+}
+
+function sameCompletion(left: ActiveCompletion | null, right: ActiveCompletion | null) {
+  return Boolean(left && right && left.from === right.from && left.to === right.to && left.query === right.query);
+}
+
+function completionOptions(options: DocumentLinkCompletionOptions, active: ActiveCompletion | null) {
+  if (!active) return [];
+
+  return documentLinkCompletionFiles(
+    options.getWorkspaceFiles(),
+    active.query,
+    options.getDocumentPath()
+  );
+}
+
+function insertDocumentLink(view: EditorView, active: ActiveCompletion, file: MarkdownDocumentLinkFile, options: DocumentLinkCompletionOptions) {
+  const href = markdownDocumentLinkHrefForFile(file, options.getDocumentPath());
+  const title = markdownDocumentLinkTitle(file);
+  const linkMark = view.state.schema.marks.link;
+  const replacement = linkMark
+    ? view.state.schema.text(title, [linkMark.create({ href })])
+    : view.state.schema.text(markdownDocumentLinkForFile(file, options.getDocumentPath()));
+  const transaction = view.state.tr
+    .replaceWith(active.from, active.to, replacement)
+    .setMeta(completionKey, { type: "close" } satisfies CompletionMeta)
+    .scrollIntoView();
+
+  view.dispatch(transaction);
+  view.focus();
+}
+
+function moveSelectedOption(view: EditorView, options: DocumentLinkCompletionOptions, delta: number) {
+  const state = completionKey.getState(view.state);
+  const active = state?.active ?? null;
+  const files = completionOptions(options, active);
+  if (!state || !active || files.length === 0) return false;
+
+  const nextIndex = (state.selectedIndex + delta + files.length) % files.length;
+  view.dispatch(view.state.tr.setMeta(completionKey, { selectedIndex: nextIndex, type: "move" } satisfies CompletionMeta));
+  return true;
+}
+
+function optionId(index: number) {
+  return `markra-document-link-option-${index}`;
+}
+
+function renderMenuOption(ownerDocument: Document, file: MarkdownDocumentLinkFile, index: number, selected: boolean) {
+  const option = ownerDocument.createElement("div");
+  const titleText = file.name.replace(/\.(md|markdown)$/iu, "");
+  option.className = "markra-document-link-option";
+  option.id = optionId(index);
+  option.setAttribute("role", "option");
+  option.setAttribute("aria-label", `${titleText} ${file.relativePath}`);
+  option.setAttribute("aria-selected", selected ? "true" : "false");
+  option.setAttribute(completionOptionAttribute, String(index));
+
+  const title = ownerDocument.createElement("span");
+  title.className = "markra-document-link-title";
+  title.textContent = titleText;
+
+  const path = ownerDocument.createElement("span");
+  path.className = "markra-document-link-path";
+  path.textContent = file.relativePath;
+
+  option.append(title, path);
+  return option;
+}
+
+function positionMenu(view: EditorView, active: ActiveCompletion, menu: HTMLElement) {
+  try {
+    const coords = view.coordsAtPos(active.to);
+    menu.style.left = `${Math.max(8, coords.left)}px`;
+    menu.style.top = `${coords.bottom + 8}px`;
+  } catch {
+    menu.style.left = "8px";
+    menu.style.top = "8px";
+  }
+}
+
+export function markraDocumentLinkCompletionPlugin(options: DocumentLinkCompletionOptions) {
+  return $prose(() => {
+    return new Plugin<CompletionState>({
+      key: completionKey,
+      state: {
+        init(_, state) {
+          return {
+            active: activeDocumentLinkCompletion(state),
+            selectedIndex: 0
+          };
+        },
+        apply(transaction, previous, _oldState, newState) {
+          const meta = transaction.getMeta(completionKey) as CompletionMeta | undefined;
+          if (meta?.type === "close") {
+            return {
+              active: null,
+              selectedIndex: 0
+            };
+          }
+
+          const active = activeDocumentLinkCompletion(newState);
+          const selectedIndex = meta?.type === "move"
+            ? meta.selectedIndex
+            : sameCompletion(previous.active, active)
+              ? previous.selectedIndex
+              : 0;
+
+          return {
+            active,
+            selectedIndex
+          };
+        }
+      },
+      props: {
+        handleKeyDown(view, event) {
+          const state = completionKey.getState(view.state);
+          const active = state?.active ?? null;
+          if (!active || event.isComposing) return false;
+
+          if (event.key === "Escape") {
+            event.preventDefault();
+            view.dispatch(view.state.tr.setMeta(completionKey, { type: "close" } satisfies CompletionMeta));
+            return true;
+          }
+
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            return moveSelectedOption(view, options, event.key === "ArrowDown" ? 1 : -1);
+          }
+
+          if (event.key !== "Enter" && event.key !== "Tab") return false;
+
+          const files = completionOptions(options, active);
+          const file = files[Math.min(state?.selectedIndex ?? 0, files.length - 1)];
+          if (!file) return false;
+
+          event.preventDefault();
+          insertDocumentLink(view, active, file, options);
+          return true;
+        }
+      },
+      view(view) {
+        const ownerDocument = view.dom.ownerDocument;
+        const menu = ownerDocument.createElement("div");
+        let currentFiles: MarkdownDocumentLinkFile[] = [];
+
+        menu.className = "markra-document-link-menu";
+        menu.hidden = true;
+        menu.setAttribute("role", "listbox");
+        menu.setAttribute("aria-label", "Document links");
+
+        const update = (nextView: EditorView) => {
+          const state = completionKey.getState(nextView.state);
+          const active = state?.active ?? null;
+          const files = completionOptions(options, active);
+
+          currentFiles = files;
+          menu.replaceChildren();
+
+          if (!active || files.length === 0) {
+            menu.hidden = true;
+            menu.removeAttribute("aria-activedescendant");
+            return;
+          }
+
+          const selectedIndex = Math.min(state?.selectedIndex ?? 0, files.length - 1);
+          files.forEach((file, index) => {
+            menu.append(renderMenuOption(ownerDocument, file, index, index === selectedIndex));
+          });
+          menu.hidden = false;
+          menu.setAttribute("aria-activedescendant", optionId(selectedIndex));
+          positionMenu(nextView, active, menu);
+        };
+
+        const handleMouseDown = (event: MouseEvent) => {
+          const target = event.target instanceof Element ? event.target : null;
+          const option = target?.closest(`[${completionOptionAttribute}]`);
+          const optionIndex = Number(option?.getAttribute(completionOptionAttribute));
+          const file = Number.isFinite(optionIndex) ? currentFiles[optionIndex] : undefined;
+          const active = completionKey.getState(view.state)?.active ?? null;
+          if (!file || !active) return;
+
+          event.preventDefault();
+          insertDocumentLink(view, active, file, options);
+        };
+
+        menu.addEventListener("mousedown", handleMouseDown);
+        ownerDocument.body.append(menu);
+        update(view);
+
+        return {
+          destroy() {
+            menu.removeEventListener("mousedown", handleMouseDown);
+            menu.remove();
+          },
+          update
+        };
+      }
+    });
+  });
+}

--- a/apps/desktop/src/lib/document-links.test.ts
+++ b/apps/desktop/src/lib/document-links.test.ts
@@ -1,0 +1,44 @@
+import {
+  documentLinkCompletionFiles,
+  markdownDocumentLinkForFile,
+  resolveMarkdownDocumentLinkFile
+} from "./document-links";
+
+const workspaceFiles = [
+  { name: "index.md", path: "/mock-files/vault/index.md", relativePath: "index.md" },
+  { name: "Guide Notes.md", path: "/mock-files/vault/docs/Guide Notes.md", relativePath: "docs/Guide Notes.md" },
+  { name: "Roadmap.markdown", path: "/mock-files/vault/Roadmap.markdown", relativePath: "Roadmap.markdown" },
+  { kind: "asset" as const, name: "cover.png", path: "/mock-files/vault/cover.png", relativePath: "cover.png" },
+  { kind: "folder" as const, name: "docs", path: "/mock-files/vault/docs", relativePath: "docs" }
+];
+
+describe("document links", () => {
+  it("builds portable markdown links relative to the current document", () => {
+    expect(markdownDocumentLinkForFile(workspaceFiles[1]!, "/mock-files/vault/index.md")).toBe(
+      "[Guide Notes](./docs/Guide%20Notes.md)"
+    );
+    expect(markdownDocumentLinkForFile(workspaceFiles[2]!, "/mock-files/vault/docs/current.md")).toBe(
+      "[Roadmap](../Roadmap.markdown)"
+    );
+  });
+
+  it("filters completion candidates to markdown documents", () => {
+    expect(documentLinkCompletionFiles(workspaceFiles, "guide", "/mock-files/vault/index.md")).toEqual([
+      workspaceFiles[1]
+    ]);
+    expect(documentLinkCompletionFiles(workspaceFiles, "", "/mock-files/vault/index.md")).toEqual([
+      workspaceFiles[1],
+      workspaceFiles[2]
+    ]);
+  });
+
+  it("resolves relative markdown links to workspace files", () => {
+    expect(resolveMarkdownDocumentLinkFile("./docs/Guide%20Notes.md", "/mock-files/vault/index.md", workspaceFiles)).toBe(
+      workspaceFiles[1]
+    );
+    expect(resolveMarkdownDocumentLinkFile("../Roadmap.markdown", "/mock-files/vault/docs/current.md", workspaceFiles)).toBe(
+      workspaceFiles[2]
+    );
+    expect(resolveMarkdownDocumentLinkFile("https://example.com", "/mock-files/vault/index.md", workspaceFiles)).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/document-links.ts
+++ b/apps/desktop/src/lib/document-links.ts
@@ -1,0 +1,188 @@
+export type MarkdownDocumentLinkFile = {
+  kind?: "asset" | "folder";
+  name: string;
+  path: string;
+  relativePath: string;
+};
+
+const markdownDocumentExtensionPattern = /\.(md|markdown)$/iu;
+const localUrlSchemePattern = /^[a-z][a-z\d+.-]*:/iu;
+const unsafeMarkdownHrefCharactersPattern = /[%\s()<>#]/gu;
+const documentLinkCompletionLimit = 8;
+
+function normalizePathSeparators(path: string) {
+  return path.replace(/\\/gu, "/");
+}
+
+function trimPathSlashes(path: string) {
+  return path.replace(/^\/+/u, "").replace(/\/+$/u, "");
+}
+
+function pathParts(path: string) {
+  const normalized = normalizePathSeparators(path);
+  const driveMatch = /^[a-z]:/iu.exec(normalized);
+  const prefix = driveMatch ? driveMatch[0] : normalized.startsWith("/") ? "/" : "";
+  const body = prefix ? normalized.slice(prefix.length) : normalized;
+  const parts = body.split("/").filter(Boolean);
+
+  return prefix ? [prefix, ...parts] : parts;
+}
+
+function pathFromParts(parts: string[]) {
+  if (parts[0] === "/") return `/${parts.slice(1).join("/")}`;
+  return parts.join("/");
+}
+
+function directoryPath(path: string) {
+  const parts = pathParts(path);
+  if (parts.length <= 1) return parts[0] === "/" ? "/" : "";
+
+  return pathFromParts(parts.slice(0, -1));
+}
+
+function normalizeAbsolutePath(path: string) {
+  const normalized = normalizePathSeparators(path);
+  const absolutePrefix = normalized.startsWith("/") ? "/" : /^[a-z]:/iu.exec(normalized)?.[0] ?? "";
+  const body = absolutePrefix ? normalized.slice(absolutePrefix.length) : normalized;
+  const parts: string[] = [];
+
+  body.split("/").forEach((part) => {
+    if (!part || part === ".") return;
+    if (part === "..") {
+      parts.pop();
+      return;
+    }
+    parts.push(part);
+  });
+
+  if (absolutePrefix === "/") return `/${parts.join("/")}`;
+  if (absolutePrefix) return `${absolutePrefix}/${parts.join("/")}`;
+  return parts.join("/");
+}
+
+function resolvePathFromDocument(href: string, documentPath: string | null | undefined) {
+  const normalizedHref = normalizePathSeparators(href);
+  if (normalizedHref.startsWith("/") || /^[a-z]:\//iu.test(normalizedHref)) {
+    return normalizeAbsolutePath(normalizedHref);
+  }
+
+  if (!documentPath) return normalizeAbsolutePath(normalizedHref);
+
+  const baseDirectory = directoryPath(documentPath);
+  return normalizeAbsolutePath(`${baseDirectory}/${normalizedHref}`);
+}
+
+function relativePathFromDocument(documentPath: string | null | undefined, targetPath: string, fallbackRelativePath: string) {
+  if (!documentPath) return `./${trimPathSlashes(normalizePathSeparators(fallbackRelativePath))}`;
+
+  const fromParts = pathParts(directoryPath(documentPath));
+  const toParts = pathParts(targetPath);
+
+  if (fromParts[0] !== toParts[0]) return `./${trimPathSlashes(normalizePathSeparators(fallbackRelativePath))}`;
+
+  let shared = 0;
+  while (shared < fromParts.length && shared < toParts.length && fromParts[shared] === toParts[shared]) {
+    shared += 1;
+  }
+
+  const upParts = fromParts.slice(shared).filter((part) => part !== "/").map(() => "..");
+  const downParts = toParts.slice(shared);
+  const relativeParts = [...upParts, ...downParts];
+  const relativePath = relativeParts.join("/");
+
+  if (!relativePath || relativePath.startsWith(".")) return relativePath || ".";
+  return `./${relativePath}`;
+}
+
+export function markdownDocumentLinkTitle(file: MarkdownDocumentLinkFile) {
+  return file.name.replace(markdownDocumentExtensionPattern, "");
+}
+
+function normalizeCompletionText(value: string) {
+  return value.trim().toLocaleLowerCase();
+}
+
+function isMarkdownDocumentFile(file: MarkdownDocumentLinkFile) {
+  return !file.kind && markdownDocumentExtensionPattern.test(file.name);
+}
+
+function encodeMarkdownHref(href: string) {
+  return href.replace(unsafeMarkdownHrefCharactersPattern, (character) =>
+    `%${character.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`
+  );
+}
+
+function decodeMarkdownHref(href: string) {
+  const trimmed = href.trim();
+  const unwrapped = trimmed.startsWith("<") && trimmed.endsWith(">") ? trimmed.slice(1, -1) : trimmed;
+
+  try {
+    return decodeURI(unwrapped);
+  } catch {
+    return unwrapped;
+  }
+}
+
+function localMarkdownHrefPath(href: string) {
+  const decoded = decodeMarkdownHref(href);
+  if (!decoded || decoded.startsWith("#") || decoded.startsWith("//") || localUrlSchemePattern.test(decoded)) {
+    return null;
+  }
+
+  return decoded.split(/[?#]/u)[0] ?? null;
+}
+
+export function documentLinkCompletionFiles(
+  files: MarkdownDocumentLinkFile[],
+  query: string,
+  currentDocumentPath?: string | null
+) {
+  const normalizedQuery = normalizeCompletionText(query);
+
+  return files
+    .filter((file) => isMarkdownDocumentFile(file) && file.path !== currentDocumentPath)
+    .filter((file) => {
+      if (!normalizedQuery) return true;
+
+      const title = normalizeCompletionText(markdownDocumentLinkTitle(file));
+      const relativePath = normalizeCompletionText(file.relativePath);
+      return title.includes(normalizedQuery) || relativePath.includes(normalizedQuery);
+    })
+    .sort((a, b) => {
+      const aTitle = normalizeCompletionText(markdownDocumentLinkTitle(a));
+      const bTitle = normalizeCompletionText(markdownDocumentLinkTitle(b));
+      const aStarts = normalizedQuery ? aTitle.startsWith(normalizedQuery) : false;
+      const bStarts = normalizedQuery ? bTitle.startsWith(normalizedQuery) : false;
+      if (aStarts !== bStarts) return aStarts ? -1 : 1;
+
+      return a.relativePath.localeCompare(b.relativePath, undefined, { numeric: true, sensitivity: "base" });
+    })
+    .slice(0, documentLinkCompletionLimit);
+}
+
+export function markdownDocumentLinkHrefForFile(file: MarkdownDocumentLinkFile, currentDocumentPath?: string | null) {
+  return encodeMarkdownHref(relativePathFromDocument(currentDocumentPath, file.path, file.relativePath));
+}
+
+export function markdownDocumentLinkForFile(file: MarkdownDocumentLinkFile, currentDocumentPath?: string | null) {
+  const href = markdownDocumentLinkHrefForFile(file, currentDocumentPath);
+  return `[${markdownDocumentLinkTitle(file)}](${href})`;
+}
+
+export function resolveMarkdownDocumentLinkFile(
+  href: string,
+  currentDocumentPath: string | null | undefined,
+  files: MarkdownDocumentLinkFile[]
+) {
+  const hrefPath = localMarkdownHrefPath(href);
+  if (!hrefPath || !markdownDocumentExtensionPattern.test(hrefPath)) return null;
+
+  const resolvedPath = resolvePathFromDocument(hrefPath, currentDocumentPath);
+  const normalizedHrefRelativePath = trimPathSlashes(normalizePathSeparators(hrefPath).replace(/^\.\//u, ""));
+
+  return files.find((file) => {
+    if (!isMarkdownDocumentFile(file)) return false;
+
+    return normalizeAbsolutePath(file.path) === resolvedPath || normalizePathSeparators(file.relativePath) === normalizedHrefRelativePath;
+  }) ?? null;
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -792,6 +792,26 @@
     @apply hidden;
   }
 
+  .markra-document-link-menu {
+    @apply fixed z-[60] min-w-60 max-w-[22rem] rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 shadow-(--ai-command-expanded-shadow);
+  }
+
+  .markra-document-link-option {
+    @apply flex cursor-pointer flex-col gap-0.5 rounded-md px-2.5 py-1.5 text-left;
+  }
+
+  .markra-document-link-option[aria-selected="true"] {
+    @apply bg-(--bg-hover);
+  }
+
+  .markra-document-link-title {
+    @apply truncate text-sm font-medium leading-5 text-(--text-heading);
+  }
+
+  .markra-document-link-path {
+    @apply truncate text-xs leading-4 text-(--text-secondary);
+  }
+
   .markdown-paper .markra-html-node {
     @apply max-w-full outline-none;
   }


### PR DESCRIPTION
## Summary
- Add a `[[...` document-link completion menu that inserts standard Markdown links instead of a custom wiki-link syntax.
- Resolve relative Markdown links against the current workspace and open matching documents inside Markra.
- Add focused tests for link generation, completion insertion, and internal document navigation.

## Why
- Keeps the document-link workflow portable by saving links as `[Title](./path.md)`.
- Provides the useful part of wiki-style linking without introducing a Markra-specific Markdown dialect.

## Validation
- `pnpm --filter @markra/desktop exec vitest run src/lib/document-links.test.ts src/components/MarkdownPaper.test.tsx src/App.test.tsx` passed: 226 tests.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed.
- `git diff --check` passed.

## Risk
- This touches editor link handling, so ordinary external-link editing/opening behavior is covered by existing MarkdownPaper and App tests.

## Related Issues
- Refs #45
