### PR TITLE
fix(theme): align ink accent across UI

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,292 @@
+---
+version: alpha
+name: Markra
+description: Local-first WYSIWYG Markdown desktop editor with quiet writing surfaces, native AI review flows, and a restrained ink-black interaction system.
+colors:
+  primary: "#1A1C1E"
+  primary-hover: "#0F1115"
+  primary-soft: "#E8E8E9"
+  primary-inverse: "#F4F4F5"
+  primary-inverse-hover: "#FAFAFA"
+  primary-inverse-soft: "#3A3A3D"
+  background: "#FFFFFF"
+  surface: "#FAFAFA"
+  surface-muted: "#F8F8F8"
+  surface-hover: "#F5F5F5"
+  surface-active: "#EEEEEE"
+  text: "#555555"
+  text-strong: "#333333"
+  text-muted: "#999999"
+  markdown-syntax: "#C7C5C5"
+  border: "#EEEEEE"
+  border-strong: "#DDDDDD"
+  ghost: "#C0C0C0"
+  overlay-ink: "#1F232C"
+typography:
+  editor-h1:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 44px
+    fontWeight: 760
+    lineHeight: 1.15
+    letterSpacing: 0em
+  editor-h2:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 31px
+    fontWeight: 760
+    lineHeight: 1.22
+    letterSpacing: 0em
+  editor-h3:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 24px
+    fontWeight: 760
+    lineHeight: 1.28
+    letterSpacing: 0em
+  editor-body:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.65
+    letterSpacing: 0em
+  ui-body:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 13px
+    fontWeight: 520
+    lineHeight: 1.54
+    letterSpacing: 0em
+  ui-label:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 12px
+    fontWeight: 560
+    lineHeight: 1.67
+    letterSpacing: 0em
+  ui-control:
+    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontSize: 12px
+    fontWeight: 620
+    lineHeight: 1.67
+    letterSpacing: 0em
+spacing:
+  none: 0px
+  xxs: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 24px
+  2xl: 32px
+  editor-block: 18px
+  editor-section: 36px
+  panel-width: 384px
+rounded:
+  none: 0px
+  xs: 2px
+  sm: 4px
+  md: 6px
+  lg: 8px
+  full: 9999px
+components:
+  app-background:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text}"
+    typography: "{typography.ui-body}"
+  editor-paper:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text}"
+    typography: "{typography.editor-body}"
+    padding: 24px
+  editor-heading:
+    textColor: "{colors.text-strong}"
+    typography: "{typography.editor-h1}"
+  editor-markdown-syntax:
+    textColor: "{colors.markdown-syntax}"
+    typography: "{typography.editor-body}"
+  panel-surface:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    typography: "{typography.ui-body}"
+    rounded: "{rounded.lg}"
+    padding: 16px
+  code-surface:
+    backgroundColor: "{colors.surface-muted}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.editor-body}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  hover-surface:
+    backgroundColor: "{colors.surface-hover}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.ui-body}"
+    rounded: "{rounded.md}"
+  active-surface:
+    backgroundColor: "{colors.surface-active}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.ui-body}"
+    rounded: "{rounded.md}"
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.background}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  button-primary-hover:
+    backgroundColor: "{colors.primary-hover}"
+    textColor: "{colors.background}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  button-primary-dark:
+    backgroundColor: "{colors.primary-inverse}"
+    textColor: "{colors.overlay-ink}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  button-primary-dark-hover:
+    backgroundColor: "{colors.primary-inverse-hover}"
+    textColor: "{colors.overlay-ink}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  button-secondary:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  toggle-active:
+    backgroundColor: "{colors.primary-soft}"
+    textColor: "{colors.primary-hover}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.full}"
+    padding: 10px
+  toggle-active-dark:
+    backgroundColor: "{colors.primary-inverse-soft}"
+    textColor: "{colors.primary-inverse}"
+    typography: "{typography.ui-control}"
+    rounded: "{rounded.full}"
+    padding: 10px
+  input-field:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.ui-body}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  caption-text:
+    textColor: "{colors.text-muted}"
+    typography: "{typography.ui-label}"
+  divider:
+    backgroundColor: "{colors.border}"
+    height: 1px
+  divider-strong:
+    backgroundColor: "{colors.border-strong}"
+    height: 1px
+  drag-ghost:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.ui-body}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+  ghost-control:
+    textColor: "{colors.ghost}"
+    typography: "{typography.ui-label}"
+  overlay:
+    backgroundColor: "{colors.overlay-ink}"
+---
+
+# Markra Design System
+
+## Overview
+
+Markra should feel like a native writing instrument: calm, fast, local, and precise. The interface gives most of its attention to the Markdown document, while file navigation, AI controls, settings, and export tools stay quiet until needed.
+
+The default visual language is light, neutral, and editorial. It avoids decorative branding, heavy panels, and marketing-style composition. The primary ink-black is reserved for interaction, focus, active states, and AI/editor affordances; it should not flood the workspace.
+
+The product serves writers, engineers, researchers, and documentation-heavy teams. Screens should feel trustworthy for long-form reading and repeated editing, with enough density for desktop productivity and enough air around the document to keep the writing surface comfortable.
+
+## Colors
+
+The palette is based on clean neutrals and one restrained ink-black accent.
+
+- **Primary (#1A1C1E):** A deep ink-black interaction color. Use for primary actions, focus rings, active toggles, drop indicators, selected status, links, and AI review controls.
+- **Primary Hover (#0F1115):** A near-black hover color for pressed states and selected link states.
+- **Primary Soft (#E8E8E9):** A quiet ink-tinted container used behind selected pills, subtle active AI states, and quiet emphasis. Pair it with Primary Hover for text when WCAG AA contrast is required.
+- **Primary Inverse (#F4F4F5):** The dark-mode interaction color. Use it as the inverted form of Primary on dark surfaces instead of reintroducing blue.
+- **Primary Inverse Hover (#FAFAFA):** The brighter dark-mode hover color for primary controls.
+- **Primary Inverse Soft (#3A3A3D):** A dark neutral container for selected dark-mode pills and subtle active states.
+- **Background (#FFFFFF):** The main application and editor surface.
+- **Surface (#FAFAFA), Surface Muted (#F8F8F8), Surface Hover (#F5F5F5), Surface Active (#EEEEEE):** Layered neutral surfaces for panels, code, hover feedback, and selected controls.
+- **Text (#555555) and Text Strong (#333333):** Body text and headings. Strong text is for document headings, selected labels, and critical UI labels.
+- **Text Muted (#999999):** Secondary labels, empty states, helper text, metadata, and inactive controls.
+- **Markdown Syntax (#C7C5C5):** Low-emphasis rendered Markdown markers and source-mode syntax characters.
+- **Border (#EEEEEE) and Border Strong (#DDDDDD):** Fine separation for tool surfaces, tables, inputs, and editor structure.
+
+Do not introduce extra brand colors for primary flows. Semantic colors may appear for table delete affordances, callout types, syntax highlighting, or destructive confirmation, but they should stay localized to those contexts.
+
+## Typography
+
+Markra uses the system UI stack for both application chrome and the default editor theme. This keeps the desktop app native-feeling across macOS, Windows, and Linux while avoiding font loading cost.
+
+Editor typography is larger and calmer than UI typography. Body copy defaults to 16px with a 1.65 line-height for comfortable long-form writing. Headings use strong weight, normal tracking, and clear scale jumps: H1 at 44px, H2 at 31px, and H3 at 24px.
+
+Application controls use compact desktop sizes. Most settings, menus, inputs, and list controls sit between 12px and 13px, with medium-to-semibold weights for clarity. Letter spacing remains 0 across the UI.
+
+Use typographic hierarchy before adding decoration. Prefer weight, size, tone, and spacing changes over colored badges or boxed labels.
+
+## Layout
+
+The layout is a desktop productivity workspace centered on the document. The editor paper owns the main visual field; file tree, tabs, source view, AI panel, settings, and export tools are supporting surfaces.
+
+Use a compact spacing rhythm built from 4px and 8px increments. Application controls use small gaps and stable heights. Editor content uses larger block spacing: paragraphs and block elements breathe, headings create section rhythm, and tables/code/callouts get enough room for scanning.
+
+Resizable panes should use stable min/max boundaries. The AI panel defaults to 384px, with enough width for chat, tool traces, and edit previews without compressing the document beyond usefulness. Split editor mode should keep both source and visual panes predictable, with no layout shift from hover states.
+
+Mobile and narrow responsive states should simplify side surfaces before shrinking the document into unusable density.
+
+## Elevation & Depth
+
+Markra uses tonal layering, fine borders, and selective shadows instead of heavy elevation. The main document surface should feel flat and stable. Popovers, AI command panels, modals, drag ghosts, and table controls may use shadows to clarify temporary floating state.
+
+Shadows should be soft and functional. They signal that a surface is transient or layered above the editor; they should not make every panel feel like a card. Persistent workspace regions rely on background contrast and borders.
+
+The strongest depth treatment belongs to AI command surfaces and modal overlays because they interrupt the writing flow and need clear foreground separation.
+
+## Shapes
+
+The shape language is quiet and practical. Standard controls use 6px radius. Larger transient surfaces such as modals, menus, and popovers may use 8px. Small editor handles and compact tool buttons may use 2px to 4px. Pills and toggles use full radius.
+
+Avoid oversized rounded rectangles in dense desktop UI. Rounded corners should soften interaction targets without turning the app into a card-heavy landing page. Editor content itself should remain document-like, not boxed unless the Markdown element requires it, such as callouts, code blocks, and tables.
+
+## Components
+
+Primary buttons use the primary ink-black background with white text and switch to primary-hover on hover or pressed states. Use them only for the most important confirmation in a local surface.
+
+Secondary buttons use the background surface, strong text, and neutral borders. Ghost buttons are text-first and should reveal hover background only when interaction is likely.
+
+Icon buttons are preferred for toolbar actions when a familiar symbol exists. Pair them with accessible labels and visible focus rings. Use `lucide-react` icons for app controls.
+
+Inputs, selects, textareas, and search fields use white background, neutral border, strong text, and the primary color for focus border and focus ring. Placeholder text uses muted text.
+
+Segmented controls sit on surface backgrounds with compact spacing. The selected segment uses active neutral surface and strong text; focus uses the primary ring.
+
+Toggles use primary for checked state and neutral surface for unchecked state. Toggle labels should be short and operational.
+
+The editor paper uses background white, body text gray, strong headings, and neutral dividers. Code blocks use muted surfaces. Tables use strong borders, compact cell padding, and neutral alternating rows.
+
+AI command bars, AI panels, and preview controls may use stronger shadow and accent focus because they are temporary decision surfaces. Accent shadows must be derived from the current theme token, such as `color-mix(... var(--accent) ...)`, rather than hardcoded to one color.
+
+Callouts use localized semantic colors by callout type, but the surrounding system remains neutral. Do not reuse callout colors as global brand accents.
+
+## Do's and Don'ts
+
+- Do keep the document as the visual anchor of every workspace screen.
+- Do use `#1A1C1E` for primary interaction, focus, active state, selected status, and AI/editor affordances.
+- Do use neutral surfaces and borders for persistent structure before adding shadow.
+- Do keep component text compact and readable, especially in title bars, menus, settings, and panels.
+- Do preserve WCAG AA contrast for interactive text and controls.
+- Do make hover, focus, pressed, loading, disabled, empty, and error states explicit.
+- Do use Tailwind CSS and shared UI components where practical.
+- Don't introduce a second dominant brand accent beside the primary ink-black.
+- Don't turn persistent app sections into floating card stacks.
+- Don't use large marketing-style hero layouts inside the desktop app.
+- Don't over-round dense controls; use 6px as the default radius and full radius only for pills/toggles.
+- Don't hide destructive file or document actions behind ambiguous icons.
+- Don't apply AI edits directly without an explicit preview and user confirmation.

--- a/apps/desktop/src/components/AiProviderBadge.tsx
+++ b/apps/desktop/src/components/AiProviderBadge.tsx
@@ -14,7 +14,6 @@ import volcengineLogo from "../assets/provider-logos/volcengine.svg";
 import xiaomiMimoLogo from "../assets/provider-logos/xiaomi-mimo.svg";
 import type { AiProviderApiStyle, AiProviderConfig } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
-import { Badge } from "@markra/ui";
 
 type Translate = (key: I18nKey) => string;
 
@@ -60,7 +59,7 @@ export function AiProviderBadge({ provider, translate }: { provider: AiProviderC
   const logo = providerLogoById[provider.id] ?? providerLogoByType[provider.type];
 
   return (
-    <Badge className="size-7 overflow-hidden border border-(--border-default) bg-[oklch(0.985_0.004_255)] px-0 leading-none font-[750] text-(--accent)">
+    <span className="inline-flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full border border-(--border-default) bg-[oklch(0.985_0.004_255)] leading-none font-[750] text-(--accent)">
       {logo ? (
         <img
           className="size-5 object-contain"
@@ -71,6 +70,6 @@ export function AiProviderBadge({ provider, translate }: { provider: AiProviderC
       ) : (
         provider.name.slice(0, 2)
       )}
-    </Badge>
+    </span>
   );
 }

--- a/apps/desktop/src/components/AiProviderSettingsPanel.tsx
+++ b/apps/desktop/src/components/AiProviderSettingsPanel.tsx
@@ -166,7 +166,7 @@ export function AiProviderSettingsPanel({
                 </span>
               ) : null}
               <button
-                className="inline-flex h-9 cursor-pointer items-center justify-center rounded-md border border-(--accent) bg-(--accent) px-4 text-[13px] leading-5 font-bold text-(--bg-primary) shadow-[0_8px_20px_rgba(63,102,216,0.24)] transition-[background-color,border-color,box-shadow] duration-150 ease-out hover:bg-(--accent-hover) hover:border-(--accent-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+                className="inline-flex h-9 cursor-pointer items-center justify-center rounded-md border border-(--accent) bg-(--accent) px-4 text-[13px] leading-5 font-bold text-(--bg-primary) shadow-[0_8px_20px_color-mix(in_srgb,var(--accent)_20%,transparent)] transition-[background-color,border-color,box-shadow] duration-150 ease-out hover:bg-(--accent-hover) hover:border-(--accent-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
                 type="button"
                 aria-label={translate("settings.ai.saveProviders")}
                 onClick={onSave}

--- a/apps/desktop/src/components/AppToaster.tsx
+++ b/apps/desktop/src/components/AppToaster.tsx
@@ -19,7 +19,7 @@ export function AppToaster({ language }: { language: AppLanguage }) {
           "app-toast app-toast-centered relative left-1/2 flex min-h-10 w-fit min-w-40 max-w-[calc(100vw-3rem)] -translate-x-1/2 items-center gap-2.5 rounded-md border border-(--border-default) bg-(--bg-primary) py-2 pr-9 pl-3 text-[12px] leading-5 font-[600] text-(--text-heading) shadow-[0_14px_34px_rgba(15,23,42,0.14)] sm:max-w-80",
         classNames: {
           actionButton:
-            "shrink-0 cursor-pointer rounded border border-(--accent) bg-(--accent) px-2 py-1 text-[11px] leading-4 font-[700] text-white transition-opacity duration-150 ease-out hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)",
+            "shrink-0 cursor-pointer rounded border border-(--accent) bg-(--accent) px-2 py-1 text-[11px] leading-4 font-[700] text-(--bg-primary) transition-opacity duration-150 ease-out hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)",
           content: "min-w-0 flex-1",
           icon: "relative inline-flex size-4 shrink-0 items-center justify-center self-center text-(--text-secondary)",
           title: "truncate",

--- a/apps/desktop/src/components/SettingsSections.tsx
+++ b/apps/desktop/src/components/SettingsSections.tsx
@@ -130,7 +130,7 @@ type ThemePreviewStyle = CSSProperties & {
 
 const themePreviewSwatches: Record<AppTheme, ThemePreviewSwatch> = {
   system: {
-    accent: "#0969da",
+    accent: "#1a1c1e",
     background: "linear-gradient(135deg, #f6f8fa 0 49%, #1f2328 50% 100%)",
     border: "#d1d9e0",
     muted: "#59636e",
@@ -138,7 +138,7 @@ const themePreviewSwatches: Record<AppTheme, ThemePreviewSwatch> = {
     text: "#1f2328"
   },
   light: {
-    accent: "#0969da",
+    accent: "#1a1c1e",
     background: "#ffffff",
     border: "#d1d9e0",
     muted: "#59636e",
@@ -146,7 +146,7 @@ const themePreviewSwatches: Record<AppTheme, ThemePreviewSwatch> = {
     text: "#1f2328"
   },
   dark: {
-    accent: "#58a6ff",
+    accent: "#f4f4f5",
     background: "#0d1117",
     border: "#30363d",
     muted: "#8b949e",
@@ -178,7 +178,7 @@ const themePreviewSwatches: Record<AppTheme, ThemePreviewSwatch> = {
     text: "#241f1a"
   },
   night: {
-    accent: "#67e8f9",
+    accent: "#f4f4f5",
     background: "#111827",
     border: "#374151",
     muted: "#9ca3af",
@@ -266,7 +266,7 @@ const themePreviewSwatches: Record<AppTheme, ThemePreviewSwatch> = {
     text: "#27272a"
   },
   custom: {
-    accent: "#0969da",
+    accent: "#1a1c1e",
     background: "#ffffff",
     border: "#d1d9e0",
     muted: "#59636e",

--- a/apps/desktop/src/lib/settings/app-settings.ts
+++ b/apps/desktop/src/lib/settings/app-settings.ts
@@ -153,9 +153,9 @@ export const defaultCustomThemeCss = `:root[data-theme="custom"] {
   --text-md-char: #818b98;
   --border-default: #d1d9e0;
   --border-strong: #d1d9e0;
-  --accent: #0969da;
-  --accent-soft: rgba(9, 105, 218, 0.12);
-  --accent-hover: #0550ae;
+  --accent: #1a1c1e;
+  --accent-soft: rgba(26, 28, 30, 0.1);
+  --accent-hover: #0f1115;
 }
 
 :root[data-theme="custom"] .markdown-paper[data-editor-theme="custom"] {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -169,9 +169,9 @@
 
     --border-default: #eeeeee;
     --border-strong: #dddddd;
-    --accent: #3f66d8;
-    --accent-soft: rgba(63, 102, 216, 0.12);
-    --accent-hover: #2f56c6;
+    --accent: #1a1c1e;
+    --accent-soft: rgba(26, 28, 30, 0.1);
+    --accent-hover: #0f1115;
 
     --ai-command-shadow: 0 18px 52px rgba(0, 0, 0, 0.12);
     --ai-command-expanded-shadow: 0 20px 64px rgba(0, 0, 0, 0.16);
@@ -213,33 +213,33 @@
 
     --border-default: #333333;
     --border-strong: #444444;
-    --accent: #91a7ff;
-    --accent-soft: rgba(145, 167, 255, 0.16);
-    --accent-hover: #b7c5ff;
+    --accent: #f4f4f5;
+    --accent-soft: rgba(244, 244, 245, 0.14);
+    --accent-hover: #fafafa;
 
     --ai-command-shadow:
       0 24px 64px rgba(0, 0, 0, 0.64),
       0 0 0 1px rgba(255, 255, 255, 0.035),
-      0 0 32px rgba(145, 167, 255, 0.08);
+      0 0 32px color-mix(in srgb, var(--accent) 7%, transparent);
     --ai-command-expanded-shadow:
       0 28px 76px rgba(0, 0, 0, 0.68),
       0 0 0 1px rgba(255, 255, 255, 0.045),
-      0 0 40px rgba(145, 167, 255, 0.11);
+      0 0 40px color-mix(in srgb, var(--accent) 9%, transparent);
     --ai-command-panel-shadow:
       0 24px 68px rgba(0, 0, 0, 0.62),
       0 0 0 1px rgba(255, 255, 255, 0.04),
-      0 0 34px rgba(145, 167, 255, 0.08);
+      0 0 34px color-mix(in srgb, var(--accent) 7%, transparent);
     --ai-command-popover-shadow:
       0 22px 58px rgba(0, 0, 0, 0.66),
       0 0 0 1px rgba(255, 255, 255, 0.04),
-      0 0 28px rgba(145, 167, 255, 0.08);
+      0 0 28px color-mix(in srgb, var(--accent) 7%, transparent);
     --ai-preview-action-shadow:
       0 16px 38px rgba(0, 0, 0, 0.7),
       0 0 0 1px rgba(255, 255, 255, 0.035);
     --ai-preview-action-quiet-shadow:
       0 18px 44px rgba(0, 0, 0, 0.78),
       0 0 0 1px rgba(255, 255, 255, 0.045),
-      0 0 24px rgba(145, 167, 255, 0.07);
+      0 0 24px color-mix(in srgb, var(--accent) 6%, transparent);
 
     --ai-ghost: #555555;
     --ai-border: #444444;


### PR DESCRIPTION
## Summary
- Add a Stitch-compatible DESIGN.md for Markra with ink-black light tokens and inverse dark-mode tokens.
- Switch default light/custom accent colors to ink black, and dark/night accent colors to near-white.
- Derive AI/provider shadows from `--accent` instead of stale hardcoded blue values.
- Fix AI provider badges to render as true circles and keep toast action text readable against themed accents.

## Why
- The default theme is moving from blue to a more solemn black/white interaction system.
- Theme-dependent shadows and controls should follow the active accent token across light and dark modes.
- Provider logos should use a stable circular badge shape instead of inheriting pill badge sizing.

## Validation
- `pnpm dlx @google/design.md lint DESIGN.md` passed with 0 errors and 0 warnings.
- `pnpm --filter @markra/desktop test -- App.test.tsx SettingsSections.test.tsx` passed, 627 tests. Vitest printed jsdom `scrollBy` not implemented warnings.
- `pnpm --filter @markra/desktop build` passed. Vite emitted non-blocking warnings about node:fs externalization and large chunks.
- `git diff --cached --check` passed.

## Risk
- Visual theme change only; named themes keep their intentional palette-specific accents.
- Browser screenshot QA was not rerun after the final hardcoded-color audit.
