### PR TITLE
fix(desktop): route Windows native menu commands

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -21,15 +21,16 @@ use markdown_files::{
     save_clipboard_image, write_markdown_file,
 };
 use menu::{
-    create_application_menu, install_application_menu, is_frontend_menu_command,
-    is_native_new_window_command, is_native_settings_window_command, NativeMenuCommand,
-    NATIVE_MENU_COMMAND_EVENT,
+    create_application_menu, emit_native_menu_command, install_application_menu,
+    is_frontend_menu_command, is_native_new_window_command, is_native_settings_window_command,
+    remember_native_menu_webview_window, remember_native_menu_window_from_event,
+    NativeMenuTargetState,
 };
 use opened_files::{
     opened_markdown_paths_from_args, opened_markdown_paths_from_urls, queue_opened_markdown_paths,
     take_opened_markdown_paths, OpenedMarkdownPathsState,
 };
-use tauri::Emitter;
+use tauri::Manager;
 use watcher::{unwatch_markdown_file, watch_markdown_file, MarkdownWatcherState};
 use web_http::{download_web_image, request_web_resource};
 use windows::{
@@ -43,6 +44,7 @@ pub fn run() {
     tauri::Builder::default()
         .manage(MarkdownWatcherState::default())
         .manage(OpenedMarkdownPathsState::default())
+        .manage(NativeMenuTargetState::default())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
@@ -50,6 +52,9 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             apply_main_window_chrome(app);
+            if let Some(window) = app.get_webview_window("main") {
+                remember_native_menu_webview_window(&window);
+            }
             let paths = opened_markdown_paths_from_args(std::env::args());
             queue_opened_markdown_paths(&app.handle(), paths);
             Ok(())
@@ -58,6 +63,7 @@ pub fn run() {
             apply_webview_window_chrome(webview);
         })
         .on_window_event(|window, event| {
+            remember_native_menu_window_from_event(window, event);
             apply_window_event_chrome(window, event);
         })
         .menu(create_application_menu)
@@ -77,12 +83,7 @@ pub fn run() {
                 return;
             }
 
-            let _ = app.emit(
-                NATIVE_MENU_COMMAND_EVENT,
-                NativeMenuCommand {
-                    command: command.to_string(),
-                },
-            );
+            emit_native_menu_command(app, command.to_string());
         })
         .invoke_handler(tauri::generate_handler![
             list_markdown_files_for_path,

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -1,8 +1,9 @@
 use crate::language::{resolve_startup_language, AppLanguage};
 use std::collections::HashMap;
+use std::sync::Mutex;
 use tauri::{
     menu::{AboutMetadata, Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder},
-    Manager,
+    Emitter, Manager,
 };
 
 pub(crate) const NATIVE_MENU_COMMAND_EVENT: &str = "markra://menu-command";
@@ -15,6 +16,66 @@ const MARKRA_GITHUB_URL: &str = "https://github.com/murongg/markra";
 #[derive(Clone, serde::Serialize)]
 pub(crate) struct NativeMenuCommand {
     pub(crate) command: String,
+}
+
+#[derive(Default)]
+pub(crate) struct NativeMenuTargetState(Mutex<Option<String>>);
+
+impl NativeMenuTargetState {
+    fn remember(&self, label: impl Into<String>) {
+        let mut target = self.0.lock().expect("native menu target lock poisoned");
+        *target = Some(label.into());
+    }
+
+    fn label(&self) -> Option<String> {
+        self.0
+            .lock()
+            .expect("native menu target lock poisoned")
+            .clone()
+    }
+}
+
+pub(crate) fn remember_native_menu_window_label<R: tauri::Runtime, M: Manager<R>>(
+    manager: &M,
+    label: impl Into<String>,
+) {
+    let state = manager.state::<NativeMenuTargetState>();
+    state.remember(label);
+}
+
+pub(crate) fn remember_native_menu_window<R: tauri::Runtime>(window: &tauri::Window<R>) {
+    remember_native_menu_window_label(window, window.label());
+}
+
+pub(crate) fn remember_native_menu_webview_window<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+) {
+    let state = window.state::<NativeMenuTargetState>();
+    state.remember(window.label());
+}
+
+pub(crate) fn remember_native_menu_window_from_event<R: tauri::Runtime>(
+    window: &tauri::Window<R>,
+    event: &tauri::WindowEvent,
+) {
+    if matches!(event, tauri::WindowEvent::Focused(true)) {
+        remember_native_menu_window(window);
+    }
+}
+
+pub(crate) fn emit_native_menu_command<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    command: String,
+) {
+    let payload = NativeMenuCommand { command };
+    let target_label = app.state::<NativeMenuTargetState>().label();
+
+    if let Some(window) = target_label.and_then(|label| app.get_webview_window(&label)) {
+        let _ = window.emit(NATIVE_MENU_COMMAND_EVENT, payload);
+        return;
+    }
+
+    let _ = app.emit(NATIVE_MENU_COMMAND_EVENT, payload);
 }
 
 fn app_menu_item<R: tauri::Runtime, M: Manager<R>>(
@@ -389,5 +450,17 @@ mod tests {
         assert!(is_native_settings_window_command("openSettings"));
         assert!(!is_native_settings_window_command("saveDocument"));
         assert!(!is_frontend_menu_command("openSettings"));
+    }
+
+    #[test]
+    fn native_menu_target_state_remembers_latest_window_label() {
+        let state = NativeMenuTargetState::default();
+
+        assert_eq!(state.label(), None);
+
+        state.remember("main");
+        state.remember("markra-editor-1");
+
+        assert_eq!(state.label().as_deref(), Some("markra-editor-1"));
     }
 }

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -99,6 +99,25 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(toggleMarkdownFiles).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the resize handle below the Windows titlebar tab strip", () => {
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath={null}
+        files={[]}
+        open
+        outlineItems={[]}
+        platform="windows"
+        rootName="Obsidian Vault"
+        width={288}
+        onOpenFile={() => {}}
+        onResize={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".markdown-file-tree-resizer")).toHaveClass("top-10", "bottom-0");
+  });
+
   it("keeps the Windows sidebar toggle reachable when the drawer is collapsed", () => {
     const toggleMarkdownFiles = vi.fn();
     const { container } = render(

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -115,7 +115,10 @@ describe("MarkdownFileTreeDrawer", () => {
       />
     );
 
-    expect(container.querySelector(".markdown-file-tree-resizer")).toHaveClass("top-10", "bottom-0");
+    const resizeHandle = container.querySelector(".markdown-file-tree-resizer");
+
+    expect(resizeHandle).toHaveClass("top-10", "bottom-0");
+    expect(container.querySelector(".markdown-file-tree-resizer-indicator")).not.toBeInTheDocument();
   });
 
   it("keeps the Windows sidebar toggle reachable when the drawer is collapsed", () => {

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
@@ -513,7 +513,7 @@ export function MarkdownFileTreeDrawer({
       >
         {open && onResize && resolvedWidth !== null ? (
           <div
-            className="absolute inset-y-0 right-0 z-30 w-2 cursor-col-resize touch-none outline-none hover:[&>span]:bg-(--accent) focus-visible:[&>span]:bg-(--accent)"
+            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-2 cursor-col-resize touch-none outline-none hover:[&>span]:bg-(--accent) focus-visible:[&>span]:bg-(--accent)"
             role="separator"
             tabIndex={0}
             aria-label={label("app.resizeMarkdownFiles")}

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
@@ -513,7 +513,7 @@ export function MarkdownFileTreeDrawer({
       >
         {open && onResize && resolvedWidth !== null ? (
           <div
-            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-2 cursor-col-resize touch-none outline-none hover:[&>span]:bg-(--accent) focus-visible:[&>span]:bg-(--accent)"
+            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-2 cursor-col-resize touch-none outline-none"
             role="separator"
             tabIndex={0}
             aria-label={label("app.resizeMarkdownFiles")}
@@ -523,9 +523,7 @@ export function MarkdownFileTreeDrawer({
             aria-valuenow={resolvedWidth}
             onKeyDown={handleResizeKeyDown}
             onPointerDown={handleResizePointerDown}
-          >
-            <span className="pointer-events-none absolute top-2 right-0 bottom-2 w-px rounded-full bg-transparent transition-colors duration-150 ease-out" />
-          </div>
+          />
         ) : null}
         <div className="grid h-10 grid-cols-[40px_minmax(0,1fr)_40px] items-center border-b border-(--border-default)">
           <IconButton

--- a/apps/desktop/src/components/NativeTitleBar.test.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.test.tsx
@@ -147,10 +147,11 @@ describe("NativeTitleBar", () => {
 
     expect(screen.getByRole("tablist", { name: "Open documents" })).toBeInTheDocument();
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      left: "220px"
+      left: "221px"
     });
     expect(container.querySelector(".native-titlebar-sidebar-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".native-title-slot")).not.toHaveStyle({ paddingLeft: "232px" });
+    expect(container.querySelector(".native-title-slot")).toHaveClass("pl-4");
   });
 
   it("toggles the right-side Markra AI panel from the file action area", () => {

--- a/apps/desktop/src/components/NativeTitleBar.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.tsx
@@ -449,7 +449,7 @@ export function NativeTitleBar({
   if (platform === "windows") {
     if (titleContent) {
       const windowsTitlebarStyle: CSSProperties = {
-        ...(markdownFilesOpen ? { left: markdownFilesWidth } : {}),
+        ...(markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
         gridTemplateColumns: `minmax(0,1fr) ${titlebarSideSlotWidth}px`
       };
 
@@ -460,7 +460,7 @@ export function NativeTitleBar({
           aria-label={label("app.windowDragRegion")}
           data-tauri-drag-region
         >
-          {renderTitleContent("native-title-slot min-w-0 h-10 px-3")}
+          {renderTitleContent("native-title-slot min-w-0 h-10 pr-3 pl-4")}
           {renderDocumentActions(
             "document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 transition-[opacity,background-color,color] duration-150 ease-out hover:opacity-100 focus-within:opacity-100"
           )}

--- a/apps/desktop/src/lib/tauri/menu.test.ts
+++ b/apps/desktop/src/lib/tauri/menu.test.ts
@@ -163,7 +163,7 @@ describe("native menu", () => {
     expect(handlers.openDocument).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores native application menu commands in unfocused windows", async () => {
+  it("routes targeted native application menu commands even when the WebView is temporarily unfocused", async () => {
     isFocused.mockResolvedValue(false);
     const handlers: NativeMenuHandlers = {
       saveDocument: vi.fn()
@@ -174,7 +174,7 @@ describe("native menu", () => {
 
     await listener?.({ payload: { command: "saveDocument" } } as Parameters<NonNullable<typeof listener>>[0]);
 
-    expect(handlers.saveDocument).not.toHaveBeenCalled();
+    expect(handlers.saveDocument).toHaveBeenCalledTimes(1);
   });
 
   it("shows a native context menu only inside the markdown paper", async () => {

--- a/apps/desktop/src/lib/tauri/menu.ts
+++ b/apps/desktop/src/lib/tauri/menu.ts
@@ -6,7 +6,6 @@ import {
   type SubmenuOptions
 } from "@tauri-apps/api/menu";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { t, type AppLanguage, type I18nKey } from "@markra/shared";
 import {
   defaultMarkdownShortcuts,
@@ -156,18 +155,8 @@ function menuLabel(language: AppLanguage, key: I18nKey) {
   return t(language, key);
 }
 
-async function isCurrentNativeWindowFocused() {
-  try {
-    return await getCurrentWindow().isFocused();
-  } catch {
-    return true;
-  }
-}
-
 export async function listenNativeApplicationMenuCommands(handlers: NativeMenuHandlers) {
-  return listen<NativeMenuCommandPayload>("markra://menu-command", async (event) => {
-    if (!(await isCurrentNativeWindowFocused())) return;
-
+  return listen<NativeMenuCommandPayload>("markra://menu-command", (event) => {
     runNativeMenuAction(handlers[event.payload.command]);
   });
 }


### PR DESCRIPTION
## Summary
- Route native menu commands to the last focused window so Windows menu clicks still reach the active editor after the menu bar temporarily steals focus.
- Align Windows titlebar document tabs away from the file tree divider and keep the file tree resize handle below the tab strip.

## Why
Windows can report the WebView as unfocused while a native menu command is being selected, which caused File > Open and File > Open Folder to be ignored on first launch. The titlebar tab strip also needed a small Windows-specific gutter at the file tree boundary.

## Validation
- `pnpm --filter @markra/desktop test -- src/lib/tauri/menu.test.ts` passed
- `cargo test` passed
- `pnpm --filter @markra/desktop test -- src/components/NativeTitleBar.test.tsx src/components/MarkdownFileTreeDrawer.test.tsx` passed
- `pnpm --filter @markra/desktop build` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
