### PR TITLE
feat(editor): add heading section folding

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { Editor } from "@milkdown/kit/core";
 import { editorViewCtx, parserCtx, serializerCtx } from "@milkdown/kit/core";
 import { Slice } from "@milkdown/kit/prose/model";
@@ -1156,6 +1156,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const handle = await screen.findByRole("button", { name: "Drag block" });
+    expect(handle.closest<HTMLElement>(".markra-block-toolbar")?.style.left).toBe("106px");
     const dataTransfer = createDragDataTransfer();
 
     dispatchDragEvent(handle, "dragstart", {
@@ -1216,6 +1217,67 @@ describe("MarkdownPaper editing", () => {
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
     restoreLayout();
+  });
+
+  it("centers the block toolbar against tall heading content", async () => {
+    const { container, view } = await renderEditor("# Parent\n\nBody");
+    const heading = container.querySelector<HTMLElement>(".ProseMirror > h1");
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    expect(heading).toBeInTheDocument();
+    expect(surface).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    heading!.style.paddingBottom = "10px";
+    heading!.style.borderBottomWidth = "1px";
+    heading!.style.borderBottomStyle = "solid";
+    heading!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 184,
+          height: 84,
+          left: 160,
+          right: 640,
+          top: 100,
+          width: 480,
+          x: 160,
+          y: 100,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+    view.dom.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 260,
+          height: 180,
+          left: 160,
+          right: 640,
+          top: 90,
+          width: 480,
+          x: 160,
+          y: 90,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+
+    const originalPosAtCoords = view.posAtCoords.bind(view);
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: () => ({ inside: 0, pos: 1 })
+    });
+
+    fireEvent.pointerMove(paper!, {
+      clientX: 136,
+      clientY: 112
+    });
+
+    const handle = await screen.findByRole("button", { name: "Drag block" });
+    expect(handle.closest<HTMLElement>(".markra-block-toolbar")?.style.top).toBe("137px");
+
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: originalPosAtCoords
+    });
   });
 
   it("reorders blocks with pointer dragging from the gutter handle", async () => {
@@ -3983,6 +4045,54 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".ProseMirror h2")).toHaveTextContent("Title");
     expect(container.querySelector(".ProseMirror")?.textContent).toBe("Title");
     await settleMarkdownListener();
+  });
+
+  it("collapses a heading section from the heading toggle", async () => {
+    const source = "# Intro\n\nIntro body\n\n## Nested\n\nNested body\n\n# Outro\n\nOutro body";
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const headings = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror h1, .ProseMirror h2"));
+    const paragraphs = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror p"));
+
+    expect(headings).toHaveLength(3);
+    expect(paragraphs).toHaveLength(3);
+
+    fireEvent.click(within(headings[0]).getByRole("button", { name: "Collapse section" }));
+
+    expect(within(headings[0]).getByRole("button", { name: "Expand section" })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(paragraphs[0]).toHaveClass("markra-heading-collapsed-content");
+    expect(headings[1]).toHaveClass("markra-heading-collapsed-content");
+    expect(paragraphs[1]).toHaveClass("markra-heading-collapsed-content");
+    expect(headings[2]).not.toHaveClass("markra-heading-collapsed-content");
+    expect(paragraphs[2]).not.toHaveClass("markra-heading-collapsed-content");
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it("preserves nested heading folds when a parent heading is expanded again", async () => {
+    const { container } = await renderEditor("# Parent\n\n## Child\n\nChild body\n\n# Next\n\nNext body");
+    const headings = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror h1, .ProseMirror h2"));
+    const paragraphs = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror p"));
+
+    fireEvent.click(within(headings[1]).getByRole("button", { name: "Collapse section" }));
+
+    expect(within(headings[1]).getByRole("button", { name: "Expand section" })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(paragraphs[0]).toHaveClass("markra-heading-collapsed-content");
+
+    fireEvent.click(within(headings[0]).getByRole("button", { name: "Collapse section" }));
+
+    expect(headings[1]).toHaveClass("markra-heading-collapsed-content");
+
+    fireEvent.click(within(headings[0]).getByRole("button", { name: "Expand section" }));
+
+    expect(headings[1]).not.toHaveClass("markra-heading-collapsed-content");
+    expect(paragraphs[0]).toHaveClass("markra-heading-collapsed-content");
+    expect(paragraphs[1]).not.toHaveClass("markra-heading-collapsed-content");
   });
 
   it("expands a rendered heading back to editable markdown source when clicked", async () => {

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -35,6 +35,7 @@ import { markraCodeBlockPlugin } from "@markra/editor";
 import { markraCalloutPlugin } from "@markra/editor";
 import { markraCalloutSerializerPlugin } from "@markra/editor";
 import { markraHeadingSourcePlugin } from "@markra/editor";
+import { markraHeadingTogglePlugin } from "@markra/editor";
 import { normalizeHeadingSourceDocument } from "@markra/editor";
 import { markraLinkImageLivePlugin } from "@markra/editor";
 import { markraRawHtmlPlugin } from "@markra/editor";
@@ -361,6 +362,10 @@ function MilkdownSurface({
     addBlock: t(language, "editor.blockAdd"),
     dragBlock: t(language, "editor.blockDrag")
   };
+  const headingToggleLabels = {
+    collapseSection: t(language, "editor.collapseSection"),
+    expandSection: t(language, "editor.expandSection")
+  };
   const slashCommandLabels = useMemo<SlashCommandLabels>(() => ({
     menu: t(language, "editor.slashCommands"),
     noResults: t(language, "editor.slashCommandsNoResults"),
@@ -453,6 +458,7 @@ function MilkdownSurface({
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)
         .use(markraBlockDragPlugin(blockDragLabels))
+        .use(markraHeadingTogglePlugin(headingToggleLabels))
         .use(
           markraDocumentLinkCompletionPlugin({
             getDocumentPath: () => documentPathRef.current,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1123,6 +1123,58 @@
     @apply mt-7.5 mb-3 text-2xl leading-[1.28];
   }
 
+  .markdown-paper .markra-heading-toggle-heading {
+    @apply relative;
+    --markra-heading-toggle-center-offset: 0px;
+  }
+
+  .markdown-paper h1.markra-heading-toggle-heading {
+    --markra-heading-toggle-center-offset: -5.5px;
+  }
+
+  .markdown-paper h2.markra-heading-toggle-heading {
+    --markra-heading-toggle-center-offset: -3.5px;
+  }
+
+  .markdown-paper .markra-heading-toggle-button {
+    @apply absolute inline-flex size-5 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 outline-none transition-[opacity,color,background-color] duration-150 ease-out focus-visible:bg-(--bg-hover) focus-visible:outline-none;
+    color: color-mix(in srgb, var(--editor-text-secondary) 62%, transparent);
+    left: -28px;
+    opacity: 0;
+    top: calc(50% + var(--markra-heading-toggle-center-offset));
+    transform: translateY(-50%);
+  }
+
+  .markdown-paper .markra-heading-toggle-heading:hover > .markra-heading-toggle-button,
+  .markdown-paper .markra-heading-toggle-heading:focus-within > .markra-heading-toggle-button {
+    opacity: 0.72;
+  }
+
+  .markdown-paper .markra-heading-toggle-button:hover,
+  .markdown-paper .markra-heading-toggle-button:focus-visible {
+    color: var(--editor-text-secondary);
+    opacity: 1;
+  }
+
+  .markdown-paper .markra-heading-toggle-button::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-right: 1.6px solid currentColor;
+    border-bottom: 1.6px solid currentColor;
+    transform: rotate(45deg);
+    transform-origin: center;
+    transition: transform 120ms ease-out;
+  }
+
+  .markdown-paper .markra-heading-toggle-button[data-collapsed="true"]::before {
+    transform: rotate(-45deg);
+  }
+
+  .markdown-paper .markra-heading-collapsed-content {
+    display: none !important;
+  }
+
   .markdown-paper p {
     @apply m-0 mb-4.5;
     color: var(--editor-text-primary);

--- a/packages/editor/src/block-drag.ts
+++ b/packages/editor/src/block-drag.ts
@@ -63,6 +63,7 @@ const dragGhostOffset = {
   top: 10
 };
 const dragGhostTextLimit = 96;
+const blockToolbarGutterOffset = 54;
 const dropIndicatorInset = 2;
 const dropIndicatorMaxWidth = 640;
 const edgeScrollMaxStep = 28;
@@ -78,6 +79,25 @@ function normalizeBlockDragLabels(labels: Partial<BlockDragLabels> | undefined):
 
 function clampedDocumentPosition(state: EditorState, position: number) {
   return Math.max(0, Math.min(position, state.doc.content.size));
+}
+
+function pixelValue(value: string) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function contentBoxCenterTop(element: Element, rect: DOMRect) {
+  const ownerWindow = element.ownerDocument.defaultView;
+  if (!ownerWindow) return rect.top + rect.height / 2;
+
+  const style = ownerWindow.getComputedStyle(element);
+  const borderTop = pixelValue(style.borderTopWidth);
+  const borderBottom = pixelValue(style.borderBottomWidth);
+  const paddingTop = pixelValue(style.paddingTop);
+  const paddingBottom = pixelValue(style.paddingBottom);
+  const contentHeight = Math.max(0, rect.height - borderTop - borderBottom - paddingTop - paddingBottom);
+
+  return rect.top + borderTop + paddingTop + contentHeight / 2;
 }
 
 function hasTableAncestor($pos: ResolvedPos) {
@@ -931,15 +951,15 @@ class MarkraBlockDragView {
 
   private positionToolbar(range: BlockDragRange) {
     const dom = this.blockDom(range);
-    const rect = dom?.getBoundingClientRect();
     const editorRect = this.view.dom.getBoundingClientRect();
-    if (!rect) {
+    if (!dom) {
       this.hideHandle();
       return;
     }
 
-    const left = Math.max(8, editorRect.left - 30);
-    const top = rect.top + Math.min(rect.height / 2, 18);
+    const rect = dom.getBoundingClientRect();
+    const left = Math.max(8, editorRect.left - blockToolbarGutterOffset);
+    const top = contentBoxCenterTop(dom, rect);
 
     this.toolbar.style.left = `${Math.round(left)}px`;
     this.toolbar.style.top = `${Math.round(top)}px`;

--- a/packages/editor/src/heading-toggle.ts
+++ b/packages/editor/src/heading-toggle.ts
@@ -1,0 +1,281 @@
+import { headingSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode, NodeType } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+export type HeadingToggleLabels = {
+  collapseSection: string;
+  expandSection: string;
+};
+
+type CollapsedHeadingState = {
+  collapsed: readonly number[];
+};
+
+type HeadingToggleMeta = {
+  from: number;
+  type: "toggle";
+};
+
+type TopLevelBlock = {
+  from: number;
+  node: ProseNode;
+  to: number;
+};
+
+type HeadingSection = {
+  contentFrom: number;
+  from: number;
+  level: number;
+  node: ProseNode;
+  to: number;
+};
+
+const defaultHeadingToggleLabels: HeadingToggleLabels = {
+  collapseSection: "Collapse section",
+  expandSection: "Expand section"
+};
+
+const emptyCollapsedHeadingState: CollapsedHeadingState = {
+  collapsed: []
+};
+
+const headingToggleKey = new PluginKey<CollapsedHeadingState>("markra-heading-toggle");
+
+function normalizeHeadingToggleLabels(labels: Partial<HeadingToggleLabels> | undefined): HeadingToggleLabels {
+  return {
+    ...defaultHeadingToggleLabels,
+    ...labels
+  };
+}
+
+function headingLevel(node: ProseNode) {
+  const level = Number(node.attrs.level ?? 1);
+  if (!Number.isFinite(level)) return 1;
+
+  return Math.max(1, Math.min(6, Math.trunc(level)));
+}
+
+function collectTopLevelBlocks(doc: ProseNode) {
+  const blocks: TopLevelBlock[] = [];
+
+  doc.forEach((node, offset) => {
+    blocks.push({
+      from: offset,
+      node,
+      to: offset + node.nodeSize
+    });
+  });
+
+  return blocks;
+}
+
+function collectHeadingSections(doc: ProseNode, heading: NodeType) {
+  const blocks = collectTopLevelBlocks(doc);
+  const sections: HeadingSection[] = [];
+
+  for (const [index, block] of blocks.entries()) {
+    if (block.node.type !== heading) continue;
+
+    const level = headingLevel(block.node);
+    let sectionEnd = doc.content.size;
+
+    for (const nextBlock of blocks.slice(index + 1)) {
+      if (nextBlock.node.type !== heading) continue;
+      if (headingLevel(nextBlock.node) > level) continue;
+
+      sectionEnd = nextBlock.from;
+      break;
+    }
+
+    sections.push({
+      contentFrom: block.to,
+      from: block.from,
+      level,
+      node: block.node,
+      to: sectionEnd
+    });
+  }
+
+  return sections;
+}
+
+function findHeadingStartAtPosition(state: EditorState, heading: NodeType, position: number) {
+  const safePosition = Math.max(0, Math.min(position, state.doc.content.size));
+  const nodeAtPosition = state.doc.nodeAt(safePosition);
+  if (nodeAtPosition?.type === heading) return safePosition;
+
+  const $position = state.doc.resolve(safePosition);
+  for (let depth = $position.depth; depth > 0; depth -= 1) {
+    if ($position.node(depth).type === heading) return $position.before(depth);
+  }
+
+  return null;
+}
+
+function normalizeCollapsedPositions(state: EditorState, heading: NodeType, positions: readonly number[]) {
+  const collapsed = new Set<number>();
+
+  for (const position of positions) {
+    const headingStart = findHeadingStartAtPosition(state, heading, position);
+    if (headingStart !== null) collapsed.add(headingStart);
+  }
+
+  return Array.from(collapsed).sort((left, right) => left - right);
+}
+
+function mapCollapsedPositions(
+  transaction: Transaction,
+  state: EditorState,
+  heading: NodeType,
+  positions: readonly number[]
+) {
+  return normalizeCollapsedPositions(
+    state,
+    heading,
+    positions.map((position) => transaction.mapping.map(position, 1))
+  );
+}
+
+function toggleCollapsedPosition(positions: readonly number[], position: number) {
+  return positions.includes(position)
+    ? positions.filter((collapsedPosition) => collapsedPosition !== position)
+    : [...positions, position].sort((left, right) => left - right);
+}
+
+function createHeadingToggleButton(
+  view: EditorView,
+  getHeadingFrom: () => number,
+  collapsed: boolean,
+  labels: HeadingToggleLabels
+) {
+  const button = view.dom.ownerDocument.createElement("button");
+  const label = collapsed ? labels.expandSection : labels.collapseSection;
+
+  button.type = "button";
+  button.className = "markra-heading-toggle-button";
+  button.contentEditable = "false";
+  button.draggable = false;
+  button.dataset.collapsed = String(collapsed);
+  button.ariaExpanded = String(!collapsed);
+  button.ariaLabel = label;
+  button.title = label;
+
+  button.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    view.dispatch(
+      view.state.tr.setMeta(headingToggleKey, {
+        from: getHeadingFrom(),
+        type: "toggle"
+      } satisfies HeadingToggleMeta)
+    );
+    view.focus();
+  });
+
+  return button;
+}
+
+function buildHeadingToggleDecorations(
+  doc: ProseNode,
+  collapsedPositions: readonly number[],
+  heading: NodeType,
+  labels: HeadingToggleLabels
+) {
+  const sections = collectHeadingSections(doc, heading);
+  const sectionByHeading = new Map(sections.map((section) => [section.from, section]));
+  const collapsed = new Set(collapsedPositions.filter((position) => sectionByHeading.has(position)));
+  const decorations: Decoration[] = [];
+
+  for (const section of sections) {
+    if (section.contentFrom >= section.to) continue;
+
+    const sectionIsCollapsed = collapsed.has(section.from);
+    decorations.push(
+      Decoration.node(section.from, section.from + section.node.nodeSize, {
+        class: "markra-heading-toggle-heading",
+        "data-heading-collapsed": String(sectionIsCollapsed)
+      }),
+      Decoration.widget(
+        section.from + 1,
+        (view, getPos) =>
+          createHeadingToggleButton(
+            view,
+            () => {
+              const position = getPos();
+              return typeof position === "number" ? Math.max(0, position - 1) : section.from;
+            },
+            sectionIsCollapsed,
+            labels
+          ),
+        {
+          ignoreSelection: true,
+          key: `markra-heading-toggle-${section.from}-${sectionIsCollapsed ? "collapsed" : "expanded"}`,
+          side: -1
+        }
+      )
+    );
+  }
+
+  if (collapsed.size === 0) return DecorationSet.create(doc, decorations);
+
+  for (const block of collectTopLevelBlocks(doc)) {
+    const hiddenByCollapsedHeading = sections.some(
+      (section) => collapsed.has(section.from) && block.from >= section.contentFrom && block.to <= section.to
+    );
+    if (!hiddenByCollapsedHeading) continue;
+
+    decorations.push(
+      Decoration.node(block.from, block.to, {
+        class: "markra-heading-collapsed-content"
+      })
+    );
+  }
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export function markraHeadingTogglePlugin(labels?: Partial<HeadingToggleLabels>) {
+  const resolvedLabels = normalizeHeadingToggleLabels(labels);
+
+  return $prose((ctx) => {
+    const heading = headingSchema.type(ctx);
+
+    return new Plugin<CollapsedHeadingState>({
+      key: headingToggleKey,
+      state: {
+        init: () => emptyCollapsedHeadingState,
+        apply(transaction, value, _oldState, newState) {
+          const meta = transaction.getMeta(headingToggleKey) as HeadingToggleMeta | undefined;
+          const mappedCollapsed = transaction.docChanged
+            ? mapCollapsedPositions(transaction, newState, heading, value.collapsed)
+            : value.collapsed;
+
+          if (meta?.type !== "toggle") {
+            return mappedCollapsed === value.collapsed ? value : { collapsed: mappedCollapsed };
+          }
+
+          const headingFrom = findHeadingStartAtPosition(newState, heading, meta.from);
+          if (headingFrom === null) return { collapsed: mappedCollapsed };
+
+          return {
+            collapsed: toggleCollapsedPosition(mappedCollapsed, headingFrom)
+          };
+        }
+      },
+      props: {
+        decorations: (state) => {
+          const pluginState = headingToggleKey.getState(state) ?? emptyCollapsedHeadingState;
+          return buildHeadingToggleDecorations(state.doc, pluginState.collapsed, heading, resolvedLabels);
+        }
+      }
+    });
+  });
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -4,6 +4,7 @@ export * from "./callout.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
 export * from "./heading-source.ts";
+export * from "./heading-toggle.ts";
 export * from "./input-rules.ts";
 export * from "./link-image-rules.ts";
 export * from "./math.ts";

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Markdown-Dokument",
   "editor.blockAdd": "Block darunter hinzufügen",
   "editor.blockDrag": "Block ziehen",
+  "editor.collapseSection": "Abschnitt einklappen",
+  "editor.expandSection": "Abschnitt ausklappen",
   "editor.htmlSource": "HTML-Quelle",
   "editor.htmlSourceApply": "HTML-Quelle anwenden",
   "editor.table.addColumnRight": "Spalte rechts hinzufügen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -339,6 +339,8 @@ const messages: BaseLocaleMessages = {
   "app.markdownDocument": "Markdown document",
   "editor.blockAdd": "Add block below",
   "editor.blockDrag": "Drag block",
+  "editor.collapseSection": "Collapse section",
+  "editor.expandSection": "Expand section",
   "editor.htmlSource": "HTML source",
   "editor.htmlSourceApply": "Apply HTML source",
   "editor.table.addColumnRight": "Add column to the right",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Documento Markdown",
   "editor.blockAdd": "Añadir bloque debajo",
   "editor.blockDrag": "Arrastrar bloque",
+  "editor.collapseSection": "Contraer sección",
+  "editor.expandSection": "Expandir sección",
   "editor.htmlSource": "Código fuente HTML",
   "editor.htmlSourceApply": "Aplicar código fuente HTML",
   "editor.table.addColumnRight": "Añadir columna a la derecha",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Document Markdown",
   "editor.blockAdd": "Ajouter un bloc en dessous",
   "editor.blockDrag": "Faire glisser le bloc",
+  "editor.collapseSection": "Replier la section",
+  "editor.expandSection": "Déplier la section",
   "editor.htmlSource": "Source HTML",
   "editor.htmlSourceApply": "Appliquer la source HTML",
   "editor.table.addColumnRight": "Ajouter une colonne à droite",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Documento Markdown",
   "editor.blockAdd": "Aggiungi blocco sotto",
   "editor.blockDrag": "Trascina blocco",
+  "editor.collapseSection": "Comprimi sezione",
+  "editor.expandSection": "Espandi sezione",
   "editor.htmlSource": "Sorgente HTML",
   "editor.htmlSourceApply": "Applica sorgente HTML",
   "editor.table.addColumnRight": "Aggiungi colonna a destra",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -233,6 +233,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Markdown ドキュメント",
   "editor.blockAdd": "下にブロックを追加",
   "editor.blockDrag": "ブロックをドラッグ",
+  "editor.collapseSection": "セクションを折りたたむ",
+  "editor.expandSection": "セクションを展開",
   "editor.htmlSource": "HTML ソース",
   "editor.htmlSourceApply": "HTML ソースを適用",
   "editor.table.addColumnRight": "右に列を追加",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Markdown 문서",
   "editor.blockAdd": "아래에 블록 추가",
   "editor.blockDrag": "블록 드래그",
+  "editor.collapseSection": "섹션 접기",
+  "editor.expandSection": "섹션 펼치기",
   "editor.htmlSource": "HTML 소스",
   "editor.htmlSourceApply": "HTML 소스 적용",
   "editor.table.addColumnRight": "오른쪽에 열 추가",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Documento Markdown",
   "editor.blockAdd": "Adicionar bloco abaixo",
   "editor.blockDrag": "Arrastar bloco",
+  "editor.collapseSection": "Recolher seção",
+  "editor.expandSection": "Expandir seção",
   "editor.htmlSource": "Código-fonte HTML",
   "editor.htmlSourceApply": "Aplicar código-fonte HTML",
   "editor.table.addColumnRight": "Adicionar coluna à direita",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -227,6 +227,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Документ Markdown",
   "editor.blockAdd": "Добавить блок ниже",
   "editor.blockDrag": "Перетащить блок",
+  "editor.collapseSection": "Свернуть раздел",
+  "editor.expandSection": "Развернуть раздел",
   "editor.htmlSource": "HTML-исходник",
   "editor.htmlSourceApply": "Применить HTML-исходник",
   "editor.table.addColumnRight": "Добавить столбец справа",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -350,6 +350,8 @@ export type I18nKey =
   | "app.markdownDocument"
   | "editor.blockAdd"
   | "editor.blockDrag"
+  | "editor.collapseSection"
+  | "editor.expandSection"
   | "editor.htmlSource"
   | "editor.htmlSourceApply"
   | "editor.table.addColumnRight"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -339,6 +339,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Markdown 文档",
   "editor.blockAdd": "在下方新增块",
   "editor.blockDrag": "拖拽块",
+  "editor.collapseSection": "折叠章节",
+  "editor.expandSection": "展开章节",
   "editor.htmlSource": "HTML 源码",
   "editor.htmlSourceApply": "应用 HTML 源码",
   "editor.table.addColumnRight": "在右侧新增列",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -233,6 +233,8 @@ const messages: LocaleMessages = {
   "app.markdownDocument": "Markdown 文件",
   "editor.blockAdd": "在下方新增區塊",
   "editor.blockDrag": "拖曳區塊",
+  "editor.collapseSection": "摺疊章節",
+  "editor.expandSection": "展開章節",
   "editor.htmlSource": "HTML 原始碼",
   "editor.htmlSourceApply": "套用 HTML 原始碼",
   "editor.table.addColumnRight": "在右側新增欄",


### PR DESCRIPTION
## Summary
- Add an editor heading toggle plugin that folds rendered heading sections without changing Markdown source.
- Wire localized expand/collapse labels into the desktop Milkdown setup.
- Reposition heading toggles and the block drag toolbar so gutter controls avoid overlap and align with heading content.

## Validation
- `git diff --check`
- `pnpm --filter @markra/desktop test -- src/components/MarkdownPaper.test.tsx -t "centers the block toolbar against tall heading content|reveals the block drag handle|heading (section|folds)|collapses a heading"` (621 passed)
- `pnpm --filter @markra/desktop build`

## Risk
- Heading fold state is editor UI state only and is not persisted to Markdown.
- Block drag gutter positioning changed to use the content box center of the target block.

Closes #41
