### PR TITLE
refactor(desktop): split markdown paper and optimize build output

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -52,7 +52,7 @@ import {
   useNativeMenuHandlers,
   useNativeMenus
 } from "./hooks/useNativeBindings";
-import { aiTranslationLanguageName, t, type I18nKey } from "@markra/shared";
+import { aiTranslationLanguageName, clampNumber, debug, t, type I18nKey } from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
@@ -61,7 +61,7 @@ import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
 import { openNativeExternalUrl, openSettingsWindow } from "./lib/tauri";
-import type { AiDiffResult, AiEditIntent, AiSelectionContext } from "@markra/ai";
+import { aiAgentWebSearchAvailable, type AiDiffResult, type AiEditIntent, type AiSelectionContext } from "@markra/ai";
 import {
   AI_EDITOR_PREVIEW_APPLIED_EVENT,
   AI_EDITOR_PREVIEW_ACTION_EVENT,
@@ -71,7 +71,6 @@ import {
   type AiEditorPreviewRestoreDetail,
   type RemoteClipboardImage
 } from "@markra/editor";
-import { aiAgentWebSearchAvailable } from "@markra/ai";
 import {
   defaultSplitVisualPanePercent,
   deleteStoredAiAgentSession,
@@ -94,8 +93,6 @@ import {
   saveNativePdfFile,
   type NativeMarkdownFolderFile
 } from "./lib/tauri";
-import { debug } from "@markra/shared";
-import { clampNumber } from "@markra/shared";
 
 const aiAgentPanelDefaultWidth = 384;
 const aiAgentPanelMinWidth = 320;

--- a/apps/desktop/src/components/AiAgentPanel.tsx
+++ b/apps/desktop/src/components/AiAgentPanel.tsx
@@ -12,10 +12,9 @@ import { AiAgentSessionMenu } from "./AiAgentSessionMenu";
 import { AiMarkdownMessage } from "./AiMarkdownMessage";
 import { AiAgentProcessList } from "./AiAgentProcessList";
 import { useImeInputGuard } from "../hooks/useImeInputGuard";
-import { t, type AppLanguage, type I18nKey } from "@markra/shared";
+import { clampNumber, t, type AppLanguage, type I18nKey } from "@markra/shared";
 import type { AiModelCapability, AiProviderApiStyle, StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
 import type { AiAgentPanelMessage } from "../hooks/useAiAgentSession";
-import { clampNumber } from "@markra/shared";
 import { IconButton, RoundIconButton, ToggleButton } from "@markra/ui";
 
 type AiAgentModelOption = AiModelPickerOption & { capabilities: AiModelCapability[] };

--- a/apps/desktop/src/components/AiAgentSessionMenu.tsx
+++ b/apps/desktop/src/components/AiAgentSessionMenu.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Archive, ArchiveRestore, Check, History, MessageSquarePlus, PencilLine, Search, Trash2 } from "lucide-react";
 import { Button, IconButton, PopoverSurface, SearchInput } from "@markra/ui";
-import type { AppLanguage, I18nKey } from "@markra/shared";
+import { t, type AppLanguage, type I18nKey } from "@markra/shared";
 import type { StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
-import { t } from "@markra/shared";
 import { confirmNativeAiAgentSessionDelete } from "../lib/tauri";
 
 const menuExitDurationMs = 140;

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
@@ -21,12 +21,11 @@ import {
   Settings,
   TableOfContents
 } from "lucide-react";
-import { t, type AppLanguage } from "@markra/shared";
+import { clampNumber, t, type AppLanguage } from "@markra/shared";
 import { IconButton } from "@markra/ui";
 import type { MarkdownOutlineItem } from "@markra/markdown";
 import type { NativeMarkdownFolderFile } from "../lib/tauri";
 import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
-import { clampNumber } from "@markra/shared";
 import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
 
 type MarkdownFileTreeDrawerProps = {

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -14,9 +14,13 @@ import {
   type RemoteClipboardImage,
   applyAiEditorResult,
   clearAiEditorPreview,
+  clearAiSelectionHold,
   confirmAiEditorResultApplied,
+  defaultMarkdownShortcuts,
   scrollAiEditorPreviewIntoView,
-  showAiEditorPreview
+  showAiEditorPreview,
+  showAiSelectionHold,
+  type MarkdownShortcutMap
 } from "@markra/editor";
 import {
   readAiSectionAnchorsFromView,
@@ -24,7 +28,6 @@ import {
   readAiTableAnchorsFromView
 } from "../hooks/useEditorController";
 import type { AiSelectionContext } from "@markra/ai";
-import { clearAiSelectionHold, defaultMarkdownShortcuts, showAiSelectionHold, type MarkdownShortcutMap } from "@markra/editor";
 
 async function renderEditor(
   initialContent = "",

--- a/apps/desktop/src/components/MarkdownPaper.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.tsx
@@ -1,58 +1,4 @@
-import { type CSSProperties, type Ref, type UIEvent, useCallback, useEffect, useMemo, useRef } from "react";
-import { defaultValueCtx, Editor, editorViewCtx, editorViewOptionsCtx, parserCtx, rootCtx, serializerCtx } from "@milkdown/kit/core";
-import { history } from "@milkdown/kit/plugin/history";
-import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
-import {
-  commands as commonmarkCommands,
-  imageSchema,
-  headingSchema,
-  inputRules as commonmarkInputRules,
-  keymap as commonmarkKeymap,
-  linkSchema,
-  paragraphSchema,
-  plugins as commonmarkPlugins,
-  schema as commonmarkSchema
-} from "@milkdown/kit/preset/commonmark";
-import {
-  commands as gfmCommands,
-  inputRules as gfmInputRules,
-  keymap as gfmKeymap,
-  pasteRules as gfmPasteRules,
-  plugins as gfmPlugins,
-  schema as gfmSchema
-} from "@milkdown/kit/preset/gfm";
-import { Milkdown, MilkdownProvider, useEditor, useInstance } from "@milkdown/react";
-import { Plugin } from "@milkdown/kit/prose/state";
-import type { EditorView } from "@milkdown/kit/prose/view";
-import { $prose } from "@milkdown/kit/utils";
-import { markraLiveMarkdownPlugin } from "@markra/editor";
-import {
-  markraClipboardImagePluginWithOptions,
-  type SaveClipboardImage,
-  type SaveRemoteClipboardImage
-} from "@markra/editor";
-import { markraCodeBlockPlugin } from "@markra/editor";
-import { markraCalloutPlugin } from "@markra/editor";
-import { markraCalloutSerializerPlugin } from "@markra/editor";
-import { markraHeadingSourcePlugin } from "@markra/editor";
-import { markraHeadingTogglePlugin } from "@markra/editor";
-import { normalizeHeadingSourceDocument } from "@markra/editor";
-import { markraLinkImageLivePlugin } from "@markra/editor";
-import { markraRawHtmlPlugin } from "@markra/editor";
-import { serializeLinkImageLiveMarkdown } from "@markra/editor";
-import { markraMarkdownShortcuts } from "@markra/editor";
-import { normalizeMarkdownShortcuts } from "@markra/editor";
-import { markraSlashCommands } from "@markra/editor";
-import { markraMathPlugin } from "@markra/editor";
-import { markraMathRemarkPlugin } from "@markra/editor";
-import { markraMathSourcePlugin } from "@markra/editor";
-import { markraTableControlsPlugin } from "@markra/editor";
-import { markraAiEditorPreviewPlugin } from "@markra/editor";
-import { markraAiSelectionHoldPlugin } from "@markra/editor";
-import { markraBlockDragPlugin } from "@markra/editor";
-import type { MarkdownShortcutMap } from "@markra/editor";
-import type { SlashCommandLabels } from "@markra/editor";
-import type { AiSelectionContext } from "@markra/ai";
+import { type CSSProperties, type Ref, type UIEvent } from "react";
 import { t, type AppLanguage } from "@markra/shared";
 import {
   editorContentWidthPixels,
@@ -61,31 +7,8 @@ import {
   type EditorContentWidth
 } from "../lib/editor-width";
 import type { EditorTheme } from "../lib/settings/app-settings";
-import { readAiSelectionContextFromView } from "../hooks/useEditorController";
-import type { MarkdownDocumentLinkFile } from "../lib/document-links";
-import { markraDocumentLinkCompletionPlugin } from "./document-link-completion";
 import { EditorWidthResizer } from "./EditorWidthResizer";
-
-const markraCommonmark = [
-  commonmarkSchema,
-  commonmarkInputRules,
-  commonmarkCommands,
-  commonmarkKeymap,
-  commonmarkPlugins
-].flat();
-
-const markraGfm = [
-  gfmSchema,
-  gfmInputRules,
-  gfmPasteRules,
-  gfmKeymap,
-  gfmCommands,
-  gfmPlugins
-].flat();
-
-function markdownShortcutSignature(shortcuts: MarkdownShortcutMap | undefined) {
-  return JSON.stringify(normalizeMarkdownShortcuts(shortcuts));
-}
+import { MarkdownPaperSurface, type MarkdownPaperSurfaceProps } from "./MarkdownPaperSurface";
 
 type MarkdownPaperProps = {
   autoFocus?: boolean;
@@ -95,428 +18,28 @@ type MarkdownPaperProps = {
   contentWidthMax?: number;
   contentWidthMin?: number;
   contentWidthPx?: number | null;
-  documentPath?: string | null;
+  documentPath?: MarkdownPaperSurfaceProps["documentPath"];
   editorTheme?: EditorTheme;
   initialContent: string;
   language?: AppLanguage;
   lineHeight?: number;
-  markdownShortcuts?: MarkdownShortcutMap;
-  onEditorReady: (editor: Editor | null, options?: { autoFocus?: boolean }) => unknown;
-  onMarkdownChange: (content: string) => unknown;
+  markdownShortcuts?: MarkdownPaperSurfaceProps["markdownShortcuts"];
+  onEditorReady: MarkdownPaperSurfaceProps["onEditorReady"];
+  onMarkdownChange: MarkdownPaperSurfaceProps["onMarkdownChange"];
   onContentWidthChange?: (width: number) => unknown;
   onContentWidthResizeEnd?: () => unknown;
   onContentWidthResizeStart?: () => unknown;
   onScroll?: (event: UIEvent<HTMLElement>) => unknown;
-  onSaveClipboardImage?: SaveClipboardImage;
-  onSaveRemoteClipboardImage?: SaveRemoteClipboardImage;
-  openExternalUrl?: (url: string) => unknown;
-  onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
-  resolveImageSrc?: (src: string) => string;
+  onSaveClipboardImage?: MarkdownPaperSurfaceProps["onSaveClipboardImage"];
+  onSaveRemoteClipboardImage?: MarkdownPaperSurfaceProps["onSaveRemoteClipboardImage"];
+  openExternalUrl?: MarkdownPaperSurfaceProps["openExternalUrl"];
+  onTextSelectionChange?: MarkdownPaperSurfaceProps["onTextSelectionChange"];
+  resolveImageSrc?: MarkdownPaperSurfaceProps["resolveImageSrc"];
   revision: number;
   scrollRef?: Ref<HTMLElement>;
   topInset?: "tabs" | "titlebar";
-  workspaceFiles?: MarkdownDocumentLinkFile[];
+  workspaceFiles?: MarkdownPaperSurfaceProps["workspaceFiles"];
 };
-
-type MilkdownSurfaceProps = {
-  autoFocus: boolean;
-  documentPath?: MarkdownPaperProps["documentPath"];
-  initialContent: string;
-  language: AppLanguage;
-  onEditorReady: MarkdownPaperProps["onEditorReady"];
-  onMarkdownChange: (content: string) => unknown;
-  onSaveClipboardImage?: MarkdownPaperProps["onSaveClipboardImage"];
-  onSaveRemoteClipboardImage?: MarkdownPaperProps["onSaveRemoteClipboardImage"];
-  openExternalUrl?: MarkdownPaperProps["openExternalUrl"];
-  onTextSelectionChange?: MarkdownPaperProps["onTextSelectionChange"];
-  resolveImageSrc?: MarkdownPaperProps["resolveImageSrc"];
-  markdownShortcuts?: MarkdownPaperProps["markdownShortcuts"];
-  workspaceFiles?: MarkdownPaperProps["workspaceFiles"];
-};
-
-function markraTextSelectionObserverPlugin(
-  onTextSelectionChange: (selection: AiSelectionContext | null) => unknown
-) {
-  return $prose(() => {
-    let lastSignature = "";
-
-    const notifySelectionChange = (view: EditorView, options: { requireFocusForEmptySelection: boolean }) => {
-      const { selection } = view.state;
-
-      if (selection.empty) {
-        if (options.requireFocusForEmptySelection && !view.hasFocus()) return;
-
-        const blockContext = readAiSelectionContextFromView(view);
-        if (blockContext.text.trim()) {
-          const signature = `${blockContext.source ?? "block"}:${blockContext.from}:${blockContext.to}:${blockContext.text}`;
-          if (signature === lastSignature) return;
-
-          lastSignature = signature;
-          onTextSelectionChange(blockContext);
-          return;
-        }
-
-        if (lastSignature) {
-          lastSignature = "";
-          onTextSelectionChange(null);
-        }
-        return;
-      }
-
-      const text = view.state.doc.textBetween(selection.from, selection.to, "\n").trim();
-      if (!text) {
-        if (view.hasFocus() && lastSignature) {
-          lastSignature = "";
-          onTextSelectionChange(null);
-        }
-
-        return;
-      }
-
-      const signature = `${selection.from}:${selection.to}:${text}`;
-      if (signature === lastSignature) return;
-
-      lastSignature = signature;
-      onTextSelectionChange({
-        from: selection.from,
-        source: "selection",
-        text,
-        to: selection.to
-      });
-    };
-
-    const clearStaleSelectionAfterEditorClick = (view: EditorView) => {
-      if (!lastSignature) return;
-
-      const domSelection = view.dom.ownerDocument.getSelection();
-      const hasDomSelectedText = Boolean(domSelection && !domSelection.isCollapsed && domSelection.toString().trim());
-      if (hasDomSelectedText) return;
-
-      if (!view.state.selection.empty) {
-        lastSignature = "";
-        onTextSelectionChange(null);
-        return;
-      }
-
-      notifySelectionChange(view, { requireFocusForEmptySelection: false });
-    };
-
-    return new Plugin({
-      view(view) {
-        const ownerDocument = view.dom.ownerDocument;
-        const handleMouseUp = (event: MouseEvent) => {
-          if (event.button !== 0) return;
-
-          const targetElement =
-            event.target instanceof Element
-              ? event.target
-              : event.target instanceof Node
-                ? event.target.parentElement
-                : null;
-          const writingSurface = view.dom.closest(".paper-scroll");
-          if (!targetElement || !writingSurface?.contains(targetElement)) return;
-
-          ownerDocument.defaultView?.setTimeout(() => {
-            clearStaleSelectionAfterEditorClick(view);
-          }, 0);
-        };
-
-        ownerDocument.addEventListener("mouseup", handleMouseUp, true);
-
-        return {
-          destroy() {
-            ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
-          },
-          update(view, previousState) {
-            const { selection } = view.state;
-            if (selection.eq(previousState.selection)) return;
-            notifySelectionChange(view, { requireFocusForEmptySelection: true });
-          }
-        };
-      }
-    });
-  });
-}
-
-function linkTargetFromClickTarget(target: EventTarget | null) {
-  const targetElement =
-    target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
-  if (!targetElement) return null;
-
-  return targetElement.closest<HTMLAnchorElement | HTMLElement>("a[href], .markra-live-link-label[data-markra-href]");
-}
-
-function linkHrefFromClickTarget(target: EventTarget | null) {
-  const linkTarget = linkTargetFromClickTarget(target);
-  if (!linkTarget) return null;
-
-  if (linkTarget instanceof HTMLAnchorElement) {
-    return linkTarget.getAttribute("href") ?? linkTarget.href;
-  }
-
-  return linkTarget.dataset.markraHref ?? null;
-}
-
-function linkOpenModifierIsPressed(event: MouseEvent) {
-  return event.metaKey || event.ctrlKey;
-}
-
-function markraExternalLinkClickPlugin(openExternalUrl: (url: string) => unknown) {
-  return $prose(() => {
-    return new Plugin({
-      props: {
-        handleDOMEvents: {
-          mousedown(_view, event) {
-            const href = linkHrefFromClickTarget(event.target);
-            if (!href) return false;
-
-            if (!linkOpenModifierIsPressed(event)) {
-              return false;
-            }
-
-            event.preventDefault();
-            return true;
-          },
-          click(_view, event) {
-            const href = linkHrefFromClickTarget(event.target);
-            if (!href) return false;
-
-            if (!linkOpenModifierIsPressed(event)) {
-              return false;
-            }
-
-            event.preventDefault();
-
-            try {
-              Promise.resolve(openExternalUrl(href)).catch(() => {});
-            } catch {
-              // Opening external links is best-effort; editing should not be interrupted by opener failures.
-            }
-
-            return true;
-          }
-        }
-      }
-    });
-  });
-}
-
-function MilkdownInstanceBridge({ autoFocus, onEditorReady }: Pick<MilkdownSurfaceProps, "autoFocus" | "onEditorReady">) {
-  const [loading, getEditor] = useInstance();
-  const autoFocusRef = useRef(autoFocus);
-
-  useEffect(() => {
-    autoFocusRef.current = autoFocus;
-  }, [autoFocus]);
-
-  useEffect(() => {
-    if (loading) return;
-
-    const editor = getEditor();
-    onEditorReady(editor, { autoFocus: autoFocusRef.current });
-
-    return () => {
-      onEditorReady(null);
-    };
-  }, [getEditor, loading, onEditorReady]);
-
-  return null;
-}
-
-function MilkdownSurface({
-  autoFocus,
-  documentPath,
-  initialContent,
-  language,
-  onEditorReady,
-  onMarkdownChange,
-  onSaveClipboardImage,
-  onSaveRemoteClipboardImage,
-  openExternalUrl,
-  onTextSelectionChange,
-  resolveImageSrc,
-  markdownShortcuts,
-  workspaceFiles
-}: MilkdownSurfaceProps) {
-  const initialContentRef = useRef(initialContent);
-  const documentPathRef = useRef(documentPath);
-  const openExternalUrlRef = useRef(openExternalUrl);
-  const onSaveClipboardImageRef = useRef(onSaveClipboardImage);
-  const onSaveRemoteClipboardImageRef = useRef(onSaveRemoteClipboardImage);
-  const onTextSelectionChangeRef = useRef(onTextSelectionChange);
-  const workspaceFilesRef = useRef(workspaceFiles ?? []);
-  const externalLinkOpeningEnabled = Boolean(openExternalUrl);
-  const markdownDocumentLabel = t(language, "app.markdownDocument");
-  const tableControlLabels = {
-    addColumnRight: t(language, "editor.table.addColumnRight"),
-    addRowBelow: t(language, "editor.table.addRowBelow"),
-    alignLeft: t(language, "editor.table.alignLeft"),
-    alignCenter: t(language, "editor.table.alignCenter"),
-    alignRight: t(language, "editor.table.alignRight"),
-    deleteColumn: t(language, "editor.table.deleteColumn"),
-    deleteRow: t(language, "editor.table.deleteRow"),
-    adjustTable: t(language, "editor.table.adjustTable"),
-    resizeTableTo: t(language, "editor.table.resizeTableTo"),
-    tableColumns: t(language, "editor.table.columns"),
-    tableRows: t(language, "editor.table.rows")
-  };
-  const blockDragLabels = {
-    addBlock: t(language, "editor.blockAdd"),
-    dragBlock: t(language, "editor.blockDrag")
-  };
-  const headingToggleLabels = {
-    collapseSection: t(language, "editor.collapseSection"),
-    expandSection: t(language, "editor.expandSection")
-  };
-  const slashCommandLabels = useMemo<SlashCommandLabels>(() => ({
-    menu: t(language, "editor.slashCommands"),
-    noResults: t(language, "editor.slashCommandsNoResults"),
-    commands: {
-      bulletList: t(language, "menu.bulletList"),
-      callout: t(language, "menu.callout"),
-      codeBlock: t(language, "menu.codeBlock"),
-      heading1: t(language, "menu.heading1"),
-      heading2: t(language, "menu.heading2"),
-      heading3: t(language, "menu.heading3"),
-      orderedList: t(language, "menu.orderedList"),
-      paragraph: t(language, "menu.paragraph"),
-      quote: t(language, "menu.quote"),
-      table: t(language, "menu.table")
-    }
-  }), [language]);
-
-  useEffect(() => {
-    onSaveClipboardImageRef.current = onSaveClipboardImage;
-  }, [onSaveClipboardImage]);
-
-  useEffect(() => {
-    documentPathRef.current = documentPath;
-  }, [documentPath]);
-
-  useEffect(() => {
-    openExternalUrlRef.current = openExternalUrl;
-  }, [openExternalUrl]);
-
-  useEffect(() => {
-    onSaveRemoteClipboardImageRef.current = onSaveRemoteClipboardImage;
-  }, [onSaveRemoteClipboardImage]);
-
-  useEffect(() => {
-    onTextSelectionChangeRef.current = onTextSelectionChange;
-  }, [onTextSelectionChange]);
-
-  useEffect(() => {
-    workspaceFilesRef.current = workspaceFiles ?? [];
-  }, [workspaceFiles]);
-
-  const createEditor = useCallback(
-    (root: HTMLElement) => {
-      const editor = Editor.make()
-        .config((ctx) => {
-          ctx.set(rootCtx, root);
-          ctx.set(defaultValueCtx, initialContentRef.current);
-          ctx.update(editorViewOptionsCtx, (options) => ({
-            ...options,
-            attributes: {
-              ...options.attributes,
-              "aria-label": markdownDocumentLabel,
-              spellcheck: "true"
-            }
-          }));
-          ctx.get(listenerCtx).updated((editorCtx, doc) => {
-            try {
-              const view = editorCtx.get(editorViewCtx);
-              const normalizedDoc = normalizeHeadingSourceDocument(
-                view.state,
-                paragraphSchema.type(editorCtx),
-                headingSchema.type(editorCtx),
-                editorCtx.get(parserCtx)
-              );
-              onMarkdownChange(
-                serializeLinkImageLiveMarkdown(
-                  normalizedDoc === view.state.doc ? doc : normalizedDoc,
-                  editorCtx.get(serializerCtx),
-                  linkSchema.type(editorCtx),
-                  imageSchema.type(editorCtx)
-                )
-              );
-            } catch {
-              // Milkdown can flush a delayed update after teardown in tests or fast window closes.
-            }
-          });
-        })
-        .use(listener)
-        .use(history)
-        .use(markraMathRemarkPlugin)
-        .use(markraCommonmark)
-        .use(markraGfm)
-        .use(markraCalloutSerializerPlugin)
-        .use(markraCalloutPlugin)
-        .use(markraSlashCommands(slashCommandLabels))
-        .use(markraMathSourcePlugin)
-        .use(markraMarkdownShortcuts(markdownShortcuts))
-        .use(markraCodeBlockPlugin)
-        .use(markraMathPlugin)
-        .use(markraAiSelectionHoldPlugin)
-        .use(markraAiEditorPreviewPlugin)
-        .use(markraBlockDragPlugin(blockDragLabels))
-        .use(markraHeadingTogglePlugin(headingToggleLabels))
-        .use(
-          markraDocumentLinkCompletionPlugin({
-            getDocumentPath: () => documentPathRef.current,
-            getWorkspaceFiles: () => workspaceFilesRef.current
-          })
-        )
-        .use(
-          markraTextSelectionObserverPlugin((selection) => {
-            onTextSelectionChangeRef.current?.(selection);
-          })
-        )
-        .use(markraTableControlsPlugin(tableControlLabels))
-        .use(markraLinkImageLivePlugin(resolveImageSrc))
-        .use(markraHeadingSourcePlugin)
-        .use(
-          markraRawHtmlPlugin({
-            htmlSourceApplyLabel: t(language, "editor.htmlSourceApply"),
-            htmlSourceLabel: t(language, "editor.htmlSource"),
-            resolveImageSrc
-          })
-        )
-        .use(markraLiveMarkdownPlugin);
-
-      if (externalLinkOpeningEnabled) {
-        editor.use(
-          markraExternalLinkClickPlugin((url) => {
-            return openExternalUrlRef.current?.(url);
-          })
-        );
-      }
-
-      if (onSaveClipboardImageRef.current || onSaveRemoteClipboardImageRef.current) {
-        editor.use(
-          markraClipboardImagePluginWithOptions(
-            (image) => onSaveClipboardImageRef.current?.(image) ?? Promise.resolve(null),
-            {
-              saveRemoteImage: (image) => onSaveRemoteClipboardImageRef.current?.(image) ?? Promise.resolve(null)
-            }
-          )
-        );
-      }
-
-      return editor;
-    },
-    [externalLinkOpeningEnabled, language, markdownDocumentLabel, markdownShortcuts, onMarkdownChange, resolveImageSrc, slashCommandLabels]
-  );
-
-  useEditor(createEditor, [createEditor]);
-
-  return (
-    <>
-      <Milkdown />
-      <MilkdownInstanceBridge autoFocus={autoFocus} onEditorReady={onEditorReady} />
-    </>
-  );
-}
 
 export function MarkdownPaper({
   autoFocus = false,
@@ -555,11 +78,6 @@ export function MarkdownPaper({
     maxWidth: `${resolvedContentWidth}px`,
     ...(bottomOverlayInset > 0 ? { paddingBottom: `${bottomOverlayInset}px` } : {})
   } satisfies CSSProperties;
-  const shortcutsSignature = markdownShortcutSignature(markdownShortcuts);
-  const normalizedMarkdownShortcuts = useMemo(
-    () => normalizeMarkdownShortcuts(markdownShortcuts),
-    [shortcutsSignature]
-  );
   const topInsetClassName = topInset === "tabs" ? "pt-24 max-[900px]:pt-20" : "pt-14 max-[900px]:pt-10";
 
   return (
@@ -586,23 +104,21 @@ export function MarkdownPaper({
           onResizeEnd={onContentWidthResizeEnd}
           onResizeStart={onContentWidthResizeStart}
         />
-        <MilkdownProvider>
-          <MilkdownSurface
-            autoFocus={autoFocus}
-            documentPath={documentPath}
-            initialContent={initialContent}
-            language={language}
-            markdownShortcuts={normalizedMarkdownShortcuts}
-            onEditorReady={onEditorReady}
-            onMarkdownChange={onMarkdownChange}
-            onSaveClipboardImage={onSaveClipboardImage}
-            onSaveRemoteClipboardImage={onSaveRemoteClipboardImage}
-            openExternalUrl={openExternalUrl}
-            onTextSelectionChange={onTextSelectionChange}
-            resolveImageSrc={resolveImageSrc}
-            workspaceFiles={workspaceFiles}
-          />
-        </MilkdownProvider>
+        <MarkdownPaperSurface
+          autoFocus={autoFocus}
+          documentPath={documentPath}
+          initialContent={initialContent}
+          language={language}
+          markdownShortcuts={markdownShortcuts}
+          onEditorReady={onEditorReady}
+          onMarkdownChange={onMarkdownChange}
+          onSaveClipboardImage={onSaveClipboardImage}
+          onSaveRemoteClipboardImage={onSaveRemoteClipboardImage}
+          openExternalUrl={openExternalUrl}
+          onTextSelectionChange={onTextSelectionChange}
+          resolveImageSrc={resolveImageSrc}
+          workspaceFiles={workspaceFiles}
+        />
       </article>
     </section>
   );

--- a/apps/desktop/src/components/MarkdownPaperSurface.tsx
+++ b/apps/desktop/src/components/MarkdownPaperSurface.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { defaultValueCtx, Editor, editorViewCtx, editorViewOptionsCtx, parserCtx, rootCtx, serializerCtx } from "@milkdown/kit/core";
+import { history } from "@milkdown/kit/plugin/history";
+import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
+import { headingSchema, imageSchema, linkSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import { Milkdown, MilkdownProvider, useEditor, useInstance } from "@milkdown/react";
+import type { AiSelectionContext } from "@markra/ai";
+import {
+  markraAiEditorPreviewPlugin,
+  markraAiSelectionHoldPlugin,
+  markraBlockDragPlugin,
+  markraCalloutPlugin,
+  markraCalloutSerializerPlugin,
+  markraClipboardImagePluginWithOptions,
+  markraCodeBlockPlugin,
+  markraHeadingSourcePlugin,
+  markraHeadingTogglePlugin,
+  markraLinkImageLivePlugin,
+  markraLiveMarkdownPlugin,
+  markraMarkdownShortcuts,
+  markraMathPlugin,
+  markraMathRemarkPlugin,
+  markraMathSourcePlugin,
+  markraRawHtmlPlugin,
+  markraSlashCommands,
+  markraTableControlsPlugin,
+  normalizeHeadingSourceDocument,
+  normalizeMarkdownShortcuts,
+  serializeLinkImageLiveMarkdown,
+  type MarkdownShortcutMap,
+  type SaveClipboardImage,
+  type SaveRemoteClipboardImage,
+  type SlashCommandLabels
+} from "@markra/editor";
+import { t, type AppLanguage } from "@markra/shared";
+import type { MarkdownDocumentLinkFile } from "../lib/document-links";
+import { markraDocumentLinkCompletionPlugin } from "./document-link-completion";
+import {
+  markraCommonmark,
+  markraExternalLinkClickPlugin,
+  markraGfm,
+  markraTextSelectionObserverPlugin
+} from "./markdown-paper-plugins";
+
+export type MarkdownPaperSurfaceProps = {
+  autoFocus: boolean;
+  documentPath?: string | null;
+  initialContent: string;
+  language: AppLanguage;
+  markdownShortcuts?: MarkdownShortcutMap;
+  onEditorReady: (editor: Editor | null, options?: { autoFocus?: boolean }) => unknown;
+  onMarkdownChange: (content: string) => unknown;
+  onSaveClipboardImage?: SaveClipboardImage;
+  onSaveRemoteClipboardImage?: SaveRemoteClipboardImage;
+  openExternalUrl?: (url: string) => unknown;
+  onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
+  resolveImageSrc?: (src: string) => string;
+  workspaceFiles?: MarkdownDocumentLinkFile[];
+};
+
+function markdownShortcutSignature(shortcuts: MarkdownShortcutMap | undefined) {
+  return JSON.stringify(normalizeMarkdownShortcuts(shortcuts));
+}
+
+function MilkdownInstanceBridge({ autoFocus, onEditorReady }: Pick<MarkdownPaperSurfaceProps, "autoFocus" | "onEditorReady">) {
+  const [loading, getEditor] = useInstance();
+  const autoFocusRef = useRef(autoFocus);
+
+  useEffect(() => {
+    autoFocusRef.current = autoFocus;
+  }, [autoFocus]);
+
+  useEffect(() => {
+    if (loading) return;
+
+    const editor = getEditor();
+    onEditorReady(editor, { autoFocus: autoFocusRef.current });
+
+    return () => {
+      onEditorReady(null);
+    };
+  }, [getEditor, loading, onEditorReady]);
+
+  return null;
+}
+
+function MilkdownEditorSurface({
+  autoFocus,
+  documentPath,
+  initialContent,
+  language,
+  markdownShortcuts,
+  onEditorReady,
+  onMarkdownChange,
+  onSaveClipboardImage,
+  onSaveRemoteClipboardImage,
+  openExternalUrl,
+  onTextSelectionChange,
+  resolveImageSrc,
+  workspaceFiles
+}: MarkdownPaperSurfaceProps) {
+  const initialContentRef = useRef(initialContent);
+  const documentPathRef = useRef(documentPath);
+  const openExternalUrlRef = useRef(openExternalUrl);
+  const onSaveClipboardImageRef = useRef(onSaveClipboardImage);
+  const onSaveRemoteClipboardImageRef = useRef(onSaveRemoteClipboardImage);
+  const onTextSelectionChangeRef = useRef(onTextSelectionChange);
+  const workspaceFilesRef = useRef(workspaceFiles ?? []);
+  const externalLinkOpeningEnabled = Boolean(openExternalUrl);
+  const markdownDocumentLabel = t(language, "app.markdownDocument");
+  const shortcutsSignature = markdownShortcutSignature(markdownShortcuts);
+  const normalizedMarkdownShortcuts = useMemo(
+    () => normalizeMarkdownShortcuts(markdownShortcuts),
+    [shortcutsSignature]
+  );
+  const tableControlLabels = {
+    addColumnRight: t(language, "editor.table.addColumnRight"),
+    addRowBelow: t(language, "editor.table.addRowBelow"),
+    alignLeft: t(language, "editor.table.alignLeft"),
+    alignCenter: t(language, "editor.table.alignCenter"),
+    alignRight: t(language, "editor.table.alignRight"),
+    deleteColumn: t(language, "editor.table.deleteColumn"),
+    deleteRow: t(language, "editor.table.deleteRow"),
+    adjustTable: t(language, "editor.table.adjustTable"),
+    resizeTableTo: t(language, "editor.table.resizeTableTo"),
+    tableColumns: t(language, "editor.table.columns"),
+    tableRows: t(language, "editor.table.rows")
+  };
+  const blockDragLabels = {
+    addBlock: t(language, "editor.blockAdd"),
+    dragBlock: t(language, "editor.blockDrag")
+  };
+  const headingToggleLabels = {
+    collapseSection: t(language, "editor.collapseSection"),
+    expandSection: t(language, "editor.expandSection")
+  };
+  const slashCommandLabels = useMemo<SlashCommandLabels>(() => ({
+    menu: t(language, "editor.slashCommands"),
+    noResults: t(language, "editor.slashCommandsNoResults"),
+    commands: {
+      bulletList: t(language, "menu.bulletList"),
+      callout: t(language, "menu.callout"),
+      codeBlock: t(language, "menu.codeBlock"),
+      heading1: t(language, "menu.heading1"),
+      heading2: t(language, "menu.heading2"),
+      heading3: t(language, "menu.heading3"),
+      orderedList: t(language, "menu.orderedList"),
+      paragraph: t(language, "menu.paragraph"),
+      quote: t(language, "menu.quote"),
+      table: t(language, "menu.table")
+    }
+  }), [language]);
+
+  useEffect(() => {
+    onSaveClipboardImageRef.current = onSaveClipboardImage;
+  }, [onSaveClipboardImage]);
+
+  useEffect(() => {
+    documentPathRef.current = documentPath;
+  }, [documentPath]);
+
+  useEffect(() => {
+    openExternalUrlRef.current = openExternalUrl;
+  }, [openExternalUrl]);
+
+  useEffect(() => {
+    onSaveRemoteClipboardImageRef.current = onSaveRemoteClipboardImage;
+  }, [onSaveRemoteClipboardImage]);
+
+  useEffect(() => {
+    onTextSelectionChangeRef.current = onTextSelectionChange;
+  }, [onTextSelectionChange]);
+
+  useEffect(() => {
+    workspaceFilesRef.current = workspaceFiles ?? [];
+  }, [workspaceFiles]);
+
+  const createEditor = useCallback(
+    (root: HTMLElement) => {
+      const editor = Editor.make()
+        .config((ctx) => {
+          ctx.set(rootCtx, root);
+          ctx.set(defaultValueCtx, initialContentRef.current);
+          ctx.update(editorViewOptionsCtx, (options) => ({
+            ...options,
+            attributes: {
+              ...options.attributes,
+              "aria-label": markdownDocumentLabel,
+              spellcheck: "true"
+            }
+          }));
+          ctx.get(listenerCtx).updated((editorCtx, doc) => {
+            try {
+              const view = editorCtx.get(editorViewCtx);
+              const normalizedDoc = normalizeHeadingSourceDocument(
+                view.state,
+                paragraphSchema.type(editorCtx),
+                headingSchema.type(editorCtx),
+                editorCtx.get(parserCtx)
+              );
+              onMarkdownChange(
+                serializeLinkImageLiveMarkdown(
+                  normalizedDoc === view.state.doc ? doc : normalizedDoc,
+                  editorCtx.get(serializerCtx),
+                  linkSchema.type(editorCtx),
+                  imageSchema.type(editorCtx)
+                )
+              );
+            } catch {
+              // Milkdown can flush a delayed update after teardown in tests or fast window closes.
+            }
+          });
+        })
+        .use(listener)
+        .use(history)
+        .use(markraMathRemarkPlugin)
+        .use(markraCommonmark)
+        .use(markraGfm)
+        .use(markraCalloutSerializerPlugin)
+        .use(markraCalloutPlugin)
+        .use(markraSlashCommands(slashCommandLabels))
+        .use(markraMathSourcePlugin)
+        .use(markraMarkdownShortcuts(normalizedMarkdownShortcuts))
+        .use(markraCodeBlockPlugin)
+        .use(markraMathPlugin)
+        .use(markraAiSelectionHoldPlugin)
+        .use(markraAiEditorPreviewPlugin)
+        .use(markraBlockDragPlugin(blockDragLabels))
+        .use(markraHeadingTogglePlugin(headingToggleLabels))
+        .use(
+          markraDocumentLinkCompletionPlugin({
+            getDocumentPath: () => documentPathRef.current,
+            getWorkspaceFiles: () => workspaceFilesRef.current
+          })
+        )
+        .use(
+          markraTextSelectionObserverPlugin((selection) => {
+            onTextSelectionChangeRef.current?.(selection);
+          })
+        )
+        .use(markraTableControlsPlugin(tableControlLabels))
+        .use(markraLinkImageLivePlugin(resolveImageSrc))
+        .use(markraHeadingSourcePlugin)
+        .use(
+          markraRawHtmlPlugin({
+            htmlSourceApplyLabel: t(language, "editor.htmlSourceApply"),
+            htmlSourceLabel: t(language, "editor.htmlSource"),
+            resolveImageSrc
+          })
+        )
+        .use(markraLiveMarkdownPlugin);
+
+      if (externalLinkOpeningEnabled) {
+        editor.use(
+          markraExternalLinkClickPlugin((url) => {
+            return openExternalUrlRef.current?.(url);
+          })
+        );
+      }
+
+      if (onSaveClipboardImageRef.current || onSaveRemoteClipboardImageRef.current) {
+        editor.use(
+          markraClipboardImagePluginWithOptions(
+            (image) => onSaveClipboardImageRef.current?.(image) ?? Promise.resolve(null),
+            {
+              saveRemoteImage: (image) => onSaveRemoteClipboardImageRef.current?.(image) ?? Promise.resolve(null)
+            }
+          )
+        );
+      }
+
+      return editor;
+    },
+    [
+      externalLinkOpeningEnabled,
+      language,
+      markdownDocumentLabel,
+      normalizedMarkdownShortcuts,
+      onMarkdownChange,
+      resolveImageSrc,
+      slashCommandLabels
+    ]
+  );
+
+  useEditor(createEditor, [createEditor]);
+
+  return (
+    <>
+      <Milkdown />
+      <MilkdownInstanceBridge autoFocus={autoFocus} onEditorReady={onEditorReady} />
+    </>
+  );
+}
+
+export function MarkdownPaperSurface(props: MarkdownPaperSurfaceProps) {
+  return (
+    <MilkdownProvider>
+      <MilkdownEditorSurface {...props} />
+    </MilkdownProvider>
+  );
+}

--- a/apps/desktop/src/components/markdown-paper-plugins.ts
+++ b/apps/desktop/src/components/markdown-paper-plugins.ts
@@ -1,0 +1,204 @@
+import {
+  commands as commonmarkCommands,
+  inputRules as commonmarkInputRules,
+  keymap as commonmarkKeymap,
+  plugins as commonmarkPlugins,
+  schema as commonmarkSchema
+} from "@milkdown/kit/preset/commonmark";
+import {
+  commands as gfmCommands,
+  inputRules as gfmInputRules,
+  keymap as gfmKeymap,
+  pasteRules as gfmPasteRules,
+  plugins as gfmPlugins,
+  schema as gfmSchema
+} from "@milkdown/kit/preset/gfm";
+import { Plugin } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+import type { AiSelectionContext } from "@markra/ai";
+import { readAiSelectionContextFromView } from "../hooks/useEditorController";
+
+export const markraCommonmark = [
+  commonmarkSchema,
+  commonmarkInputRules,
+  commonmarkCommands,
+  commonmarkKeymap,
+  commonmarkPlugins
+].flat();
+
+export const markraGfm = [
+  gfmSchema,
+  gfmInputRules,
+  gfmPasteRules,
+  gfmKeymap,
+  gfmCommands,
+  gfmPlugins
+].flat();
+
+export function markraTextSelectionObserverPlugin(
+  onTextSelectionChange: (selection: AiSelectionContext | null) => unknown
+) {
+  return $prose(() => {
+    let lastSignature = "";
+
+    const notifySelectionChange = (view: EditorView, options: { requireFocusForEmptySelection: boolean }) => {
+      const { selection } = view.state;
+
+      if (selection.empty) {
+        if (options.requireFocusForEmptySelection && !view.hasFocus()) return;
+
+        const blockContext = readAiSelectionContextFromView(view);
+        if (blockContext.text.trim()) {
+          const signature = `${blockContext.source ?? "block"}:${blockContext.from}:${blockContext.to}:${blockContext.text}`;
+          if (signature === lastSignature) return;
+
+          lastSignature = signature;
+          onTextSelectionChange(blockContext);
+          return;
+        }
+
+        if (lastSignature) {
+          lastSignature = "";
+          onTextSelectionChange(null);
+        }
+        return;
+      }
+
+      const text = view.state.doc.textBetween(selection.from, selection.to, "\n").trim();
+      if (!text) {
+        if (view.hasFocus() && lastSignature) {
+          lastSignature = "";
+          onTextSelectionChange(null);
+        }
+
+        return;
+      }
+
+      const signature = `${selection.from}:${selection.to}:${text}`;
+      if (signature === lastSignature) return;
+
+      lastSignature = signature;
+      onTextSelectionChange({
+        from: selection.from,
+        source: "selection",
+        text,
+        to: selection.to
+      });
+    };
+
+    const clearStaleSelectionAfterEditorClick = (view: EditorView) => {
+      if (!lastSignature) return;
+
+      const domSelection = view.dom.ownerDocument.getSelection();
+      const hasDomSelectedText = Boolean(domSelection && !domSelection.isCollapsed && domSelection.toString().trim());
+      if (hasDomSelectedText) return;
+
+      if (!view.state.selection.empty) {
+        lastSignature = "";
+        onTextSelectionChange(null);
+        return;
+      }
+
+      notifySelectionChange(view, { requireFocusForEmptySelection: false });
+    };
+
+    return new Plugin({
+      view(view) {
+        const ownerDocument = view.dom.ownerDocument;
+        const handleMouseUp = (event: MouseEvent) => {
+          if (event.button !== 0) return;
+
+          const targetElement =
+            event.target instanceof Element
+              ? event.target
+              : event.target instanceof Node
+                ? event.target.parentElement
+                : null;
+          const writingSurface = view.dom.closest(".paper-scroll");
+          if (!targetElement || !writingSurface?.contains(targetElement)) return;
+
+          ownerDocument.defaultView?.setTimeout(() => {
+            clearStaleSelectionAfterEditorClick(view);
+          }, 0);
+        };
+
+        ownerDocument.addEventListener("mouseup", handleMouseUp, true);
+
+        return {
+          destroy() {
+            ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
+          },
+          update(view, previousState) {
+            const { selection } = view.state;
+            if (selection.eq(previousState.selection)) return;
+            notifySelectionChange(view, { requireFocusForEmptySelection: true });
+          }
+        };
+      }
+    });
+  });
+}
+
+function linkTargetFromClickTarget(target: EventTarget | null) {
+  const targetElement =
+    target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+  if (!targetElement) return null;
+
+  return targetElement.closest<HTMLAnchorElement | HTMLElement>("a[href], .markra-live-link-label[data-markra-href]");
+}
+
+function linkHrefFromClickTarget(target: EventTarget | null) {
+  const linkTarget = linkTargetFromClickTarget(target);
+  if (!linkTarget) return null;
+
+  if (linkTarget instanceof HTMLAnchorElement) {
+    return linkTarget.getAttribute("href") ?? linkTarget.href;
+  }
+
+  return linkTarget.dataset.markraHref ?? null;
+}
+
+function linkOpenModifierIsPressed(event: MouseEvent) {
+  return event.metaKey || event.ctrlKey;
+}
+
+export function markraExternalLinkClickPlugin(openExternalUrl: (url: string) => unknown) {
+  return $prose(() => {
+    return new Plugin({
+      props: {
+        handleDOMEvents: {
+          mousedown(_view, event) {
+            const href = linkHrefFromClickTarget(event.target);
+            if (!href) return false;
+
+            if (!linkOpenModifierIsPressed(event)) {
+              return false;
+            }
+
+            event.preventDefault();
+            return true;
+          },
+          click(_view, event) {
+            const href = linkHrefFromClickTarget(event.target);
+            if (!href) return false;
+
+            if (!linkOpenModifierIsPressed(event)) {
+              return false;
+            }
+
+            event.preventDefault();
+
+            try {
+              Promise.resolve(openExternalUrl(href)).catch(() => {});
+            } catch {
+              // Opening external links is best-effort; editing should not be interrupted by opener failures.
+            }
+
+            return true;
+          }
+        }
+      }
+    });
+  });
+}

--- a/apps/desktop/src/hooks/useAiAgentSession.test.tsx
+++ b/apps/desktop/src/hooks/useAiAgentSession.test.tsx
@@ -1,6 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { runDocumentAiAgent } from "@markra/ai";
-import { generateAiAgentSessionTitle } from "@markra/ai";
+import { generateAiAgentSessionTitle, runDocumentAiAgent } from "@markra/ai";
 import {
   getStoredAiAgentSession,
   getStoredAiAgentPreferences,

--- a/apps/desktop/src/hooks/useAiAgentSession.ts
+++ b/apps/desktop/src/hooks/useAiAgentSession.ts
@@ -1,25 +1,28 @@
 import { useCallback, useEffect, useRef, useState, type SetStateAction } from "react";
-import { chatCompletionStream, runDocumentAiAgent, type DocumentAiHistoryMessage, type DocumentAiImage } from "@markra/ai";
-import { generateAiAgentSessionTitle } from "@markra/ai";
 import {
   applyAgentEventToProcesses,
   cancelAgentProcesses,
+  chatCompletionStream,
+  createDefaultAiAgentSessionState,
   createInitialAgentProcesses,
   failAgentProcesses,
-  finalizeAgentProcesses
-} from "@markra/ai";
-import {
-  createDefaultAiAgentSessionState,
+  finalizeAgentProcesses,
+  generateAiAgentSessionTitle,
+  runDocumentAiAgent,
+  type AgentWorkspaceFile,
+  type AiDiffResult,
+  type AiDocumentAnchor,
+  type AiHeadingAnchor,
+  type AiSelectionContext,
   type AiAgentSessionPreview,
   type AiAgentSessionMessage,
+  type DocumentAiHistoryMessage,
+  type DocumentAiImage,
+  type WebSearchSettings,
   type StoredAiAgentSessionState
 } from "@markra/ai";
-import type { AgentWorkspaceFile } from "@markra/ai";
-import { getProviderCapabilities } from "@markra/providers";
-import type { AiDiffResult, AiDocumentAnchor, AiHeadingAnchor, AiSelectionContext } from "@markra/ai";
-import type { AiProviderConfig } from "@markra/providers";
+import { getProviderCapabilities, type AiProviderConfig } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
-import type { WebSearchSettings } from "@markra/ai";
 import { requestNativeChat, requestNativeChatStream, requestNativeWebResource } from "../lib/tauri";
 import {
   getStoredAiAgentPreferences,

--- a/apps/desktop/src/hooks/useAiCommandUi.ts
+++ b/apps/desktop/src/hooks/useAiCommandUi.ts
@@ -1,10 +1,14 @@
 import { useCallback, useRef, useState } from "react";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { chatCompletionStream, runInlineAiAgent } from "@markra/ai";
-import type { AgentWorkspaceFile } from "@markra/ai";
-import { getProviderCapabilities } from "@markra/providers";
-import type { AiDiffResult, AiEditIntent, AiSelectionContext } from "@markra/ai";
-import type { AiProviderConfig } from "@markra/providers";
+import {
+  chatCompletionStream,
+  runInlineAiAgent,
+  type AgentWorkspaceFile,
+  type AiDiffResult,
+  type AiEditIntent,
+  type AiSelectionContext
+} from "@markra/ai";
+import { getProviderCapabilities, type AiProviderConfig } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
 import { requestNativeChatStream } from "../lib/tauri";
 

--- a/apps/desktop/src/hooks/useEditorController.ts
+++ b/apps/desktop/src/hooks/useEditorController.ts
@@ -7,16 +7,17 @@ import type { EditorView } from "@milkdown/kit/prose/view";
 import type { AiDiffResult, AiDocumentAnchor, AiHeadingAnchor, AiSelectionContext } from "@markra/ai";
 import {
   applyAiEditorResult,
+  clearAiSelectionHold,
   clearAiEditorPreview,
   confirmAiEditorResultApplied,
   listAiEditorPreviewResults,
+  normalizeHeadingSourceDocument,
   scrollAiEditorPreviewIntoView,
+  serializeLinkImageLiveMarkdown,
   showAiEditorPreview,
+  showAiSelectionHold,
   type AiEditorPreviewLabels
 } from "@markra/editor";
-import { serializeLinkImageLiveMarkdown } from "@markra/editor";
-import { normalizeHeadingSourceDocument } from "@markra/editor";
-import { clearAiSelectionHold, showAiSelectionHold } from "@markra/editor";
 import type { MarkdownOutlineItem } from "@markra/markdown";
 
 const outlineScrollTopOffset = 24;

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -22,8 +22,7 @@ import {
   type NativeMarkdownFolderFile
 } from "../lib/tauri";
 import { setNativeWindowTitle } from "../lib/tauri";
-import { pathNameFromPath } from "@markra/shared";
-import type { DocumentState } from "@markra/shared";
+import { pathNameFromPath, type DocumentState } from "@markra/shared";
 
 function isBlankEditorWindow() {
   return new URLSearchParams(window.location.search).has("blank");

--- a/apps/desktop/src/lib/browser-node-stub.ts
+++ b/apps/desktop/src/lib/browser-node-stub.ts
@@ -1,0 +1,15 @@
+export function existsSync() {
+  return false;
+}
+
+export function readFileSync() {
+  throw new Error("node:fs is unavailable in the browser build.");
+}
+
+export function homedir() {
+  return "";
+}
+
+export function join(...parts: string[]) {
+  return parts.filter(Boolean).join("/").replace(/\/+/gu, "/");
+}

--- a/apps/desktop/src/lib/settings/app-settings.ts
+++ b/apps/desktop/src/lib/settings/app-settings.ts
@@ -8,12 +8,13 @@ import {
   normalizeStoredAiAgentSessionSummaries,
   normalizeStoredAiAgentSessionSummary,
   type StoredAiAgentSessionSummary,
-  type StoredAiAgentSessionState
+  type StoredAiAgentSessionState,
+  type WebSearchProviderId,
+  type WebSearchSettings
 } from "@markra/ai";
 import { defaultMarkdownShortcuts, normalizeMarkdownShortcuts, type MarkdownShortcutBindings } from "@markra/editor";
 import { createDefaultAiSettings, normalizeAiSettings, type AiProviderSettings } from "@markra/providers";
 import { clampNumber, isAppLanguage, normalizeNullableString, type AppLanguage } from "@markra/shared";
-import { type WebSearchProviderId, type WebSearchSettings } from "@markra/ai";
 import {
   editorContentWidthOptions,
   normalizeEditorContentWidthPx,

--- a/apps/desktop/src/lib/settings/settings-events.ts
+++ b/apps/desktop/src/lib/settings/settings-events.ts
@@ -12,8 +12,7 @@ import {
   type ExportSettings,
   type WebSearchSettings
 } from "./app-settings";
-import { isAppLanguage, type AppLanguage } from "@markra/shared";
-import { hasTauriRuntime } from "@markra/shared";
+import { hasTauriRuntime, isAppLanguage, type AppLanguage } from "@markra/shared";
 
 const themeChangedEvent = "markra://theme-changed";
 const customThemeCssChangedEvent = "markra://custom-theme-css-changed";

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -77,8 +77,7 @@ import {
   notifyAppWebSearchSettingsChanged
 } from "../lib/settings/settings-events";
 import { fetchAiProviderModels, testAiProviderConnection } from "@markra/providers";
-import { chatCompletion } from "@markra/ai";
-import { generateAiAgentSessionTitle } from "@markra/ai";
+import { chatCompletion, generateAiAgentSessionTitle } from "@markra/ai";
 import { resolveDesktopPlatform } from "../lib/platform";
 
 const testAiQuickActionPrompts = vi.hoisted(() => ({

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,15 +1,19 @@
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import { stripDebugPlugin } from "./scripts/vite/strip-debug";
 
 const chunkSizeWarningLimitKb = 1200;
+const fontAssetPattern = /\.(?:otf|ttf|woff2?)$/i;
 const imageAssetPattern = /\.(?:avif|gif|ico|jpe?g|png|svg|webp)$/i;
+const browserNodeStubPath = fileURLToPath(new URL("./src/lib/browser-node-stub.ts", import.meta.url));
 
 function outputAssetFileName(asset: { names?: string[]; originalFileNames?: string[] }) {
   const sourceName = asset.names?.[0] ?? asset.originalFileNames?.[0] ?? "";
 
   if (imageAssetPattern.test(sourceName)) return "assets/images/[name]-[hash][extname]";
+  if (fontAssetPattern.test(sourceName)) return "assets/fonts/[name]-[hash][extname]";
 
   return "assets/[name]-[hash][extname]";
 }
@@ -39,6 +43,12 @@ const milkdownDependencies = dependencyPattern([
 const tauriDependencies = dependencyPattern(["@tauri-apps"]);
 const iconDependencies = dependencyPattern(["lucide-react", "lucide-static"]);
 const piAgentDependencies = dependencyPattern(["@mariozechner/pi-agent-core", "@mariozechner/pi-ai", "typebox"]);
+const codeEditorDependencies = dependencyPattern(["@codemirror", "codemirror"]);
+const dndDependencies = dependencyPattern(["@dnd-kit"]);
+const mathDependencies = dependencyPattern(["katex"]);
+const syntaxHighlightDependencies = dependencyPattern(["highlight.js", "lowlight"]);
+const toastDependencies = dependencyPattern(["sonner"]);
+const contentExtractionDependencies = dependencyPattern(["@mozilla/readability"]);
 const aiSdkDependencies = dependencyPattern([
   "@anthropic-ai",
   "@aws-sdk",
@@ -57,6 +67,12 @@ function vendorChunkName(id: string) {
   if (tauriDependencies.test(id)) return "tauri-vendor";
   if (iconDependencies.test(id)) return "icons-vendor";
   if (piAgentDependencies.test(id)) return "pi-agent-vendor";
+  if (codeEditorDependencies.test(id)) return "code-editor-vendor";
+  if (dndDependencies.test(id)) return "dnd-vendor";
+  if (mathDependencies.test(id)) return "math-vendor";
+  if (syntaxHighlightDependencies.test(id)) return "syntax-highlight-vendor";
+  if (toastDependencies.test(id)) return "toast-vendor";
+  if (contentExtractionDependencies.test(id)) return "content-extraction-vendor";
   if (aiSdkDependencies.test(id)) return "ai-sdk-vendor";
   if (id.includes("node_modules")) return "vendor";
 
@@ -66,6 +82,14 @@ function vendorChunkName(id: string) {
 export default defineConfig(({ mode }) => ({
   define: {
     __MARKRA_DEBUG__: JSON.stringify(mode !== "production")
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^node:(?:fs|os|path)$/,
+        replacement: browserNodeStubPath
+      }
+    ]
   },
   plugins: [react(), tailwindcss(), ...(mode === "production" ? [stripDebugPlugin()] : [])],
   build: {

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -83,14 +83,16 @@ export default defineConfig(({ mode }) => ({
   define: {
     __MARKRA_DEBUG__: JSON.stringify(mode !== "production")
   },
-  resolve: {
-    alias: [
-      {
-        find: /^node:(?:fs|os|path)$/,
-        replacement: browserNodeStubPath
-      }
-    ]
-  },
+  resolve: mode === "test"
+    ? undefined
+    : {
+        alias: [
+          {
+            find: /^node:(?:fs|os|path)$/,
+            replacement: browserNodeStubPath
+          }
+        ]
+      },
   plugins: [react(), tailwindcss(), ...(mode === "production" ? [stripDebugPlugin()] : [])],
   build: {
     chunkSizeWarningLimit: chunkSizeWarningLimitKb,

--- a/packages/ai/src/agent/chat-adapters.ts
+++ b/packages/ai/src/agent/chat-adapters.ts
@@ -1,11 +1,12 @@
-import type { AiProviderApiStyle, AiProviderConfig } from "@markra/providers";
 import {
   buildAnthropicThinkingRequestOptions,
   buildDeepSeekThinkingRequestOptions,
   buildOpenAiCompatibleRequestParts,
   buildResponsesStyleRequestOptions,
   getNativeWebSearchKind,
-  readAiProviderCustomHeaders
+  readAiProviderCustomHeaders,
+  type AiProviderApiStyle,
+  type AiProviderConfig
 } from "@markra/providers";
 import { isRecord, joinApiUrl } from "@markra/shared";
 import type {

--- a/packages/ai/src/agent/document-agent.ts
+++ b/packages/ai/src/agent/document-agent.ts
@@ -1,10 +1,9 @@
 import { Agent } from "@mariozechner/pi-agent-core";
-import type { AiProviderConfig } from "@markra/providers";
+import { getProviderCapabilities, providerSupportsNativeWebSearch, type AiProviderConfig } from "@markra/providers";
 import { createNativeChatStreamFn, createPiAgentModel } from "./runtime";
 import { chatCompletionStream } from "./chat-completion";
 import { runReadOnlyAgentTools } from "./read-only-tools";
 import type { ChatImageAttachment } from "./chat/types";
-import { getProviderCapabilities } from "@markra/providers";
 import { createDocumentAgentTools } from "./document-tools";
 import { readPromptedDocumentImages } from "./document/images";
 import {
@@ -18,7 +17,6 @@ import {
 import { modelSupportsTools, modelSupportsVision } from "./document/models";
 import type { RunDocumentAiAgentInput, RunDocumentAiAgentResult } from "./document/types";
 import { webSearchSettingsAreUsable } from "./tools/web-search";
-import { providerSupportsNativeWebSearch } from "@markra/providers";
 export type * from "./document/types";
 
 export async function runDocumentAiAgent({

--- a/packages/ai/src/agent/tool-builders/anthropic.ts
+++ b/packages/ai/src/agent/tool-builders/anthropic.ts
@@ -1,6 +1,5 @@
 import type { Tool } from "@mariozechner/pi-ai";
-import type { AiProviderConfig } from "@markra/providers";
-import { getNativeWebSearchKind } from "@markra/providers";
+import { getNativeWebSearchKind, type AiProviderConfig } from "@markra/providers";
 
 export function buildAnthropicTools(
   config: AiProviderConfig,

--- a/packages/ai/src/agent/tool-builders/google.ts
+++ b/packages/ai/src/agent/tool-builders/google.ts
@@ -1,5 +1,4 @@
-import type { AiProviderConfig } from "@markra/providers";
-import { getNativeWebSearchKind } from "@markra/providers";
+import { getNativeWebSearchKind, type AiProviderConfig } from "@markra/providers";
 
 export function buildGoogleTools(config: AiProviderConfig, model: string, webSearchEnabled: boolean | undefined) {
   return webSearchEnabled === true && getNativeWebSearchKind(config, model) === "google-search-grounding"

--- a/packages/ai/src/agent/web-search-availability.ts
+++ b/packages/ai/src/agent/web-search-availability.ts
@@ -1,7 +1,10 @@
-import type { AiProviderConfig, AiProviderModel } from "@markra/providers";
+import {
+  getProviderCapabilities,
+  providerSupportsNativeWebSearch,
+  type AiProviderConfig,
+  type AiProviderModel
+} from "@markra/providers";
 import { webSearchSettingsAreUsable, type WebSearchSettings } from "./tools/web-search";
-import { providerSupportsNativeWebSearch } from "@markra/providers";
-import { getProviderCapabilities } from "@markra/providers";
 
 type WebSearchModel = Pick<AiProviderModel, "capabilities" | "id">;
 

--- a/packages/editor/src/ai-preview.ts
+++ b/packages/editor/src/ai-preview.ts
@@ -3,8 +3,7 @@ import { Plugin, PluginKey, TextSelection, type Transaction } from "@milkdown/ki
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 import type { AiDiffResult } from "@markra/ai";
-import { debug } from "@markra/shared";
-import { clampNumber } from "@markra/shared";
+import { clampNumber, debug } from "@markra/shared";
 
 export const AI_EDITOR_PREVIEW_ACTION_EVENT = "markra-ai-preview-action";
 export const AI_EDITOR_PREVIEW_APPLIED_EVENT = "markra-ai-preview-applied";


### PR DESCRIPTION
## Summary
- Split `MarkdownPaper` into a layout shell, Milkdown surface, and editor plugin helpers.
- Consolidate repeated `@markra/*` imports across touched files.
- Improve Vite output by separating vendor chunks, stubbing browser-only Node builtins, and emitting fonts under `assets/fonts/`.

## Validation
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop test -- MarkdownPaper` passed: 43 files / 627 tests.
- `pnpm --filter @markra/ai build` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/desktop build` passed with no Vite chunk-size or Node builtin externalization warnings.
- `pnpm --filter @markra/desktop exec tsc -p tsconfig.node.json --noEmit` passed.
- Previewed `http://127.0.0.1:4174/`; app shell and titlebar rendered, browser console errors were empty.
- Verified preview HTTP responses for built HTML, CSS, JS, and a font file returned 200.
- Verified 59 built font references point to `/assets/fonts/` and no font files remain in the `dist/assets` root.

## Risk
- Behavior is intended to stay unchanged; risk is mostly around Milkdown initialization boundaries and build chunk grouping. The focused MarkdownPaper tests and preview smoke test cover the main regression paths.