### PR TITLE
feat(desktop): add document tab context menu

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1254,7 +1254,7 @@ export default function App() {
     };
   }, [editor, restoreAiCommand, updateAiResults]);
 
-  const handleCloseTitlebarTab = useCallback((tabId: string) => {
+  const handleCloseTitlebarTab = useCallback(async (tabId: string) => {
     const imageTab = imageTabs.find((tab) => tab.id === tabId);
     if (imageTab) {
       const closingActiveImage = activeImageFile ? imageDocumentTabId(activeImageFile.path) === tabId : false;
@@ -1262,15 +1262,15 @@ export default function App() {
       if (closingActiveImage) setActiveImageFile(null);
       updateActiveAiSelection(null);
       handleAiCommandClose();
-      return;
+      return true;
     }
 
-    closeMarkdownTab(tabId).then((closed) => {
-      if (!closed) return;
+    const closed = await closeMarkdownTab(tabId);
+    if (!closed) return false;
 
-      updateActiveAiSelection(null);
-      handleAiCommandClose();
-    }).catch(() => {});
+    updateActiveAiSelection(null);
+    handleAiCommandClose();
+    return true;
   }, [
     activeImageFile,
     closeMarkdownTab,

--- a/apps/desktop/src/components/MarkdownTabsBar.test.tsx
+++ b/apps/desktop/src/components/MarkdownTabsBar.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { vi } from "vitest";
 import { MarkdownTabsBar } from "./MarkdownTabsBar";
 
 describe("MarkdownTabsBar", () => {
@@ -24,5 +25,54 @@ describe("MarkdownTabsBar", () => {
     expect(screen.getByRole("tablist", { name: "Open documents" })).toBeInTheDocument();
     expect(container.querySelector(".document-tabs-titlebar")).toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".document-tabs-drag-spacer")).toHaveAttribute("data-tauri-drag-region");
+  });
+
+  it("opens tab actions from right click and closes related tabs", async () => {
+    const onCloseTab = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-b"
+        tabs={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          },
+          {
+            dirty: false,
+            id: "tab-c",
+            name: "Gamma.md",
+            path: "/synthetic/gamma.md"
+          }
+        ]}
+        onCloseTab={onCloseTab}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /Beta\.md/ }));
+
+    const menu = screen.getByRole("menu", { name: "Beta.md" });
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Close other tabs" }));
+
+    await waitFor(() => expect(onCloseTab).toHaveBeenCalledTimes(2));
+    expect(onCloseTab).toHaveBeenNthCalledWith(1, "tab-a");
+    expect(onCloseTab).toHaveBeenNthCalledWith(2, "tab-c");
+
+    onCloseTab.mockClear();
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /Beta\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Close tabs to the right" }));
+
+    await waitFor(() => expect(onCloseTab).toHaveBeenCalledTimes(1));
+    expect(onCloseTab).toHaveBeenCalledWith("tab-c");
   });
 });

--- a/apps/desktop/src/components/MarkdownTabsBar.tsx
+++ b/apps/desktop/src/components/MarkdownTabsBar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
-import { FileText, ImageIcon, Plus, X } from "lucide-react";
-import { IconButton } from "@markra/ui";
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { FileText, ImageIcon, Pencil, Plus, X } from "lucide-react";
+import { Button, IconButton, PopoverSurface } from "@markra/ui";
 import { t, type AppLanguage } from "@markra/shared";
 import type { MarkdownDocumentTab } from "../hooks/useMarkdownDocument";
 
@@ -20,6 +20,12 @@ type MarkdownTabsBarProps = {
   onSelectTab: (tabId: string) => unknown;
 };
 
+type TabContextMenuState = {
+  tabId: string;
+  x: number;
+  y: number;
+};
+
 export function MarkdownTabsBar({
   activeTabId,
   language = "en",
@@ -35,6 +41,8 @@ export function MarkdownTabsBar({
   const [renameFileName, setRenameFileName] = useState("");
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameCancelledRef = useRef(false);
+  const contextMenuRef = useRef<HTMLDivElement | null>(null);
+  const [contextMenu, setContextMenu] = useState<TabContextMenuState | null>(null);
 
   useEffect(() => {
     if (!renameInputRef.current) return;
@@ -43,9 +51,32 @@ export function MarkdownTabsBar({
     renameInputRef.current.select();
   }, [renamingTabId]);
 
+  useEffect(() => {
+    if (!contextMenu) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!contextMenuRef.current?.contains(event.target as Node)) setContextMenu(null);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setContextMenu(null);
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [contextMenu]);
+
   if (tabs.length === 0) return null;
 
   const titlebarPlacement = placement === "titlebar";
+  const contextMenuTab = contextMenu ? tabs.find((tab) => tab.id === contextMenu.tabId) ?? null : null;
+  const contextMenuTabIndex = contextMenuTab ? tabs.findIndex((tab) => tab.id === contextMenuTab.id) : -1;
+  const contextMenuOtherTabIds = contextMenuTab ? tabs.filter((tab) => tab.id !== contextMenuTab.id).map((tab) => tab.id) : [];
+  const contextMenuRightTabIds = contextMenuTabIndex >= 0 ? tabs.slice(contextMenuTabIndex + 1).map((tab) => tab.id) : [];
   const startRenamingTab = (tab: MarkdownTabsBarItem) => {
     if (!tab.path || !onRenameTab) return;
 
@@ -70,6 +101,28 @@ export function MarkdownTabsBar({
     if (!normalizedName || normalizedName === tab.name) return;
 
     onRenameTab?.(tab, normalizedName);
+  };
+  const closeTabs = (tabIds: string[]) => {
+    let closeSequence: Promise<unknown> = Promise.resolve(null);
+
+    for (const tabId of tabIds) {
+      closeSequence = closeSequence.then(() => onCloseTab(tabId));
+    }
+
+    closeSequence.catch(() => {});
+  };
+  const openTabContextMenu = (event: ReactMouseEvent, tab: MarkdownTabsBarItem) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setContextMenu({
+      tabId: tab.id,
+      x: Math.max(8, event.clientX),
+      y: Math.max(8, event.clientY)
+    });
+  };
+  const runTabContextMenuAction = (action: () => unknown) => {
+    setContextMenu(null);
+    action();
   };
 
   return (
@@ -104,6 +157,7 @@ export function MarkdownTabsBar({
                   : "border-transparent bg-transparent text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading)"
               }`}
               key={tab.id}
+              onContextMenu={(event) => openTabContextMenu(event, tab)}
             >
               {renaming ? (
                 <div className="flex h-full min-w-0 items-center gap-1.5 rounded-l-md px-2">
@@ -152,7 +206,7 @@ export function MarkdownTabsBar({
                 }`}
                 type="button"
                 aria-label={`${label("app.closeDocumentTab")} ${tab.name || "Untitled.md"}`}
-                onClick={() => onCloseTab(tab.id)}
+                onClick={() => closeTabs([tab.id])}
               >
                 <X aria-hidden="true" size={12} />
               </button>
@@ -175,6 +229,69 @@ export function MarkdownTabsBar({
           />
         ) : null}
       </div>
+      {contextMenu && contextMenuTab ? (
+        <div
+          ref={contextMenuRef}
+          className="fixed z-50"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y
+          }}
+        >
+          <PopoverSurface
+            className="grid w-52 gap-1 rounded-lg p-1 text-[12px] leading-5 font-[560]"
+            open
+            role="menu"
+            aria-label={contextMenuTab.name || "Untitled.md"}
+            onContextMenu={(event) => event.preventDefault()}
+          >
+            {onRenameTab && contextMenuTab.path ? (
+              <Button
+                className="w-full justify-start rounded-md text-left"
+                size="sm"
+                variant="ghost"
+                role="menuitem"
+                onClick={() => runTabContextMenuAction(() => startRenamingTab(contextMenuTab))}
+              >
+                <Pencil aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+                <span className="truncate">{label("app.renameMarkdownFile")}</span>
+              </Button>
+            ) : null}
+            <Button
+              className="w-full justify-start rounded-md text-left"
+              size="sm"
+              variant="ghost"
+              role="menuitem"
+              onClick={() => runTabContextMenuAction(() => closeTabs([contextMenuTab.id]))}
+            >
+              <X aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+              <span className="truncate">{label("app.closeDocumentTab")}</span>
+            </Button>
+            <Button
+              className="w-full justify-start rounded-md text-left"
+              disabled={contextMenuOtherTabIds.length === 0}
+              size="sm"
+              variant="ghost"
+              role="menuitem"
+              onClick={() => runTabContextMenuAction(() => closeTabs(contextMenuOtherTabIds))}
+            >
+              <X aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+              <span className="truncate">{label("app.closeOtherDocumentTabs")}</span>
+            </Button>
+            <Button
+              className="w-full justify-start rounded-md text-left"
+              disabled={contextMenuRightTabIds.length === 0}
+              size="sm"
+              variant="ghost"
+              role="menuitem"
+              onClick={() => runTabContextMenuAction(() => closeTabs(contextMenuRightTabIds))}
+            >
+              <X aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+              <span className="truncate">{label("app.closeDocumentTabsToRight")}</span>
+            </Button>
+          </PopoverSurface>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "Nicht gespeicherte Änderungen",
   "app.documentTabs": "Geöffnete Dokumente",
   "app.closeDocumentTab": "Tab schließen",
+  "app.closeOtherDocumentTabs": "Andere Tabs schließen",
+  "app.closeDocumentTabsToRight": "Tabs rechts schließen",
   "app.newDocumentTab": "Neuer Tab",
   "app.toggleMarkdownFiles": "Dateiliste umschalten",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -262,6 +262,8 @@ const messages: BaseLocaleMessages = {
   "app.unsavedChanges": "Unsaved changes",
   "app.documentTabs": "Open documents",
   "app.closeDocumentTab": "Close tab",
+  "app.closeOtherDocumentTabs": "Close other tabs",
+  "app.closeDocumentTabsToRight": "Close tabs to the right",
   "app.newDocumentTab": "New tab",
   "app.toggleMarkdownFiles": "Toggle file list",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "Cambios sin guardar",
   "app.documentTabs": "Documentos abiertos",
   "app.closeDocumentTab": "Cerrar pestaña",
+  "app.closeOtherDocumentTabs": "Cerrar otras pestañas",
+  "app.closeDocumentTabsToRight": "Cerrar pestañas a la derecha",
   "app.newDocumentTab": "Nueva pestaña",
   "app.toggleMarkdownFiles": "Alternar lista de archivos",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "Modifications non enregistrées",
   "app.documentTabs": "Documents ouverts",
   "app.closeDocumentTab": "Fermer l’onglet",
+  "app.closeOtherDocumentTabs": "Fermer les autres onglets",
+  "app.closeDocumentTabsToRight": "Fermer les onglets à droite",
   "app.newDocumentTab": "Nouvel onglet",
   "app.toggleMarkdownFiles": "Afficher ou masquer la liste des fichiers",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "Modifiche non salvate",
   "app.documentTabs": "Documenti aperti",
   "app.closeDocumentTab": "Chiudi scheda",
+  "app.closeOtherDocumentTabs": "Chiudi altre schede",
+  "app.closeDocumentTabsToRight": "Chiudi schede a destra",
   "app.newDocumentTab": "Nuova scheda",
   "app.toggleMarkdownFiles": "Mostra/nascondi elenco file",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -156,6 +156,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "未保存の変更",
   "app.documentTabs": "開いているドキュメント",
   "app.closeDocumentTab": "タブを閉じる",
+  "app.closeOtherDocumentTabs": "他のタブを閉じる",
+  "app.closeDocumentTabsToRight": "右側のタブを閉じる",
   "app.newDocumentTab": "新しいタブ",
   "app.toggleMarkdownFiles": "ファイルリストを切り替え",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "저장되지 않은 변경 사항",
   "app.documentTabs": "열린 문서",
   "app.closeDocumentTab": "탭 닫기",
+  "app.closeOtherDocumentTabs": "다른 탭 닫기",
+  "app.closeDocumentTabsToRight": "오른쪽 탭 닫기",
   "app.newDocumentTab": "새 탭",
   "app.toggleMarkdownFiles": "파일 목록 전환",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "Alterações não salvas",
   "app.documentTabs": "Documentos abertos",
   "app.closeDocumentTab": "Fechar aba",
+  "app.closeOtherDocumentTabs": "Fechar outras abas",
+  "app.closeDocumentTabsToRight": "Fechar abas à direita",
   "app.newDocumentTab": "Nova aba",
   "app.toggleMarkdownFiles": "Alternar lista de arquivos",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -150,6 +150,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "Несохранённые изменения",
   "app.documentTabs": "Открытые документы",
   "app.closeDocumentTab": "Закрыть вкладку",
+  "app.closeOtherDocumentTabs": "Закрыть другие вкладки",
+  "app.closeDocumentTabsToRight": "Закрыть вкладки справа",
   "app.newDocumentTab": "Новая вкладка",
   "app.toggleMarkdownFiles": "Показать или скрыть список файлов",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -273,6 +273,8 @@ export type I18nKey =
   | "app.unsavedChanges"
   | "app.documentTabs"
   | "app.closeDocumentTab"
+  | "app.closeOtherDocumentTabs"
+  | "app.closeDocumentTabsToRight"
   | "app.newDocumentTab"
   | "app.toggleMarkdownFiles"
   | "app.aiAgent"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -262,6 +262,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "未保存的更改",
   "app.documentTabs": "打开的文档",
   "app.closeDocumentTab": "关闭标签页",
+  "app.closeOtherDocumentTabs": "关闭其他标签页",
+  "app.closeDocumentTabsToRight": "关闭右侧标签页",
   "app.newDocumentTab": "新建标签页",
   "app.toggleMarkdownFiles": "切换文件列表",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -156,6 +156,8 @@ const messages: LocaleMessages = {
   "app.unsavedChanges": "未儲存的變更",
   "app.documentTabs": "開啟的文件",
   "app.closeDocumentTab": "關閉標籤頁",
+  "app.closeOtherDocumentTabs": "關閉其他標籤頁",
+  "app.closeDocumentTabsToRight": "關閉右側標籤頁",
   "app.newDocumentTab": "新增標籤頁",
   "app.toggleMarkdownFiles": "切換檔案列表",
   "app.aiAgent": "Markra AI",


### PR DESCRIPTION
## Summary
- Add a right-click context menu to document tabs with rename, close current, close other, and close tabs to the right actions.
- Route tab closing through the existing async close flow so unsaved-change checks still apply.
- Add localized labels for the new tab menu actions across all supported languages.

## Validation
- `pnpm --filter @markra/desktop test -- MarkdownTabsBar.test.tsx` passed: 622 tests passed.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed with existing chunk-size warnings.