### PR TITLE
fix(desktop): polish sidebar and titlebar controls

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -2115,6 +2115,42 @@ describe("Markra workspace", () => {
     expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
   });
 
+  it("keeps a restored workspace file in source mode without rerunning startup restore", async () => {
+    const restoredContent = "# Restored source\n\nBack from the saved workspace.";
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-app",
+      filePath: mockNativePath,
+      fileTreeOpen: true,
+      folderName: "vault",
+      folderPath: mockFolderPath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "native.md", path: mockNativePath, relativePath: "native.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: restoredContent,
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    renderApp();
+
+    expect(await screen.findByText("Restored source")).toBeInTheDocument();
+    await waitFor(() => expect(mockedReadNativeMarkdownFile).toHaveBeenCalledTimes(1));
+    mockedReadNativeMarkdownFile.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+    expect(sourceEditor).toHaveValue(restoredContent);
+
+    await settleEditorUpdates();
+
+    expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(restoredContent);
+    expect(screen.getByRole("button", { name: "Switch to visual mode" })).toBeInTheDocument();
+    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+  });
+
   it("keeps source and visual editors synchronized in split mode", async () => {
     const { container } = renderApp();
 

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -68,7 +68,7 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(outlineSwitch).toContainElement(container.querySelector(".lucide-table-of-contents"));
   });
 
-  it("places the Windows sidebar toggle at the lower drawer edge", () => {
+  it("places open Windows sidebar controls inside a separated drawer footer", () => {
     const toggleMarkdownFiles = vi.fn();
     const { container } = render(
       <MarkdownFileTreeDrawer
@@ -86,10 +86,16 @@ describe("MarkdownFileTreeDrawer", () => {
     );
 
     const toggle = screen.getByRole("button", { name: "Toggle file list" });
+    const settings = screen.getByRole("button", { name: "Settings" });
+    const footer = container.querySelector(".markdown-file-tree-footer");
 
     expect(toggle).toHaveAttribute("aria-pressed", "true");
-    expect(toggle).toHaveClass("fixed", "bottom-3");
-    expect(toggle).toHaveStyle({ left: "300px" });
+    expect(footer).toHaveClass("shrink-0", "border-t");
+    expect(settings.closest(".markdown-file-tree-footer")).toBe(footer);
+    expect(toggle.closest(".markdown-file-tree-footer")).toBe(footer);
+    expect(settings).not.toHaveClass("fixed", "bottom-3", "left-3");
+    expect(toggle).not.toHaveClass("fixed", "bottom-3");
+    expect(toggle).not.toHaveStyle({ left: "300px" });
     expect(toggle).toContainElement(container.querySelector(".lucide-panel-left"));
     expect(container.querySelector(".markdown-file-tree")).toHaveClass("pt-0");
     expect(container.querySelector(".markdown-file-tree")).not.toHaveClass("pt-10");

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
@@ -191,7 +191,6 @@ export function MarkdownFileTreeDrawer({
   const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
   const showWindowsSidebarToggle = platform === "windows" && onToggleMarkdownFiles;
   const WindowsSidebarToggleIcon = open ? PanelLeft : PanelRight;
-  const windowsSidebarToggleLeft = open && resolvedWidth !== null ? `${resolvedWidth + 12}px` : "48px";
   const drawerTopPaddingClassName = platform === "windows" ? "pt-0" : "pt-10";
 
   useEffect(() => {
@@ -482,22 +481,22 @@ export function MarkdownFileTreeDrawer({
 
   return (
     <>
-      <IconButton
-        className="fixed bottom-3 left-3 z-30 opacity-40 hover:opacity-100 focus-visible:opacity-100"
-        label={label("settings.title")}
-        onClick={onOpenSettings}
-      >
-        <Settings aria-hidden="true" size={15} />
-      </IconButton>
-
-      {showWindowsSidebarToggle ? (
+      {!open ? (
         <IconButton
-          className={`fixed bottom-3 z-30 transition-[left,opacity,background-color,color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:opacity-100 focus-visible:opacity-100 ${
-            open ? "bg-(--bg-active) text-(--text-heading) opacity-80" : "opacity-45"
-          }`}
+          className="fixed bottom-3 left-3 z-30 opacity-40 hover:opacity-100 focus-visible:opacity-100"
+          label={label("settings.title")}
+          onClick={onOpenSettings}
+        >
+          <Settings aria-hidden="true" size={15} />
+        </IconButton>
+      ) : null}
+
+      {!open && showWindowsSidebarToggle ? (
+        <IconButton
+          className="fixed bottom-3 z-30 opacity-45 transition-[left,opacity,background-color,color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:opacity-100 focus-visible:opacity-100"
           label={label("app.toggleMarkdownFiles")}
           pressed={open}
-          style={{ left: windowsSidebarToggleLeft }}
+          style={{ left: "48px" }}
           onClick={onToggleMarkdownFiles}
         >
           <WindowsSidebarToggleIcon aria-hidden="true" size={15} />
@@ -682,6 +681,28 @@ export function MarkdownFileTreeDrawer({
             </div>
           </>
         )}
+        {open ? (
+          <div className="markdown-file-tree-footer flex h-12 shrink-0 items-center justify-between border-t border-(--border-default) bg-(--bg-secondary) px-2.5">
+            <IconButton
+              className="rounded-md opacity-70 hover:opacity-100 focus-visible:opacity-100"
+              label={label("settings.title")}
+              onClick={onOpenSettings}
+            >
+              <Settings aria-hidden="true" size={15} />
+            </IconButton>
+
+            {showWindowsSidebarToggle ? (
+              <IconButton
+                className="rounded-md bg-(--bg-active) text-(--text-heading) opacity-80 transition-[opacity,background-color,color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:opacity-100 focus-visible:opacity-100"
+                label={label("app.toggleMarkdownFiles")}
+                pressed={open}
+                onClick={onToggleMarkdownFiles}
+              >
+                <WindowsSidebarToggleIcon aria-hidden="true" size={15} />
+              </IconButton>
+            ) : null}
+          </div>
+        ) : null}
       </aside>
     </>
   );

--- a/apps/desktop/src/components/NativeTitleBar.test.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.test.tsx
@@ -154,6 +154,40 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".native-title-slot")).toHaveClass("pl-4");
   });
 
+  it("keeps Windows titlebar file actions outside the drag region", () => {
+    const toggleSourceMode = vi.fn();
+    const { container } = render(
+      <NativeTitleBar
+        aiAgentOpen={false}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen={false}
+        platform="windows"
+        sourceMode={false}
+        theme="light"
+        titleContent={(
+          <div role="tablist" aria-label="Open documents">
+            <button type="button" role="tab" aria-selected="true">Draft.md</button>
+          </div>
+        )}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleSourceMode={toggleSourceMode}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".native-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".document-actions")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".native-title-slot")).toHaveAttribute("data-tauri-drag-region");
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    expect(toggleSourceMode).toHaveBeenCalledTimes(1);
+  });
+
   it("toggles the right-side Markra AI panel from the file action area", () => {
     const toggleAiAgent = vi.fn();
     const { container } = render(

--- a/apps/desktop/src/components/NativeTitleBar.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.tsx
@@ -458,7 +458,6 @@ export function NativeTitleBar({
           className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-10 grid h-10 grid-cols-[minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
           style={windowsTitlebarStyle}
           aria-label={label("app.windowDragRegion")}
-          data-tauri-drag-region
         >
           {renderTitleContent("native-title-slot min-w-0 h-10 pr-3 pl-4")}
           {renderDocumentActions(
@@ -472,7 +471,6 @@ export function NativeTitleBar({
       <header
         className="native-titlebar fixed top-0 right-3.5 z-10 flex h-10 w-auto select-none items-center justify-end [-webkit-user-select:none]"
         aria-label={label("app.windowDragRegion")}
-        data-tauri-drag-region
       >
         {renderDocumentActions(
           "document-actions relative flex h-10 items-center justify-end gap-0.5 text-(--text-secondary) opacity-40 transition-[opacity,background-color,color] duration-150 ease-out hover:opacity-100 focus-within:opacity-100"

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -172,6 +172,7 @@ export function useMarkdownDocument({
   const untitledTabIndexRef = useRef(1);
   const workspaceSessionIdRef = useRef<string | null>(null);
   const openedFromNativeRef = useRef(false);
+  const startupWorkspaceRestoreAttemptedRef = useRef(false);
   const outlineItems = useMemo(() => getMarkdownOutline(document.content), [document.content]);
   const wordCount = useMemo(() => getWordCount(document.content), [document.content]);
 
@@ -754,6 +755,9 @@ export function useMarkdownDocument({
     if (!nativeOpenedPathsReady) return;
     if (openedFromNativeRef.current) return;
     if (!preferencesReady) return;
+    if (startupWorkspaceRestoreAttemptedRef.current) return;
+
+    startupWorkspaceRestoreAttemptedRef.current = true;
 
     let active = true;
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -173,6 +173,10 @@
     --accent-soft: rgba(26, 28, 30, 0.1);
     --accent-hover: #0f1115;
     --link-color: #2f56c6;
+    --scrollbar-track: transparent;
+    --scrollbar-thumb: color-mix(in srgb, var(--text-secondary) 44%, transparent);
+    --scrollbar-thumb-hover: color-mix(in srgb, var(--text-secondary) 64%, transparent);
+    --scrollbar-thumb-active: color-mix(in srgb, var(--accent) 48%, transparent);
 
     --ai-command-shadow: 0 18px 52px rgba(0, 0, 0, 0.12);
     --ai-command-expanded-shadow: 0 20px 64px rgba(0, 0, 0, 0.16);
@@ -513,6 +517,41 @@
 
   * {
     @apply box-border;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    scrollbar-width: thin;
+  }
+
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  *::-webkit-scrollbar-track,
+  *::-webkit-scrollbar-track-piece,
+  *::-webkit-scrollbar-corner {
+    background: var(--scrollbar-track);
+  }
+
+  *::-webkit-scrollbar-thumb {
+    min-height: 48px;
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background-color: var(--scrollbar-thumb);
+    background-clip: content-box;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
+  }
+
+  *::-webkit-scrollbar-thumb:active {
+    background-color: var(--scrollbar-thumb-active);
+  }
+
+  *::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
   }
 
   html,

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -11,6 +11,21 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper tbody tr:nth-child(even)");
   });
 
+  it("uses app-themed custom scrollbars across scroll containers", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).toContain("--scrollbar-thumb: color-mix");
+    expect(styles).toContain("scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track)");
+    expect(styles).toContain("scrollbar-width: thin");
+    expect(styles).toContain("*::-webkit-scrollbar");
+    expect(styles).toContain("width: 10px");
+    expect(styles).toContain("height: 10px");
+    expect(styles).toContain("*::-webkit-scrollbar-corner");
+    expect(styles).toContain("*::-webkit-scrollbar-button");
+    expect(styles).toContain("display: none");
+    expect(styles).toContain("background-clip: content-box");
+  });
+
   it("positions collapsible list controls", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const buttonStart = styles.indexOf(".markdown-paper .markra-list-toggle-button {");


### PR DESCRIPTION
## Summary
- Moves the settings button and Windows sidebar collapse control into a dedicated sidebar footer while the file tree is open.
- Keeps the collapsed Windows sidebar reopen control as a lightweight fixed button.
- Adds app-themed custom scrollbar styling across scroll containers, including transparent tracks, rounded thumbs, hidden WebKit scrollbar buttons, and transparent corners.
- Keeps titlebar file actions outside Tauri drag regions on macOS and Windows so toolbar buttons remain clickable.
- Prevents startup workspace restore from rerunning when switching to Markdown source mode, so restored workspace files stay in the source editor instead of flashing back to visual mode.
- Adds regression coverage for the separated sidebar footer, global scrollbar styling, titlebar action drag-region boundaries, and restored-workspace source-mode switching.

## Why
The sidebar controls were fixed to the viewport, so long file tree or outline content could visually overlap the settings button, and the Windows collapse button could collide with editor block controls. Windows also rendered heavy native scrollbars with visible corner/button cuts in split editor surfaces.

The source-mode flash was a separate restore-state issue rather than a missed button click. Switching into source mode changes editor-surface-dependent callbacks passed into `useMarkdownDocument`, which could retrigger the startup workspace restore effect. For a restored folder + file workspace, that restore path briefly cleared the open document before reloading the file, making `sourceModeAvailable` false and causing App to reset back to visual mode. The startup restore path now only attempts once after launch readiness.

## Validation
- `pnpm --filter @markra/desktop exec vitest run src/components/MarkdownFileTreeDrawer.test.tsx src/styles.test.ts` passed: 35 tests.
- `pnpm --filter @markra/desktop exec vitest run src/components/NativeTitleBar.test.tsx` passed: 25 tests.
- `pnpm --filter @markra/desktop exec vitest run src/App.test.tsx -t "restored workspace file in source mode|source mode|Windows titlebar tabs|titlebar action order"` passed: 6 tests.
- `pnpm --filter @markra/desktop exec vitest run src/hooks/useMarkdownDocument.test.tsx` passed: 9 tests.
- `pnpm --filter @markra/desktop build` passed, including `verify:chunks`.
- `git diff --check` passed.

## Related Issues
- Refs #76
