### PR TITLE
feat(editor): improve list and block interactions

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -4110,6 +4110,36 @@ describe("MarkdownPaper editing", () => {
     expect(paragraphs[1]).not.toHaveClass("markra-heading-collapsed-content");
   });
 
+  it("collapses a nested list from the list toggle", async () => {
+    const source = ["- Parent", "  - Child", "- Peer"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const topLevelItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li"));
+    const nestedList = container.querySelector<HTMLElement>(".ProseMirror > ul > li > ul");
+    const initialMarkdown = serializeMarkdown(view.state.doc);
+
+    expect(topLevelItems).toHaveLength(2);
+    expect(nestedList).toBeInTheDocument();
+
+    fireEvent.click(within(topLevelItems[0]!).getByRole("button", { name: "Collapse list item" }));
+
+    expect(within(topLevelItems[0]!).getByRole("button", { name: "Expand list item" })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(nestedList).toHaveClass("markra-list-collapsed-content");
+    expect(topLevelItems[1]).not.toHaveClass("markra-list-collapsed-content");
+    expect(serializeMarkdown(view.state.doc)).toBe(initialMarkdown);
+
+    fireEvent.click(within(topLevelItems[0]!).getByRole("button", { name: "Expand list item" }));
+
+    expect(within(topLevelItems[0]!).getByRole("button", { name: "Collapse list item" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(nestedList).not.toHaveClass("markra-list-collapsed-content");
+  });
+
   it("expands a rendered heading back to editable markdown source when clicked", async () => {
     const { container, editor, view } = await renderEditor("## Title");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -3551,6 +3551,17 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps Tab inside plain text blocks as indentation", async () => {
+    const { editor, view } = await renderEditor("Alphabeta");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "beta"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("Alpha  beta");
+    await settleMarkdownListener();
+  });
+
   it("exits a terminal code block so text can be added below it", async () => {
     const source = ["## Pull image", "", "```", "sudo docker pull image", "```"].join("\n");
     const { editor, view } = await renderEditor(source);

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -3563,6 +3563,23 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("nests the current list item when Tab is pressed inside it", async () => {
+    const { container, editor, view } = await renderEditor(["- First", "- Second"].join("\n"));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    const topLevelItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li"));
+    const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li > ul > li"));
+    expect(topLevelItems).toHaveLength(1);
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Second");
+    expect(serializeMarkdown(view.state.doc)).toContain("  * Second");
+    await settleMarkdownListener();
+  });
+
   it("exits a terminal code block so text can be added below it", async () => {
     const source = ["## Pull image", "", "```", "sudo docker pull image", "```"].join("\n");
     const { editor, view } = await renderEditor(source);

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1222,7 +1222,7 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
-  it("centers the block toolbar against tall heading content", async () => {
+  it("anchors the block toolbar near the first line of tall heading content", async () => {
     const { container, view } = await renderEditor("# Parent\n\nBody");
     const heading = container.querySelector<HTMLElement>(".ProseMirror > h1");
     const surface = container.querySelector<HTMLElement>(".ProseMirror");
@@ -1234,6 +1234,7 @@ describe("MarkdownPaper editing", () => {
     heading!.style.paddingBottom = "10px";
     heading!.style.borderBottomWidth = "1px";
     heading!.style.borderBottomStyle = "solid";
+    heading!.style.lineHeight = "52px";
     heading!.getBoundingClientRect = vi.fn(
       () =>
         ({
@@ -1275,7 +1276,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const handle = await screen.findByRole("button", { name: "Drag block" });
-    expect(handle.closest<HTMLElement>(".markra-block-toolbar")?.style.top).toBe("137px");
+    expect(handle.closest<HTMLElement>(".markra-block-toolbar")?.style.top).toBe("126px");
 
     Object.defineProperty(view, "posAtCoords", {
       configurable: true,

--- a/apps/desktop/src/components/MarkdownPaperSurface.tsx
+++ b/apps/desktop/src/components/MarkdownPaperSurface.tsx
@@ -15,6 +15,7 @@ import {
   markraCodeBlockPlugin,
   markraHeadingSourcePlugin,
   markraHeadingTogglePlugin,
+  markraListTogglePlugin,
   markraLinkImageLivePlugin,
   markraLiveMarkdownPlugin,
   markraMarkdownShortcuts,
@@ -134,6 +135,10 @@ function MilkdownEditorSurface({
     collapseSection: t(language, "editor.collapseSection"),
     expandSection: t(language, "editor.expandSection")
   };
+  const listToggleLabels = {
+    collapseListItem: t(language, "editor.collapseListItem"),
+    expandListItem: t(language, "editor.expandListItem")
+  };
   const slashCommandLabels = useMemo<SlashCommandLabels>(() => ({
     menu: t(language, "editor.slashCommands"),
     noResults: t(language, "editor.slashCommandsNoResults"),
@@ -227,6 +232,7 @@ function MilkdownEditorSurface({
         .use(markraAiEditorPreviewPlugin)
         .use(markraBlockDragPlugin(blockDragLabels))
         .use(markraHeadingTogglePlugin(headingToggleLabels))
+        .use(markraListTogglePlugin(listToggleLabels))
         .use(
           markraDocumentLinkCompletionPlugin({
             getDocumentPath: () => documentPathRef.current,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1208,6 +1208,56 @@
     display: none !important;
   }
 
+  .markdown-paper .markra-list-toggle-item {
+    position: relative;
+  }
+
+  .markdown-paper .markra-list-toggle-button {
+    @apply absolute inline-flex size-4 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 outline-none transition-[opacity,color,background-color] duration-150 ease-out focus-visible:bg-(--bg-hover) focus-visible:outline-none;
+    color: color-mix(in srgb, var(--editor-text-secondary) 62%, transparent);
+    left: -1.35em;
+    opacity: 0;
+    top: 0.42em;
+  }
+
+  .markdown-paper .markra-list-toggle-item:hover > .markra-list-toggle-button,
+  .markdown-paper .markra-list-toggle-item:focus-within > .markra-list-toggle-button,
+  .markdown-paper .markra-list-toggle-item[data-list-collapsed="true"] > .markra-list-toggle-button {
+    opacity: 0.72;
+  }
+
+  .markdown-paper .markra-list-toggle-button:hover,
+  .markdown-paper .markra-list-toggle-button:focus-visible {
+    color: var(--editor-text-secondary);
+    opacity: 1;
+  }
+
+  .markdown-paper .markra-list-toggle-button::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-right: 1.4px solid currentColor;
+    border-bottom: 1.4px solid currentColor;
+    transform: rotate(45deg);
+    transform-origin: center;
+    transition: transform 120ms ease-out;
+  }
+
+  .markdown-paper .markra-list-toggle-button[data-collapsed="true"]::before {
+    transform: rotate(-45deg);
+  }
+
+  .markdown-paper .markra-list-toggle-item > ul,
+  .markdown-paper .markra-list-toggle-item > ol {
+    margin-left: 0.15em;
+    padding-left: 1.2em;
+    border-left: 1px solid color-mix(in srgb, var(--editor-border-strong) 70%, transparent);
+  }
+
+  .markdown-paper .markra-list-collapsed-content {
+    display: none !important;
+  }
+
   .markdown-paper p {
     @apply m-0 mb-4.5;
     color: var(--editor-text-primary);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1215,9 +1215,9 @@
   .markdown-paper .markra-list-toggle-button {
     @apply absolute inline-flex size-4 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 outline-none transition-[opacity,color,background-color] duration-150 ease-out focus-visible:bg-(--bg-hover) focus-visible:outline-none;
     color: color-mix(in srgb, var(--editor-text-secondary) 62%, transparent);
-    left: -1.35em;
+    left: -2.2em;
     opacity: 0;
-    top: 0.42em;
+    top: calc((1lh - 1rem) / 2);
   }
 
   .markdown-paper .markra-list-toggle-item:hover > .markra-list-toggle-button,
@@ -1251,7 +1251,6 @@
   .markdown-paper .markra-list-toggle-item > ol {
     margin-left: 0.15em;
     padding-left: 1.2em;
-    border-left: 1px solid color-mix(in srgb, var(--editor-border-strong) 70%, transparent);
   }
 
   .markdown-paper .markra-list-collapsed-content {

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -11,6 +11,16 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper tbody tr:nth-child(even)");
   });
 
+  it("draws nested list guide rails for collapsible list items", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).toContain(".markdown-paper .markra-list-toggle-item");
+    expect(styles).toContain(".markdown-paper .markra-list-toggle-item > ul");
+    expect(styles).toContain(".markdown-paper .markra-list-toggle-item > ol");
+    expect(styles).toContain("border-left: 1px solid color-mix");
+    expect(styles).toContain(".markdown-paper .markra-list-collapsed-content");
+  });
+
   it("keeps table add controls hidden until table hover or focus", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const tableControlStart = styles.indexOf(".markdown-paper .markra-table-control {");

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -11,13 +11,16 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper tbody tr:nth-child(even)");
   });
 
-  it("draws nested list guide rails for collapsible list items", () => {
+  it("positions collapsible list controls", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const buttonStart = styles.indexOf(".markdown-paper .markra-list-toggle-button {");
+    const buttonEnd = styles.indexOf(".markdown-paper .markra-list-toggle-item:hover");
+    const buttonStyles = styles.slice(buttonStart, buttonEnd);
 
     expect(styles).toContain(".markdown-paper .markra-list-toggle-item");
-    expect(styles).toContain(".markdown-paper .markra-list-toggle-item > ul");
-    expect(styles).toContain(".markdown-paper .markra-list-toggle-item > ol");
-    expect(styles).toContain("border-left: 1px solid color-mix");
+    expect(buttonStyles).toContain("left: -2.2em");
+    expect(buttonStyles).toContain("top: calc((1lh - 1rem) / 2);");
+    expect(styles).toContain(".markdown-paper .markra-list-toggle-item:hover > .markra-list-toggle-button");
     expect(styles).toContain(".markdown-paper .markra-list-collapsed-content");
   });
 

--- a/packages/editor/src/block-drag.ts
+++ b/packages/editor/src/block-drag.ts
@@ -86,9 +86,20 @@ function pixelValue(value: string) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function contentBoxCenterTop(element: Element, rect: DOMRect) {
+function lineHeightValue(lineHeight: string, fontSize: string) {
+  const parsedLineHeight = Number.parseFloat(lineHeight);
+  if (!Number.isFinite(parsedLineHeight)) return 0;
+  if (lineHeight.endsWith("px")) return parsedLineHeight;
+
+  const parsedFontSize = pixelValue(fontSize);
+  if (parsedFontSize <= 0) return 0;
+
+  return parsedLineHeight * parsedFontSize;
+}
+
+function contentBoxFirstLineCenterTop(element: Element, rect: DOMRect) {
   const ownerWindow = element.ownerDocument.defaultView;
-  if (!ownerWindow) return rect.top + rect.height / 2;
+  if (!ownerWindow) return rect.top;
 
   const style = ownerWindow.getComputedStyle(element);
   const borderTop = pixelValue(style.borderTopWidth);
@@ -96,8 +107,10 @@ function contentBoxCenterTop(element: Element, rect: DOMRect) {
   const paddingTop = pixelValue(style.paddingTop);
   const paddingBottom = pixelValue(style.paddingBottom);
   const contentHeight = Math.max(0, rect.height - borderTop - borderBottom - paddingTop - paddingBottom);
+  const lineHeight = lineHeightValue(style.lineHeight, style.fontSize);
+  const firstLineHeight = lineHeight > 0 ? Math.min(contentHeight, lineHeight) : contentHeight;
 
-  return rect.top + borderTop + paddingTop + contentHeight / 2;
+  return rect.top + borderTop + paddingTop + firstLineHeight / 2;
 }
 
 function hasTableAncestor($pos: ResolvedPos) {
@@ -959,7 +972,7 @@ class MarkraBlockDragView {
 
     const rect = dom.getBoundingClientRect();
     const left = Math.max(8, editorRect.left - blockToolbarGutterOffset);
-    const top = contentBoxCenterTop(dom, rect);
+    const top = contentBoxFirstLineCenterTop(dom, rect);
 
     this.toolbar.style.left = `${Math.round(left)}px`;
     this.toolbar.style.top = `${Math.round(top)}px`;

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -7,6 +7,7 @@ export * from "./heading-source.ts";
 export * from "./heading-toggle.ts";
 export * from "./input-rules.ts";
 export * from "./link-image-rules.ts";
+export * from "./list-toggle.ts";
 export * from "./math.ts";
 export * from "./raw-html.ts";
 export * from "./selection-hold.ts";

--- a/packages/editor/src/list-toggle.ts
+++ b/packages/editor/src/list-toggle.ts
@@ -1,0 +1,279 @@
+import {
+  bulletListSchema,
+  listItemSchema,
+  orderedListSchema
+} from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode, NodeType } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+export type ListToggleLabels = {
+  collapseListItem: string;
+  expandListItem: string;
+};
+
+type CollapsedListState = {
+  collapsed: readonly number[];
+};
+
+type ListToggleMeta = {
+  from: number;
+  type: "toggle";
+};
+
+type ListRange = {
+  from: number;
+  to: number;
+};
+
+type CollapsibleListItem = {
+  from: number;
+  nestedLists: ListRange[];
+  node: ProseNode;
+  to: number;
+};
+
+const defaultListToggleLabels: ListToggleLabels = {
+  collapseListItem: "Collapse list item",
+  expandListItem: "Expand list item"
+};
+
+const emptyCollapsedListState: CollapsedListState = {
+  collapsed: []
+};
+
+const listToggleKey = new PluginKey<CollapsedListState>("markra-list-toggle");
+
+function normalizeListToggleLabels(labels: Partial<ListToggleLabels> | undefined): ListToggleLabels {
+  return {
+    ...defaultListToggleLabels,
+    ...labels
+  };
+}
+
+function isListNode(node: ProseNode, bulletList: NodeType, orderedList: NodeType) {
+  return node.type === bulletList || node.type === orderedList;
+}
+
+function collectCollapsibleListItems(
+  doc: ProseNode,
+  listItem: NodeType,
+  bulletList: NodeType,
+  orderedList: NodeType
+) {
+  const items: CollapsibleListItem[] = [];
+
+  doc.descendants((node, position) => {
+    if (node.type !== listItem) return true;
+
+    const nestedLists: ListRange[] = [];
+    node.forEach((child, offset) => {
+      if (!isListNode(child, bulletList, orderedList)) return;
+
+      const from = position + 1 + offset;
+      nestedLists.push({
+        from,
+        to: from + child.nodeSize
+      });
+    });
+
+    if (nestedLists.length > 0) {
+      items.push({
+        from: position,
+        nestedLists,
+        node,
+        to: position + node.nodeSize
+      });
+    }
+
+    return true;
+  });
+
+  return items;
+}
+
+function findListItemStartAtPosition(state: EditorState, listItem: NodeType, position: number) {
+  const safePosition = Math.max(0, Math.min(position, state.doc.content.size));
+  const nodeAtPosition = state.doc.nodeAt(safePosition);
+  if (nodeAtPosition?.type === listItem) return safePosition;
+
+  const $position = state.doc.resolve(safePosition);
+  for (let depth = $position.depth; depth > 0; depth -= 1) {
+    if ($position.node(depth).type === listItem) return $position.before(depth);
+  }
+
+  return null;
+}
+
+function normalizeCollapsedPositions(state: EditorState, listItem: NodeType, positions: readonly number[]) {
+  const collapsed = new Set<number>();
+
+  for (const position of positions) {
+    const listItemStart = findListItemStartAtPosition(state, listItem, position);
+    if (listItemStart !== null) collapsed.add(listItemStart);
+  }
+
+  return Array.from(collapsed).sort((left, right) => left - right);
+}
+
+function mapCollapsedPositions(
+  transaction: Transaction,
+  state: EditorState,
+  listItem: NodeType,
+  positions: readonly number[]
+) {
+  return normalizeCollapsedPositions(
+    state,
+    listItem,
+    positions.map((position) => transaction.mapping.map(position, 1))
+  );
+}
+
+function toggleCollapsedPosition(positions: readonly number[], position: number) {
+  return positions.includes(position)
+    ? positions.filter((collapsedPosition) => collapsedPosition !== position)
+    : [...positions, position].sort((left, right) => left - right);
+}
+
+function createListToggleButton(
+  view: EditorView,
+  getListItemFrom: () => number,
+  collapsed: boolean,
+  labels: ListToggleLabels
+) {
+  const button = view.dom.ownerDocument.createElement("button");
+  const label = collapsed ? labels.expandListItem : labels.collapseListItem;
+
+  button.type = "button";
+  button.className = "markra-list-toggle-button";
+  button.contentEditable = "false";
+  button.draggable = false;
+  button.dataset.collapsed = String(collapsed);
+  button.ariaExpanded = String(!collapsed);
+  button.ariaLabel = label;
+  button.title = label;
+
+  button.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    view.dispatch(
+      view.state.tr.setMeta(listToggleKey, {
+        from: getListItemFrom(),
+        type: "toggle"
+      } satisfies ListToggleMeta)
+    );
+    view.focus();
+  });
+
+  return button;
+}
+
+function buildListToggleDecorations(
+  doc: ProseNode,
+  collapsedPositions: readonly number[],
+  listItem: NodeType,
+  bulletList: NodeType,
+  orderedList: NodeType,
+  labels: ListToggleLabels
+) {
+  const items = collectCollapsibleListItems(doc, listItem, bulletList, orderedList);
+  const itemByStart = new Map(items.map((item) => [item.from, item]));
+  const collapsed = new Set(collapsedPositions.filter((position) => itemByStart.has(position)));
+  const decorations: Decoration[] = [];
+
+  for (const item of items) {
+    const itemIsCollapsed = collapsed.has(item.from);
+    decorations.push(
+      Decoration.node(item.from, item.to, {
+        class: "markra-list-toggle-item",
+        "data-list-collapsed": String(itemIsCollapsed)
+      }),
+      Decoration.widget(
+        item.from + 1,
+        (view, getPos) =>
+          createListToggleButton(
+            view,
+            () => {
+              const position = getPos();
+              if (typeof position !== "number") return item.from;
+
+              return findListItemStartAtPosition(view.state, listItem, position) ?? item.from;
+            },
+            itemIsCollapsed,
+            labels
+          ),
+        {
+          ignoreSelection: true,
+          key: `markra-list-toggle-${item.from}-${itemIsCollapsed ? "collapsed" : "expanded"}`,
+          side: -1
+        }
+      )
+    );
+
+    if (!itemIsCollapsed) continue;
+
+    for (const nestedList of item.nestedLists) {
+      decorations.push(
+        Decoration.node(nestedList.from, nestedList.to, {
+          class: "markra-list-collapsed-content"
+        })
+      );
+    }
+  }
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export function markraListTogglePlugin(labels?: Partial<ListToggleLabels>) {
+  const resolvedLabels = normalizeListToggleLabels(labels);
+
+  return $prose((ctx) => {
+    const bulletList = bulletListSchema.type(ctx);
+    const listItem = listItemSchema.type(ctx);
+    const orderedList = orderedListSchema.type(ctx);
+
+    return new Plugin<CollapsedListState>({
+      key: listToggleKey,
+      state: {
+        init: () => emptyCollapsedListState,
+        apply(transaction, value, _oldState, newState) {
+          const meta = transaction.getMeta(listToggleKey) as ListToggleMeta | undefined;
+          const mappedCollapsed = transaction.docChanged
+            ? mapCollapsedPositions(transaction, newState, listItem, value.collapsed)
+            : value.collapsed;
+
+          if (meta?.type !== "toggle") {
+            return mappedCollapsed === value.collapsed ? value : { collapsed: mappedCollapsed };
+          }
+
+          const listItemFrom = findListItemStartAtPosition(newState, listItem, meta.from);
+          if (listItemFrom === null) return { collapsed: mappedCollapsed };
+
+          return {
+            collapsed: toggleCollapsedPosition(mappedCollapsed, listItemFrom)
+          };
+        }
+      },
+      props: {
+        decorations: (state) => {
+          const pluginState = listToggleKey.getState(state) ?? emptyCollapsedListState;
+          return buildListToggleDecorations(
+            state.doc,
+            pluginState.collapsed,
+            listItem,
+            bulletList,
+            orderedList,
+            resolvedLabels
+          );
+        }
+      }
+    });
+  });
+}

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -156,6 +156,20 @@ function moveBelowTerminalBlock(view: EditorView, paragraph: ReturnType<typeof p
   return true;
 }
 
+const plainTextIndentation = "  ";
+
+function insertPlainTextIndentation(view: EditorView) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection)) return false;
+  if (!selection.$to.parent.isTextblock) return false;
+
+  const position = selection.empty ? selection.from : selection.to;
+  view.dispatch(view.state.tr.insertText(plainTextIndentation, position, position).scrollIntoView());
+  view.focus();
+
+  return true;
+}
+
 export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap = {}) => $prose((ctx) => {
   const strong = strongSchema.type(ctx);
   const emphasis = emphasisSchema.type(ctx);
@@ -208,6 +222,12 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
           return true;
         } else if (event.key === "ArrowDown" && !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
           const handled = moveBelowTerminalBlock(view, paragraph);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        } else if (event.key === "Tab" && !hasModifier) {
+          const handled = insertPlainTextIndentation(view);
           if (!handled) return false;
 
           event.preventDefault();

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -5,6 +5,7 @@ import {
   emphasisSchema,
   headingSchema,
   inlineCodeSchema,
+  listItemSchema,
   orderedListSchema,
   paragraphSchema,
   strongSchema
@@ -16,7 +17,7 @@ import type { NodeType, ResolvedPos } from "@milkdown/kit/prose/model";
 import type { Command, Selection } from "@milkdown/kit/prose/state";
 import { NodeSelection, Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
-import { wrapInList } from "@milkdown/kit/prose/schema-list";
+import { liftListItem, sinkListItem, wrapInList } from "@milkdown/kit/prose/schema-list";
 import { $prose } from "@milkdown/kit/utils";
 import {
   defaultKeyboardShortcuts,
@@ -177,6 +178,7 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
   const strikethrough = strikethroughSchema.type(ctx);
   const paragraph = paragraphSchema.type(ctx);
   const heading = headingSchema.type(ctx);
+  const listItem = listItemSchema.type(ctx);
   const bulletList = bulletListSchema.type(ctx);
   const orderedList = orderedListSchema.type(ctx);
   const blockquote = blockquoteSchema.type(ctx);
@@ -226,7 +228,17 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
 
           event.preventDefault();
           return true;
-        } else if (event.key === "Tab" && !hasModifier) {
+        } else if (event.key === "Tab" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+          if (selectionIsInsideNodeType(view.state.selection, listItem)) {
+            const handled = runCommand(view, event.shiftKey ? liftListItem(listItem) : sinkListItem(listItem));
+            if (!handled) view.focus();
+
+            event.preventDefault();
+            return true;
+          }
+
+          if (event.shiftKey) return false;
+
           const handled = insertPlainTextIndentation(view);
           if (!handled) return false;
 

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "Block ziehen",
   "editor.collapseSection": "Abschnitt einklappen",
   "editor.expandSection": "Abschnitt ausklappen",
+  "editor.collapseListItem": "Listeneintrag einklappen",
+  "editor.expandListItem": "Listeneintrag ausklappen",
   "editor.htmlSource": "HTML-Quelle",
   "editor.htmlSourceApply": "HTML-Quelle anwenden",
   "editor.table.addColumnRight": "Spalte rechts hinzufügen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -346,6 +346,8 @@ const messages: BaseLocaleMessages = {
   "editor.blockDrag": "Drag block",
   "editor.collapseSection": "Collapse section",
   "editor.expandSection": "Expand section",
+  "editor.collapseListItem": "Collapse list item",
+  "editor.expandListItem": "Expand list item",
   "editor.htmlSource": "HTML source",
   "editor.htmlSourceApply": "Apply HTML source",
   "editor.table.addColumnRight": "Add column to the right",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "Arrastrar bloque",
   "editor.collapseSection": "Contraer sección",
   "editor.expandSection": "Expandir sección",
+  "editor.collapseListItem": "Contraer elemento de lista",
+  "editor.expandListItem": "Expandir elemento de lista",
   "editor.htmlSource": "Código fuente HTML",
   "editor.htmlSourceApply": "Aplicar código fuente HTML",
   "editor.table.addColumnRight": "Añadir columna a la derecha",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "Faire glisser le bloc",
   "editor.collapseSection": "Replier la section",
   "editor.expandSection": "Déplier la section",
+  "editor.collapseListItem": "Replier l’élément de liste",
+  "editor.expandListItem": "Déplier l’élément de liste",
   "editor.htmlSource": "Source HTML",
   "editor.htmlSourceApply": "Appliquer la source HTML",
   "editor.table.addColumnRight": "Ajouter une colonne à droite",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "Trascina blocco",
   "editor.collapseSection": "Comprimi sezione",
   "editor.expandSection": "Espandi sezione",
+  "editor.collapseListItem": "Comprimi elemento elenco",
+  "editor.expandListItem": "Espandi elemento elenco",
   "editor.htmlSource": "Sorgente HTML",
   "editor.htmlSourceApply": "Applica sorgente HTML",
   "editor.table.addColumnRight": "Aggiungi colonna a destra",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -240,6 +240,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "ブロックをドラッグ",
   "editor.collapseSection": "セクションを折りたたむ",
   "editor.expandSection": "セクションを展開",
+  "editor.collapseListItem": "リスト項目を折りたたむ",
+  "editor.expandListItem": "リスト項目を展開",
   "editor.htmlSource": "HTML ソース",
   "editor.htmlSourceApply": "HTML ソースを適用",
   "editor.table.addColumnRight": "右に列を追加",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "블록 드래그",
   "editor.collapseSection": "섹션 접기",
   "editor.expandSection": "섹션 펼치기",
+  "editor.collapseListItem": "목록 항목 접기",
+  "editor.expandListItem": "목록 항목 펼치기",
   "editor.htmlSource": "HTML 소스",
   "editor.htmlSourceApply": "HTML 소스 적용",
   "editor.table.addColumnRight": "오른쪽에 열 추가",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "Arrastar bloco",
   "editor.collapseSection": "Recolher seção",
   "editor.expandSection": "Expandir seção",
+  "editor.collapseListItem": "Recolher item de lista",
+  "editor.expandListItem": "Expandir item de lista",
   "editor.htmlSource": "Código-fonte HTML",
   "editor.htmlSourceApply": "Aplicar código-fonte HTML",
   "editor.table.addColumnRight": "Adicionar coluna à direita",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -234,6 +234,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "Перетащить блок",
   "editor.collapseSection": "Свернуть раздел",
   "editor.expandSection": "Развернуть раздел",
+  "editor.collapseListItem": "Свернуть пункт списка",
+  "editor.expandListItem": "Развернуть пункт списка",
   "editor.htmlSource": "HTML-исходник",
   "editor.htmlSourceApply": "Применить HTML-исходник",
   "editor.table.addColumnRight": "Добавить столбец справа",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -357,6 +357,8 @@ export type I18nKey =
   | "editor.blockDrag"
   | "editor.collapseSection"
   | "editor.expandSection"
+  | "editor.collapseListItem"
+  | "editor.expandListItem"
   | "editor.htmlSource"
   | "editor.htmlSourceApply"
   | "editor.table.addColumnRight"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -346,6 +346,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "拖拽块",
   "editor.collapseSection": "折叠章节",
   "editor.expandSection": "展开章节",
+  "editor.collapseListItem": "折叠列表项",
+  "editor.expandListItem": "展开列表项",
   "editor.htmlSource": "HTML 源码",
   "editor.htmlSourceApply": "应用 HTML 源码",
   "editor.table.addColumnRight": "在右侧新增列",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -240,6 +240,8 @@ const messages: LocaleMessages = {
   "editor.blockDrag": "拖曳區塊",
   "editor.collapseSection": "摺疊章節",
   "editor.expandSection": "展開章節",
+  "editor.collapseListItem": "摺疊列表項目",
+  "editor.expandListItem": "展開列表項目",
   "editor.htmlSource": "HTML 原始碼",
   "editor.htmlSourceApply": "套用 HTML 原始碼",
   "editor.table.addColumnRight": "在右側新增欄",


### PR DESCRIPTION
## Summary
- Keep plain-text Tab key presses inside the editor by inserting two-space indentation.
- Anchor the block operation toolbar near the first line for tall blocks instead of the block midpoint.
- Add collapsible nested list items with localized expand/collapse labels.
- Let Tab inside a list item sink the current item to the next list level.
- Keep the list fold toggle outside the marker gutter and vertically centered on the first line, without drawing a nested-list guide line.

## Why
- Plain paragraphs did not consume Tab, so the browser could move focus and make the editor appear to jump.
- Long blocks showed operation controls midway through the block, away from the text start.
- Issue #79 also requested nested list folding and list-item Tab indentation.
- The fold control needed layout polish so it does not overlap markers or sit off-center.

## Validation
- `pnpm --dir apps/desktop exec vitest run src/components/MarkdownPaper.test.tsx src/styles.test.ts` passed, 185 tests.
- `pnpm --filter @markra/desktop build` passed.
- Not run: manual screenshot QA; the latest visual adjustments are covered by style assertions and the editor behavior test.

## Risk
- Moderate; changes are scoped to editor keyboard handling and ProseMirror decoration-based list folding.
- Fold state is editor-local UI state and does not alter serialized Markdown.

Close #79