### PR TITLE
feat(editor): add GitHub-style callout blocks

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -2241,8 +2241,12 @@ describe("Markra workspace", () => {
     renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true });
-    const link = await screen.findByText("Guide");
-    link.closest("a")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true }));
+    let link: HTMLAnchorElement | null = null;
+    await waitFor(() => {
+      link = document.querySelector<HTMLAnchorElement>('.ProseMirror a[href="./docs/guide.md"]');
+      expect(link).toHaveTextContent("Guide");
+    });
+    link!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true }));
 
     expect(await screen.findByText("Opened through a document link.")).toBeInTheDocument();
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);

--- a/apps/desktop/src/components/MarkdownExportDocument.test.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.test.tsx
@@ -48,4 +48,52 @@ describe("MarkdownExportDocument", () => {
     expect(bodyHtml).toContain("katex");
     expect(bodyHtml).not.toContain("language-math");
   });
+
+  it("renders GitHub-style alert blockquotes as callouts before exporting HTML", async () => {
+    const onRendered = vi.fn();
+
+    render(
+      <MarkdownExportDocument
+        onRendered={onRendered}
+        snapshot={{
+          id: 1,
+          kind: "html",
+          markdown: "> [!WARNING]\n> Check this before publishing.",
+          title: "callout.md"
+        }}
+      />
+    );
+
+    await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
+
+    const bodyHtml = onRendered.mock.calls[0]?.[0].bodyHtml as string;
+    expect(bodyHtml).toContain("markra-callout");
+    expect(bodyHtml).toContain("markra-callout-warning");
+    expect(bodyHtml).toContain('data-callout-type="warning"');
+    expect(bodyHtml).toContain("Warning");
+    expect(bodyHtml).toContain("Check this before publishing.");
+  });
+
+  it("omits empty marker paragraphs from exported callouts", async () => {
+    const onRendered = vi.fn();
+
+    render(
+      <MarkdownExportDocument
+        onRendered={onRendered}
+        snapshot={{
+          id: 1,
+          kind: "html",
+          markdown: "> [!NOTE]\n>\n> Keep this in mind.",
+          title: "callout.md"
+        }}
+      />
+    );
+
+    await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
+
+    const bodyHtml = onRendered.mock.calls[0]?.[0].bodyHtml as string;
+    expect(bodyHtml).toContain("markra-callout-note");
+    expect(bodyHtml).toContain("Keep this in mind.");
+    expect(bodyHtml).not.toContain("<p></p>");
+  });
 });

--- a/apps/desktop/src/components/MarkdownExportDocument.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.tsx
@@ -1,9 +1,10 @@
-import { Children, isValidElement, useEffect, useRef, type ReactNode } from "react";
+import { Children, cloneElement, isValidElement, useEffect, useRef, type ReactElement, type ReactNode } from "react";
 import { renderToString } from "katex";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import { parseMarkdownCalloutMarker, type ParsedMarkdownCalloutMarker } from "@markra/shared";
 import type { ExportDocumentFormat } from "../lib/document-export";
 
 export type MarkdownExportSnapshot = {
@@ -53,6 +54,87 @@ function renderMathSource(source: string, kind: "display" | "inline") {
   );
 }
 
+function removeCalloutMarkerFromChildren(children: ReactNode, marker: string) {
+  let remainingMarkerLength = marker.length;
+  let trimLeadingBreak = false;
+
+  return Children.toArray(children)
+    .map((child) => {
+      if (remainingMarkerLength <= 0 && !trimLeadingBreak) return child;
+
+      if (typeof child === "string" || typeof child === "number") {
+        let text = String(child);
+
+        if (remainingMarkerLength > 0) {
+          const removeLength = Math.min(remainingMarkerLength, text.length);
+          text = text.slice(removeLength);
+          remainingMarkerLength -= removeLength;
+          if (remainingMarkerLength === 0) trimLeadingBreak = true;
+        }
+
+        if (trimLeadingBreak) {
+          text = text.replace(/^[\s\r\n]+/u, "");
+          if (text.length > 0) trimLeadingBreak = false;
+        }
+
+        return text || null;
+      }
+
+      if (trimLeadingBreak && isValidElement(child) && child.type === "br") {
+        return null;
+      }
+
+      return child;
+    })
+    .filter((child) => child !== null);
+}
+
+function renderCalloutHeader(marker: ParsedMarkdownCalloutMarker) {
+  return (
+    <div className="markra-callout-header">
+      <span aria-hidden="true" className="markra-callout-icon" />
+      <span className="markra-callout-title">{marker.label}</span>
+    </div>
+  );
+}
+
+function renderCalloutBlockquote(props: {
+  children?: ReactNode;
+}) {
+  const children = Children.toArray(props.children);
+  const firstParagraphIndex = children.findIndex((child) =>
+    isValidElement<{ children?: ReactNode }>(child) && child.type === "p"
+  );
+  const firstChild = children[firstParagraphIndex];
+  if (!isValidElement<{ children?: ReactNode }>(firstChild) || firstChild.type !== "p") {
+    return <blockquote>{props.children}</blockquote>;
+  }
+
+  const marker = parseMarkdownCalloutMarker(childrenToText(firstChild.props.children));
+  if (!marker) return <blockquote>{props.children}</blockquote>;
+
+  const nextFirstChildContent = removeCalloutMarkerFromChildren(firstChild.props.children, marker.source);
+  const nextFirstChild = nextFirstChildContent.length > 0
+    ? cloneElement(firstChild as ReactElement<{ children?: ReactNode }>, undefined, nextFirstChildContent)
+    : null;
+  const nextChildren = [
+    ...children.slice(0, firstParagraphIndex),
+    ...(nextFirstChild ? [nextFirstChild] : []),
+    ...children.slice(firstParagraphIndex + 1)
+  ];
+
+  return (
+    <blockquote
+      className={`markra-callout markra-callout-${marker.type}`}
+      data-callout-label={marker.label}
+      data-callout-type={marker.type}
+    >
+      {renderCalloutHeader(marker)}
+      {nextChildren}
+    </blockquote>
+  );
+}
+
 export function MarkdownExportDocument({
   onRendered,
   resolveImageSrc,
@@ -84,6 +166,7 @@ export function MarkdownExportDocument({
           remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
           components={{
             a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
+            blockquote: ({ node: _node, ...props }) => renderCalloutBlockquote(props),
             code: ({ node: _node, className, children, ...props }) => {
               if (hasMathClass(className, "inline")) {
                 return renderMathSource(childrenToText(children), "inline");

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -138,6 +138,23 @@ function findFirstTextBlockCursor(view: EditorView) {
   return position;
 }
 
+function findLastTextBlockCursor(view: EditorView) {
+  let position: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (!node.isTextblock) return true;
+
+    position = nodePosition + 1;
+    return true;
+  });
+
+  if (position === null) {
+    throw new Error("Could not find text block in editor.");
+  }
+
+  return position;
+}
+
 function splitCurrentTextBlockDirectly(view: EditorView) {
   view.dispatch(view.state.tr.split(view.state.selection.from).scrollIntoView());
 }
@@ -369,6 +386,16 @@ function positionWithAncestorExcluding(view: EditorView, typeName: string, exclu
   }
 
   return null;
+}
+
+function selectionHasAncestor(view: EditorView, typeName: string) {
+  const { $from } = view.state.selection;
+
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    if ($from.node(depth).type.name === typeName) return true;
+  }
+
+  return false;
 }
 
 function mockBlockDragLayout(view: EditorView, blocks: HTMLElement[], positions: number[]) {
@@ -4021,6 +4048,60 @@ describe("MarkdownPaper editing", () => {
     expect(table).toHaveTextContent("Editor");
   });
 
+  it("renders GitHub-style alert blockquotes as callouts while preserving Markdown source", async () => {
+    const source = "> [!NOTE]\n> Keep this in mind.";
+    const { container, editor, view } = await renderEditor(source);
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveAttribute("data-callout-type", "note");
+    expect(callout).toHaveAttribute("data-callout-label", "Note");
+    expect(callout?.querySelector(".markra-callout-title")).toHaveTextContent("Note");
+    expect(callout).toHaveTextContent("Keep this in mind.");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+  });
+
+  it("marks empty callout source lines so the display has no spacer paragraph", async () => {
+    const { container } = await renderEditor("> [!NOTE]\n>\n> Keep this in mind.");
+
+    const markerLine = container.querySelector<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout .markra-callout-marker-line"
+    );
+
+    expect(markerLine).toBeInTheDocument();
+    expect(markerLine).toHaveTextContent("[!NOTE]");
+  });
+
+  it("keeps same-paragraph callout content visible", async () => {
+    const { container } = await renderEditor("> [!WARNING]\n> Check before publishing.");
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+
+    expect(callout).toHaveTextContent("Check before publishing.");
+    expect(callout?.querySelector(".markra-callout-marker-line")).not.toBeInTheDocument();
+  });
+
+  it("updates the callout type without leaving GitHub Alerts syntax", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n> Keep this in mind.");
+
+    const typeSelect = screen.getByRole("combobox", { name: "Callout type" });
+    fireEvent.change(typeSelect, {
+      target: {
+        value: "warning"
+      }
+    });
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    expect(callout).toHaveAttribute("data-callout-type", "warning");
+    expect(callout?.querySelector(".markra-callout-title")).toHaveTextContent("Warning");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n> Keep this in mind.");
+  });
+
   it("renders links and images from existing markdown", async () => {
     const { container } = await renderEditor(
       "[Markra](https://example.com)\n\n![Markra logo](https://example.com/logo.png)"
@@ -4450,6 +4531,71 @@ describe("MarkdownPaper editing", () => {
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
     expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 1");
     expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/ta");
+    await settleMarkdownListener();
+  });
+
+  it("inserts a note callout from the slash command menu", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    typeText(view, "/call");
+
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Callout" })).toHaveAttribute("aria-selected", "true");
+
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveAttribute("data-callout-type", "note");
+    expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/call");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> [!NOTE]");
+    expect(markdown).not.toContain("<br");
+    await settleMarkdownListener();
+  });
+
+  it("uses slash command callout aliases as the inserted callout type", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    typeText(view, "/warn");
+
+    expect(await screen.findByRole("option", { name: "Callout" })).toHaveAttribute("aria-selected", "true");
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveAttribute("data-callout-type", "warning");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]");
+    await settleMarkdownListener();
+  });
+
+  it("removes an empty callout when pressing Backspace from its body", async () => {
+    const { container, view } = await renderEditor("> [!NOTE]\n> ");
+    moveCursor(view, findLastTextBlockCursor(view));
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(pressBackspace(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror p")).toHaveTextContent("");
+    await settleMarkdownListener();
+  });
+
+  it("keeps the cursor inside a callout when deleting an empty middle line", async () => {
+    const { container, view } = await renderEditor("> [!NOTE]\n>\n> First line\n>\n> Second line");
+    const secondLineFrom = findTextPosition(view, "Second line");
+
+    selectText(view, secondLineFrom, secondLineFrom + "Second line".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line");
+    expect(pressBackspace(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(view.state.selection.$from.parent.textContent).toBe("First line");
     await settleMarkdownListener();
   });
 

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -32,6 +32,8 @@ import {
   type SaveRemoteClipboardImage
 } from "@markra/editor";
 import { markraCodeBlockPlugin } from "@markra/editor";
+import { markraCalloutPlugin } from "@markra/editor";
+import { markraCalloutSerializerPlugin } from "@markra/editor";
 import { markraHeadingSourcePlugin } from "@markra/editor";
 import { normalizeHeadingSourceDocument } from "@markra/editor";
 import { markraLinkImageLivePlugin } from "@markra/editor";
@@ -364,6 +366,7 @@ function MilkdownSurface({
     noResults: t(language, "editor.slashCommandsNoResults"),
     commands: {
       bulletList: t(language, "menu.bulletList"),
+      callout: t(language, "menu.callout"),
       codeBlock: t(language, "menu.codeBlock"),
       heading1: t(language, "menu.heading1"),
       heading2: t(language, "menu.heading2"),
@@ -440,6 +443,8 @@ function MilkdownSurface({
         .use(markraMathRemarkPlugin)
         .use(markraCommonmark)
         .use(markraGfm)
+        .use(markraCalloutSerializerPlugin)
+        .use(markraCalloutPlugin)
         .use(markraSlashCommands(slashCommandLabels))
         .use(markraMathSourcePlugin)
         .use(markraMarkdownShortcuts(markdownShortcuts))

--- a/apps/desktop/src/components/MarkdownSourceEditor.test.tsx
+++ b/apps/desktop/src/components/MarkdownSourceEditor.test.tsx
@@ -35,4 +35,18 @@ describe("MarkdownSourceEditor", () => {
 
     expect(handleChange).toHaveBeenCalledWith("# Changed");
   });
+
+  it("highlights GitHub-style alert markers in source mode", () => {
+    const content = "> [!TIP]\n> Keep notes portable.";
+
+    const { container } = render(
+      <MarkdownSourceEditor
+        content={content}
+        onChange={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".markdown-source-token-callout")).toHaveTextContent("[!TIP]");
+    expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
+  });
 });

--- a/apps/desktop/src/components/MarkdownSourceEditor.tsx
+++ b/apps/desktop/src/components/MarkdownSourceEditor.tsx
@@ -1,5 +1,5 @@
 import { Fragment, type CSSProperties, type ChangeEvent, type ReactNode } from "react";
-import { t, type AppLanguage } from "@markra/shared";
+import { parseMarkdownCalloutMarker, t, type AppLanguage } from "@markra/shared";
 import {
   editorContentWidthPixels,
   editorCustomContentWidthMax,
@@ -72,6 +72,25 @@ function renderMarkdownSourceLine(line: string, lineIndex: number, fenceState: F
 
   const blockquoteMatch = line.match(/^(\s*>+)(\s.*)?$/u);
   if (blockquoteMatch) {
+    const calloutContent = blockquoteMatch[2] ?? "";
+    const calloutPrefixMatch = /^(\s*)(.*)$/u.exec(calloutContent);
+    const calloutMarker = parseMarkdownCalloutMarker(calloutPrefixMatch?.[2] ?? "");
+    if (calloutMarker && calloutPrefixMatch) {
+      const [, prefix = "", content = ""] = calloutPrefixMatch;
+      const markerIndex = content.indexOf(calloutMarker.source);
+      const afterMarker = content.slice(markerIndex + calloutMarker.source.length);
+
+      return (
+        <>
+          <span className="markdown-source-token-quote-marker">{blockquoteMatch[1]}</span>
+          {prefix ? <span className="markdown-source-token-muted">{prefix}</span> : null}
+          {markerIndex > 0 ? renderInlineMarkdownSource(content.slice(0, markerIndex), lineIndex) : null}
+          <span className="markdown-source-token-callout">{calloutMarker.source}</span>
+          {afterMarker ? renderInlineMarkdownSource(afterMarker, lineIndex) : null}
+        </>
+      );
+    }
+
     return (
       <>
         <span className="markdown-source-token-quote-marker">{blockquoteMatch[1]}</span>

--- a/apps/desktop/src/lib/document-export.ts
+++ b/apps/desktop/src/lib/document-export.ts
@@ -122,6 +122,101 @@ body {
   color: #555;
 }
 
+.markdown-export blockquote.markra-callout {
+  --callout-color: oklch(52% 0.11 252);
+  --callout-bg: color-mix(in srgb, var(--callout-color) 5%, #fbfbfb);
+  --callout-border: color-mix(in srgb, var(--callout-color) 22%, #d8d8d8);
+  margin: 1.1em 0;
+  padding: 0.85em 1em 0.9em;
+  border: 1px solid var(--callout-border);
+  border-radius: 7px;
+  background: var(--callout-bg);
+  color: #222;
+}
+
+.markdown-export blockquote.markra-callout-tip {
+  --callout-color: oklch(50% 0.11 154);
+}
+
+.markdown-export blockquote.markra-callout-important {
+  --callout-color: oklch(50% 0.12 292);
+}
+
+.markdown-export blockquote.markra-callout-warning {
+  --callout-color: oklch(54% 0.12 72);
+}
+
+.markdown-export blockquote.markra-callout-caution {
+  --callout-color: oklch(52% 0.13 28);
+}
+
+.markdown-export .markra-callout-header {
+  display: flex;
+  min-height: 1.25em;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.45em;
+  color: var(--callout-color);
+  font-size: 0.78em;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.markdown-export .markra-callout-icon {
+  position: relative;
+  display: inline-grid;
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 11%, #fbfbfb);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 24%, transparent);
+}
+
+.markdown-export .markra-callout-icon::before {
+  display: block;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 999px;
+  background: currentColor;
+  content: "";
+}
+
+.markdown-export .markra-callout-tip .markra-callout-icon::before {
+  width: 0.44rem;
+  height: 0.44rem;
+  border-radius: 2px;
+  transform: rotate(45deg);
+}
+
+.markdown-export .markra-callout-important .markra-callout-icon::before {
+  width: 0.25rem;
+  height: 0.56rem;
+  border-radius: 999px;
+}
+
+.markdown-export .markra-callout-warning .markra-callout-icon::before {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 0;
+  clip-path: polygon(50% 4%, 96% 92%, 4% 92%);
+}
+
+.markdown-export .markra-callout-caution .markra-callout-icon::before {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 2px;
+}
+
+.markdown-export blockquote.markra-callout p {
+  margin: 0 0 0.75em;
+}
+
+.markdown-export blockquote.markra-callout p:last-child {
+  margin-bottom: 0;
+}
+
 .markdown-export .markra-math-render {
   color: #222;
   letter-spacing: 0;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -716,6 +716,11 @@
     color: oklch(43% 0.13 151);
   }
 
+  .markdown-source-token-callout {
+    color: color-mix(in srgb, var(--accent-hover) 82%, var(--text-primary));
+    font-weight: 700;
+  }
+
   .markdown-source-token-link {
     color: var(--accent-hover);
   }
@@ -1127,6 +1132,134 @@
     @apply my-4.5 mr-0 border-l border-(--border-strong) py-0 pr-0 pl-5 text-(--text-secondary);
     border-color: var(--editor-border-strong);
     color: var(--editor-text-secondary);
+  }
+
+  .markdown-paper blockquote.markra-callout {
+    --callout-color: oklch(57% 0.11 252);
+    --callout-bg: color-mix(in srgb, var(--callout-color) 5%, var(--editor-paper-bg));
+    --callout-border: color-mix(in srgb, var(--callout-color) 22%, var(--editor-border));
+    --callout-border-focus: color-mix(in srgb, var(--callout-color) 38%, var(--editor-border-strong));
+    @apply relative my-5 rounded-[7px] border px-4 py-3.5 text-(--text-primary) transition-[background-color,border-color] duration-150 ease-out;
+    background: var(--callout-bg);
+    border-color: var(--callout-border);
+    color: var(--editor-text-primary);
+  }
+
+  .markdown-paper blockquote.markra-callout-tip {
+    --callout-color: oklch(56% 0.11 154);
+  }
+
+  .markdown-paper blockquote.markra-callout-important {
+    --callout-color: oklch(55% 0.12 292);
+  }
+
+  .markdown-paper blockquote.markra-callout-warning {
+    --callout-color: oklch(62% 0.12 72);
+  }
+
+  .markdown-paper blockquote.markra-callout-caution {
+    --callout-color: oklch(57% 0.13 28);
+  }
+
+  [data-theme="dark"] .markdown-paper blockquote.markra-callout,
+  [data-theme="night"] .markdown-paper blockquote.markra-callout,
+  [data-theme="solarized-dark"] .markdown-paper blockquote.markra-callout,
+  [data-theme="nord"] .markdown-paper blockquote.markra-callout,
+  [data-theme="catppuccin-mocha"] .markdown-paper blockquote.markra-callout,
+  .markdown-paper[data-editor-theme="dark"] blockquote.markra-callout,
+  .markdown-paper[data-editor-theme="night"] blockquote.markra-callout,
+  .markdown-paper[data-editor-theme="solarized-dark"] blockquote.markra-callout,
+  .markdown-paper[data-editor-theme="nord"] blockquote.markra-callout,
+  .markdown-paper[data-editor-theme="catppuccin-mocha"] blockquote.markra-callout {
+    --callout-bg: color-mix(in srgb, var(--callout-color) 10%, var(--editor-paper-bg));
+    --callout-border: color-mix(in srgb, var(--callout-color) 32%, var(--editor-border));
+  }
+
+  .markdown-paper .markra-callout-header {
+    @apply mb-2 flex min-h-5 items-center gap-2 text-[0.76em] leading-5 font-[720] tracking-normal;
+    color: var(--callout-color);
+  }
+
+  .markdown-paper .markra-callout-icon {
+    @apply relative inline-grid size-4 shrink-0 place-items-center rounded-full;
+    background: color-mix(in srgb, currentColor 11%, var(--editor-paper-bg));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 24%, transparent);
+  }
+
+  .markdown-paper .markra-callout-icon::before {
+    @apply block size-1.5 rounded-full;
+    content: "";
+    background: currentColor;
+  }
+
+  .markdown-paper .markra-callout-tip .markra-callout-icon::before {
+    @apply size-1.75 rounded-[2px];
+    transform: rotate(45deg);
+  }
+
+  .markdown-paper .markra-callout-important .markra-callout-icon::before {
+    @apply h-2.25 w-1 rounded-full;
+  }
+
+  .markdown-paper .markra-callout-warning .markra-callout-icon::before {
+    @apply size-2.5 rounded-none;
+    clip-path: polygon(50% 4%, 96% 92%, 4% 92%);
+  }
+
+  .markdown-paper .markra-callout-caution .markra-callout-icon::before {
+    @apply size-2 rounded-[2px];
+  }
+
+  .markdown-paper .markra-callout-title {
+    @apply shrink-0;
+  }
+
+  .markdown-paper .markra-callout-type-select {
+    @apply ml-auto h-6 max-w-30 rounded-md border border-(--border-default) px-2 text-[12px] leading-4 font-[520] text-(--text-secondary) outline-none transition-[opacity,border-color,color,background-color] duration-150 ease-out;
+    background: color-mix(in srgb, var(--editor-paper-bg) 86%, var(--callout-bg));
+    border-color: color-mix(in srgb, var(--callout-color) 18%, var(--editor-border));
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .markdown-paper .markra-callout:hover .markra-callout-type-select,
+  .markdown-paper .markra-callout:focus-within .markra-callout-type-select {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .markdown-paper blockquote.markra-callout:focus-within {
+    border-color: var(--callout-border-focus);
+  }
+
+  .markdown-paper .markra-callout-type-select:focus {
+    border-color: var(--callout-color);
+    color: var(--editor-text-primary);
+  }
+
+  .markdown-paper .markra-callout-marker-line {
+    @apply hidden;
+  }
+
+  .markdown-paper .markra-callout-source-marker {
+    @apply hidden;
+  }
+
+  .markdown-paper .markra-callout-source-marker + br {
+    @apply hidden;
+  }
+
+  .markdown-paper blockquote.markra-callout p {
+    @apply mb-3;
+    color: var(--editor-text-primary);
+  }
+
+  .markdown-paper blockquote.markra-callout p:first-of-type {
+    @apply mt-0;
+  }
+
+  .markdown-paper blockquote.markra-callout p:last-child {
+    @apply mb-0;
   }
 
   .markdown-paper blockquote p {

--- a/packages/editor/src/callout.ts
+++ b/packages/editor/src/callout.ts
@@ -1,0 +1,294 @@
+import { SerializerReady, serializerCtx } from "@milkdown/kit/core";
+import type { Ctx, MilkdownPlugin } from "@milkdown/kit/ctx";
+import { paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+import {
+  markdownCalloutDefinitions,
+  markdownCalloutMarkerForType,
+  parseMarkdownCalloutMarker,
+  restoreEscapedMarkdownCalloutMarkers,
+  type MarkdownCalloutType,
+  type ParsedMarkdownCalloutMarker
+} from "@markra/shared";
+
+type CalloutBlock = {
+  blockquote: ProseNode;
+  blockquoteFrom: number;
+  blockquoteTo: number;
+  marker: ParsedMarkdownCalloutMarker;
+  markerBlockFrom: number;
+  markerBlockTo: number;
+  markerLineIsEmpty: boolean;
+  markerFrom: number;
+  markerTo: number;
+};
+
+const calloutTypeOrder: MarkdownCalloutType[] = ["note", "tip", "important", "warning", "caution"];
+
+type MarkdownSerializer = (doc: ProseNode) => string;
+
+export const markraCalloutSerializerPlugin: MilkdownPlugin = (ctx: Ctx) => async () => {
+  await ctx.wait(SerializerReady);
+  ctx.update(serializerCtx, (serializeMarkdown: MarkdownSerializer) => (doc: ProseNode) =>
+    restoreEscapedMarkdownCalloutMarkers(serializeMarkdown(doc))
+  );
+
+  return () => {};
+};
+
+function firstTextMarkerRange(blockquote: ProseNode, blockquoteFrom: number): CalloutBlock | null {
+  const firstBlock = blockquote.firstChild;
+  const firstText = firstBlock?.firstChild;
+  if (!firstBlock?.isTextblock || !firstText?.isText || !firstText.text) return null;
+
+  const marker = parseMarkdownCalloutMarker(firstText.text);
+  if (!marker) return null;
+
+  const markerOffset = firstText.text.indexOf(marker.source);
+  if (markerOffset < 0) return null;
+
+  const markerBlockFrom = blockquoteFrom + 1;
+  const markerFrom = blockquoteFrom + 2 + markerOffset;
+  const markerLineText = firstBlock.textContent.slice(
+    firstBlock.textContent.indexOf(marker.source) + marker.source.length
+  );
+
+  return {
+    blockquote,
+    blockquoteFrom,
+    blockquoteTo: blockquoteFrom + blockquote.nodeSize,
+    marker,
+    markerBlockFrom,
+    markerBlockTo: markerBlockFrom + firstBlock.nodeSize,
+    markerLineIsEmpty: markerLineText.trim().length === 0,
+    markerFrom,
+    markerTo: markerFrom + marker.source.length
+  };
+}
+
+function isDeleteKey(event: KeyboardEvent) {
+  return event.key === "Backspace" || event.key === "Delete";
+}
+
+function hasModifier(event: KeyboardEvent) {
+  return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+}
+
+function calloutVisibleText(callout: CalloutBlock) {
+  let text = "";
+
+  callout.blockquote.forEach((child, _offset, index) => {
+    if (index === 0) {
+      const markerIndex = child.textContent.indexOf(callout.marker.source);
+      const contentStart = markerIndex >= 0 ? markerIndex + callout.marker.source.length : 0;
+      text += child.textContent.slice(contentStart);
+      return;
+    }
+
+    text += child.textContent;
+  });
+
+  return text.trim();
+}
+
+function findCalloutAtSelection(view: EditorView): CalloutBlock | null {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const node = $from.node(depth);
+    if (node.type.name !== "blockquote") continue;
+
+    return firstTextMarkerRange(node, $from.before(depth));
+  }
+
+  return null;
+}
+
+function removeEmptyCallout(view: EditorView, callout: CalloutBlock, paragraph: ReturnType<typeof paragraphSchema.type>) {
+  if (calloutVisibleText(callout).length > 0) return false;
+
+  const transaction = view.state.tr.replaceWith(callout.blockquoteFrom, callout.blockquoteTo, paragraph.create());
+  const selectionPosition = Math.min(callout.blockquoteFrom + 1, transaction.doc.content.size);
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, selectionPosition))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function emptySelectionBlockRange(view: EditorView) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+  if (!selection.$from.parent.isTextblock || selection.$from.parent.content.size > 0) return null;
+
+  return {
+    from: selection.$from.before(selection.$from.depth),
+    to: selection.$from.after(selection.$from.depth)
+  };
+}
+
+function adjacentCalloutTextPosition(callout: CalloutBlock, emptyBlockFrom: number, direction: "backward" | "forward") {
+  let fallbackPosition: number | null = null;
+
+  callout.blockquote.forEach((child, offset, index) => {
+    if (!child.isTextblock || index === 0 || child.content.size === 0) return;
+
+    const childFrom = callout.blockquoteFrom + 1 + offset;
+    if (direction === "backward" && childFrom < emptyBlockFrom) {
+      fallbackPosition = childFrom + 1 + child.content.size;
+      return;
+    }
+
+    if (direction === "forward" && fallbackPosition === null && childFrom > emptyBlockFrom) {
+      fallbackPosition = childFrom + 1;
+    }
+  });
+
+  return fallbackPosition;
+}
+
+function removeEmptyCalloutLine(view: EditorView, callout: CalloutBlock, key: KeyboardEvent["key"]) {
+  const emptyBlock = emptySelectionBlockRange(view);
+  if (!emptyBlock) return false;
+
+  const direction = key === "Delete" ? "forward" : "backward";
+  const targetPosition =
+    adjacentCalloutTextPosition(callout, emptyBlock.from, direction) ??
+    adjacentCalloutTextPosition(callout, emptyBlock.from, direction === "forward" ? "backward" : "forward");
+  if (targetPosition === null) return false;
+
+  const transaction = view.state.tr.delete(emptyBlock.from, emptyBlock.to);
+  const mappedTargetPosition = transaction.mapping.map(targetPosition);
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, mappedTargetPosition))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function createCalloutTypeSelect(
+  ownerDocument: Document,
+  view: EditorView,
+  callout: CalloutBlock
+) {
+  const select = ownerDocument.createElement("select");
+  select.className = "markra-callout-type-select";
+  select.setAttribute("aria-label", "Callout type");
+  select.contentEditable = "false";
+
+  for (const type of calloutTypeOrder) {
+    const definition = markdownCalloutDefinitions[type];
+    const option = ownerDocument.createElement("option");
+    option.value = type;
+    option.textContent = definition.label;
+    option.selected = type === callout.marker.type;
+    select.append(option);
+  }
+
+  select.addEventListener("mousedown", (event) => {
+    event.stopPropagation();
+  });
+  select.addEventListener("change", () => {
+    const nextType = select.value as MarkdownCalloutType;
+    const nextMarker = markdownCalloutMarkerForType(nextType);
+    const transaction = view.state.tr
+      .insertText(nextMarker, callout.markerFrom, callout.markerTo)
+      .scrollIntoView();
+
+    view.dispatch(transaction);
+    view.focus();
+  });
+
+  return select;
+}
+
+function createCalloutHeader(callout: CalloutBlock) {
+  return (view: EditorView) => {
+    const ownerDocument = view.dom.ownerDocument;
+    const header = ownerDocument.createElement("div");
+    header.className = "markra-callout-header";
+    header.contentEditable = "false";
+
+    const icon = ownerDocument.createElement("span");
+    icon.className = "markra-callout-icon";
+    icon.setAttribute("aria-hidden", "true");
+
+    const title = ownerDocument.createElement("span");
+    title.className = "markra-callout-title";
+    title.textContent = callout.marker.label;
+
+    header.append(icon, title, createCalloutTypeSelect(ownerDocument, view, callout));
+    return header;
+  };
+}
+
+function buildCalloutDecorations(doc: ProseNode) {
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, position) => {
+    if (node.type.name !== "blockquote") return;
+
+    const callout = firstTextMarkerRange(node, position);
+    if (!callout) return;
+
+    decorations.push(
+      Decoration.node(callout.blockquoteFrom, callout.blockquoteTo, {
+        class: `markra-callout markra-callout-${callout.marker.type}`,
+        "data-callout-label": callout.marker.label,
+        "data-callout-type": callout.marker.type
+      }),
+      Decoration.widget(callout.blockquoteFrom + 1, createCalloutHeader(callout), {
+        key: `markra-callout-header-${callout.blockquoteFrom}-${callout.marker.type}`,
+        side: -1
+      }),
+      Decoration.inline(callout.markerFrom, callout.markerTo, {
+        class: "markra-callout-source-marker"
+      })
+    );
+
+    if (callout.markerLineIsEmpty) {
+      decorations.push(
+        Decoration.node(callout.markerBlockFrom, callout.markerBlockTo, {
+          class: "markra-callout-marker-line"
+        })
+      );
+    }
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const markraCalloutPlugin = $prose((ctx) => {
+  const paragraph = paragraphSchema.type(ctx);
+
+  return new Plugin({
+    props: {
+      decorations: (state) => buildCalloutDecorations(state.doc),
+      handleKeyDown: (view, event) => {
+        if (!isDeleteKey(event) || hasModifier(event)) return false;
+
+        const callout = findCalloutAtSelection(view);
+        if (!callout) return false;
+
+        const handled = removeEmptyCallout(view, callout, paragraph);
+        if (!handled && !removeEmptyCalloutLine(view, callout, event.key)) return false;
+
+        event.preventDefault();
+        return true;
+      }
+    }
+  });
+});

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./ai-preview.ts";
 export * from "./block-drag.ts";
+export * from "./callout.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
 export * from "./heading-source.ts";

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -19,6 +19,7 @@ import { Plugin, PluginKey, TextSelection, type Command, type EditorState, type 
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { wrapInList } from "@milkdown/kit/prose/schema-list";
 import { $prose } from "@milkdown/kit/utils";
+import { markdownCalloutMarkerForType, type MarkdownCalloutType } from "@markra/shared";
 
 export type SlashCommandId =
   | "paragraph"
@@ -28,6 +29,7 @@ export type SlashCommandId =
   | "bulletList"
   | "orderedList"
   | "quote"
+  | "callout"
   | "codeBlock"
   | "table";
 
@@ -89,6 +91,7 @@ export const defaultSlashCommandLabels: SlashCommandLabels = {
     heading3: "Heading 3",
     orderedList: "Ordered List",
     paragraph: "Paragraph",
+    callout: "Callout",
     quote: "Quote",
     table: "Table"
   }
@@ -246,6 +249,55 @@ function runTableCommand(view: EditorView, range: SlashCommandRange, commands: {
   return true;
 }
 
+function calloutTypeFromQuery(query: string): MarkdownCalloutType {
+  const normalizedQuery = normalizedSearchText(query);
+  if (!normalizedQuery) return "note";
+
+  if ("warning".startsWith(normalizedQuery) || normalizedQuery.startsWith("warn")) return "warning";
+  if ("caution".startsWith(normalizedQuery) || "danger".startsWith(normalizedQuery)) return "caution";
+  if ("important".startsWith(normalizedQuery)) return "important";
+  if ("tip".startsWith(normalizedQuery)) return "tip";
+  if ("note".startsWith(normalizedQuery) || "info".startsWith(normalizedQuery)) return "note";
+
+  return "note";
+}
+
+function createDefaultCalloutNode(view: EditorView, type: MarkdownCalloutType, commands: {
+  paragraph: NodeType;
+  quote: NodeType;
+}) {
+  const markerParagraph = commands.paragraph.create(null, view.state.schema.text(markdownCalloutMarkerForType(type)));
+  const bodyParagraph = commands.paragraph.create();
+
+  return commands.quote.create(null, [markerParagraph, bodyParagraph]);
+}
+
+function runCalloutCommand(view: EditorView, range: SlashCommandRange, commands: {
+  paragraph: NodeType;
+  quote: NodeType;
+}) {
+  const { state } = view;
+  const $from = state.doc.resolve(range.from);
+  if (!$from.parent.isTextblock || $from.depth < 1) return false;
+
+  const blockFrom = $from.before();
+  const blockTo = $from.after();
+  const callout = createDefaultCalloutNode(view, calloutTypeFromQuery(range.query), commands);
+  const markerParagraph = callout.firstChild;
+  if (!markerParagraph) return false;
+
+  let transaction = state.tr.replaceWith(blockFrom, blockTo, callout);
+  const selectionPosition = Math.min(blockFrom + 1 + markerParagraph.nodeSize + 1, transaction.doc.content.size);
+
+  transaction = transaction
+    .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition)))
+    .scrollIntoView();
+  view.dispatch(transaction);
+  view.focus();
+
+  return true;
+}
+
 function createSlashCommands(
   labels: SlashCommandLabels,
   commands: {
@@ -300,10 +352,16 @@ function createSlashCommands(
       run: (view, range) => runCommandAfterDeletingSlash(view, range, wrapInList(commands.orderedList))
     },
     {
-      aliases: ["blockquote", "callout"],
+      aliases: ["blockquote"],
       id: "quote",
       label: labels.commands.quote,
       run: (view, range) => runCommandAfterDeletingSlash(view, range, wrapIn(commands.quote))
+    },
+    {
+      aliases: ["alert", "note", "info", "tip", "warning", "caution", "danger", "important"],
+      id: "callout",
+      label: labels.commands.callout,
+      run: (view, range) => runCalloutCommand(view, range, commands)
     },
     {
       aliases: ["code", "pre", "fence"],

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "Aufzählung",
   "menu.orderedList": "Nummerierte Liste",
   "menu.quote": "Zitat",
+  "menu.callout": "Hinweisblock",
   "menu.codeBlock": "Codeblock",
   "menu.link": "Link",
   "menu.image": "Bild",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -468,6 +468,7 @@ const messages: BaseLocaleMessages = {
   "menu.bulletList": "Bullet List",
   "menu.orderedList": "Ordered List",
   "menu.quote": "Quote",
+  "menu.callout": "Callout",
   "menu.codeBlock": "Code Block",
   "menu.link": "Link",
   "menu.image": "Image",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "Lista con viñetas",
   "menu.orderedList": "Lista numerada",
   "menu.quote": "Cita",
+  "menu.callout": "Aviso",
   "menu.codeBlock": "Bloque de código",
   "menu.link": "Enlace",
   "menu.image": "Imagen",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "Liste à puces",
   "menu.orderedList": "Liste numérotée",
   "menu.quote": "Citation",
+  "menu.callout": "Encadré",
   "menu.codeBlock": "Bloc de code",
   "menu.link": "Lien",
   "menu.image": "Image",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "Elenco puntato",
   "menu.orderedList": "Elenco numerato",
   "menu.quote": "Citazione",
+  "menu.callout": "Avviso",
   "menu.codeBlock": "Blocco di codice",
   "menu.link": "Link",
   "menu.image": "Immagine",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "箇条書き",
   "menu.orderedList": "番号付きリスト",
   "menu.quote": "引用",
+  "menu.callout": "コールアウト",
   "menu.codeBlock": "コードブロック",
   "menu.link": "リンク",
   "menu.image": "画像",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "글머리 기호 목록",
   "menu.orderedList": "번호 매기기 목록",
   "menu.quote": "인용",
+  "menu.callout": "콜아웃",
   "menu.codeBlock": "코드 블록",
   "menu.link": "링크",
   "menu.image": "이미지",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "Lista com marcadores",
   "menu.orderedList": "Lista numerada",
   "menu.quote": "Citação",
+  "menu.callout": "Aviso",
   "menu.codeBlock": "Bloco de código",
   "menu.link": "Link",
   "menu.image": "Imagem",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "Маркированный список",
   "menu.orderedList": "Нумерованный список",
   "menu.quote": "Цитата",
+  "menu.callout": "Выноска",
   "menu.codeBlock": "Блок кода",
   "menu.link": "Ссылка",
   "menu.image": "Изображение",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -479,6 +479,7 @@ export type I18nKey =
   | "menu.bulletList"
   | "menu.orderedList"
   | "menu.quote"
+  | "menu.callout"
   | "menu.codeBlock"
   | "menu.link"
   | "menu.image"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "无序列表",
   "menu.orderedList": "有序列表",
   "menu.quote": "引用",
+  "menu.callout": "提示块",
   "menu.codeBlock": "代码块",
   "menu.link": "链接",
   "menu.image": "图片",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -468,6 +468,7 @@ const messages: LocaleMessages = {
   "menu.bulletList": "項目符號清單",
   "menu.orderedList": "編號清單",
   "menu.quote": "引用",
+  "menu.callout": "提示區塊",
   "menu.codeBlock": "程式碼區塊",
   "menu.link": "連結",
   "menu.image": "圖片",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export type { DocumentState } from "./document.ts";
 export * from "./debug.ts";
 export * from "./i18n/index.ts";
 export * from "./keyboard-shortcuts.ts";
+export * from "./markdown-callout.ts";
 export * from "./number.ts";
 export * from "./path.ts";
 export * from "./record.ts";

--- a/packages/shared/src/markdown-callout.ts
+++ b/packages/shared/src/markdown-callout.ts
@@ -1,0 +1,67 @@
+export type MarkdownCalloutType = "note" | "tip" | "important" | "warning" | "caution";
+
+export type MarkdownCalloutDefinition = {
+  label: string;
+  marker: string;
+  type: MarkdownCalloutType;
+};
+
+export type ParsedMarkdownCalloutMarker = MarkdownCalloutDefinition & {
+  source: string;
+};
+
+export const markdownCalloutDefinitions: Record<MarkdownCalloutType, MarkdownCalloutDefinition> = {
+  caution: {
+    label: "Caution",
+    marker: "CAUTION",
+    type: "caution"
+  },
+  important: {
+    label: "Important",
+    marker: "IMPORTANT",
+    type: "important"
+  },
+  note: {
+    label: "Note",
+    marker: "NOTE",
+    type: "note"
+  },
+  tip: {
+    label: "Tip",
+    marker: "TIP",
+    type: "tip"
+  },
+  warning: {
+    label: "Warning",
+    marker: "WARNING",
+    type: "warning"
+  }
+};
+
+const markdownCalloutMarkerPattern = /^\s*(\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\])/iu;
+
+export function parseMarkdownCalloutMarker(text: string): ParsedMarkdownCalloutMarker | null {
+  const match = markdownCalloutMarkerPattern.exec(text);
+  const source = match?.[1];
+  const marker = match?.[2]?.toUpperCase();
+  if (!source || !marker) return null;
+
+  const definition = Object.values(markdownCalloutDefinitions).find((candidate) => candidate.marker === marker);
+  if (!definition) return null;
+
+  return {
+    ...definition,
+    source
+  };
+}
+
+export function markdownCalloutMarkerForType(type: MarkdownCalloutType) {
+  return `[!${markdownCalloutDefinitions[type].marker}]`;
+}
+
+export function restoreEscapedMarkdownCalloutMarkers(markdown: string) {
+  return markdown.replace(
+    /(^|\n)((?:>\s*)+)\\(\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\])/giu,
+    "$1$2$3"
+  ).replace(/(^|\n)((?:>\s*)+)<br \/>(?=\n|$)/gu, "$1$2");
+}


### PR DESCRIPTION
## Summary
- Add GitHub-style callout rendering and editing for `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION` blockquotes.
- Add `/callout` plus type aliases such as `/tip`, `/warn`, `/danger`, and `/important` for quick insertion.
- Preserve GitHub Alerts Markdown through editor serialization, source mode highlighting, and HTML/PDF export rendering.
- Fix deletion for empty callouts so Backspace/Delete removes the block cleanly.

## Why
- Issue #42 asks for callout/highlight blocks; using GitHub Alerts syntax keeps the Markdown portable instead of introducing app-only syntax.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx src/components/MarkdownExportDocument.test.tsx src/components/MarkdownSourceEditor.test.tsx` passed
- `pnpm --filter @markra/shared test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/desktop build` passed
- `git diff --cached --check` passed before commit

## Risk
- Callout support is intentionally scoped to GitHub Alerts blockquote syntax; folding and custom fenced callout syntax are not included.

## Related Issues
Closes #42
