### PR TITLE
refactor(ai): migrate provider requests to AI SDK

### DIFF
--- a/apps/desktop/src/App.ai.test.tsx
+++ b/apps/desktop/src/App.ai.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import { defaultAiQuickActionPrompts } from "./lib/ai-actions";
 import {
@@ -8,9 +8,11 @@ import {
   mockFolderPath,
   mockNativePath,
   mockedCreateAiAgentSessionId,
+  mockedInitializeStoredAiAgentSession,
   mockedGetStoredAiAgentSession,
   mockedGetStoredEditorPreferences,
   mockedGetStoredAiSettings,
+  mockedGetStoredAiAgentPreferences,
   mockedGetStoredWorkspaceState,
   mockedListNativeMarkdownFilesForPath,
   mockedListStoredAiAgentSessions,
@@ -480,6 +482,90 @@ describe("Markra AI workspace", () => {
       )
     );
     await waitFor(() => expect(within(agentPanel).getByRole("button", { name: "Deep thinking" })).toHaveAttribute("aria-pressed", "true"));
+    expect(within(agentPanel).getByRole("button", { name: "Web search" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps remembered mode toggles when creating a new Markra AI session", async () => {
+    const initializedSessions = new Set(["session-app"]);
+    let finishInitialize: (() => unknown) | undefined;
+
+    mockedCreateAiAgentSessionId
+      .mockReturnValueOnce("session-app")
+      .mockReturnValue("session-new");
+    mockedGetStoredAiAgentPreferences.mockResolvedValue({ thinkingEnabled: false, webSearchEnabled: false });
+    mockedGetStoredAiSettings.mockResolvedValue({
+      agentDefaultModelId: "gpt-5.5",
+      agentDefaultProviderId: "openai",
+      defaultModelId: "gpt-5.5",
+      defaultProviderId: "openai",
+      providers: [
+        {
+          apiKey: "openai-key",
+          baseUrl: "https://api.openai.com/v1",
+          defaultModelId: "gpt-5.5",
+          enabled: true,
+          id: "openai",
+          models: [{ capabilities: ["text", "reasoning", "tools", "web"], enabled: true, id: "gpt-5.5", name: "GPT-5.5" }],
+          name: "OpenAI",
+          type: "openai"
+        }
+      ]
+    });
+    mockedListStoredAiAgentSessions.mockResolvedValue([
+      agentSessionSummary({
+        createdAt: 10,
+        id: "session-app",
+        title: "OpenAI session",
+        updatedAt: 20,
+        workspaceKey: "__untitled__"
+      })
+    ]);
+    mockedGetStoredAiAgentSession.mockImplementation(async (sessionId) =>
+      storedAgentSession({
+        agentModelId: "gpt-5.5",
+        agentProviderId: "openai",
+        panelOpen: true,
+        thinkingEnabled: sessionId === "session-new" && initializedSessions.has(sessionId),
+        webSearchEnabled: sessionId === "session-new" && initializedSessions.has(sessionId)
+      })
+    );
+    mockedInitializeStoredAiAgentSession.mockImplementation(async (sessionId) => {
+      await new Promise((resolve) => {
+        finishInitialize = () => resolve(undefined);
+      });
+      initializedSessions.add(sessionId);
+    });
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Markra AI" }));
+    const agentPanel = screen.getByRole("complementary", { name: "Markra AI" });
+    const deepThinking = within(agentPanel).getByRole("button", { name: "Deep thinking" });
+    const webSearch = within(agentPanel).getByRole("button", { name: "Web search" });
+
+    await waitFor(() => expect(mockedGetStoredAiAgentSession).toHaveBeenCalledWith("session-app"));
+    await waitFor(() => expect(deepThinking).toHaveAttribute("aria-pressed", "false"));
+    fireEvent.click(deepThinking);
+    fireEvent.click(webSearch);
+    expect(deepThinking).toHaveAttribute("aria-pressed", "true");
+    expect(webSearch).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(within(agentPanel).getByRole("button", { name: "Sessions" }));
+    fireEvent.click(await within(agentPanel).findByRole("menuitem", { name: "New session" }));
+
+    await waitFor(() => expect(mockedInitializeStoredAiAgentSession).toHaveBeenCalledWith("session-new", null, {
+      agentModelId: "gpt-5.5",
+      agentProviderId: "openai",
+      thinkingEnabled: true,
+      webSearchEnabled: true
+    }));
+
+    await act(async () => {
+      finishInitialize?.();
+    });
+
+    await waitFor(() => expect(mockedGetStoredAiAgentSession).toHaveBeenCalledWith("session-new"));
+    expect(within(agentPanel).getByRole("button", { name: "Deep thinking" })).toHaveAttribute("aria-pressed", "true");
     expect(within(agentPanel).getByRole("button", { name: "Web search" })).toHaveAttribute("aria-pressed", "true");
   });
 

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -733,7 +733,7 @@ describe("Markra workspace", () => {
     expect(screen.getByLabelText("Search providers")).toHaveValue("");
     expect(screen.getByRole("button", { name: "Add provider" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Provider name")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("API style")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("API style")).toHaveValue("openai-responses");
     expect(screen.getByLabelText("API key")).toHaveValue("");
     expect(screen.getByLabelText("API URL")).toHaveValue("https://api.openai.com/v1");
 
@@ -843,10 +843,10 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("button", { name: "Delete provider" })).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("API style"), {
-      target: { value: "mistral" }
+      target: { value: "anthropic" }
     });
 
-    expect(screen.getByLabelText("API URL")).toHaveValue("https://api.mistral.ai/v1");
+    expect(screen.getByLabelText("API URL")).toHaveValue("https://api.anthropic.com/v1");
 
     fireEvent.click(screen.getByRole("button", { name: "Delete provider" }));
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -72,6 +72,7 @@ import {
   type RemoteClipboardImage
 } from "@markra/editor";
 import {
+  createAiAgentSessionId,
   defaultSplitVisualPanePercent,
   deleteStoredAiAgentSession,
   initializeStoredAiAgentSession,
@@ -230,6 +231,12 @@ export default function App() {
     name: "Untitled.md"
   });
   const reconciledAiWorkspaceKeyRef = useRef<string | null | undefined>(undefined);
+  const aiAgentInitialSessionOptionsRef = useRef({
+    agentModelId: null as string | null,
+    agentProviderId: null as string | null,
+    thinkingEnabled: false,
+    webSearchEnabled: false
+  });
   const translate = useCallback((key: I18nKey) => t(appLanguage.language, key), [appLanguage.language]);
   const editor = useEditorController();
   const getEditorCurrentMarkdown = editor.getCurrentMarkdown;
@@ -316,7 +323,6 @@ export default function App() {
   const {
     clearOpenDocument,
     createBlankDocument,
-    createWorkspaceSession,
     confirmCanDiscardCurrentDocument,
     detachDeletedDocumentFile,
     document,
@@ -461,10 +467,6 @@ export default function App() {
   const handleAiPreviewReady = useCallback((result: AiDiffResult, previewId?: string) => {
     editor.scrollToAiPreview(result, { previewId });
   }, [editor]);
-  const createAiAgentInitialSessionOptions = useCallback(() => ({
-    agentModelId: aiSettings.agentModelId,
-    agentProviderId: aiSettings.agentProviderId
-  }), [aiSettings.agentModelId, aiSettings.agentProviderId]);
   const handleAiAgentSessionRestore = useCallback((session: { panelOpen: boolean; panelWidth: number | null }) => {
     setAiAgentOpen(session.panelOpen);
     setAiAgentPanelWidth(clampNumber(session.panelWidth, aiAgentPanelMinWidth, aiAgentPanelMaxWidth) ?? aiAgentPanelDefaultWidth);
@@ -514,6 +516,22 @@ export default function App() {
     workspaceKey,
     workspaceFiles: fileTreeFiles
   });
+  aiAgentInitialSessionOptionsRef.current = {
+    agentModelId: aiSettings.agentModelId,
+    agentProviderId: aiSettings.agentProviderId,
+    thinkingEnabled: aiAgent.thinkingEnabled,
+    webSearchEnabled: aiAgent.webSearchEnabled
+  };
+  const createAiAgentInitialSessionOptions = useCallback(() => ({
+    ...aiAgentInitialSessionOptionsRef.current
+  }), []);
+  const createInitializedAiAgentSession = useCallback(async () => {
+    const sessionId = createAiAgentSessionId();
+
+    await initializeStoredAiAgentSession(sessionId, workspaceKey, createAiAgentInitialSessionOptions());
+    selectWorkspaceSession(sessionId);
+    return sessionId;
+  }, [createAiAgentInitialSessionOptions, selectWorkspaceSession, workspaceKey]);
   const aiAgentSessionRefreshKey = [
     activeAiAgentSessionId ?? "none",
     workspaceKey ?? "none",
@@ -550,11 +568,17 @@ export default function App() {
       return;
     }
 
-    const nextSessionId = createWorkspaceSession();
-    initializeStoredAiAgentSession(nextSessionId, workspaceKey, createAiAgentInitialSessionOptions()).then(() => {
+    createInitializedAiAgentSession().then(() => {
       aiAgentSessions.refresh().catch(() => {});
     }).catch(() => {});
-  }, [activeAiAgentSessionId, aiAgentSessions, createAiAgentInitialSessionOptions, createWorkspaceSession, selectWorkspaceSession, workspaceKey]);
+  }, [
+    activeAiAgentSessionId,
+    aiAgentSessions,
+    createAiAgentInitialSessionOptions,
+    createInitializedAiAgentSession,
+    selectWorkspaceSession,
+    workspaceKey
+  ]);
   const closeAiCommand = aiCommand.closeAiCommand;
   const restoreAiCommand = aiCommand.restoreAiCommand;
   const handleAiCommandClose = useCallback(() => {
@@ -602,13 +626,11 @@ export default function App() {
     aiCommand.closeAiCommand();
   }, [aiAgentOpen, aiCommand.closeAiCommand, editorPreferences.preferences.closeAiCommandOnAgentPanelOpen]);
   const handleCreateAiAgentSession = useCallback(() => {
-    const sessionId = createWorkspaceSession();
-
     openAiAgentPanel();
-    initializeStoredAiAgentSession(sessionId, workspaceKey, createAiAgentInitialSessionOptions()).then(() => {
+    createInitializedAiAgentSession().then(() => {
       aiAgentSessions.refresh().catch(() => {});
     }).catch(() => {});
-  }, [aiAgentSessions, createAiAgentInitialSessionOptions, createWorkspaceSession, openAiAgentPanel, workspaceKey]);
+  }, [aiAgentSessions, createInitializedAiAgentSession, openAiAgentPanel]);
   const handleSelectAiAgentSession = useCallback((sessionId: string) => {
     selectWorkspaceSession(sessionId);
     openAiAgentPanel();
@@ -631,14 +653,13 @@ export default function App() {
       if (remainingSessions[0]) {
         selectWorkspaceSession(remainingSessions[0].id);
       } else {
-        const nextSessionId = createWorkspaceSession();
-        await initializeStoredAiAgentSession(nextSessionId, workspaceKey, createAiAgentInitialSessionOptions());
+        await createInitializedAiAgentSession();
       }
     }
 
     await aiAgentSessions.refresh();
     openAiAgentPanel();
-  }, [activeAiAgentSessionId, aiAgentSessions, createAiAgentInitialSessionOptions, createWorkspaceSession, openAiAgentPanel, selectWorkspaceSession, workspaceKey]);
+  }, [activeAiAgentSessionId, aiAgentSessions, createInitializedAiAgentSession, openAiAgentPanel, selectWorkspaceSession]);
   const handleArchiveAiAgentSession = useCallback(async (sessionId: string, archived: boolean) => {
     const remainingSessions = aiAgentSessions.sessions.filter(
       (session) => session.id !== sessionId && session.archivedAt === null
@@ -650,14 +671,13 @@ export default function App() {
       if (remainingSessions[0]) {
         selectWorkspaceSession(remainingSessions[0].id);
       } else {
-        const nextSessionId = createWorkspaceSession();
-        await initializeStoredAiAgentSession(nextSessionId, workspaceKey, createAiAgentInitialSessionOptions());
+        await createInitializedAiAgentSession();
       }
     }
 
     await aiAgentSessions.refresh();
     openAiAgentPanel();
-  }, [activeAiAgentSessionId, aiAgentSessions, createAiAgentInitialSessionOptions, createWorkspaceSession, openAiAgentPanel, selectWorkspaceSession, workspaceKey]);
+  }, [activeAiAgentSessionId, aiAgentSessions, createInitializedAiAgentSession, openAiAgentPanel, selectWorkspaceSession]);
   const handleTextSelectionChange = useCallback((selection: AiSelectionContext | null) => {
     updateActiveAiSelection(selection);
 

--- a/apps/desktop/src/components/AiAgentPanel.test.tsx
+++ b/apps/desktop/src/components/AiAgentPanel.test.tsx
@@ -580,6 +580,20 @@ describe("AiAgentPanel", () => {
     expect(screen.getByText("First item").closest("ul")).toBeInTheDocument();
   });
 
+  it("renders assistant errors with a danger bubble treatment", () => {
+    renderAgentPanel({
+      messages: [assistantMessage({ isError: true, text: "Concurrency limit exceeded." })]
+    });
+
+    const bubble = screen.getByText("Concurrency limit exceeded.").closest(".ai-chat-markdown")?.parentElement;
+
+    if (!bubble) throw new Error("Expected assistant error bubble");
+    expect(bubble).toHaveClass("border-(--danger)");
+    expect(bubble).toHaveClass("bg-(--bg-primary)");
+    expect(bubble).toHaveClass("text-(--danger)");
+    expect(screen.getByText("Concurrency limit exceeded.").closest(".ai-chat-markdown")).toHaveClass("ai-chat-markdown-danger");
+  });
+
   it("renders visible process steps for assistant messages", () => {
     renderAgentPanel({
       messages: [

--- a/apps/desktop/src/components/AiAgentPanel.tsx
+++ b/apps/desktop/src/components/AiAgentPanel.tsx
@@ -502,7 +502,7 @@ export function AiAgentPanel({
                 }
 
                 const assistantBubbleClassName = message.isError
-                  ? "min-w-0 overflow-hidden rounded-lg border border-[color:color-mix(in_oklab,var(--danger)_28%,var(--border-default))] bg-[color:color-mix(in_oklab,var(--danger)_8%,var(--bg-primary))] px-3 py-2 text-[13px] leading-5 font-[540] text-(--text-primary)"
+                  ? "min-w-0 overflow-hidden rounded-lg border border-(--danger) bg-(--bg-primary) px-3 py-2 text-[13px] leading-5 font-[540] text-(--danger)"
                   : "min-w-0 overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) px-3 py-2 text-[13px] leading-5 font-[540] text-(--text-primary)";
                 const hasVisibleActivities = message.activities?.some(
                   (activity) => activity.kind === "assistant_message" || activity.kind === "tool_call"
@@ -541,7 +541,7 @@ export function AiAgentPanel({
                                       className={index === 0 ? "" : "mt-2 border-t border-(--border-default) pt-2"}
                                       key={`${message.id}:thinking:${index + 1}`}
                                     >
-                                      <AiMarkdownMessage content={section} />
+                                      <AiMarkdownMessage className="ai-chat-markdown-thinking" content={section} />
                                     </div>
                                   ))}
                                 </div>
@@ -550,7 +550,7 @@ export function AiAgentPanel({
                           ) : showFallbackThinking && !message.text ? (
                             <p className="m-0 text-[12px] leading-5 text-(--text-secondary)">{label("app.aiAgentThinking")}</p>
                           ) : null}
-                          <AiMarkdownMessage content={message.text} />
+                          <AiMarkdownMessage className={message.isError ? "ai-chat-markdown-danger" : ""} content={message.text} />
                         </div>
                       ) : null}
                     </div>

--- a/apps/desktop/src/components/AiProviderBadge.tsx
+++ b/apps/desktop/src/components/AiProviderBadge.tsx
@@ -12,7 +12,7 @@ import qwenLogo from "../assets/provider-logos/qwen.svg";
 import togetherLogo from "../assets/provider-logos/together.svg";
 import volcengineLogo from "../assets/provider-logos/volcengine.svg";
 import xiaomiMimoLogo from "../assets/provider-logos/xiaomi-mimo.svg";
-import type { AiProviderApiStyle, AiProviderConfig } from "@markra/providers";
+import type { AiProviderApiStyle, AiProviderConfig, AiProviderRequestStyle } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
 
 type Translate = (key: I18nKey) => string;
@@ -37,7 +37,15 @@ const providerLogoById: Partial<Record<string, string>> = {
   "xiaomi-mimo": xiaomiMimoLogo
 };
 
-export function aiProviderApiStyleLabel(type: AiProviderApiStyle, translate: Translate) {
+export function aiProviderApiStyleLabel(type: AiProviderApiStyle | AiProviderRequestStyle, translate: Translate) {
+  const requestStyleLabels: Partial<Record<AiProviderRequestStyle, string>> = {
+    anthropic: "Anthropic",
+    google: "Google (Gemini)",
+    "openai-responses": "OpenAI Responses"
+  };
+  if (type === "openai-compatible") return translate("settings.ai.apiStyleOpenAiCompatible");
+  if (type in requestStyleLabels) return requestStyleLabels[type as AiProviderRequestStyle] ?? type;
+
   const labels: Partial<Record<AiProviderApiStyle, string>> = {
     anthropic: "Anthropic",
     "azure-openai": "Azure OpenAI",
@@ -52,7 +60,7 @@ export function aiProviderApiStyleLabel(type: AiProviderApiStyle, translate: Tra
     xai: "xAI"
   };
 
-  return type === "openai-compatible" ? translate("settings.ai.apiStyleOpenAiCompatible") : labels[type] ?? type;
+  return labels[type as AiProviderApiStyle] ?? type;
 }
 
 export function AiProviderBadge({ provider, translate }: { provider: AiProviderConfig; translate: Translate }) {

--- a/apps/desktop/src/components/AiProviderConnectionSection.test.tsx
+++ b/apps/desktop/src/components/AiProviderConnectionSection.test.tsx
@@ -9,6 +9,7 @@ function translate(key: I18nKey) {
     "settings.ai.apiAddress": "API URL",
     "settings.ai.apiKey": "API key",
     "settings.ai.apiStyle": "API style",
+    "settings.ai.apiStyleOpenAiCompatible": "OpenAI compatible",
     "settings.ai.cancelEditModel": "Cancel",
     "settings.ai.customHeaders": "Custom headers",
     "settings.ai.customHeadersDescription": "Added to model list and chat requests.",
@@ -63,6 +64,127 @@ function replaceCodeMirrorDoc(view: EditorView, value: string) {
 }
 
 describe("AiProviderConnectionSection", () => {
+  it("lets OpenAI choose the supported OpenAI request styles", () => {
+    const updateSelectedProvider = vi.fn();
+
+    render(
+      <AiProviderConnectionSection
+        actionState={{ status: "idle" }}
+        isCustomProvider={false}
+        provider={provider({
+          apiStyle: "openai-responses",
+          id: "openai",
+          name: "OpenAI",
+          type: "openai"
+        } as Partial<AiProviderConfig>)}
+        translate={translate}
+        onTestProvider={() => {}}
+        updateSelectedProvider={updateSelectedProvider}
+      />
+    );
+
+    const apiStyleSelect = screen.getByLabelText("API style");
+    expect(within(apiStyleSelect).getAllByRole("option").map((option) => option.textContent)).toEqual([
+      "OpenAI Responses",
+      "OpenAI compatible"
+    ]);
+
+    fireEvent.change(apiStyleSelect, { target: { value: "openai-compatible" } });
+
+    expect(updateSelectedProvider).toHaveBeenCalledWith(expect.any(Function));
+    const updater = updateSelectedProvider.mock.calls.at(-1)?.[0] as (current: AiProviderConfig) => AiProviderConfig;
+    expect(updater(provider({ apiStyle: "openai-responses", type: "openai" } as Partial<AiProviderConfig>))).toMatchObject({
+      apiStyle: "openai-compatible",
+      type: "openai"
+    });
+  });
+
+  it("hides API style for fixed built-in providers", () => {
+    const updateSelectedProvider = vi.fn();
+
+    render(
+      <AiProviderConnectionSection
+        actionState={{ status: "idle" }}
+        isCustomProvider={false}
+        provider={provider({
+          apiStyle: "openai-compatible",
+          id: "groq",
+          name: "Groq",
+          type: "groq"
+        } as Partial<AiProviderConfig>)}
+        translate={translate}
+        onTestProvider={() => {}}
+        updateSelectedProvider={updateSelectedProvider}
+      />
+    );
+
+    expect(screen.queryByRole("combobox", { name: "API style" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("API style")).not.toBeInTheDocument();
+    expect(screen.queryByText("API style")).not.toBeInTheDocument();
+    expect(screen.queryByText("OpenAI compatible")).not.toBeInTheDocument();
+  });
+
+  it("hides API key settings for providers that do not need keys", () => {
+    const updateSelectedProvider = vi.fn();
+
+    render(
+      <AiProviderConnectionSection
+        actionState={{ status: "idle" }}
+        isCustomProvider={false}
+        provider={provider({
+          apiKey: "",
+          baseUrl: "http://localhost:11434/v1",
+          id: "ollama",
+          name: "Ollama",
+          type: "ollama"
+        } as Partial<AiProviderConfig>)}
+        translate={translate}
+        onTestProvider={() => {}}
+        updateSelectedProvider={updateSelectedProvider}
+      />
+    );
+
+    expect(screen.queryByLabelText("API key")).not.toBeInTheDocument();
+    expect(screen.queryByText("API keys are stored locally.")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("API URL")).toHaveValue("http://localhost:11434/v1");
+  });
+
+  it("lets custom providers choose any supported API style", () => {
+    const updateSelectedProvider = vi.fn();
+
+    render(
+      <AiProviderConnectionSection
+        actionState={{ status: "idle" }}
+        isCustomProvider={true}
+        provider={provider()}
+        translate={translate}
+        onTestProvider={() => {}}
+        updateSelectedProvider={updateSelectedProvider}
+      />
+    );
+
+    const apiStyleSelect = screen.getByLabelText("API style");
+    expect(within(apiStyleSelect).getAllByRole("option").map((option) => option.textContent)).toEqual([
+      "OpenAI Responses",
+      "OpenAI compatible",
+      "Anthropic",
+      "Google (Gemini)"
+    ]);
+
+    fireEvent.change(apiStyleSelect, { target: { value: "anthropic" } });
+
+    expect(updateSelectedProvider).toHaveBeenCalledWith(expect.any(Function));
+    const updater = updateSelectedProvider.mock.calls.at(-1)?.[0] as (current: AiProviderConfig) => AiProviderConfig;
+    expect(updater(provider())).toMatchObject({
+      apiStyle: "anthropic",
+      baseUrl: "https://proxy.example.test/v1"
+    });
+    expect(updater(provider({ baseUrl: "" }))).toMatchObject({
+      apiStyle: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1"
+    });
+  });
+
   it("lets custom providers configure request headers without exposing thinking request body settings", async () => {
     const updateSelectedProvider = vi.fn();
 

--- a/apps/desktop/src/components/AiProviderConnectionSection.tsx
+++ b/apps/desktop/src/components/AiProviderConnectionSection.tsx
@@ -9,11 +9,13 @@ import {
 } from "./AiProviderSettingsControls";
 import { aiProviderApiStyleLabel } from "./AiProviderBadge";
 import {
-  aiProviderApiStyles,
-  defaultApiUrlForApiStyle,
+  defaultApiUrlForRequestStyle,
+  editableRequestStylesForProvider,
+  providerRequiresApiKey,
+  requestStyleForProviderType,
   readAiProviderCustomHeaders,
-  type AiProviderApiStyle,
-  type AiProviderConfig
+  type AiProviderConfig,
+  type AiProviderRequestStyle
 } from "@markra/providers";
 import type { AiProviderActionState } from "../hooks/useAiProviderSettingsPanelState";
 import type { I18nKey } from "@markra/shared";
@@ -58,6 +60,9 @@ export function AiProviderConnectionSection({
   const [customHeadersDraft, setCustomHeadersDraft] = useState(provider.customHeaders ?? "");
   const [customHeadersError, setCustomHeadersError] = useState<string | null>(null);
   const customHeadersJsonLabel = translate("settings.ai.customHeadersJson");
+  const selectedApiStyle = provider.apiStyle ?? requestStyleForProviderType(provider.type);
+  const editableApiStyles = editableRequestStylesForProvider(provider);
+  const requiresApiKey = providerRequiresApiKey(provider);
 
   const openCustomHeadersDialog = () => {
     setCustomHeadersDraft(provider.customHeaders ?? "");
@@ -83,37 +88,39 @@ export function AiProviderConnectionSection({
     <AiSettingsSection label={translate("settings.sections.aiProviders")}>
       <div className="grid gap-4 py-2">
         {isCustomProvider ? (
-          <>
-            <AiSettingsTextField
-              label={translate("settings.ai.providerName")}
-              value={provider.name}
-              onChange={(name) => updateSelectedProvider((current) => ({ ...current, name }))}
-            />
-            <AiSettingsSelectField<AiProviderApiStyle>
-              label={translate("settings.ai.apiStyle")}
-              value={provider.type}
-              onChange={(type) =>
-                updateSelectedProvider((current) => ({
-                  ...current,
-                  baseUrl: current.baseUrl || defaultApiUrlForApiStyle(type),
-                  type
-                }))
-              }
-            >
-              {aiProviderApiStyles.map((type) => (
-                <option key={type} value={type}>
-                  {aiProviderApiStyleLabel(type, translate)}
-                </option>
-              ))}
-            </AiSettingsSelectField>
-          </>
+          <AiSettingsTextField
+            label={translate("settings.ai.providerName")}
+            value={provider.name}
+            onChange={(name) => updateSelectedProvider((current) => ({ ...current, name }))}
+          />
         ) : null}
-        <AiSettingsTextField
-          label={translate("settings.ai.apiKey")}
-          type="password"
-          value={provider.apiKey ?? ""}
-          onChange={(apiKey) => updateSelectedProvider((current) => ({ ...current, apiKey }))}
-        />
+        {editableApiStyles.length > 0 ? (
+          <AiSettingsSelectField<AiProviderRequestStyle>
+            label={translate("settings.ai.apiStyle")}
+            value={selectedApiStyle}
+            onChange={(apiStyle) =>
+              updateSelectedProvider((current) => ({
+                ...current,
+                apiStyle,
+                baseUrl: current.baseUrl || defaultApiUrlForRequestStyle(apiStyle)
+              }))
+            }
+          >
+            {editableApiStyles.map((apiStyle) => (
+              <option key={apiStyle} value={apiStyle}>
+                {aiProviderApiStyleLabel(apiStyle, translate)}
+              </option>
+            ))}
+          </AiSettingsSelectField>
+        ) : null}
+        {requiresApiKey ? (
+          <AiSettingsTextField
+            label={translate("settings.ai.apiKey")}
+            type="password"
+            value={provider.apiKey ?? ""}
+            onChange={(apiKey) => updateSelectedProvider((current) => ({ ...current, apiKey }))}
+          />
+        ) : null}
         <div className="grid gap-3 min-[720px]:grid-cols-[minmax(0,1fr)_auto] min-[720px]:items-end">
           <AiSettingsTextField
             label={translate("settings.ai.apiAddress")}
@@ -143,10 +150,12 @@ export function AiProviderConnectionSection({
             {translate("settings.ai.customHeadersEdit")}
           </AiSettingsActionButton>
         </div>
-        <p className="m-0 flex items-center gap-2 text-[12px] leading-5 text-(--text-secondary)">
-          <KeyRound aria-hidden="true" size={13} />
-          {translate("settings.ai.localStorageNotice")}
-        </p>
+        {requiresApiKey ? (
+          <p className="m-0 flex items-center gap-2 text-[12px] leading-5 text-(--text-secondary)">
+            <KeyRound aria-hidden="true" size={13} />
+            {translate("settings.ai.localStorageNotice")}
+          </p>
+        ) : null}
       </div>
       {customHeadersDialogOpen ? (
         <Modal

--- a/apps/desktop/src/components/AiProviderDetailHeader.test.tsx
+++ b/apps/desktop/src/components/AiProviderDetailHeader.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { AiProviderDetailHeader } from "./AiProviderDetailHeader";
+import type { AiProviderConfig } from "@markra/providers";
+import type { I18nKey } from "@markra/shared";
+
+function translate(key: I18nKey) {
+  const labels: Partial<Record<string, string>> = {
+    "settings.ai.apiStyleAnthropic": "Anthropic",
+    "settings.ai.apiStyleOpenAiCompatible": "OpenAI compatible",
+    "settings.ai.apiStyleOpenAiResponses": "OpenAI Responses",
+    "settings.ai.configured": "Configured",
+    "settings.ai.deleteProvider": "Delete provider",
+    "settings.ai.enableProviderLabel": "Enable provider",
+    "settings.ai.notConfigured": "Not configured"
+  };
+
+  return labels[key] ?? key;
+}
+
+function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
+  return {
+    apiKey: "",
+    baseUrl: "https://proxy.example.test/v1",
+    defaultModelId: "default",
+    enabled: true,
+    id: "custom-provider-1",
+    models: [],
+    name: "Custom Provider",
+    type: "openai-compatible",
+    ...overrides
+  };
+}
+
+describe("AiProviderDetailHeader", () => {
+  it("hides the API style label for fixed built-in providers", () => {
+    render(
+      <AiProviderDetailHeader
+        isCustomProvider={false}
+        provider={provider({
+          apiStyle: "openai-compatible",
+          id: "groq",
+          name: "Groq",
+          type: "groq"
+        } as Partial<AiProviderConfig>)}
+        translate={translate}
+        onDeleteProvider={() => {}}
+        onToggleEnabled={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Groq" })).toBeInTheDocument();
+    expect(screen.queryByText("OpenAI compatible")).not.toBeInTheDocument();
+  });
+
+  it("shows the API style label for providers that can edit it", () => {
+    render(
+      <AiProviderDetailHeader
+        isCustomProvider={true}
+        provider={provider({
+          apiStyle: "anthropic"
+        } as Partial<AiProviderConfig>)}
+        translate={translate}
+        onDeleteProvider={() => {}}
+        onToggleEnabled={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Custom Provider" })).toBeInTheDocument();
+    expect(screen.getByText("Anthropic")).toBeInTheDocument();
+  });
+
+  it("treats providers without API keys as configured", () => {
+    render(
+      <AiProviderDetailHeader
+        isCustomProvider={false}
+        provider={provider({
+          apiKey: "",
+          baseUrl: "http://localhost:11434/v1",
+          id: "ollama",
+          name: "Ollama",
+          type: "ollama"
+        } as Partial<AiProviderConfig>)}
+        translate={translate}
+        onDeleteProvider={() => {}}
+        onToggleEnabled={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Ollama" })).toBeInTheDocument();
+    expect(screen.getByText("Configured")).toBeInTheDocument();
+    expect(screen.queryByText("Not configured")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/AiProviderDetailHeader.tsx
+++ b/apps/desktop/src/components/AiProviderDetailHeader.tsx
@@ -1,7 +1,12 @@
 import { Trash2 } from "lucide-react";
 import { AiProviderBadge, aiProviderApiStyleLabel } from "./AiProviderBadge";
 import { AiProviderSwitch, AiSettingsActionButton } from "./AiProviderSettingsControls";
-import type { AiProviderConfig } from "@markra/providers";
+import {
+  editableRequestStylesForProvider,
+  providerRequiresApiKey,
+  requestStyleForProviderType,
+  type AiProviderConfig
+} from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
 
 type Translate = (key: I18nKey) => string;
@@ -19,6 +24,12 @@ export function AiProviderDetailHeader({
   onDeleteProvider: () => unknown;
   onToggleEnabled: () => unknown;
 }) {
+  const editableApiStyles = editableRequestStylesForProvider(provider);
+  const selectedApiStyle = provider.apiStyle ?? requestStyleForProviderType(provider.type);
+  const configured = providerRequiresApiKey(provider)
+    ? Boolean(provider.apiKey?.trim())
+    : Boolean(provider.baseUrl?.trim());
+
   return (
     <div className="flex min-h-16 items-center justify-between gap-4 border-b border-(--border-default) px-6 py-3">
       <div className="flex min-w-0 items-center gap-3">
@@ -27,14 +38,14 @@ export function AiProviderDetailHeader({
           <h3 className="m-0 truncate text-[16px] leading-6 font-[750] text-(--text-heading)">
             {provider.name}
           </h3>
-          {isCustomProvider ? (
+          {editableApiStyles.length > 0 ? (
             <p className="m-0 text-[12px] leading-5 text-(--text-secondary)">
-              {aiProviderApiStyleLabel(provider.type, translate)}
+              {aiProviderApiStyleLabel(selectedApiStyle, translate)}
             </p>
           ) : null}
         </div>
         <span className="rounded-md bg-(--bg-secondary) px-2 py-1 text-[12px] leading-4 font-[650] text-(--text-secondary)">
-          {provider.apiKey ? translate("settings.ai.configured") : translate("settings.ai.notConfigured")}
+          {configured ? translate("settings.ai.configured") : translate("settings.ai.notConfigured")}
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-2">

--- a/apps/desktop/src/hooks/useAiAgentSession.test.tsx
+++ b/apps/desktop/src/hooks/useAiAgentSession.test.tsx
@@ -1051,6 +1051,102 @@ describe("useAiAgentSession", () => {
     });
   });
 
+  it("lets an in-flight agent request finish in its original session after switching sessions", async () => {
+    let finishRun: (() => unknown) | undefined;
+    const runCanFinish = new Promise((resolve) => {
+      finishRun = () => resolve(undefined);
+    });
+    mockedGetStoredAiAgentSession
+      .mockResolvedValueOnce(storedAgentSession({
+        agentModelId: "gpt-5.5",
+        agentProviderId: "openai",
+        draft: "Session A",
+        panelOpen: true,
+        panelWidth: 456
+      }))
+      .mockResolvedValueOnce(storedAgentSession({
+        agentModelId: "gpt-5.5",
+        agentProviderId: "openai",
+        draft: "Session B",
+        panelOpen: true,
+        panelWidth: 456
+      }));
+    mockedRunDocumentAiAgent.mockImplementation(async ({ onTextDelta }) => {
+      await runCanFinish;
+      onTextDelta?.("Finished after switching away.");
+
+      return {
+        content: "Finished after switching away.",
+        finishReason: "stop"
+      };
+    });
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }) =>
+        useAiAgentSession(aiAgentSessionContext({
+          panelOpen: true,
+          panelWidth: 456,
+          sessionId,
+          workspaceKey: "/vault"
+        })),
+      {
+        initialProps: {
+          sessionId: "session-a"
+        }
+      }
+    );
+
+    await waitFor(() => expect(result.current.draft).toBe("Session A"));
+
+    let submitPromise: Promise<unknown> | undefined;
+    act(() => {
+      submitPromise = result.current.submit("Keep this request running");
+    });
+    await waitFor(() => expect(mockedRunDocumentAiAgent).toHaveBeenCalledTimes(1));
+
+    rerender({
+      sessionId: "session-b"
+    });
+    await waitFor(() => expect(result.current.draft).toBe("Session B"));
+
+    await act(async () => {
+      finishRun?.();
+      await submitPromise;
+    });
+
+    await waitFor(() =>
+      expect(mockedSaveStoredAiAgentSession).toHaveBeenCalledWith("session-a", {
+        agentModelId: "gpt-5.5",
+        agentProviderId: "openai",
+        draft: "",
+        messages: [
+          { id: expect.any(Number), role: "user", text: "Keep this request running" },
+          {
+            activities: [
+              {
+                id: "call:1",
+                kind: "ai_call",
+                label: "app.aiAgentTraceCall 1",
+                status: "completed",
+                turn: 1
+              }
+            ],
+            id: expect.any(Number),
+            role: "assistant",
+            text: "Finished after switching away.",
+            thinking: ""
+          }
+        ],
+        panelOpen: true,
+        panelWidth: 456,
+        thinkingEnabled: false,
+        webSearchEnabled: false
+      }, {
+        workspaceKey: "/vault"
+      })
+    );
+  });
+
   it("generates and persists an AI session title after the first completed exchange", async () => {
     mockedRunDocumentAiAgent.mockResolvedValue({
       content: "Gold pricing looks incorrect while XAU is missing in the dataset.",

--- a/apps/desktop/src/hooks/useAiAgentSession.ts
+++ b/apps/desktop/src/hooks/useAiAgentSession.ts
@@ -63,6 +63,16 @@ type AiAgentSessionContext = {
   workspaceFiles?: AgentWorkspaceFile[];
 };
 
+type RunningAiAgentRequest = {
+  assistantMessageId: number;
+  draft: string;
+  messages: AiAgentPanelMessage[];
+  requestId: number;
+  status: "thinking" | "streaming";
+  thinkingEnabled: boolean;
+  webSearchEnabled: boolean;
+};
+
 export function useAiAgentSession(ctx: AiAgentSessionContext) {
   const [draft, setDraft] = useState("");
   const [messages, setMessages] = useState<AiAgentPanelMessage[]>([]);
@@ -71,7 +81,9 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
   const [status, setStatus] = useState<"idle" | "thinking" | "streaming" | "error">("idle");
   const [titleVersion, setTitleVersion] = useState(0);
   const requestIdRef = useRef(0);
-  const assistantMessageIdRef = useRef<number | null>(null);
+  const hydrationRequestIdRef = useRef(0);
+  const activeSessionKeyRef = useRef<string | null>(null);
+  const runningRequestsRef = useRef(new Map<string | null, RunningAiAgentRequest>());
   const hydratedSessionKeyRef = useRef<string | null>(null);
   const didRestorePanelStateRef = useRef(false);
   const persistTimerRef = useRef<number | null>(null);
@@ -86,6 +98,7 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
   const agentModelId = ctx.model ?? null;
   const agentProviderId = ctx.provider?.id ?? null;
 
+  activeSessionKeyRef.current = sessionKey;
   onSessionModelRestoreRef.current = ctx.onSessionModelRestore;
   onSessionRestoreRef.current = ctx.onSessionRestore;
 
@@ -132,44 +145,43 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
     };
   }, [sessionKey]);
 
-  const updateAssistantMessage = useCallback((updater: (message: AiAgentPanelMessage) => AiAgentPanelMessage) => {
-    const assistantId = assistantMessageIdRef.current;
-    if (assistantId === null) return;
-
-    setMessages((currentMessages) =>
-      currentMessages.map((message) => (message.id === assistantId ? updater(message) : message))
-    );
-  }, []);
-
   const interrupt = useCallback(() => {
-    requestIdRef.current += 1;
-    updateAssistantMessage((currentMessage) => ({
-      ...currentMessage,
-      activities: cancelAgentProcesses(currentMessage.activities ?? [])
-    }));
-    assistantMessageIdRef.current = null;
+    const runningRequest = runningRequestsRef.current.get(sessionKey);
+    if (runningRequest) {
+      runningRequestsRef.current.delete(sessionKey);
+      setMessages((currentMessages) =>
+        currentMessages.map((message) =>
+          message.id === runningRequest.assistantMessageId
+            ? {
+                ...message,
+                activities: cancelAgentProcesses(message.activities ?? [])
+              }
+            : message
+        )
+      );
+    }
     setStatus("idle");
-  }, [updateAssistantMessage]);
+  }, [sessionKey]);
 
   useEffect(() => {
     let active = true;
 
-    requestIdRef.current += 1;
-    const hydrationRequestId = requestIdRef.current;
-    assistantMessageIdRef.current = null;
+    hydrationRequestIdRef.current += 1;
+    const hydrationRequestId = hydrationRequestIdRef.current;
+    const runningRequest = runningRequestsRef.current.get(sessionKey);
     hydratedSessionKeyRef.current = null;
     skipNextPersistRef.current = false;
     sessionTitleSourceRef.current = null;
     titleGenerationSignatureRef.current = null;
-    setStatus("idle");
+    setStatus(runningRequest?.status ?? "idle");
     const shouldRestorePanelState = !didRestorePanelStateRef.current;
 
     if (!sessionKey) {
       const defaultSession = createDefaultAiAgentSessionState();
-      setDraft(defaultSession.draft);
-      setMessages(defaultSession.messages);
-      setThinkingEnabledState(defaultSession.thinkingEnabled);
-      setWebSearchEnabledState(defaultSession.webSearchEnabled);
+      setDraft(runningRequest?.draft ?? defaultSession.draft);
+      setMessages(runningRequest?.messages ?? defaultSession.messages);
+      setThinkingEnabledState(runningRequest?.thinkingEnabled ?? defaultSession.thinkingEnabled);
+      setWebSearchEnabledState(runningRequest?.webSearchEnabled ?? defaultSession.webSearchEnabled);
       hydratedSessionKeyRef.current = null;
       skipNextPersistRef.current = true;
       return () => {
@@ -180,15 +192,17 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
     Promise.all([getStoredAiAgentSession(sessionKey), getStoredAiAgentSessionSummary(sessionKey)])
       .then(([storedSession, storedSummary]) => {
         if (!active) return;
-        if (requestIdRef.current !== hydrationRequestId) {
+        if (hydrationRequestIdRef.current !== hydrationRequestId) {
           hydratedSessionKeyRef.current = sessionKey;
           return;
         }
 
-        setDraft(storedSession.draft);
-        setMessages(storedSession.messages);
-        setThinkingEnabledState(storedSession.thinkingEnabled);
-        setWebSearchEnabledState(storedSession.webSearchEnabled);
+        const currentRunningRequest = runningRequestsRef.current.get(sessionKey);
+        setDraft(currentRunningRequest?.draft ?? storedSession.draft);
+        setMessages(currentRunningRequest?.messages ?? storedSession.messages);
+        setThinkingEnabledState(currentRunningRequest?.thinkingEnabled ?? storedSession.thinkingEnabled);
+        setWebSearchEnabledState(currentRunningRequest?.webSearchEnabled ?? storedSession.webSearchEnabled);
+        setStatus(currentRunningRequest?.status ?? "idle");
         onSessionModelRestoreRef.current?.({
           agentModelId: storedSession.agentModelId,
           agentProviderId: storedSession.agentProviderId
@@ -206,16 +220,18 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
       })
       .catch(() => {
         if (!active) return;
-        if (requestIdRef.current !== hydrationRequestId) {
+        if (hydrationRequestIdRef.current !== hydrationRequestId) {
           hydratedSessionKeyRef.current = sessionKey;
           return;
         }
 
         const defaultSession = createDefaultAiAgentSessionState();
-        setDraft(defaultSession.draft);
-        setMessages(defaultSession.messages);
-        setThinkingEnabledState(defaultSession.thinkingEnabled);
-        setWebSearchEnabledState(defaultSession.webSearchEnabled);
+        const currentRunningRequest = runningRequestsRef.current.get(sessionKey);
+        setDraft(currentRunningRequest?.draft ?? defaultSession.draft);
+        setMessages(currentRunningRequest?.messages ?? defaultSession.messages);
+        setThinkingEnabledState(currentRunningRequest?.thinkingEnabled ?? defaultSession.thinkingEnabled);
+        setWebSearchEnabledState(currentRunningRequest?.webSearchEnabled ?? defaultSession.webSearchEnabled);
+        setStatus(currentRunningRequest?.status ?? "idle");
         onSessionModelRestoreRef.current?.({
           agentModelId: defaultSession.agentModelId,
           agentProviderId: defaultSession.agentProviderId
@@ -338,7 +354,7 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
     const requestId = requestIdRef.current + 1;
 
     requestIdRef.current = requestId;
-    assistantMessageIdRef.current = null;
+    hydrationRequestIdRef.current += 1;
 
     if (ctx.settingsLoading) {
       setStatus("error");
@@ -385,6 +401,14 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
 
     const userMessageId = Date.now();
     const assistantMessageId = userMessageId + 1;
+    const runSessionKey = sessionKey;
+    const runAgentModelId = agentModelId;
+    const runAgentProviderId = agentProviderId;
+    const runPanelOpen = ctx.panelOpen === true;
+    const runPanelWidth = ctx.panelWidth ?? null;
+    const runThinkingEnabled = thinkingEnabled;
+    const runWebSearchEnabled = webSearchEnabled;
+    const runWorkspaceKey = ctx.workspaceKey ?? null;
     const history: DocumentAiHistoryMessage[] = messages
       .filter((item) => !item.isError)
       .map((item) => ({
@@ -393,15 +417,8 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
         role: item.role,
         text: item.text
       }));
-    assistantMessageIdRef.current = assistantMessageId;
-    setDraft("");
-    setStatus("thinking");
-    let preparedEditorPreview = false;
-    const latestPreparedEditorPreview: { current: { previewId?: string; result: AiDiffResult } | null } = {
-      current: null
-    };
-    setMessages((currentMessages) => [
-      ...currentMessages,
+    const initialMessages: AiAgentPanelMessage[] = [
+      ...messages,
       { id: userMessageId, role: "user", text: prompt },
       {
         activities: createInitialAgentProcesses(message),
@@ -410,14 +427,78 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
         text: "",
         thinking: ""
       }
-    ]);
+    ];
+    const runIsCurrent = () => runningRequestsRef.current.get(runSessionKey)?.requestId === requestId;
+    const updateRunRequest = (updater: (request: RunningAiAgentRequest) => RunningAiAgentRequest) => {
+      const currentRequest = runningRequestsRef.current.get(runSessionKey);
+      if (!currentRequest || currentRequest.requestId !== requestId) return null;
+
+      const nextRequest = updater(currentRequest);
+      runningRequestsRef.current.set(runSessionKey, nextRequest);
+
+      if (activeSessionKeyRef.current === runSessionKey) {
+        setMessages(nextRequest.messages);
+        setStatus(nextRequest.status);
+      }
+
+      return nextRequest;
+    };
+    const updateRunAssistantMessage = (
+      updater: (message: AiAgentPanelMessage) => AiAgentPanelMessage,
+      nextStatus?: RunningAiAgentRequest["status"]
+    ) =>
+      updateRunRequest((currentRequest) => ({
+        ...currentRequest,
+        messages: currentRequest.messages.map((message) =>
+          message.id === currentRequest.assistantMessageId ? updater(message) : message
+        ),
+        status: nextStatus ?? currentRequest.status
+      }));
+    const persistCompletedRun = async (completedRequest: RunningAiAgentRequest) => {
+      if (activeSessionKeyRef.current === runSessionKey) {
+        hydrationRequestIdRef.current += 1;
+      }
+
+      await saveStoredAiAgentSession(runSessionKey, {
+        agentModelId: runAgentModelId,
+        agentProviderId: runAgentProviderId,
+        draft: completedRequest.draft,
+        messages: completedRequest.messages,
+        panelOpen: runPanelOpen,
+        panelWidth: runPanelWidth,
+        thinkingEnabled: runThinkingEnabled,
+        webSearchEnabled: runWebSearchEnabled
+      }, {
+        workspaceKey: runWorkspaceKey
+      }).catch(() => {});
+      setTitleVersion((currentVersion) => currentVersion + 1);
+    };
+
+    runningRequestsRef.current.set(runSessionKey, {
+      assistantMessageId,
+      draft: "",
+      messages: initialMessages,
+      requestId,
+      status: "thinking",
+      thinkingEnabled: runThinkingEnabled,
+      webSearchEnabled: runWebSearchEnabled
+    });
+    setDraft("");
+    setStatus("thinking");
+    let preparedEditorPreview = false;
+    const latestPreparedEditorPreview: { current: { previewId?: string; result: AiDiffResult } | null } = {
+      current: null
+    };
+    setMessages(initialMessages);
 
     try {
       const response = await runDocumentAiAgent({
         complete: (provider, model, messages, completionOptions) =>
           chatCompletionStream(provider, model, messages, {
             ...completionOptions,
-            streamTransport: requestNativeChatStream
+            fallbackTransport: requestNativeChat,
+            streamTransport: requestNativeChatStream,
+            useVercelAiSdk: true
           }),
         documentContent: ctx.getDocumentContent(),
         documentEndPosition: ctx.getDocumentEndPosition?.() ?? 0,
@@ -425,24 +506,26 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
         history,
         model: ctx.model,
         onPreviewResult: (result, previewId) => {
-          if (requestIdRef.current !== requestId) return;
+          if (!runIsCurrent()) return;
 
           const preview = sessionPreviewFromAiResult(result);
           if (preview) {
             preparedEditorPreview = true;
             latestPreparedEditorPreview.current = { previewId, result };
-            updateAssistantMessage((currentMessage) => ({
+            updateRunAssistantMessage((currentMessage) => ({
               ...currentMessage,
               previews: [...(currentMessage.previews ?? []), preview],
               preview
             }));
           }
-          ctx.onAiResult?.(result, previewId);
+          if (activeSessionKeyRef.current === runSessionKey) {
+            ctx.onAiResult?.(result, previewId);
+          }
         },
         onEvent: (event) => {
-          if (requestIdRef.current !== requestId) return;
+          if (!runIsCurrent()) return;
 
-          updateAssistantMessage((currentMessage) => ({
+          updateRunAssistantMessage((currentMessage) => ({
             ...currentMessage,
             activities: applyAgentEventToProcesses(currentMessage.activities ?? [], event, message)
           }));
@@ -451,28 +534,26 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
             const completedThinking = assistantThinkingFromAgentMessageContent(event.message.content);
             if (!completedThinking) return;
 
-            updateAssistantMessage((currentMessage) => ({
+            updateRunAssistantMessage((currentMessage) => ({
               ...currentMessage,
               thinkingTurns: appendThinkingTurn(currentMessage.thinkingTurns, completedThinking)
             }));
           }
         },
         onTextDelta: (text) => {
-          if (requestIdRef.current !== requestId) return;
-          setStatus("streaming");
-          updateAssistantMessage((currentMessage) => ({
+          if (!runIsCurrent()) return;
+          updateRunAssistantMessage((currentMessage) => ({
             ...currentMessage,
             text
-          }));
+          }), "streaming");
         },
         onThinkingDelta: (thinking) => {
-          if (requestIdRef.current !== requestId) return;
+          if (!runIsCurrent()) return;
 
-          setStatus("thinking");
-          updateAssistantMessage((currentMessage) => ({
+          updateRunAssistantMessage((currentMessage) => ({
             ...currentMessage,
             thinking
-          }));
+          }), "thinking");
         },
         prompt,
         provider: ctx.provider,
@@ -489,17 +570,21 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
         workspaceFiles: ctx.workspaceFiles ?? []
       });
 
-      if (requestIdRef.current !== requestId) return;
+      if (!runIsCurrent()) return;
 
       if (!response.content.trim()) {
         if (preparedEditorPreview || response.preparedPreview) {
-          updateAssistantMessage((currentMessage) => ({
+          const completedRequest = updateRunAssistantMessage((currentMessage) => ({
             ...currentMessage,
             activities: finalizeAgentProcesses(currentMessage.activities ?? [], message, true),
             text: message("app.aiAgentPreviewReady")
           }));
-          setStatus("idle");
-          if (latestPreparedEditorPreview.current) {
+          if (!completedRequest) return;
+
+          runningRequestsRef.current.delete(runSessionKey);
+          if (activeSessionKeyRef.current === runSessionKey) setStatus("idle");
+          await persistCompletedRun(completedRequest);
+          if (latestPreparedEditorPreview.current && activeSessionKeyRef.current === runSessionKey) {
             ctx.onAiPreviewReady?.(
               latestPreparedEditorPreview.current.result,
               latestPreparedEditorPreview.current.previewId
@@ -508,42 +593,52 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
           return;
         }
 
-        updateAssistantMessage((currentMessage) => ({
+        const failedRequest = updateRunAssistantMessage((currentMessage) => ({
           ...currentMessage,
           activities: failAgentProcesses(currentMessage.activities ?? []),
           isError: true,
           text: message(emptyResponseMessageKey(response.stopReasonCode))
         }));
-        setStatus("error");
+        if (!failedRequest) return;
+
+        runningRequestsRef.current.delete(runSessionKey);
+        if (activeSessionKeyRef.current === runSessionKey) setStatus("error");
+        await persistCompletedRun(failedRequest);
         return;
       }
 
-      updateAssistantMessage((currentMessage) => ({
+      const completedRequest = updateRunAssistantMessage((currentMessage) => ({
         ...currentMessage,
         activities: finalizeAgentProcesses(currentMessage.activities ?? [], message, response.content.trim().length > 0),
         text: response.content
       }));
-      setStatus("idle");
-      if (latestPreparedEditorPreview.current) {
+      if (!completedRequest) return;
+
+      runningRequestsRef.current.delete(runSessionKey);
+      if (activeSessionKeyRef.current === runSessionKey) setStatus("idle");
+      await persistCompletedRun(completedRequest);
+      if (latestPreparedEditorPreview.current && activeSessionKeyRef.current === runSessionKey) {
         ctx.onAiPreviewReady?.(
           latestPreparedEditorPreview.current.result,
           latestPreparedEditorPreview.current.previewId
         );
       }
     } catch (error) {
-      if (requestIdRef.current !== requestId) return;
+      if (!runIsCurrent()) return;
 
-      updateAssistantMessage((currentMessage) => ({
+      const failedRequest = updateRunAssistantMessage((currentMessage) => ({
         ...currentMessage,
         activities: failAgentProcesses(currentMessage.activities ?? []),
         isError: true,
         text: error instanceof Error ? error.message : message("app.aiRequestFailed")
       }));
-      setStatus("error");
-    } finally {
-      if (requestIdRef.current === requestId) assistantMessageIdRef.current = null;
+      if (!failedRequest) return;
+
+      runningRequestsRef.current.delete(runSessionKey);
+      if (activeSessionKeyRef.current === runSessionKey) setStatus("error");
+      await persistCompletedRun(failedRequest);
     }
-  }, [ctx, draft, messages, thinkingEnabled, updateAssistantMessage, webSearchEnabled]);
+  }, [agentModelId, agentProviderId, ctx, draft, messages, sessionKey, thinkingEnabled, webSearchEnabled]);
 
   return {
     draft,

--- a/apps/desktop/src/hooks/useAiCommandUi.ts
+++ b/apps/desktop/src/hooks/useAiCommandUi.ts
@@ -10,7 +10,7 @@ import {
 } from "@markra/ai";
 import { getProviderCapabilities, type AiProviderConfig } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
-import { requestNativeChatStream } from "../lib/tauri";
+import { requestNativeChat, requestNativeChatStream } from "../lib/tauri";
 
 type AiTextDiffResult = Extract<AiDiffResult, { type: "insert" | "replace" }>;
 export type AiCommandStatus = "idle" | "composing" | "thinking" | "streaming" | "suggestion" | "error";
@@ -121,7 +121,9 @@ export function useAiCommandUi(ctx: AiCommandContext) {
         complete: (provider, model, messages, completionOptions) =>
           chatCompletionStream(provider, model, messages, {
             ...completionOptions,
-            streamTransport: requestNativeChatStream
+            fallbackTransport: requestNativeChat,
+            streamTransport: requestNativeChatStream,
+            useVercelAiSdk: true
           }),
         documentContent,
         documentPath: ctx.documentPath ?? null,

--- a/apps/desktop/src/lib/settings/app-settings.test.ts
+++ b/apps/desktop/src/lib/settings/app-settings.test.ts
@@ -1615,6 +1615,44 @@ describe("app settings", () => {
     }));
   });
 
+  it("lets new AI agent sessions use explicit mode options over remembered preferences", async () => {
+    const sessionStore = {
+      get: vi.fn(),
+      save: vi.fn(),
+      set: vi.fn()
+    };
+    const indexStore = {
+      get: vi.fn(),
+      save: vi.fn(),
+      set: vi.fn()
+    };
+    mockedLoad.mockImplementation(async (path) => {
+      if (path === "ai-agent-sessions/session-new.json") return sessionStore as unknown as Awaited<ReturnType<typeof load>>;
+      if (path === "ai-agent-sessions/index.json") return indexStore as unknown as Awaited<ReturnType<typeof load>>;
+
+      return store as unknown as Awaited<ReturnType<typeof load>>;
+    });
+    store.get.mockImplementation(async (key) =>
+      key === "aiAgentPreferences" ? { thinkingEnabled: false, webSearchEnabled: false } : undefined
+    );
+    sessionStore.get.mockResolvedValue(undefined);
+    indexStore.get.mockResolvedValue([]);
+
+    await initializeStoredAiAgentSession("session-new", "/mock-files/vault", {
+      agentModelId: "gpt-5.5",
+      agentProviderId: "openai",
+      thinkingEnabled: true,
+      webSearchEnabled: true
+    });
+
+    expect(sessionStore.set).toHaveBeenCalledWith("session", expect.objectContaining({
+      agentModelId: "gpt-5.5",
+      agentProviderId: "openai",
+      thinkingEnabled: true,
+      webSearchEnabled: true
+    }));
+  });
+
   it("loads and persists AI agent preferences", async () => {
     store.get.mockResolvedValue({ thinkingEnabled: true, webSearchEnabled: true });
 

--- a/apps/desktop/src/lib/settings/app-settings.ts
+++ b/apps/desktop/src/lib/settings/app-settings.ts
@@ -436,15 +436,17 @@ export async function listStoredAiAgentSessions(
 export async function initializeStoredAiAgentSession(
   sessionId: string,
   workspaceKey: string | null,
-  options: Partial<Pick<StoredAiAgentSessionState, "agentModelId" | "agentProviderId">> = {}
+  options: Partial<
+    Pick<StoredAiAgentSessionState, "agentModelId" | "agentProviderId" | "thinkingEnabled" | "webSearchEnabled">
+  > = {}
 ) {
   const preferences = await getStoredAiAgentPreferences();
 
   await saveStoredAiAgentSession(sessionId, createDefaultAiAgentSessionState({
     agentModelId: options.agentModelId,
     agentProviderId: options.agentProviderId,
-    thinkingEnabled: preferences.thinkingEnabled,
-    webSearchEnabled: preferences.webSearchEnabled
+    thinkingEnabled: options.thinkingEnabled ?? preferences.thinkingEnabled,
+    webSearchEnabled: options.webSearchEnabled ?? preferences.webSearchEnabled
   }), { workspaceKey });
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -172,6 +172,7 @@
     --accent: #1a1c1e;
     --accent-soft: rgba(26, 28, 30, 0.1);
     --accent-hover: #0f1115;
+    --danger: #b42318;
     --link-color: #2f56c6;
     --scrollbar-track: transparent;
     --scrollbar-thumb: color-mix(in srgb, var(--text-secondary) 44%, transparent);
@@ -222,6 +223,7 @@
     --accent: #f4f4f5;
     --accent-soft: rgba(244, 244, 245, 0.14);
     --accent-hover: #fafafa;
+    --danger: #ff8a80;
     --link-color: #b7c5ff;
 
     --ai-command-shadow:
@@ -2368,6 +2370,27 @@
     @apply text-[13px] leading-5;
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .ai-chat-markdown-danger {
+    --editor-text-primary: var(--danger);
+    --editor-text-heading: var(--danger);
+    --editor-link-color: var(--danger);
+  }
+
+  .ai-chat-markdown-thinking {
+    --editor-text-primary: color-mix(in srgb, var(--text-secondary) 72%, transparent);
+    --editor-text-heading: color-mix(in srgb, var(--text-secondary) 78%, transparent);
+    --editor-text-secondary: color-mix(in srgb, var(--text-secondary) 58%, transparent);
+    --editor-code-text: color-mix(in srgb, var(--text-secondary) 82%, transparent);
+    --editor-inline-code-text: color-mix(in srgb, var(--text-secondary) 82%, transparent);
+    --editor-link-color: color-mix(in srgb, var(--link-color) 48%, var(--text-secondary));
+  }
+
+  .ai-chat-markdown-thinking strong,
+  .ai-chat-markdown-thinking b,
+  .ai-chat-markdown-thinking .markra-live-mark-strong {
+    color: color-mix(in srgb, var(--text-secondary) 78%, transparent);
   }
 
   .ai-chat-markdown h1,

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -52,6 +52,7 @@ import {
   initializeStoredAiAgentSession,
   listStoredAiAgentSessions,
   resetWelcomeDocumentState,
+  saveStoredAiAgentPreferences,
   saveStoredAiAgentSession,
   saveStoredAiAgentSessionTitle,
   saveStoredAiSettings,
@@ -503,6 +504,7 @@ export const mockedInitializeStoredAiAgentSession = vi.mocked(initializeStoredAi
 export const mockedListStoredAiAgentSessions = vi.mocked(listStoredAiAgentSessions);
 export const mockedResetWelcomeDocumentState = vi.mocked(resetWelcomeDocumentState);
 export const mockedSaveStoredAiAgentSession = vi.mocked(saveStoredAiAgentSession);
+export const mockedSaveStoredAiAgentPreferences = vi.mocked(saveStoredAiAgentPreferences);
 export const mockedSaveStoredAiAgentSessionTitle = vi.mocked(saveStoredAiAgentSessionTitle);
 export const mockedSaveStoredAiSettings = vi.mocked(saveStoredAiSettings);
 export const mockedSaveStoredCustomThemeCss = vi.mocked(saveStoredCustomThemeCss);
@@ -649,6 +651,7 @@ export function installAppTestHarness() {
     mockedInitializeStoredAiAgentSession.mockReset();
     mockedListStoredAiAgentSessions.mockReset();
     mockedResetWelcomeDocumentState.mockReset();
+    mockedSaveStoredAiAgentPreferences.mockReset();
     mockedSaveStoredAiAgentSession.mockReset();
     mockedSaveStoredAiAgentSessionTitle.mockReset();
     mockedSaveStoredAiSettings.mockReset();
@@ -873,6 +876,7 @@ export function installAppTestHarness() {
       folderPath: null
     });
     mockedResetWelcomeDocumentState.mockResolvedValue(undefined);
+    mockedSaveStoredAiAgentPreferences.mockResolvedValue(undefined);
     mockedInitializeStoredAiAgentSession.mockResolvedValue(undefined);
     mockedListStoredAiAgentSessions.mockResolvedValue([]);
     mockedDeleteStoredAiAgentSession.mockResolvedValue(undefined);

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -17,11 +17,23 @@
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
   "dependencies": {
-    "@markra/shared": "workspace:*",
-    "@markra/providers": "workspace:*",
+    "@ai-sdk/alibaba": "1.0.23",
+    "@ai-sdk/anthropic": "3.0.78",
+    "@ai-sdk/azure": "3.0.65",
+    "@ai-sdk/deepseek": "2.0.35",
+    "@ai-sdk/google": "3.0.75",
+    "@ai-sdk/groq": "3.0.39",
+    "@ai-sdk/mistral": "3.0.37",
+    "@ai-sdk/openai": "3.0.64",
+    "@ai-sdk/openai-compatible": "2.0.47",
+    "@ai-sdk/togetherai": "2.0.51",
+    "@ai-sdk/xai": "3.0.91",
     "@mariozechner/pi-agent-core": "0.73.0",
     "@mariozechner/pi-ai": "0.73.0",
+    "@markra/providers": "workspace:*",
+    "@markra/shared": "workspace:*",
     "@mozilla/readability": "^0.6.0",
+    "ai": "6.0.184",
     "turndown": "^7.2.4"
   },
   "devDependencies": {

--- a/packages/ai/src/agent/chat-adapters.test.ts
+++ b/packages/ai/src/agent/chat-adapters.test.ts
@@ -71,6 +71,36 @@ describe("AI chat adapters", () => {
     });
   });
 
+  it("builds OpenAI Responses requests with Codex-shaped input messages", () => {
+    const request = getChatAdapter("openai-responses").buildRequest(
+      provider({ apiStyle: "openai-responses", baseUrl: "https://proxy.example.test/v1", type: "openai" }),
+      "writer-model",
+      messages,
+      { stream: true }
+    );
+
+    expect(request).toEqual({
+      body: {
+        input: [
+          {
+            content: [{ text: "Rewrite this.", type: "input_text" }],
+            role: "user",
+            type: "message"
+          }
+        ],
+        instructions: "You edit Markdown.",
+        model: "writer-model",
+        stream: true,
+        tools: []
+      },
+      headers: {
+        Authorization: "Bearer secret",
+        "content-type": "application/json"
+      },
+      url: "https://proxy.example.test/v1/responses"
+    });
+  });
+
   it("adds custom provider headers to chat requests", () => {
     const request = getChatAdapter("openai-compatible").buildRequest(
       provider({
@@ -864,6 +894,22 @@ describe("AI chat adapters", () => {
       reasoning: { effort: "none" },
       tools: [{ type: "web_search" }]
     });
+  });
+
+  it("does not send API key auth for Ollama chat requests", () => {
+    const request = getChatAdapter("ollama").buildRequest(
+      provider({
+        apiKey: "stale-local-key",
+        baseUrl: "http://localhost:11434/v1",
+        type: "ollama"
+      }),
+      "llama3.3",
+      messages,
+      { stream: true }
+    );
+
+    expect(request.headers).not.toHaveProperty("Authorization");
+    expect(request.headers).not.toHaveProperty("authorization");
   });
 
   it("parses DeepSeek reasoning stream fields separately from final text", () => {

--- a/packages/ai/src/agent/chat-adapters.ts
+++ b/packages/ai/src/agent/chat-adapters.ts
@@ -4,9 +4,11 @@ import {
   buildOpenAiCompatibleRequestParts,
   buildResponsesStyleRequestOptions,
   getNativeWebSearchKind,
+  providerRequiresApiKey,
   readAiProviderCustomHeaders,
   type AiProviderApiStyle,
-  type AiProviderConfig
+  type AiProviderConfig,
+  type AiProviderRequestStyle
 } from "@markra/providers";
 import { isRecord, joinApiUrl } from "@markra/shared";
 import type {
@@ -38,10 +40,18 @@ const defaultChatBaseUrlByApiStyle: Partial<Record<AiProviderApiStyle, string>> 
   openai: "https://api.openai.com/v1"
 };
 
+const defaultChatBaseUrlByRequestStyle: Partial<Record<AiProviderRequestStyle, string>> = {
+  anthropic: "https://api.anthropic.com/v1",
+  google: "https://generativelanguage.googleapis.com/v1beta",
+  "openai-compatible": "https://api.openai.com/v1",
+  "openai-responses": "https://api.openai.com/v1"
+};
+
 const openAiCompatibleAdapter: ChatAdapter = {
   buildRequest(config, model, messages, options = {}) {
     const baseUrl = config.baseUrl?.trim() || defaultChatBaseUrlByApiStyle[config.type] || "";
     if (!baseUrl) throw new Error("API URL is required.");
+    const apiKey = readProviderApiKey(config);
     const nativeWebSearchKind = options.webSearchEnabled === true ? getNativeWebSearchKind(config, model) : null;
     if (
       nativeWebSearchKind === "dashscope-responses-tool" ||
@@ -51,7 +61,7 @@ const openAiCompatibleAdapter: ChatAdapter = {
     ) {
       return buildResponsesStyleRequest({
         authHeaders: {
-          ...(config.apiKey?.trim() ? { Authorization: `Bearer ${config.apiKey.trim()}` } : {}),
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
           "content-type": "application/json",
           ...readAiProviderCustomHeaders(config)
         },
@@ -78,7 +88,7 @@ const openAiCompatibleAdapter: ChatAdapter = {
     return {
       body,
       headers: {
-        ...(config.apiKey?.trim() ? { Authorization: `Bearer ${config.apiKey.trim()}` } : {}),
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
         "content-type": "application/json",
         ...readAiProviderCustomHeaders(config)
       },
@@ -107,6 +117,32 @@ const openAiCompatibleAdapter: ChatAdapter = {
     return parseOpenAiCompatibleStreamEvent(body);
   }
 };
+
+const openAiResponsesAdapter: ChatAdapter = {
+  buildRequest(config, model, messages, options = {}) {
+    const baseUrl = config.baseUrl?.trim() || defaultChatBaseUrlByRequestStyle["openai-responses"] || "";
+    if (!baseUrl) throw new Error("API URL is required.");
+    const apiKey = readProviderApiKey(config);
+
+    return buildResponsesStyleRequest({
+      authHeaders: {
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+        "content-type": "application/json",
+        ...readAiProviderCustomHeaders(config)
+      },
+      baseUrl,
+      config,
+      messages,
+      model,
+      nativeWebSearchToolType: options.webSearchEnabled === true ? "web_search" : undefined,
+      options,
+      responsePath: "/responses"
+    });
+  },
+  parseResponse: openAiCompatibleAdapter.parseResponse,
+  parseStreamEvent: openAiCompatibleAdapter.parseStreamEvent
+};
+
 function buildResponsesStyleRequest({
   authHeaders,
   baseUrl,
@@ -122,12 +158,12 @@ function buildResponsesStyleRequest({
   config: AiProviderConfig;
   messages: ChatMessage[];
   model: string;
-  nativeWebSearchToolType: "openrouter:web_search" | "web_search";
+  nativeWebSearchToolType?: "openrouter:web_search" | "web_search";
   options: ChatRequestOptions;
   responsePath: string;
 }): ChatRequest {
   const body = buildResponsesRequestBody({
-    extraBody: buildResponsesStyleRequestOptions(config, model, nativeWebSearchToolType, options),
+    extraBody: buildResponsesStyleRequestOptions(config, model, nativeWebSearchToolType ?? "web_search", options),
     messages,
     model,
     nativeWebSearchToolType,
@@ -145,6 +181,7 @@ function buildResponsesStyleRequest({
 const deepseekAdapter: ChatAdapter = {
   buildRequest(config, model, messages, options = {}) {
     const baseUrl = config.baseUrl?.trim() || defaultChatBaseUrlByApiStyle.deepseek!;
+    const apiKey = readProviderApiKey(config);
     const body = buildChatCompletionsRequestBody({
       extraBody: buildDeepSeekThinkingRequestOptions(options),
       messages: messages.map((message) => deepseekCompatibleMessage(message, options.thinkingEnabled)),
@@ -156,7 +193,7 @@ const deepseekAdapter: ChatAdapter = {
     return {
       body,
       headers: {
-        ...(config.apiKey?.trim() ? { Authorization: `Bearer ${config.apiKey.trim()}` } : {}),
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
         "content-type": "application/json",
         ...readAiProviderCustomHeaders(config)
       },
@@ -204,7 +241,7 @@ const anthropicAdapter: ChatAdapter = {
       headers: {
         "anthropic-version": anthropicVersion,
         "content-type": "application/json",
-        "x-api-key": config.apiKey?.trim() ?? "",
+        "x-api-key": readProviderApiKey(config),
         ...readAiProviderCustomHeaders(config)
       },
       url: joinApiUrl(config.baseUrl?.trim() || defaultChatBaseUrlByApiStyle.anthropic!, "/messages")
@@ -286,7 +323,7 @@ const azureAdapter: ChatAdapter = {
     if (options.webSearchEnabled === true && getNativeWebSearchKind(config, model) === "azure-openai-responses") {
       return buildResponsesStyleRequest({
         authHeaders: {
-          "api-key": config.apiKey?.trim() ?? "",
+          "api-key": readProviderApiKey(config),
           "content-type": "application/json",
           ...readAiProviderCustomHeaders(config)
         },
@@ -310,7 +347,7 @@ const azureAdapter: ChatAdapter = {
     return {
       body,
       headers: {
-        "api-key": config.apiKey?.trim() ?? "",
+        "api-key": readProviderApiKey(config),
         "content-type": "application/json",
         ...readAiProviderCustomHeaders(config)
       },
@@ -331,7 +368,7 @@ const googleAdapter: ChatAdapter = {
         role: message.role === "assistant" ? "model" : "user"
     }));
     const baseUrl = config.baseUrl?.trim() || defaultChatBaseUrlByApiStyle.google!;
-    const key = encodeURIComponent(config.apiKey?.trim() ?? "");
+    const key = encodeURIComponent(readProviderApiKey(config));
     const tools = buildGoogleTools(config, model, options.webSearchEnabled);
     const body = mergeRequestBody(
       {
@@ -426,8 +463,25 @@ const adapterByApiStyle: Record<AiProviderApiStyle, ChatAdapter> = {
   xai: openAiCompatibleAdapter
 };
 
-export function getChatAdapter(apiStyle: AiProviderApiStyle): ChatAdapter {
-  return adapterByApiStyle[apiStyle] ?? openAiCompatibleAdapter;
+const adapterByRequestStyle: Record<AiProviderRequestStyle, ChatAdapter> = {
+  anthropic: anthropicAdapter,
+  google: googleAdapter,
+  "openai-compatible": openAiCompatibleAdapter,
+  "openai-responses": openAiResponsesAdapter
+};
+
+export function getChatAdapter(apiStyle: AiProviderApiStyle | AiProviderRequestStyle): ChatAdapter {
+  if (isRequestStyleAdapterKey(apiStyle)) return adapterByRequestStyle[apiStyle];
+
+  return adapterByApiStyle[apiStyle as AiProviderApiStyle] ?? openAiCompatibleAdapter;
+}
+
+export function getChatAdapterForProvider(provider: AiProviderConfig): ChatAdapter {
+  return provider.apiStyle ? getChatAdapter(provider.apiStyle) : getChatAdapter(provider.type);
+}
+
+function isRequestStyleAdapterKey(apiStyle: AiProviderApiStyle | AiProviderRequestStyle): apiStyle is AiProviderRequestStyle {
+  return Object.hasOwn(adapterByRequestStyle, apiStyle);
 }
 
 function openAiCompatibleMessage(message: ChatMessage) {
@@ -773,4 +827,8 @@ function parseToolArguments(rawArguments: string) {
   } catch {
     return {};
   }
+}
+
+function readProviderApiKey(config: AiProviderConfig) {
+  return providerRequiresApiKey(config) ? config.apiKey?.trim() ?? "" : "";
 }

--- a/packages/ai/src/agent/chat-completion.test.ts
+++ b/packages/ai/src/agent/chat-completion.test.ts
@@ -53,6 +53,17 @@ describe("chatCompletion", () => {
     );
   });
 
+  it("throws provider errors returned with a successful native status", async () => {
+    const transport = vi.fn().mockResolvedValue({
+      body: { error: { message: "Upstream service temporarily unavailable", type: "upstream_error" } },
+      status: 200
+    });
+
+    await expect(chatCompletion(provider(), "gpt-5.5", [{ content: "Hi", role: "user" }], transport)).rejects.toThrow(
+      "Upstream service temporarily unavailable"
+    );
+  });
+
   it("includes provider error details for failed native stream responses", async () => {
     const streamTransport = vi.fn(async () => ({
       body: {
@@ -79,6 +90,1014 @@ describe("chatCompletion", () => {
         }
       )
     ).rejects.toThrow("Param Incorrect: web search tool found in the request body, but webSearchEnabled is false");
+  });
+
+  it("throws provider errors from successful raw JSON stream chunks", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('{"error":{"message":"Upstream service temporarily unavailable","type":"upstream_error"}}\n');
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(provider(), "gpt-5.5", [{ content: "Hi", role: "user" }], {
+        streamTransport
+      })
+    ).rejects.toThrow("Upstream service temporarily unavailable");
+  });
+
+  it("falls back to non-stream Responses requests when the stream transport fails before content", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async () => ({
+      body: { error: { message: "Upstream service temporarily unavailable", type: "upstream_error" } },
+      status: 502
+    }));
+    const fallbackTransport = vi.fn(async () => ({
+      body: {
+        object: "response",
+        output: [
+          {
+            content: [{ text: "Fallback answer", type: "output_text" }],
+            role: "assistant",
+            type: "message"
+          }
+        ],
+        status: "completed"
+      },
+      status: 200
+    }));
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport,
+          onDelta,
+          streamTransport
+        }
+      )
+    ).resolves.toEqual({
+      content: "Fallback answer",
+      finishReason: "completed"
+    });
+
+    expect(streamTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('"stream":true'),
+        url: "https://api.openai.com/v1/responses"
+      }),
+      expect.any(Function)
+    );
+    expect(fallbackTransport).toHaveBeenCalledWith({
+      body: JSON.stringify({
+        input: [{ content: [{ text: "Hi", type: "input_text" }], role: "user", type: "message" }],
+        model: "gpt-5.5",
+        tools: []
+      }),
+      headers: {
+        Authorization: "Bearer secret",
+        "content-type": "application/json"
+      },
+      url: "https://api.openai.com/v1/responses"
+    });
+    expect(onDelta).toHaveBeenCalledWith("Fallback answer");
+  });
+
+  it("falls back to non-stream compatible chat when non-stream Responses also fails", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async () => ({
+      body: { error: { message: "Upstream service temporarily unavailable", type: "upstream_error" } },
+      status: 502
+    }));
+    const fallbackTransport = vi.fn()
+      .mockResolvedValueOnce({
+        body: { error: { message: "Upstream service temporarily unavailable", type: "upstream_error" } },
+        status: 502
+      })
+      .mockResolvedValueOnce({
+        body: {
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: "Compatible chat answer",
+                role: "assistant"
+              }
+            }
+          ]
+        },
+        status: 200
+      });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport,
+          onDelta,
+          streamTransport
+        }
+      )
+    ).resolves.toEqual({
+      content: "Compatible chat answer",
+      finishReason: "stop"
+    });
+
+    expect(fallbackTransport).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      body: expect.stringContaining('"input"'),
+      url: "https://api.openai.com/v1/responses"
+    }));
+    expect(fallbackTransport).toHaveBeenNthCalledWith(2, {
+      body: JSON.stringify({
+        messages: [{ content: "Hi", role: "user" }],
+        model: "gpt-5.5",
+        temperature: 0.7
+      }),
+      headers: {
+        Authorization: "Bearer secret",
+        "content-type": "application/json"
+      },
+      url: "https://api.openai.com/v1/chat/completions"
+    });
+    expect(onDelta).toHaveBeenCalledWith("Compatible chat answer");
+  });
+
+  it("falls back to non-stream compatible chat when a compatible stream has malformed JSON before text", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"unterminated}\n\n');
+
+      return { status: 200 };
+    });
+    const fallbackTransport = vi.fn(async () => ({
+      body: {
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              content: "Recovered compatible answer",
+              role: "assistant"
+            }
+          }
+        ]
+      },
+      status: 200
+    }));
+
+    await expect(
+      chatCompletionStream(provider(), "gpt-5.5", [{ content: "Hi", role: "user" }], {
+        fallbackTransport,
+        onDelta,
+        streamTransport
+      })
+    ).resolves.toEqual({
+      content: "Recovered compatible answer",
+      finishReason: "stop"
+    });
+
+    expect(fallbackTransport).toHaveBeenCalledWith({
+      body: JSON.stringify({
+        messages: [{ content: "Hi", role: "user" }],
+        model: "gpt-5.5",
+        temperature: 0.7
+      }),
+      headers: {
+        Authorization: "Bearer secret",
+        "content-type": "application/json"
+      },
+      url: "https://api.openai.com/v1/chat/completions"
+    });
+    expect(onDelta).toHaveBeenCalledWith("Recovered compatible answer");
+  });
+
+  it("uses the Vercel AI SDK stream path for OpenAI Responses when enabled", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.created","response":{"id":"resp_test","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
+      onChunk('data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n');
+      onChunk('data: {"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}\n\n');
+      onChunk('data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"SDK "}\n\n');
+      onChunk('data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"answer"}\n\n');
+      onChunk('data: {"type":"response.output_text.done","item_id":"msg_1","output_index":0,"content_index":0,"text":"SDK answer"}\n\n');
+      onChunk('data: {"type":"response.content_part.done","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"SDK answer","annotations":[]}}\n\n');
+      onChunk('data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"SDK answer","annotations":[]}]}}\n\n');
+      onChunk('data: {"type":"response.completed","response":{"id":"resp_test","created_at":0,"model":"gpt-5.5","object":"response","status":"completed","output":[{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"SDK answer","annotations":[]}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+    const fallbackTransport = vi.fn();
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport,
+          onDelta,
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "SDK answer",
+      finishReason: "stop"
+    });
+
+    expect(streamTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('"stream":true'),
+        url: "https://api.openai.com/v1/responses"
+      }),
+      expect.any(Function)
+    );
+    expect(onDelta).toHaveBeenNthCalledWith(1, "SDK ");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+    expect(fallbackTransport).not.toHaveBeenCalled();
+  });
+
+  it("uses the Vercel AI SDK stream path for OpenAI Responses thinking and web search", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.created","response":{"id":"resp_test","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
+      onChunk('data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n');
+      onChunk('data: {"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}\n\n');
+      onChunk('data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"Fresh "}\n\n');
+      onChunk('data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"answer"}\n\n');
+      onChunk('data: {"type":"response.output_text.done","item_id":"msg_1","output_index":0,"content_index":0,"text":"Fresh answer"}\n\n');
+      onChunk('data: {"type":"response.completed","response":{"id":"resp_test","created_at":0,"model":"gpt-5.5","object":"response","status":"completed","output":[{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Fresh answer","annotations":[]}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses",
+          models: [{ capabilities: ["text", "web"], enabled: true, id: "gpt-5.5", name: "GPT-5.5" }]
+        }),
+        "gpt-5.5",
+        [{ content: "Find current info.", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          streamTransport,
+          thinkingEnabled: true,
+          useVercelAiSdk: true,
+          webSearchEnabled: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Fresh answer",
+      finishReason: "stop"
+    });
+
+    const request = streamTransport.mock.calls[0]?.[0];
+    const body = JSON.parse(request?.body ?? "{}") as Record<string, unknown>;
+    expect(request?.headers).toEqual(expect.objectContaining({
+      "user-agent": expect.stringContaining("ai-sdk/openai/")
+    }));
+    expect(body.reasoning).toEqual({ effort: "high", summary: "auto" });
+    expect(body.tools).toContainEqual(expect.objectContaining({ type: "web_search" }));
+  });
+
+  it("streams Vercel AI SDK tool calls for OpenAI Responses when enabled", async () => {
+    const onToolCallDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.created","response":{"id":"resp_tool","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
+      onChunk('data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"in_progress","call_id":"call_read","name":"get_document","arguments":""}}\n\n');
+      onChunk('data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\\"path\\":"}\n\n');
+      onChunk('data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"\\"README.md\\"}"}\n\n');
+      onChunk('data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"arguments":"{\\"path\\":\\"README.md\\"}"}\n\n');
+      onChunk('data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_read","name":"get_document","arguments":"{\\"path\\":\\"README.md\\"}"}}\n\n');
+      onChunk('data: {"type":"response.completed","response":{"id":"resp_tool","created_at":0,"model":"gpt-5.5","object":"response","status":"completed","output":[{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_read","name":"get_document","arguments":"{\\"path\\":\\"README.md\\"}"}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Read the document.", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onToolCallDelta,
+          streamTransport,
+          tools: [
+            {
+              description: "Read the current document.",
+              name: "get_document",
+              parameters: {
+                additionalProperties: false,
+                properties: {
+                  path: { type: "string" }
+                },
+                required: ["path"],
+                type: "object"
+              }
+            }
+          ],
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "",
+      finishReason: "tool-calls",
+      toolCalls: [
+        {
+          arguments: { path: "README.md" },
+          id: "call_read",
+          name: "get_document"
+        }
+      ]
+    });
+
+    expect(onToolCallDelta).toHaveBeenCalledWith({
+      id: "call_read",
+      index: 0,
+      nameDelta: "get_document"
+    });
+    expect(onToolCallDelta).toHaveBeenCalledWith({
+      argumentsDelta: "{\"path\":\"README.md\"}",
+      id: "call_read",
+      index: 0,
+      nameDelta: "get_document",
+      replaceArguments: true,
+      replaceName: true
+    });
+  });
+
+  it("falls back when the Vercel AI SDK Responses stream hits malformed JSON before text", async () => {
+    const onToolCallDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.created","response":{"id":"resp_tool","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
+      onChunk('data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"in_progress","call_id":"call_read","name":"get_document","arguments":""}}\n\n');
+      onChunk('data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\\"path\\":"}\n\n');
+      onChunk('data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":"unterminated}\n\n');
+
+      return { status: 200 };
+    });
+    const fallbackTransport = vi.fn(async () => ({
+      body: {
+        object: "response",
+        output: [
+          {
+            arguments: "{\"path\":\"README.md\"}",
+            call_id: "call_read",
+            name: "get_document",
+            type: "function_call"
+          }
+        ],
+        status: "completed"
+      },
+      status: 200
+    }));
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Read the document.", role: "user" }],
+        {
+          fallbackTransport,
+          onToolCallDelta,
+          streamTransport,
+          tools: [
+            {
+              description: "Read the current document.",
+              name: "get_document",
+              parameters: {
+                additionalProperties: false,
+                properties: {
+                  path: { type: "string" }
+                },
+                required: ["path"],
+                type: "object"
+              }
+            }
+          ],
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "",
+      finishReason: "completed",
+      toolCalls: [
+        {
+          arguments: { path: "README.md" },
+          id: "call_read",
+          name: "get_document"
+        }
+      ]
+    });
+
+    expect(onToolCallDelta).toHaveBeenCalledWith({
+      id: "call_read",
+      index: 0,
+      nameDelta: "get_document"
+    });
+    expect(fallbackTransport).toHaveBeenCalledOnce();
+  });
+
+  it("uses the Vercel AI SDK stream path for Anthropic when enabled", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n');
+      onChunk('data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Claude "}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"answer"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":0}\n\n');
+      onChunk('data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}\n\n');
+      onChunk('data: {"type":"message_stop"}\n\n');
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "anthropic",
+          baseUrl: "https://api.anthropic.com/v1",
+          id: "anthropic",
+          name: "Anthropic",
+          type: "anthropic"
+        }),
+        "claude-sonnet-4-5",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onDelta,
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Claude answer",
+      finishReason: "stop"
+    });
+
+    expect(streamTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('"max_tokens":64000'),
+        headers: expect.objectContaining({
+          "x-api-key": "secret"
+        }),
+        url: "https://api.anthropic.com/v1/messages"
+      }),
+      expect.any(Function)
+    );
+    expect(onDelta).toHaveBeenNthCalledWith(1, "Claude ");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+  });
+
+  it("uses the Vercel AI SDK stream path for Anthropic thinking and web search", async () => {
+    const onThinkingDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n');
+      onChunk('data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Checking sources"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":0}\n\n');
+      onChunk('data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Claude answer"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":1}\n\n');
+      onChunk('data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}\n\n');
+      onChunk('data: {"type":"message_stop"}\n\n');
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "anthropic",
+          baseUrl: "https://api.anthropic.com/v1",
+          id: "anthropic",
+          models: [{ capabilities: ["text", "web"], enabled: true, id: "claude-sonnet-4-5", name: "Claude Sonnet" }],
+          name: "Anthropic",
+          type: "anthropic"
+        }),
+        "claude-sonnet-4-5",
+        [{ content: "Find current info.", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onThinkingDelta,
+          streamTransport,
+          thinkingEnabled: true,
+          useVercelAiSdk: true,
+          webSearchEnabled: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Claude answer",
+      finishReason: "stop"
+    });
+
+    const request = streamTransport.mock.calls[0]?.[0];
+    const body = JSON.parse(request?.body ?? "{}") as Record<string, unknown>;
+    expect(request?.headers).toEqual(expect.objectContaining({
+      "user-agent": expect.stringContaining("ai-sdk/anthropic/")
+    }));
+    expect(body.thinking).toEqual({ budget_tokens: 1024, type: "enabled" });
+    expect(body.tools).toContainEqual(expect.objectContaining({
+      name: "web_search",
+      type: "web_search_20250305"
+    }));
+    expect(onThinkingDelta).toHaveBeenCalledWith("Checking sources");
+  });
+
+  it("preserves Anthropic tool call arguments emitted as SDK string input", async () => {
+    const onToolCallDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n');
+      onChunk('data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_read","name":"get_document","input":{}}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"README.md\\"}"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":0}\n\n');
+      onChunk('data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":2}}\n\n');
+      onChunk('data: {"type":"message_stop"}\n\n');
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "anthropic",
+          baseUrl: "https://api.anthropic.com/v1",
+          id: "anthropic",
+          name: "Anthropic",
+          type: "anthropic"
+        }),
+        "claude-sonnet-4-5",
+        [{ content: "Read the document.", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onToolCallDelta,
+          streamTransport,
+          tools: [
+            {
+              description: "Read the current document.",
+              name: "get_document",
+              parameters: {
+                additionalProperties: false,
+                properties: {
+                  path: { type: "string" }
+                },
+                required: ["path"],
+                type: "object"
+              }
+            }
+          ],
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "",
+      finishReason: "tool-calls",
+      toolCalls: [
+        {
+          arguments: { path: "README.md" },
+          id: "call_read",
+          name: "get_document"
+        }
+      ]
+    });
+
+    expect(onToolCallDelta).toHaveBeenCalledWith({
+      argumentsDelta: "{\"path\":\"README.md\"}",
+      id: "call_read",
+      index: 0,
+      nameDelta: "get_document",
+      replaceArguments: true,
+      replaceName: true
+    });
+  });
+
+  it("uses the Vercel AI SDK stream path for Google when enabled", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Gemini "}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}\n\n');
+      onChunk('data: {"candidates":[{"content":{"role":"model","parts":[{"text":"answer"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}\n\n');
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "google",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+          id: "google",
+          name: "Google",
+          type: "google"
+        }),
+        "gemini-2.5-pro",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onDelta,
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Gemini answer",
+      finishReason: "stop"
+    });
+
+    expect(streamTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-goog-api-key": "secret"
+        }),
+        url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+      }),
+      expect.any(Function)
+    );
+    expect(streamTransport.mock.calls[0]?.[0].url).not.toContain("key=");
+    expect(onDelta).toHaveBeenNthCalledWith(1, "Gemini ");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+  });
+
+  it("uses the Vercel AI SDK stream path for Google thinking and web search", async () => {
+    const onThinkingDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"candidates":[{"content":{"role":"model","parts":[{"thought":true,"text":"Grounding "},{"text":"Gemini answer"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}\n\n');
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "google",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+          id: "google",
+          models: [{ capabilities: ["text", "web"], enabled: true, id: "gemini-3.1-pro-preview", name: "Gemini" }],
+          name: "Google",
+          type: "google"
+        }),
+        "gemini-3.1-pro-preview",
+        [{ content: "Find current info.", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onThinkingDelta,
+          streamTransport,
+          thinkingEnabled: true,
+          useVercelAiSdk: true,
+          webSearchEnabled: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Gemini answer",
+      finishReason: "stop"
+    });
+
+    const request = streamTransport.mock.calls[0]?.[0];
+    const body = JSON.parse(request?.body ?? "{}") as Record<string, unknown>;
+    expect(request?.headers).toEqual(expect.objectContaining({
+      "user-agent": expect.stringContaining("ai-sdk/google/")
+    }));
+    expect(request?.url).toBe("https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse");
+    expect(body.generationConfig).toEqual(expect.objectContaining({
+      thinkingConfig: { includeThoughts: true }
+    }));
+    expect(body.tools).toContainEqual({ googleSearch: {} });
+    expect(onThinkingDelta).toHaveBeenCalledWith("Grounding ");
+  });
+
+  it.each([
+    {
+      baseUrl: "https://api.deepseek.com",
+      id: "deepseek",
+      model: "deepseek-chat",
+      name: "DeepSeek",
+      type: "deepseek",
+      url: "https://api.deepseek.com/chat/completions",
+      userAgent: "ai-sdk/deepseek/"
+    },
+    {
+      baseUrl: "https://api.mistral.ai/v1",
+      id: "mistral",
+      model: "mistral-large-latest",
+      name: "Mistral",
+      type: "mistral",
+      url: "https://api.mistral.ai/v1/chat/completions",
+      userAgent: "ai-sdk/mistral/"
+    },
+    {
+      baseUrl: "https://api.groq.com/openai/v1",
+      id: "groq",
+      model: "llama-3.3-70b-versatile",
+      name: "Groq",
+      type: "groq",
+      url: "https://api.groq.com/openai/v1/chat/completions",
+      userAgent: "ai-sdk/groq/"
+    },
+    {
+      baseUrl: "https://api.x.ai/v1",
+      id: "xai",
+      model: "grok-4",
+      name: "xAI",
+      type: "xai",
+      url: "https://api.x.ai/v1/chat/completions",
+      userAgent: "ai-sdk/xai/"
+    },
+    {
+      baseUrl: "https://api.together.xyz/v1",
+      id: "together",
+      model: "moonshotai/Kimi-K2.5",
+      name: "Together.ai",
+      type: "together",
+      url: "https://api.together.xyz/v1/chat/completions",
+      userAgent: "ai-sdk/togetherai/"
+    },
+    {
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      id: "aliyun-bailian",
+      model: "qwen3.6-plus",
+      name: "Qwen",
+      type: "openai-compatible",
+      url: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+      userAgent: "ai-sdk/alibaba/"
+    }
+  ] as const)("uses the provider-specific Vercel AI SDK package for $name", async ({ baseUrl, id, model, name, type, url, userAgent }) => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"test","choices":[{"index":0,"delta":{"content":"SDK "}}]}\n\n');
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"test","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-compatible",
+          baseUrl,
+          id,
+          name,
+          type
+        }),
+        model,
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onDelta,
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "SDK answer",
+      finishReason: "stop"
+    });
+
+    expect(streamTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(`"model":"${model}"`),
+        headers: expect.objectContaining({
+          "user-agent": expect.stringContaining(userAgent)
+        }),
+        url
+      }),
+      expect.any(Function)
+    );
+    expect(onDelta).toHaveBeenNthCalledWith(1, "SDK ");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+  });
+
+  it("uses the Azure OpenAI Vercel AI SDK package with deployment URLs", async () => {
+    const onDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"test","choices":[{"index":0,"delta":{"content":"Azure "}}]}\n\n');
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"test","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-compatible",
+          baseUrl: "https://markra.openai.azure.com",
+          id: "azure-openai",
+          name: "Azure OpenAI",
+          type: "azure-openai"
+        }),
+        "writer-deployment",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onDelta,
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Azure answer",
+      finishReason: "stop"
+    });
+
+    expect(streamTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('"model":"writer-deployment"'),
+        headers: expect.objectContaining({
+          "api-key": "secret",
+          "user-agent": expect.stringContaining("ai-sdk/azure/")
+        }),
+        url: "https://markra.openai.azure.com/openai/deployments/writer-deployment/chat/completions?api-version=2024-10-21"
+      }),
+      expect.any(Function)
+    );
+    expect(onDelta).toHaveBeenNthCalledWith(1, "Azure ");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+  });
+
+  it("does not send API key auth for Ollama Vercel AI SDK requests", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"test","choices":[{"index":0,"delta":{"content":"Local"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiKey: "stale-local-key",
+          apiStyle: "openai-compatible",
+          baseUrl: "http://localhost:11434/v1",
+          id: "ollama",
+          name: "Ollama",
+          type: "ollama"
+        }),
+        "llama3.3",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Local",
+      finishReason: "stop"
+    });
+
+    const requestHeaders = streamTransport.mock.calls[0]?.[0].headers ?? {};
+    expect(requestHeaders).not.toHaveProperty("authorization");
+    expect(requestHeaders).not.toHaveProperty("Authorization");
+  });
+
+  it("falls back to non-stream Responses requests when the stream returns a provider error event before content", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"error":{"message":"Concurrency limit exceeded for user, please retry later","type":"rate_limit_error"}}\n\n');
+
+      return { status: 200 };
+    });
+    const fallbackTransport = vi.fn(async () => ({
+      body: {
+        object: "response",
+        output_text: "Recovered answer",
+        status: "completed"
+      },
+      status: 200
+    }));
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport,
+          streamTransport
+        }
+      )
+    ).resolves.toEqual({
+      content: "Recovered answer",
+      finishReason: "completed"
+    });
+    expect(fallbackTransport).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to non-stream Responses requests when the stream ends without output", async () => {
+    const streamTransport = vi.fn(async () => ({ status: 200 }));
+    const fallbackTransport = vi.fn(async () => ({
+      body: {
+        object: "response",
+        output_text: "Recovered empty stream",
+        status: "completed"
+      },
+      status: 200
+    }));
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Hi", role: "user" }],
+        {
+          fallbackTransport,
+          streamTransport
+        }
+      )
+    ).resolves.toEqual({
+      content: "Recovered empty stream",
+      finishReason: "completed"
+    });
+    expect(fallbackTransport).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to non-stream Responses requests when malformed stream JSON follows tool call deltas", async () => {
+    const onToolCallDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_read_document","name":"get_document"}}\n\n');
+      onChunk('data: {"type":"response.function_call_arguments.delta","output_index":0,"call_id":"call_read_document","delta":"{\\"path\\"\n\n');
+
+      return { status: 200 };
+    });
+    const fallbackTransport = vi.fn(async () => ({
+      body: {
+        object: "response",
+        output: [
+          {
+            arguments: "{\"path\":\"README.md\"}",
+            call_id: "call_read_document",
+            name: "get_document",
+            type: "function_call"
+          }
+        ],
+        status: "completed"
+      },
+      status: 200
+    }));
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-responses"
+        }),
+        "gpt-5.5",
+        [{ content: "Summarize this document.", role: "user" }],
+        {
+          fallbackTransport,
+          onToolCallDelta,
+          streamTransport,
+          tools: [
+            {
+              description: "Read the current document.",
+              name: "get_document",
+              parameters: {
+                additionalProperties: false,
+                properties: {},
+                type: "object"
+              }
+            }
+          ]
+        }
+      )
+    ).resolves.toEqual({
+      content: "",
+      finishReason: "completed",
+      toolCalls: [
+        {
+          arguments: { path: "README.md" },
+          id: "call_read_document",
+          name: "get_document"
+        }
+      ]
+    });
+
+    expect(onToolCallDelta).toHaveBeenCalledWith({
+      id: "call_read_document",
+      index: 0,
+      nameDelta: "get_document"
+    });
+    expect(fallbackTransport).toHaveBeenCalledOnce();
   });
 
   it("streams provider SSE chunks through the native transport", async () => {

--- a/packages/ai/src/agent/chat-completion.ts
+++ b/packages/ai/src/agent/chat-completion.ts
@@ -1,7 +1,8 @@
 import type { AiProviderConfig } from "@markra/providers";
 import { isRecord } from "@markra/shared";
 import {
-  getChatAdapter
+  getChatAdapter,
+  getChatAdapterForProvider
 } from "./chat-adapters";
 import type { ChatMessage, ChatResponse, ChatToolCallDelta } from "./chat/types";
 
@@ -28,12 +29,14 @@ export type ChatCompletionStreamTransport = (
 ) => Promise<NativeAiStreamResponse>;
 
 export type ChatCompletionStreamOptions = {
+  fallbackTransport?: ChatCompletionTransport;
   onDelta?: (delta: string) => unknown;
   onThinkingDelta?: (delta: string) => unknown;
   onToolCallDelta?: (delta: ChatToolCallDelta) => unknown;
   streamTransport?: ChatCompletionStreamTransport;
   thinkingEnabled?: boolean;
   tools?: import("@mariozechner/pi-ai").Tool[];
+  useVercelAiSdk?: boolean;
   webSearchEnabled?: boolean;
 };
 
@@ -43,7 +46,7 @@ export async function chatCompletion(
   messages: ChatMessage[],
   transport: ChatCompletionTransport = missingChatCompletionTransport
 ): Promise<ChatResponse> {
-  const adapter = getChatAdapter(provider.type);
+  const adapter = getChatAdapterForProvider(provider);
   const request = adapter.buildRequest(provider, model, messages);
   const response = await transport({
     body: JSON.stringify(request.body),
@@ -54,6 +57,10 @@ export async function chatCompletion(
   if (response.status < 200 || response.status >= 300) {
     throw new Error(readResponseError(response));
   }
+  const providerError = readProviderErrorMessage(response.body);
+  if (providerError) {
+    throw new Error(providerError);
+  }
 
   return adapter.parseResponse(response.body);
 }
@@ -63,22 +70,36 @@ export async function chatCompletionStream(
   model: string,
   messages: ChatMessage[],
   {
+    fallbackTransport,
     onDelta,
     onThinkingDelta,
     onToolCallDelta,
     streamTransport = missingChatCompletionStreamTransport,
     thinkingEnabled,
     tools,
+    useVercelAiSdk,
     webSearchEnabled
   }: ChatCompletionStreamOptions = {}
 ): Promise<ChatResponse> {
-  const adapter = getChatAdapter(provider.type);
-  const request = adapter.buildRequest(provider, model, messages, { stream: true, thinkingEnabled, tools, webSearchEnabled });
+  const adapter = getChatAdapterForProvider(provider);
+  let streamRequest: NativeAiChatRequest | undefined;
+  const buildStreamRequest = () => {
+    if (streamRequest) return streamRequest;
+    const request = adapter.buildRequest(provider, model, messages, { stream: true, thinkingEnabled, tools, webSearchEnabled });
+    streamRequest = {
+      body: JSON.stringify(request.body),
+      headers: request.headers,
+      url: request.url
+    };
+
+    return streamRequest;
+  };
   let content = "";
   let finishReason: string | undefined;
   const toolCalls = new Map<number, { argumentsText: string; id: string; name: string }>();
   const parser = createServerSentEventParser();
   const inlineThinkingExtractor = thinkingEnabled ? createInlineThinkingExtractor() : null;
+  let streamErrorMessage: string | undefined;
   const emitContentDelta = (delta: string) => {
     content += delta;
     onDelta?.(delta);
@@ -97,6 +118,12 @@ export async function chatCompletionStream(
     if (extracted.contentDelta) emitContentDelta(extracted.contentDelta);
   };
   const processStreamEvent = (event: unknown) => {
+    const providerError = readProviderErrorMessage(event);
+    if (providerError) {
+      streamErrorMessage = providerError;
+      return;
+    }
+
     const parsed = adapter.parseStreamEvent(event);
     if (parsed.done) return;
 
@@ -135,30 +162,7 @@ export async function chatCompletionStream(
       });
     }
   };
-  const response = await streamTransport(
-    {
-      body: JSON.stringify(request.body),
-      headers: request.headers,
-      url: request.url
-    },
-    (chunk) => {
-      parser.push(chunk).forEach(processStreamEvent);
-    }
-  );
-
-  parser.finish().forEach(processStreamEvent);
-  const finalInlineThinkingDelta = inlineThinkingExtractor?.finish();
-  if (finalInlineThinkingDelta?.thinkingDelta) emitThinkingDelta(finalInlineThinkingDelta.thinkingDelta);
-  if (finalInlineThinkingDelta?.contentDelta) emitContentDelta(finalInlineThinkingDelta.contentDelta);
-
-  if (response.status < 200 || response.status >= 300) {
-    throw new Error(readResponseError({ body: response.body ?? null, status: response.status }));
-  }
-  if ((!content || !finishReason) && response.body !== undefined) {
-    applyParsedFallbackResponse(adapter.parseResponse(response.body));
-  }
-
-  return {
+  const buildResponse = (): ChatResponse => ({
     content,
     finishReason,
     ...(toolCalls.size > 0
@@ -170,7 +174,139 @@ export async function chatCompletionStream(
           }))
         }
       : {})
+  });
+  const flushInlineThinking = () => {
+    const finalInlineThinkingDelta = inlineThinkingExtractor?.finish();
+    if (finalInlineThinkingDelta?.thinkingDelta) emitThinkingDelta(finalInlineThinkingDelta.thinkingDelta);
+    if (finalInlineThinkingDelta?.contentDelta) emitContentDelta(finalInlineThinkingDelta.contentDelta);
   };
+  const canFallbackToNonStream = () => fallbackTransport !== undefined && !content;
+  const applyParsedFallback = (parsed: ChatResponse) => {
+    toolCalls.clear();
+    applyParsedFallbackResponse(parsed);
+    flushInlineThinking();
+
+    return buildResponse();
+  };
+  const runCompatibleChatFallback = async () => {
+    if (!fallbackTransport) throw new Error("AI chat fallback transport is not configured.");
+    const compatibleAdapter = getChatAdapter("openai-compatible");
+    const compatibleRequest = compatibleAdapter.buildRequest(provider, model, messages, { thinkingEnabled, tools });
+    const compatibleResponse = await fallbackTransport({
+      body: JSON.stringify(compatibleRequest.body),
+      headers: compatibleRequest.headers,
+      url: compatibleRequest.url
+    });
+
+    if (compatibleResponse.status < 200 || compatibleResponse.status >= 300) {
+      throw new Error(readResponseError(compatibleResponse));
+    }
+    const compatibleProviderError = readProviderErrorMessage(compatibleResponse.body);
+    if (compatibleProviderError) {
+      throw new Error(compatibleProviderError);
+    }
+
+    return applyParsedFallback(compatibleAdapter.parseResponse(compatibleResponse.body));
+  };
+  const runNonStreamFallback = async () => {
+    if (!fallbackTransport) throw new Error("AI chat fallback transport is not configured.");
+    const fallbackRequest = adapter.buildRequest(provider, model, messages, { thinkingEnabled, tools, webSearchEnabled });
+    const fallbackResponse = await fallbackTransport({
+      body: JSON.stringify(fallbackRequest.body),
+      headers: fallbackRequest.headers,
+      url: fallbackRequest.url
+    });
+
+    if (fallbackResponse.status < 200 || fallbackResponse.status >= 300) {
+      if (provider.apiStyle === "openai-responses") return runCompatibleChatFallback();
+      throw new Error(readResponseError(fallbackResponse));
+    }
+    const fallbackProviderError = readProviderErrorMessage(fallbackResponse.body);
+    if (fallbackProviderError) {
+      if (provider.apiStyle === "openai-responses") return runCompatibleChatFallback();
+      throw new Error(fallbackProviderError);
+    }
+
+    return applyParsedFallback(adapter.parseResponse(fallbackResponse.body));
+  };
+  if (useVercelAiSdk === true) {
+    const {
+      canUseVercelAiSdkChatCompletion,
+      chatCompletionStreamWithVercelAiSdk
+    } = await loadVercelAiSdkChatCompletion();
+
+    if (canUseVercelAiSdkChatCompletion({
+      fallbackTransport,
+      messages,
+      model,
+      provider,
+      streamTransport,
+      thinkingEnabled,
+      tools,
+      useVercelAiSdk,
+      webSearchEnabled
+    })) {
+      let sdkContentEmitted = false;
+      try {
+        return await chatCompletionStreamWithVercelAiSdk({
+          fallbackTransport,
+          messages,
+          model,
+          onDelta: (delta) => {
+            sdkContentEmitted = true;
+            onDelta?.(delta);
+          },
+          onThinkingDelta,
+          onToolCallDelta,
+          provider,
+          streamTransport,
+          thinkingEnabled,
+          tools,
+          webSearchEnabled
+        });
+      } catch (error) {
+        if (sdkContentEmitted) throw error;
+        if (canFallbackToNonStream()) return runNonStreamFallback();
+      }
+    }
+  }
+  let response: NativeAiStreamResponse;
+  try {
+    response = await streamTransport(buildStreamRequest(), (chunk) => {
+      parser.push(chunk).forEach(processStreamEvent);
+    });
+  } catch (error) {
+    if (canFallbackToNonStream()) return runNonStreamFallback();
+    throw error;
+  }
+
+  try {
+    parser.finish().forEach(processStreamEvent);
+  } catch (error) {
+    if (canFallbackToNonStream()) return runNonStreamFallback();
+    throw error;
+  }
+  flushInlineThinking();
+
+  if (response.status < 200 || response.status >= 300) {
+    if (canFallbackToNonStream()) return runNonStreamFallback();
+    throw new Error(readResponseError({ body: response.body ?? null, status: response.status }));
+  }
+  const providerError = streamErrorMessage ?? (response.body === undefined ? undefined : readProviderErrorMessage(response.body));
+  if (providerError) {
+    if (canFallbackToNonStream()) return runNonStreamFallback();
+    throw new Error(providerError);
+  }
+  if ((!content || !finishReason) && response.body !== undefined) {
+    applyParsedFallbackResponse(adapter.parseResponse(response.body));
+  }
+  if (!content && toolCalls.size === 0 && canFallbackToNonStream()) return runNonStreamFallback();
+
+  return buildResponse();
+}
+
+function loadVercelAiSdkChatCompletion() {
+  return import("./sdk/chat-completion");
 }
 
 function missingChatCompletionTransport(): never {
@@ -184,17 +320,25 @@ function missingChatCompletionStreamTransport(): never {
 function readResponseError(response: NativeAiHttpResponse) {
   if (isRecord(response.body)) {
     if (typeof response.body.message === "string") return response.body.message;
-    if (isRecord(response.body.error) && typeof response.body.error.message === "string") {
-      if (typeof response.body.error.param === "string" && response.body.error.param.trim()) {
-        return `${response.body.error.message}: ${response.body.error.param}`;
-      }
-
-      return response.body.error.message;
-    }
-    if (typeof response.body.error === "string") return response.body.error;
+    const providerError = readProviderErrorMessage(response.body);
+    if (providerError) return providerError;
   }
 
   return `Request failed with HTTP ${response.status}.`;
+}
+
+function readProviderErrorMessage(body: unknown) {
+  if (!isRecord(body)) return undefined;
+  if (isRecord(body.error) && typeof body.error.message === "string") {
+    if (typeof body.error.param === "string" && body.error.param.trim()) {
+      return `${body.error.message}: ${body.error.param}`;
+    }
+
+    return body.error.message;
+  }
+  if (typeof body.error === "string") return body.error;
+
+  return undefined;
 }
 
 function createServerSentEventParser() {

--- a/packages/ai/src/agent/document-agent.test.ts
+++ b/packages/ai/src/agent/document-agent.test.ts
@@ -17,6 +17,20 @@ function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
 }
 
 describe("document AI agent", () => {
+  it("surfaces provider errors from the tool-calling runtime", async () => {
+    const complete = vi.fn().mockRejectedValue(new Error("Concurrency limit exceeded for user, please retry later"));
+
+    await expect(runDocumentAiAgent({
+      complete,
+      documentContent: "# Draft",
+      documentPath: "/vault/README.md",
+      model: "gpt-5.5",
+      prompt: "Summarize this document.",
+      provider: provider(),
+      workspaceFiles: []
+    })).rejects.toThrow("Concurrency limit exceeded for user, please retry later");
+  });
+
   it("asks the tool-calling agent to answer in the user's language", async () => {
     const complete = vi.fn().mockImplementationOnce(async (_provider, _model, messages: ChatMessage[]) => {
       expect(messages[0]?.content).toContain("Reply in the user's language");

--- a/packages/ai/src/agent/document-agent.ts
+++ b/packages/ai/src/agent/document-agent.ts
@@ -240,6 +240,7 @@ async function runDocumentToolCallingAgent({
   let finalContent = "";
   let finishReason: string | undefined;
   let latestAssistantText = "";
+  let providerErrorMessage = "";
 
   agent.subscribe((event) => {
     onEvent?.(event);
@@ -259,6 +260,9 @@ async function runDocumentToolCallingAgent({
 
     finalContent = assistantTextFromAgentMessage(event.message.content);
     if (finalContent.trim()) latestAssistantText = finalContent;
+    if (typeof event.message.errorMessage === "string" && event.message.errorMessage.trim()) {
+      providerErrorMessage = event.message.errorMessage.trim();
+    }
     finishReason = event.message.stopReason;
   });
 
@@ -271,6 +275,9 @@ async function runDocumentToolCallingAgent({
     selection,
     webSearchMode: nativeWebSearchEnabled ? "native" : activeWebSearchSettings ? "custom" : "none"
   }));
+  if (providerErrorMessage) {
+    throw new Error(providerErrorMessage);
+  }
 
   return {
     content: preparedPreview ? "" : (finalContent || latestAssistantText).trim(),

--- a/packages/ai/src/agent/document-tools.test.ts
+++ b/packages/ai/src/agent/document-tools.test.ts
@@ -634,6 +634,32 @@ describe("documentAgentTools", () => {
     expect(toolText(result)).toContain("Prepared an insertion preview at after_anchor (heading:1).");
   });
 
+  it("prepares a cursor insertion at the end of the document when no editor selection is active", async () => {
+    const onPreviewResult = vi.fn();
+    const tool = createDocumentAgentTools({
+      documentContent: "# Title\n\nBody",
+      documentEndPosition: 14,
+      documentPath: "/vault/README.md",
+      onPreviewResult,
+      selection: null,
+      workspaceFiles: []
+    }).find((item) => item.name === "insert_markdown");
+
+    const result = await tool?.execute("tool_insert_markdown", {
+      content: "\n\nContinue here.",
+      placement: "cursor"
+    });
+
+    expect(onPreviewResult).toHaveBeenCalledWith({
+      from: 14,
+      original: "",
+      replacement: "\n\nContinue here.",
+      to: 14,
+      type: "insert"
+    }, expect.any(String));
+    expect(toolText(result)).toContain("Prepared an insertion preview at cursor.");
+  });
+
   it("rejects anchor-based insertion when the anchor is missing", async () => {
     const tool = createDocumentAgentTools({
       documentContent: "# Title\n\nBody",

--- a/packages/ai/src/agent/provider-package-boundary.test.ts
+++ b/packages/ai/src/agent/provider-package-boundary.test.ts
@@ -1,6 +1,6 @@
 import { createDefaultAiSettings } from "@markra/providers";
 
-import { getChatAdapter } from "./chat-adapters";
+import { getChatAdapterForProvider } from "./chat-adapters";
 
 describe("provider package boundary", () => {
   it("builds chat requests from provider settings owned by @markra/providers", () => {
@@ -8,13 +8,13 @@ describe("provider package boundary", () => {
     if (!provider) throw new Error("OpenAI provider template is missing.");
     if (!provider.defaultModelId) throw new Error("OpenAI provider default model is missing.");
 
-    const request = getChatAdapter(provider.type).buildRequest(provider, provider.defaultModelId, [
+    const request = getChatAdapterForProvider(provider).buildRequest(provider, provider.defaultModelId, [
       { content: "Say ok.", role: "user" }
     ]);
 
-    expect(request.url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(request.url).toBe("https://api.openai.com/v1/responses");
     expect(request.body).toMatchObject({
-      messages: [{ content: "Say ok.", role: "user" }],
+      input: [{ content: [{ text: "Say ok.", type: "input_text" }], role: "user", type: "message" }],
       model: provider.defaultModelId
     });
   });

--- a/packages/ai/src/agent/requests/requests.test.ts
+++ b/packages/ai/src/agent/requests/requests.test.ts
@@ -57,13 +57,32 @@ describe("request builders", () => {
       tools: [readDocumentTool]
     })).toEqual({
       enable_thinking: true,
-      input: [{ content: [{ text: "Rewrite this.", type: "input_text" }], role: "user" }],
+      input: [{ content: [{ text: "Rewrite this.", type: "input_text" }], role: "user", type: "message" }],
       instructions: "You edit Markdown.",
       model: "qwen3.6-plus",
       parallel_tool_calls: false,
       stream: true,
       tools: [
         { type: "web_search" },
+        {
+          description: "Read the document.",
+          name: "read_document",
+          parameters: readDocumentTool.parameters,
+          type: "function"
+        }
+      ]
+    });
+  });
+
+  it("keeps Responses function tools when native web search is disabled", () => {
+    expect(buildResponsesRequestBody({
+      messages,
+      model: "gpt-5.5",
+      stream: true,
+      tools: [readDocumentTool]
+    })).toMatchObject({
+      parallel_tool_calls: false,
+      tools: [
         {
           description: "Read the document.",
           name: "read_document",
@@ -103,7 +122,7 @@ describe("request builders", () => {
       nativeWebSearchToolType: "web_search"
     })).toEqual({
       input: [
-        { content: [{ text: "Read the current document.", type: "input_text" }], role: "user" },
+        { content: [{ text: "Read the current document.", type: "input_text" }], role: "user", type: "message" },
         {
           arguments: "{\"path\":\"README.md\"}",
           call_id: "call_read_document",

--- a/packages/ai/src/agent/requests/responses.ts
+++ b/packages/ai/src/agent/requests/responses.ts
@@ -7,7 +7,7 @@ type ResponsesRequestBodyParams = {
   extraBody?: Record<string, unknown>;
   messages: ChatMessage[];
   model: string;
-  nativeWebSearchToolType: "openrouter:web_search" | "web_search";
+  nativeWebSearchToolType?: "openrouter:web_search" | "web_search";
   stream?: boolean;
   tools?: Tool[];
 };
@@ -16,6 +16,10 @@ type ResponsesContentPart =
   | {
       text: string;
       type: "input_text";
+    }
+  | {
+      text: string;
+      type: "output_text";
     }
   | {
       image_url: string;
@@ -30,6 +34,7 @@ type ResponsesInputItem =
   | {
       content: ResponsesMessageContent;
       role: ChatMessage["role"];
+      type: "message";
     }
   | {
       arguments: string;
@@ -98,7 +103,8 @@ function buildResponsesInputMessage(message: ChatMessage): ResponsesInputItem[] 
         ? [
             {
               content: buildResponsesMessageContent(message),
-              role: message.role
+              role: message.role,
+              type: "message" as const
             }
           ]
         : []),
@@ -115,13 +121,16 @@ function buildResponsesInputMessage(message: ChatMessage): ResponsesInputItem[] 
   return [
     {
       content: buildResponsesMessageContent(message),
-      role: message.role
+      role: message.role,
+      type: "message"
     }
   ];
 }
 
 function buildResponsesMessageContent(message: ChatMessage): ResponsesMessageContent {
-  if (message.role === "assistant" && !message.images?.length) return message.content;
+  if (message.role === "assistant" && !message.images?.length) {
+    return [{ text: message.content, type: "output_text" as const }];
+  }
 
   return [
     { text: message.content, type: "input_text" as const },

--- a/packages/ai/src/agent/runtime.test.ts
+++ b/packages/ai/src/agent/runtime.test.ts
@@ -18,6 +18,26 @@ function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
 }
 
 describe("inline AI agent runtime", () => {
+  it("surfaces provider errors from the streaming runtime", async () => {
+    const complete = vi.fn().mockRejectedValue(new Error("Concurrency limit exceeded for user, please retry later"));
+
+    await expect(runInlineAiAgent({
+      complete,
+      documentContent: "# Draft\n\nOriginal body",
+      documentPath: "/vault/README.md",
+      model: "gpt-5.5",
+      prompt: "make it clearer",
+      provider: provider(),
+      target: {
+        from: 9,
+        original: "Original body",
+        promptText: "Original body",
+        to: 22,
+        type: "replace"
+      }
+    })).rejects.toThrow("Concurrency limit exceeded for user, please retry later");
+  });
+
   it("keeps continuation context local instead of sending unrelated document sections", async () => {
     const documentContent = [
       "# Synthetic Topic Alpha",

--- a/packages/ai/src/agent/runtime.ts
+++ b/packages/ai/src/agent/runtime.ts
@@ -53,16 +53,23 @@ export async function runInlineAiAgent({
   });
   let finalContent = "";
   let finishReason: string | undefined;
+  let providerErrorMessage = "";
 
   agent.subscribe((event) => {
     onEvent?.(event);
     if (event.type !== "message_end" || event.message.role !== "assistant") return;
 
     finalContent = assistantTextContent(event.message);
+    if (typeof event.message.errorMessage === "string" && event.message.errorMessage.trim()) {
+      providerErrorMessage = event.message.errorMessage.trim();
+    }
     finishReason = event.message.stopReason;
   });
 
   await agent.prompt(userPrompt);
+  if (providerErrorMessage) {
+    throw new Error(providerErrorMessage);
+  }
 
   return {
     content: normalizeInlineAiReplacement(finalContent, {

--- a/packages/ai/src/agent/sdk/chat-completion.ts
+++ b/packages/ai/src/agent/sdk/chat-completion.ts
@@ -1,0 +1,823 @@
+import { createAlibaba } from "@ai-sdk/alibaba";
+import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
+import { createAzure } from "@ai-sdk/azure";
+import { createDeepSeek } from "@ai-sdk/deepseek";
+import { createGoogleGenerativeAI, google } from "@ai-sdk/google";
+import { browserSearch, createGroq } from "@ai-sdk/groq";
+import { createMistral } from "@ai-sdk/mistral";
+import { createOpenAI, openai } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createTogetherAI } from "@ai-sdk/togetherai";
+import { createXai } from "@ai-sdk/xai";
+import type { AiProviderConfig } from "@markra/providers";
+import {
+  buildAnthropicThinkingRequestOptions,
+  buildDeepSeekThinkingRequestOptions,
+  getNativeWebSearchKind,
+  providerRequiresApiKey,
+  readAiProviderCustomHeaders,
+  requestStyleForProviderType
+} from "@markra/providers";
+import { isRecord } from "@markra/shared";
+import type { Tool as PiTool } from "@mariozechner/pi-ai";
+import {
+  jsonSchema,
+  streamText,
+  tool as aiSdkTool,
+  type AssistantModelMessage,
+  type JSONValue,
+  type LanguageModel,
+  type ModelMessage,
+  type ToolModelMessage,
+  type ToolSet,
+  type UserModelMessage
+} from "ai";
+import type {
+  ChatCompletionStreamTransport,
+  ChatCompletionTransport
+} from "../chat-completion";
+import type { ChatImageAttachment, ChatMessage, ChatResponse, ChatToolCallDelta } from "../chat/types";
+import { createNativeAiSdkFetch, type AiSdkFetch } from "./native-fetch";
+
+type AiSdkChatCompletionOptions = {
+  fallbackTransport?: ChatCompletionTransport;
+  messages: ChatMessage[];
+  model: string;
+  onDelta?: (delta: string) => unknown;
+  onThinkingDelta?: (delta: string) => unknown;
+  onToolCallDelta?: (delta: ChatToolCallDelta) => unknown;
+  provider: AiProviderConfig;
+  streamTransport?: ChatCompletionStreamTransport;
+  thinkingEnabled?: boolean;
+  tools?: PiTool[];
+  useVercelAiSdk?: boolean;
+  webSearchEnabled?: boolean;
+};
+
+type SdkToolCallState = {
+  arguments: Record<string, unknown>;
+  argumentsText: string;
+  id: string;
+  index: number;
+  name: string;
+};
+
+type AiSdkProviderOptions = Record<string, Record<string, JSONValue>>;
+
+type AiSdkRequestFeatureOptions = {
+  thinkingEnabled?: boolean;
+  tools?: PiTool[];
+  webSearchEnabled?: boolean;
+};
+
+type AiSdkProviderKind =
+  | "alibaba"
+  | "anthropic"
+  | "azure-openai"
+  | "deepseek"
+  | "google"
+  | "groq"
+  | "mistral"
+  | "openai-compatible"
+  | "openai-responses"
+  | "together"
+  | "xai";
+
+const azureApiVersion = "2024-10-21";
+
+const defaultBaseUrlBySdkProviderKind: Partial<Record<AiSdkProviderKind, string>> = {
+  alibaba: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  anthropic: "https://api.anthropic.com/v1",
+  "azure-openai": "https://your-resource-name.openai.azure.com",
+  deepseek: "https://api.deepseek.com",
+  google: "https://generativelanguage.googleapis.com/v1beta",
+  groq: "https://api.groq.com/openai/v1",
+  mistral: "https://api.mistral.ai/v1",
+  "openai-compatible": "https://api.openai.com/v1",
+  "openai-responses": "https://api.openai.com/v1",
+  together: "https://api.together.xyz/v1",
+  xai: "https://api.x.ai/v1"
+};
+const sdkSupportedProviderKinds = new Set<AiSdkProviderKind>([
+  "alibaba",
+  "anthropic",
+  "azure-openai",
+  "deepseek",
+  "google",
+  "groq",
+  "mistral",
+  "openai-compatible",
+  "openai-responses",
+  "together",
+  "xai"
+]);
+
+export function canUseVercelAiSdkChatCompletion({
+  fallbackTransport,
+  model,
+  provider,
+  streamTransport,
+  thinkingEnabled,
+  useVercelAiSdk,
+  webSearchEnabled
+}: AiSdkChatCompletionOptions) {
+  const providerKind = resolveAiSdkProviderKind(provider);
+
+  return (
+    useVercelAiSdk === true &&
+    providerKind !== null &&
+    streamTransport !== undefined &&
+    fallbackTransport !== undefined &&
+    canUseAiSdkThinking(provider, model, thinkingEnabled) &&
+    canUseAiSdkWebSearch(provider, model, webSearchEnabled) &&
+    sdkSupportedProviderKinds.has(providerKind)
+  );
+}
+
+export async function chatCompletionStreamWithVercelAiSdk({
+  fallbackTransport,
+  messages,
+  model,
+  onDelta,
+  onThinkingDelta,
+  onToolCallDelta,
+  provider,
+  streamTransport,
+  thinkingEnabled,
+  tools,
+  webSearchEnabled
+}: AiSdkChatCompletionOptions): Promise<ChatResponse> {
+  if (!streamTransport) throw new Error("AI chat stream transport is not configured.");
+  const nativeFetch = createNativeAiSdkFetch({ streamTransport, transport: fallbackTransport });
+  const result = streamText({
+    maxRetries: 0,
+    messages: buildAiSdkMessages(messages),
+    model: createAiSdkLanguageModel(provider, model, nativeFetch),
+    providerOptions: buildAiSdkProviderOptions(provider, model, { thinkingEnabled, tools, webSearchEnabled }),
+    tools: buildAiSdkTools(provider, model, { tools, webSearchEnabled })
+  });
+
+  let content = "";
+  let finishReason: string | undefined;
+  const toolCallsByIndex = new Map<number, SdkToolCallState>();
+  const toolCallIndexById = new Map<string, number>();
+
+  const ensureToolCall = (id: string, name = "") => {
+    const existingIndex = toolCallIndexById.get(id);
+    if (existingIndex !== undefined) {
+      const existingToolCall = toolCallsByIndex.get(existingIndex);
+      if (existingToolCall && name && !existingToolCall.name) existingToolCall.name = name;
+
+      return existingToolCall;
+    }
+
+    const index = toolCallsByIndex.size;
+    const toolCall = { arguments: {}, argumentsText: "", id, index, name };
+    toolCallIndexById.set(id, index);
+    toolCallsByIndex.set(index, toolCall);
+
+    return toolCall;
+  };
+
+  for await (const part of result.fullStream) {
+    if (part.type === "text-delta") {
+      content += part.text;
+      onDelta?.(part.text);
+      continue;
+    }
+
+    if (part.type === "reasoning-delta") {
+      onThinkingDelta?.(part.text);
+      continue;
+    }
+
+    if (part.type === "tool-input-start") {
+      const toolCall = ensureToolCall(part.id, part.toolName);
+      if (!toolCall) continue;
+
+      onToolCallDelta?.({
+        id: part.id,
+        index: toolCall.index,
+        nameDelta: part.toolName
+      });
+      continue;
+    }
+
+    if (part.type === "tool-input-delta") {
+      const toolCall = ensureToolCall(part.id);
+      if (!toolCall) continue;
+
+      toolCall.argumentsText += part.delta;
+      onToolCallDelta?.({
+        argumentsDelta: part.delta,
+        id: part.id,
+        index: toolCall.index
+      });
+      continue;
+    }
+
+    if (part.type === "tool-call") {
+      const toolCall = ensureToolCall(part.toolCallId, part.toolName);
+      if (!toolCall) continue;
+
+      toolCall.arguments = isRecord(part.input) ? part.input : {};
+      toolCall.argumentsText = JSON.stringify(toolCall.arguments);
+      toolCall.name = part.toolName;
+      onToolCallDelta?.({
+        argumentsDelta: toolCall.argumentsText,
+        id: part.toolCallId,
+        index: toolCall.index,
+        nameDelta: part.toolName,
+        replaceArguments: true,
+        replaceName: true
+      });
+      continue;
+    }
+
+    if (part.type === "finish-step" || part.type === "finish") {
+      finishReason = part.finishReason ?? part.rawFinishReason;
+      continue;
+    }
+
+    if (part.type === "error") {
+      throw readAiSdkStreamError(part.error);
+    }
+  }
+
+  return {
+    content,
+    finishReason,
+    ...(toolCallsByIndex.size > 0
+      ? {
+          toolCalls: [...toolCallsByIndex.values()].map((toolCall) => ({
+            arguments: toolCall.argumentsText ? parseToolArguments(toolCall.argumentsText) : toolCall.arguments,
+            id: toolCall.id,
+            name: toolCall.name
+          }))
+        }
+      : {})
+  };
+}
+
+function createAiSdkLanguageModel(provider: AiProviderConfig, model: string, nativeFetch: AiSdkFetch): LanguageModel {
+  const providerKind = resolveAiSdkProviderKind(provider);
+  if (!providerKind) throw new Error("AI SDK does not support this provider API style.");
+
+  const baseURL = readAiSdkBaseUrl(provider, providerKind);
+  const apiKey = providerRequiresApiKey(provider) ? provider.apiKey?.trim() || undefined : undefined;
+  const headers = readAiProviderCustomHeaders(provider);
+
+  if (providerKind === "openai-responses") {
+    return createOpenAI({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).responses(model);
+  }
+  if (providerKind === "anthropic") {
+    return createAnthropic({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).messages(model);
+  }
+  if (providerKind === "google") {
+    return createGoogleGenerativeAI({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).chat(model);
+  }
+  if (providerKind === "deepseek") {
+    return createDeepSeek({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).chat(model);
+  }
+  if (providerKind === "mistral") {
+    return createMistral({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).chat(model);
+  }
+  if (providerKind === "groq") {
+    return createGroq({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).languageModel(model);
+  }
+  if (providerKind === "xai") {
+    return createXai({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).chat(model);
+  }
+  if (providerKind === "together") {
+    return createTogetherAI({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).languageModel(model);
+  }
+  if (providerKind === "alibaba") {
+    return createAlibaba({
+      apiKey,
+      baseURL,
+      fetch: nativeFetch,
+      headers
+    }).languageModel(model);
+  }
+  if (providerKind === "azure-openai") {
+    return createAzure({
+      apiKey,
+      apiVersion: azureApiVersion,
+      baseURL,
+      fetch: nativeFetch,
+      headers,
+      useDeploymentBasedUrls: true
+    }).chat(model);
+  }
+
+  return createOpenAICompatible({
+    apiKey,
+    baseURL,
+    fetch: nativeFetch,
+    headers,
+    name: provider.id || provider.name || "openai-compatible"
+  }).chatModel(model);
+}
+
+function resolveAiSdkProviderKind(provider: AiProviderConfig): AiSdkProviderKind | null {
+  const apiStyle = provider.apiStyle ?? requestStyleForProviderType(provider.type);
+
+  if (apiStyle !== "openai-compatible") return apiStyle;
+
+  switch (provider.type) {
+    case "azure-openai":
+    case "deepseek":
+    case "groq":
+    case "mistral":
+    case "together":
+    case "xai":
+      return provider.type;
+    default:
+      return provider.id === "aliyun-bailian" ? "alibaba" : "openai-compatible";
+  }
+}
+
+function readAiSdkBaseUrl(provider: AiProviderConfig, providerKind: AiSdkProviderKind) {
+  const configuredBaseUrl = provider.baseUrl?.trim();
+  if (configuredBaseUrl) {
+    return providerKind === "azure-openai" ? normalizeAzureOpenAiBaseUrl(configuredBaseUrl) : configuredBaseUrl;
+  }
+  if (provider.type === "openai") return defaultBaseUrlBySdkProviderKind["openai-responses"]!;
+  const defaultBaseUrl = defaultBaseUrlBySdkProviderKind[providerKind];
+  if (defaultBaseUrl) return providerKind === "azure-openai" ? normalizeAzureOpenAiBaseUrl(defaultBaseUrl) : defaultBaseUrl;
+
+  throw new Error("API URL is required.");
+}
+
+function normalizeAzureOpenAiBaseUrl(baseUrl: string) {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  const deploymentBaseUrl = trimmed.endsWith("/openai/v1") ? trimmed.slice(0, -"/v1".length) : trimmed;
+
+  return deploymentBaseUrl.endsWith("/openai") ? deploymentBaseUrl : `${deploymentBaseUrl}/openai`;
+}
+
+function canUseAiSdkThinking(provider: AiProviderConfig, model: string, thinkingEnabled: boolean | undefined) {
+  if (thinkingEnabled !== true) return true;
+
+  return buildAiSdkThinkingProviderOptions(provider, model, thinkingEnabled) !== undefined;
+}
+
+function canUseAiSdkWebSearch(provider: AiProviderConfig, model: string, webSearchEnabled: boolean | undefined) {
+  if (webSearchEnabled !== true) return true;
+
+  const providerKind = resolveAiSdkProviderKind(provider);
+  const nativeWebSearchKind = getNativeWebSearchKind(provider, model);
+  if (nativeWebSearchKind === null || nativeWebSearchKind === "perplexity-sonar") return true;
+  if (providerKind === "xai" && nativeWebSearchKind === "openai-responses") return true;
+
+  return (
+    (providerKind === "openai-responses" && nativeWebSearchKind === "openai-responses") ||
+    (providerKind === "anthropic" && nativeWebSearchKind === "anthropic-server-tool") ||
+    (providerKind === "google" && nativeWebSearchKind === "google-search-grounding") ||
+    (providerKind === "groq" && nativeWebSearchKind === "groq-compound")
+  );
+}
+
+function buildAiSdkProviderOptions(
+  provider: AiProviderConfig,
+  model: string,
+  options: AiSdkRequestFeatureOptions
+): AiSdkProviderOptions | undefined {
+  return mergeAiSdkProviderOptions(
+    buildAiSdkToolProviderOptions(provider, model, options),
+    buildAiSdkThinkingProviderOptions(provider, model, options.thinkingEnabled),
+    buildAiSdkWebSearchProviderOptions(provider, model, options.webSearchEnabled)
+  );
+}
+
+function buildAiSdkToolProviderOptions(
+  provider: AiProviderConfig,
+  model: string,
+  options: AiSdkRequestFeatureOptions
+): AiSdkProviderOptions | undefined {
+  const hasTools = Boolean(options.tools?.length || hasAiSdkNativeWebSearchTool(provider, model, options.webSearchEnabled));
+  if (!hasTools) return undefined;
+
+  const providerKind = resolveAiSdkProviderKind(provider);
+  if (providerKind === "anthropic") {
+    return {
+      anthropic: {
+        disableParallelToolUse: true
+      }
+    };
+  }
+  if (providerKind === "xai") {
+    return {
+      xai: {
+        parallel_function_calling: false
+      }
+    };
+  }
+  if (providerKind === "alibaba") {
+    return {
+      alibaba: {
+        parallelToolCalls: false
+      }
+    };
+  }
+  if (
+    providerKind !== "openai-responses" &&
+    providerKind !== "openai-compatible" &&
+    providerKind !== "mistral" &&
+    providerKind !== "groq"
+  ) {
+    return undefined;
+  }
+  return {
+    [providerOptionsKey(provider, providerKind)]: {
+      parallelToolCalls: false
+    }
+  };
+}
+
+function buildAiSdkThinkingProviderOptions(
+  provider: AiProviderConfig,
+  model: string,
+  thinkingEnabled: boolean | undefined
+): AiSdkProviderOptions | undefined {
+  if (thinkingEnabled !== true) return undefined;
+
+  const providerKind = resolveAiSdkProviderKind(provider);
+  if (providerKind === "openai-responses") {
+    return {
+      openai: {
+        forceReasoning: true,
+        reasoningEffort: "high",
+        reasoningSummary: "auto"
+      }
+    };
+  }
+  if (providerKind === "anthropic") return buildAnthropicAiSdkThinkingProviderOptions(model, thinkingEnabled);
+  if (providerKind === "google") {
+    return {
+      google: {
+        thinkingConfig: {
+          includeThoughts: true
+        }
+      }
+    };
+  }
+  if (providerKind === "deepseek") {
+    return {
+      deepseek: {
+        ...buildDeepSeekThinkingRequestOptions({ thinkingEnabled }),
+        reasoningEffort: "high"
+      }
+    };
+  }
+  if (providerKind === "mistral") {
+    return {
+      mistral: {
+        reasoningEffort: "high"
+      }
+    };
+  }
+  if (providerKind === "groq") return buildGroqAiSdkThinkingProviderOptions(model);
+  if (providerKind === "xai") {
+    return {
+      xai: {
+        reasoningEffort: "high"
+      }
+    };
+  }
+  if (providerKind === "alibaba") {
+    return {
+      alibaba: {
+        enableThinking: true
+      }
+    };
+  }
+
+  return undefined;
+}
+
+function buildAnthropicAiSdkThinkingProviderOptions(
+  model: string,
+  thinkingEnabled: boolean
+): AiSdkProviderOptions | undefined {
+  const thinkingOptions = buildAnthropicThinkingRequestOptions(model, { thinkingEnabled });
+  if (!isRecord(thinkingOptions.thinking)) return undefined;
+  const thinking = thinkingOptions.thinking;
+  if (thinking.type === "adaptive") {
+    return {
+      anthropic: {
+        thinking: {
+          display: typeof thinking.display === "string" ? thinking.display : "summarized",
+          type: "adaptive"
+        }
+      }
+    };
+  }
+  if (thinking.type === "enabled") {
+    return {
+      anthropic: {
+        thinking: {
+          budgetTokens: typeof thinking.budget_tokens === "number" ? thinking.budget_tokens : 1024,
+          type: "enabled"
+        }
+      }
+    };
+  }
+
+  return undefined;
+}
+
+function buildGroqAiSdkThinkingProviderOptions(model: string): AiSdkProviderOptions | undefined {
+  const normalizedModel = model.toLowerCase();
+  if (normalizedModel.includes("gpt-oss")) {
+    return {
+      groq: {
+        reasoningEffort: "high",
+        reasoningFormat: "parsed"
+      }
+    };
+  }
+  if (normalizedModel.includes("qwen")) {
+    return {
+      groq: {
+        reasoningEffort: "default",
+        reasoningFormat: "parsed"
+      }
+    };
+  }
+
+  return undefined;
+}
+
+function buildAiSdkWebSearchProviderOptions(
+  provider: AiProviderConfig,
+  model: string,
+  webSearchEnabled: boolean | undefined
+): AiSdkProviderOptions | undefined {
+  if (webSearchEnabled !== true) return undefined;
+  if (resolveAiSdkProviderKind(provider) !== "xai") return undefined;
+  if (getNativeWebSearchKind(provider, model) !== "openai-responses") return undefined;
+
+  return {
+    xai: {
+      searchParameters: {
+        mode: "on",
+        returnCitations: true,
+        sources: [{ type: "web" }]
+      }
+    }
+  };
+}
+
+function buildAiSdkTools(
+  provider: AiProviderConfig,
+  model: string,
+  options: Pick<AiSdkRequestFeatureOptions, "tools" | "webSearchEnabled">
+): ToolSet | undefined {
+  const nativeTools = buildAiSdkNativeWebSearchTools(provider, model, options.webSearchEnabled);
+  const functionTools = Object.fromEntries(
+    (options.tools ?? []).map((toolDefinition) => [
+      toolDefinition.name,
+      aiSdkTool({
+        description: toolDefinition.description,
+        inputSchema: jsonSchema(toolDefinition.parameters as Parameters<typeof jsonSchema>[0])
+      })
+    ])
+  );
+  const mergedTools = { ...nativeTools, ...functionTools };
+  if (Object.keys(mergedTools).length === 0) return undefined;
+
+  return mergedTools as ToolSet;
+}
+
+function buildAiSdkNativeWebSearchTools(
+  provider: AiProviderConfig,
+  model: string,
+  webSearchEnabled: boolean | undefined
+): ToolSet {
+  if (webSearchEnabled !== true) return {};
+
+  const providerKind = resolveAiSdkProviderKind(provider);
+  const nativeWebSearchKind = getNativeWebSearchKind(provider, model);
+  if (providerKind === "openai-responses" && nativeWebSearchKind === "openai-responses") {
+    return {
+      web_search: openai.tools.webSearch({})
+    } as ToolSet;
+  }
+  if (providerKind === "anthropic" && nativeWebSearchKind === "anthropic-server-tool") {
+    return {
+      web_search: anthropic.tools.webSearch_20250305({ maxUses: 5 })
+    } as ToolSet;
+  }
+  if (providerKind === "google" && nativeWebSearchKind === "google-search-grounding") {
+    return {
+      google_search: google.tools.googleSearch({})
+    } as ToolSet;
+  }
+  if (providerKind === "groq" && nativeWebSearchKind === "groq-compound" && isGroqBrowserSearchModel(model)) {
+    return {
+      browser_search: browserSearch({})
+    } as ToolSet;
+  }
+
+  return {};
+}
+
+function hasAiSdkNativeWebSearchTool(provider: AiProviderConfig, model: string, webSearchEnabled: boolean | undefined) {
+  return Object.keys(buildAiSdkNativeWebSearchTools(provider, model, webSearchEnabled)).length > 0;
+}
+
+function isGroqBrowserSearchModel(model: string) {
+  return model === "openai/gpt-oss-20b" || model === "openai/gpt-oss-120b";
+}
+
+function providerOptionsKey(provider: AiProviderConfig, providerKind: AiSdkProviderKind) {
+  if (providerKind === "openai-responses") return "openai";
+  if (providerKind === "openai-compatible") return provider.id || "openai-compatible";
+
+  return providerKind;
+}
+
+function mergeAiSdkProviderOptions(
+  ...options: (AiSdkProviderOptions | undefined)[]
+): AiSdkProviderOptions | undefined {
+  const merged: AiSdkProviderOptions = {};
+
+  for (const providerOptions of options) {
+    if (!providerOptions) continue;
+
+    for (const [providerName, providerValues] of Object.entries(providerOptions)) {
+      merged[providerName] = {
+        ...(merged[providerName] ?? {}),
+        ...providerValues
+      };
+    }
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function buildAiSdkMessages(messages: ChatMessage[]): ModelMessage[] {
+  return messages.map((message) => {
+    if (message.toolResult) return buildAiSdkToolMessage(message);
+    if (message.role === "assistant") return buildAiSdkAssistantMessage(message);
+    if (message.role === "system") {
+      return {
+        content: message.content,
+        role: "system"
+      };
+    }
+
+    return buildAiSdkUserMessage(message);
+  });
+}
+
+function buildAiSdkAssistantMessage(message: ChatMessage): AssistantModelMessage {
+  if (!message.toolCalls?.length) {
+    return {
+      content: message.content,
+      role: "assistant"
+    };
+  }
+
+  return {
+    content: [
+      ...(message.content.trim() ? [{ text: message.content, type: "text" as const }] : []),
+      ...message.toolCalls.map((toolCall) => ({
+        input: toolCall.arguments,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        type: "tool-call" as const
+      }))
+    ],
+    role: "assistant"
+  };
+}
+
+function buildAiSdkUserMessage(message: ChatMessage): UserModelMessage {
+  if (!message.images?.length) {
+    return {
+      content: message.content,
+      role: "user"
+    };
+  }
+
+  return {
+    content: [
+      { text: message.content, type: "text" as const },
+      ...message.images.map((image) => ({
+        image: base64DataFromDataUrl(image.dataUrl),
+        mediaType: image.mimeType,
+        type: "image" as const
+      }))
+    ],
+    role: "user"
+  };
+}
+
+function buildAiSdkToolMessage(message: ChatMessage): ToolModelMessage {
+  const toolResult = message.toolResult;
+  if (!toolResult) {
+    return {
+      content: [],
+      role: "tool"
+    };
+  }
+
+  return {
+    content: [
+      {
+        output: buildAiSdkToolResultOutput(message),
+        toolCallId: toolResult.toolCallId,
+        toolName: toolResult.toolName,
+        type: "tool-result"
+      }
+    ],
+    role: "tool"
+  };
+}
+
+function buildAiSdkToolResultOutput(message: ChatMessage) {
+  const outputText = message.toolResult?.outputText ?? "";
+  if (!message.images?.length) {
+    return {
+      type: "text" as const,
+      value: outputText
+    };
+  }
+
+  return {
+    type: "content" as const,
+    value: [
+      ...(outputText ? [{ text: outputText, type: "text" as const }] : []),
+      ...message.images.map((image) => ({
+        data: base64DataFromDataUrl(image.dataUrl),
+        mediaType: image.mimeType,
+        type: "image-data" as const
+      }))
+    ]
+  };
+}
+
+function base64DataFromDataUrl(dataUrl: ChatImageAttachment["dataUrl"]) {
+  const marker = ";base64,";
+  const markerIndex = dataUrl.indexOf(marker);
+
+  return markerIndex >= 0 ? dataUrl.slice(markerIndex + marker.length) : dataUrl;
+}
+
+function parseToolArguments(rawArguments: string) {
+  try {
+    const parsed = JSON.parse(rawArguments) as unknown;
+
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function readAiSdkStreamError(error: unknown) {
+  if (error instanceof Error) return error;
+
+  return new Error(typeof error === "string" ? error : "AI SDK stream error.");
+}

--- a/packages/ai/src/agent/sdk/native-fetch.test.ts
+++ b/packages/ai/src/agent/sdk/native-fetch.test.ts
@@ -1,0 +1,98 @@
+import { createNativeAiSdkFetch } from "./native-fetch";
+
+describe("createNativeAiSdkFetch", () => {
+  it("streams native chunks through a fetch Response body", async () => {
+    const transport = vi.fn();
+    const streamTransport = vi.fn(async (request, onChunk) => {
+      expect(request).toEqual({
+        body: JSON.stringify({ messages: [], stream: true }),
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json"
+        },
+        url: "https://example.test/v1/responses"
+      });
+      onChunk("data: first\n\n");
+      onChunk("data: second\n\n");
+
+      return { status: 200 };
+    });
+    const nativeFetch = createNativeAiSdkFetch({ streamTransport, transport });
+
+    const response = await nativeFetch("https://example.test/v1/responses", {
+      body: JSON.stringify({ messages: [], stream: true }),
+      headers: {
+        Authorization: "Bearer secret",
+        "content-type": "application/json"
+      },
+      method: "POST"
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await expect(response.text()).resolves.toBe("data: first\n\ndata: second\n\n");
+    expect(streamTransport).toHaveBeenCalledOnce();
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("returns native stream errors as non-2xx fetch responses when no chunks were emitted", async () => {
+    const streamTransport = vi.fn(async () => ({
+      body: { error: { message: "Upstream service temporarily unavailable" } },
+      status: 502
+    }));
+    const nativeFetch = createNativeAiSdkFetch({ streamTransport });
+
+    const response = await nativeFetch("https://example.test/v1/responses", {
+      body: JSON.stringify({ stream: true }),
+      method: "POST"
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: { message: "Upstream service temporarily unavailable" }
+    });
+  });
+
+  it("errors the fetch response body when the native stream fails after chunks were emitted", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk("data: partial\n\n");
+
+      return {
+        body: { error: { message: "Late upstream failure" } },
+        status: 502
+      };
+    });
+    const nativeFetch = createNativeAiSdkFetch({ streamTransport });
+
+    const response = await nativeFetch("https://example.test/v1/responses", {
+      body: JSON.stringify({ stream: true }),
+      method: "POST"
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).rejects.toThrow("Late upstream failure");
+  });
+
+  it("uses the non-stream native transport for ordinary JSON requests", async () => {
+    const transport = vi.fn(async () => ({
+      body: { ok: true },
+      status: 200
+    }));
+    const streamTransport = vi.fn();
+    const nativeFetch = createNativeAiSdkFetch({ streamTransport, transport });
+
+    const response = await nativeFetch("https://example.test/v1/chat/completions", {
+      body: JSON.stringify({ messages: [], stream: false }),
+      method: "POST"
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(transport).toHaveBeenCalledWith({
+      body: JSON.stringify({ messages: [], stream: false }),
+      headers: {},
+      url: "https://example.test/v1/chat/completions"
+    });
+    expect(streamTransport).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai/src/agent/sdk/native-fetch.ts
+++ b/packages/ai/src/agent/sdk/native-fetch.ts
@@ -1,0 +1,148 @@
+import type {
+  ChatCompletionStreamTransport,
+  ChatCompletionTransport,
+  NativeAiChatRequest,
+  NativeAiHttpResponse
+} from "../chat-completion";
+
+type NativeAiSdkFetchOptions = {
+  streamTransport?: ChatCompletionStreamTransport;
+  transport?: ChatCompletionTransport;
+};
+
+export type AiSdkFetch = (input: Request | URL | string, init?: RequestInit) => Promise<Response>;
+
+export function createNativeAiSdkFetch({ streamTransport, transport }: NativeAiSdkFetchOptions): AiSdkFetch {
+  return async (input, init) => {
+    const request = await nativeRequestFromFetch(input, init);
+
+    if (requestUsesStreaming(request)) {
+      if (!streamTransport) throw new Error("AI chat stream transport is not configured.");
+
+      return streamNativeResponse(request, streamTransport);
+    }
+
+    if (!transport) throw new Error("AI chat transport is not configured.");
+
+    return jsonResponseFromNative(await transport(request));
+  };
+}
+
+async function nativeRequestFromFetch(input: Request | URL | string, init: RequestInit | undefined): Promise<NativeAiChatRequest> {
+  const sourceRequest = input instanceof Request ? input : null;
+  const headers = new Headers(sourceRequest?.headers);
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+
+  return {
+    body: await readFetchBody(init?.body ?? (sourceRequest ? sourceRequest.clone().text() : undefined)),
+    headers: Object.fromEntries(headers.entries()),
+    url: sourceRequest?.url ?? input.toString()
+  };
+}
+
+async function readFetchBody(body: BodyInit | Promise<string> | null | undefined) {
+  if (body === null || body === undefined) return "";
+  if (typeof body === "string") return body;
+  if (body instanceof Promise) return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (body instanceof Blob) return body.text();
+
+  const textDecoder = new TextDecoder();
+  if (body instanceof ArrayBuffer) return textDecoder.decode(body);
+  if (ArrayBuffer.isView(body)) return textDecoder.decode(body);
+
+  throw new Error("AI SDK native fetch only supports text request bodies.");
+}
+
+function requestUsesStreaming(request: NativeAiChatRequest) {
+  if (request.url.includes(":streamGenerateContent")) return true;
+
+  try {
+    const parsed = JSON.parse(request.body) as unknown;
+    return typeof parsed === "object" && parsed !== null && "stream" in parsed && parsed.stream === true;
+  } catch {
+    return false;
+  }
+}
+
+function jsonResponseFromNative(response: NativeAiHttpResponse) {
+  return new Response(response.body === undefined || response.body === null ? null : JSON.stringify(response.body), {
+    headers: {
+      "content-type": "application/json"
+    },
+    status: response.status
+  });
+}
+
+function streamNativeResponse(request: NativeAiChatRequest, streamTransport: ChatCompletionStreamTransport) {
+  const textEncoder = new TextEncoder();
+  const stream = new TransformStream<Uint8Array, Uint8Array>();
+  const writer = stream.writable.getWriter();
+  const response = new Response(stream.readable, {
+    headers: {
+      "content-type": "text/event-stream"
+    },
+    status: 200
+  });
+  const pendingWrites: Promise<unknown>[] = [];
+  let responseSettled = false;
+
+  return new Promise<Response>((resolve, reject) => {
+    const settleWithStream = () => {
+      if (responseSettled) return;
+      responseSettled = true;
+      resolve(response);
+    };
+
+    streamTransport(request, (chunk) => {
+      settleWithStream();
+      const pendingWrite = writer.write(textEncoder.encode(chunk));
+      pendingWrites.push(pendingWrite);
+
+      return pendingWrite;
+    })
+      .then(async (nativeResponse) => {
+        if (!responseSettled) {
+          responseSettled = true;
+          resolve(jsonResponseFromNative({ body: nativeResponse.body ?? null, status: nativeResponse.status }));
+          return;
+        }
+
+        await Promise.all(pendingWrites);
+        if (nativeResponse.status < 200 || nativeResponse.status >= 300) {
+          await writer.abort(new Error(readNativeResponseError({ body: nativeResponse.body ?? null, status: nativeResponse.status })));
+          return;
+        }
+
+        await writer.close();
+      })
+      .catch(async (error: unknown) => {
+        if (!responseSettled) {
+          responseSettled = true;
+          reject(error);
+          return;
+        }
+
+        await writer.abort(error);
+      });
+  });
+}
+
+function readNativeResponseError(response: NativeAiHttpResponse) {
+  const body = response.body;
+  if (isPlainRecord(body)) {
+    if (typeof body.message === "string") return body.message;
+    if (isPlainRecord(body.error) && typeof body.error.message === "string") return body.error.message;
+    if (typeof body.error === "string") return body.error;
+  }
+
+  return `Request failed with HTTP ${response.status}.`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/ai/src/agent/tool-builders/openai-compatible.ts
+++ b/packages/ai/src/agent/tool-builders/openai-compatible.ts
@@ -12,11 +12,11 @@ export function buildOpenAiCompatibleFunctionTools(tools: Tool[] | undefined) {
 }
 
 export function buildResponsesStyleTools(
-  nativeWebSearchToolType: "openrouter:web_search" | "web_search",
+  nativeWebSearchToolType: "openrouter:web_search" | "web_search" | undefined,
   tools: Tool[] | undefined
 ) {
   return [
-    { type: nativeWebSearchToolType },
+    ...(nativeWebSearchToolType ? [{ type: nativeWebSearchToolType }] : []),
     ...(tools ?? []).map((tool) => ({
       description: tool.description,
       name: tool.name,

--- a/packages/ai/src/agent/tools/regions.ts
+++ b/packages/ai/src/agent/tools/regions.ts
@@ -402,9 +402,15 @@ export function resolveInsertionPosition(
     };
   }
 
+  if (args.placement === "cursor") {
+    return {
+      position: context.documentEndPosition
+    };
+  }
+
   return {
     error: toolErrorResult(
-      "Cannot insert because there is no active editor context. Call locate_markdown_region or get_available_anchors first and then insert via anchorId."
+      "Cannot insert because there is no active editor selection for that placement. Call locate_markdown_region or get_available_anchors first and then insert via anchorId."
     )
   };
 }

--- a/packages/providers/src/auth.test.ts
+++ b/packages/providers/src/auth.test.ts
@@ -1,0 +1,9 @@
+import { providerRequiresApiKey } from "./providers";
+
+describe("AI provider auth", () => {
+  it("marks local providers as not requiring API keys", () => {
+    expect(providerRequiresApiKey({ id: "ollama", type: "ollama" })).toBe(false);
+    expect(providerRequiresApiKey({ id: "openai", type: "openai" })).toBe(true);
+    expect(providerRequiresApiKey({ id: "custom-provider-1", type: "openai-compatible" })).toBe(true);
+  });
+});

--- a/packages/providers/src/auth.ts
+++ b/packages/providers/src/auth.ts
@@ -1,0 +1,5 @@
+import type { AiProviderConfig } from "./types";
+
+export function providerRequiresApiKey(provider: Pick<AiProviderConfig, "id" | "type">) {
+  return provider.type !== "ollama";
+}

--- a/packages/providers/src/catalog.ts
+++ b/packages/providers/src/catalog.ts
@@ -1,4 +1,4 @@
-import type { AiProviderApiStyle, AiProviderConfigSeed } from "./types";
+import type { AiProviderApiStyle, AiProviderConfigSeed, AiProviderRequestStyle } from "./types";
 
 export const defaultApiUrlByApiStyle: Partial<Record<AiProviderApiStyle, string>> = {
   anthropic: "https://api.anthropic.com/v1",
@@ -12,6 +12,13 @@ export const defaultApiUrlByApiStyle: Partial<Record<AiProviderApiStyle, string>
   openrouter: "https://openrouter.ai/api/v1",
   together: "https://api.together.xyz/v1",
   xai: "https://api.x.ai/v1"
+};
+
+export const defaultApiUrlByRequestStyle: Partial<Record<AiProviderRequestStyle, string>> = {
+  anthropic: "https://api.anthropic.com/v1",
+  google: "https://generativelanguage.googleapis.com/v1beta",
+  "openai-compatible": "https://api.openai.com/v1",
+  "openai-responses": "https://api.openai.com/v1"
 };
 
 export const defaultProviderTemplates: AiProviderConfigSeed[] = [
@@ -29,6 +36,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["image"], enabled: true, id: "gpt-image-2", name: "GPT Image 2" }
     ],
     name: "OpenAI",
+    apiStyle: "openai-responses",
     type: "openai"
   },
   {
@@ -43,6 +51,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "vision", "reasoning", "tools"], enabled: true, id: "claude-haiku-4-5", name: "Claude Haiku 4.5" }
     ],
     name: "Anthropic",
+    apiStyle: "anthropic",
     type: "anthropic"
   },
   {
@@ -62,6 +71,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       }
     ],
     name: "Google",
+    apiStyle: "google",
     type: "google"
   },
   {
@@ -75,6 +85,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "reasoning", "tools"], enabled: true, id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" }
     ],
     name: "DeepSeek",
+    apiStyle: "openai-compatible",
     type: "deepseek"
   },
   {
@@ -90,6 +101,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "tools"], enabled: true, id: "devstral-latest", name: "Devstral 2" }
     ],
     name: "Mistral",
+    apiStyle: "openai-compatible",
     type: "mistral"
   },
   {
@@ -105,6 +117,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "tools"], enabled: true, id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B Versatile" }
     ],
     name: "Groq",
+    apiStyle: "openai-compatible",
     type: "groq"
   },
   {
@@ -121,6 +134,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "vision", "reasoning", "tools", "web"], enabled: true, id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" }
     ],
     name: "OpenRouter",
+    apiStyle: "openai-compatible",
     type: "openrouter"
   },
   {
@@ -140,6 +154,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "reasoning", "tools"], enabled: true, id: "deepseek-ai/DeepSeek-R1", name: "DeepSeek R1" }
     ],
     name: "Together.ai",
+    apiStyle: "openai-compatible",
     type: "together"
   },
   {
@@ -155,6 +170,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "vision", "reasoning", "tools", "web"], enabled: true, id: "qwen3.5-flash", name: "Qwen3.5 Flash" }
     ],
     name: "Qwen",
+    apiStyle: "openai-compatible",
     type: "openai-compatible"
   },
   {
@@ -169,6 +185,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "tools", "web"], enabled: true, id: "mimo-v2.5-flash", name: "MiMo V2.5 Flash" }
     ],
     name: "Xiaomi MiMo",
+    apiStyle: "openai-compatible",
     type: "openai-compatible"
   },
   {
@@ -184,6 +201,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "reasoning"], enabled: true, id: "deepseek-r1-250528", name: "DeepSeek R1" }
     ],
     name: "Volcengine Ark",
+    apiStyle: "openai-compatible",
     type: "openai-compatible"
   },
   {
@@ -197,6 +215,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "vision", "reasoning", "tools", "web"], enabled: true, id: "grok-4.3-fast", name: "Grok 4.3 Fast" }
     ],
     name: "xAI",
+    apiStyle: "openai-compatible",
     type: "xai"
   },
   {
@@ -211,6 +230,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text", "vision", "reasoning", "tools", "web"], enabled: true, id: "gpt-5.4-nano", name: "GPT-5.4 nano deployment" }
     ],
     name: "Azure OpenAI",
+    apiStyle: "openai-compatible",
     type: "azure-openai"
   },
   {
@@ -225,6 +245,7 @@ export const defaultProviderTemplates: AiProviderConfigSeed[] = [
       { capabilities: ["text"], enabled: true, id: "gpt-oss:20b", name: "GPT-OSS 20B" }
     ],
     name: "Ollama",
+    apiStyle: "openai-compatible",
     type: "ollama"
   }
 ];
@@ -249,6 +270,10 @@ export function defaultProviderTemplateForProviderId(providerId: string): AiProv
 
 export function defaultApiUrlForApiStyle(apiStyle: AiProviderApiStyle) {
   return defaultApiUrlByApiStyle[apiStyle] ?? "";
+}
+
+export function defaultApiUrlForRequestStyle(apiStyle: AiProviderRequestStyle) {
+  return defaultApiUrlByRequestStyle[apiStyle] ?? "";
 }
 
 export function defaultApiUrlForStoredProvider(providerId: string, type: AiProviderApiStyle) {

--- a/packages/providers/src/native-web-search.ts
+++ b/packages/providers/src/native-web-search.ts
@@ -30,6 +30,10 @@ export function getNativeWebSearchKind(provider: AiProviderConfig, model: Native
 
   if (!modelSupportsConfiguredWebSearch(provider, model)) return null;
 
+  if (provider.apiStyle === "openai-responses") return "openai-responses";
+  if (provider.apiStyle === "anthropic") return "anthropic-server-tool";
+  if (provider.apiStyle === "google") return "google-search-grounding";
+
   if (provider.type === "openai") return "openai-responses";
   if (provider.type === "xai") return "openai-responses";
   if (provider.type === "anthropic") return "anthropic-server-tool";

--- a/packages/providers/src/providers.ts
+++ b/packages/providers/src/providers.ts
@@ -5,9 +5,12 @@ export {
   type AiProviderApiStyle,
   type AiProviderConfig,
   type AiProviderModel,
+  type AiProviderRequestStyle,
   type AiProviderSettings
 } from "./types";
-export { defaultApiUrlForApiStyle } from "./catalog";
+export { providerRequiresApiKey } from "./auth";
+export { editableRequestStylesForProvider, requestStyleForProviderType } from "./request-styles";
+export { defaultApiUrlForApiStyle, defaultApiUrlForRequestStyle } from "./catalog";
 export { enrichAiProviderModelCapabilities, normalizeAiModelCapabilities } from "./capabilities";
 export { readAiProviderCustomHeaders } from "./headers";
 export { createCustomAiProvider, createDefaultAiSettings, normalizeAiSettings } from "./settings";

--- a/packages/providers/src/request-styles.test.ts
+++ b/packages/providers/src/request-styles.test.ts
@@ -1,0 +1,24 @@
+import { editableRequestStylesForProvider, requestStyleForProviderType } from "./providers";
+
+describe("AI provider request styles", () => {
+  it("exposes editable request styles only for providers that can change API style", () => {
+    expect(editableRequestStylesForProvider({ id: "openai", type: "openai" })).toEqual([
+      "openai-responses",
+      "openai-compatible"
+    ]);
+    expect(editableRequestStylesForProvider({ id: "custom-provider-1", type: "openai-compatible" })).toEqual([
+      "openai-responses",
+      "openai-compatible",
+      "anthropic",
+      "google"
+    ]);
+    expect(editableRequestStylesForProvider({ id: "groq", type: "groq" })).toEqual([]);
+  });
+
+  it("maps provider types to their default request style", () => {
+    expect(requestStyleForProviderType("openai")).toBe("openai-responses");
+    expect(requestStyleForProviderType("anthropic")).toBe("anthropic");
+    expect(requestStyleForProviderType("google")).toBe("google");
+    expect(requestStyleForProviderType("groq")).toBe("openai-compatible");
+  });
+});

--- a/packages/providers/src/request-styles.ts
+++ b/packages/providers/src/request-styles.ts
@@ -1,0 +1,33 @@
+import {
+  aiProviderRequestStyles,
+  type AiProviderApiStyle,
+  type AiProviderConfig,
+  type AiProviderRequestStyle
+} from "./types";
+
+const openAiEditableRequestStyles: AiProviderRequestStyle[] = ["openai-responses", "openai-compatible"];
+
+export function isAiProviderRequestStyle(value: unknown): value is AiProviderRequestStyle {
+  return typeof value === "string" && aiProviderRequestStyles.includes(value as AiProviderRequestStyle);
+}
+
+export function requestStyleForProviderType(type: AiProviderApiStyle): AiProviderRequestStyle {
+  if (type === "openai") return "openai-responses";
+  if (type === "anthropic") return "anthropic";
+  if (type === "google") return "google";
+
+  return "openai-compatible";
+}
+
+export function editableRequestStylesForProvider(
+  provider: Pick<AiProviderConfig, "id" | "type">
+): AiProviderRequestStyle[] {
+  if (isCustomAiProviderId(provider.id)) return [...aiProviderRequestStyles];
+  if (provider.type === "openai") return [...openAiEditableRequestStyles];
+
+  return [];
+}
+
+function isCustomAiProviderId(providerId: string) {
+  return providerId.startsWith("custom-provider-");
+}

--- a/packages/providers/src/requests.test.ts
+++ b/packages/providers/src/requests.test.ts
@@ -163,6 +163,15 @@ describe("AI provider requests", () => {
       headers: {},
       url: "http://localhost:11434/v1/models"
     });
+    expect(buildAiProviderModelsRequest(provider({
+      apiKey: "stale-local-key",
+      apiStyle: "openai-compatible",
+      baseUrl: "http://localhost:11434/v1",
+      type: "ollama"
+    }))).toMatchObject({
+      headers: {},
+      url: "http://localhost:11434/v1/models"
+    });
     expect(buildAiProviderModelsRequest(provider({ type: "mistral" }))).toMatchObject({
       headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
       url: "https://api.mistral.ai/v1/models"

--- a/packages/providers/src/requests.ts
+++ b/packages/providers/src/requests.ts
@@ -1,5 +1,10 @@
-import type { AiModelCapability, AiProviderApiStyle, AiProviderConfig, AiProviderModel } from "./providers";
-import { enrichAiProviderModelCapabilities, normalizeAiModelCapabilities, readAiProviderCustomHeaders } from "./providers";
+import type { AiModelCapability, AiProviderApiStyle, AiProviderConfig, AiProviderModel, AiProviderRequestStyle } from "./providers";
+import {
+  enrichAiProviderModelCapabilities,
+  normalizeAiModelCapabilities,
+  providerRequiresApiKey,
+  readAiProviderCustomHeaders
+} from "./providers";
 import { isRecord, joinApiUrl } from "@markra/shared";
 
 type NativeAiHttpRequest = {
@@ -88,14 +93,22 @@ const endpointByApiStyle: Record<AiProviderApiStyle, ProviderEndpoint> = {
   }
 };
 
+const endpointByRequestStyle: Record<AiProviderRequestStyle, ProviderEndpoint | null> = {
+  anthropic: endpointByApiStyle.anthropic,
+  google: endpointByApiStyle.google,
+  "openai-compatible": endpointByApiStyle["openai-compatible"],
+  "openai-responses": endpointByApiStyle.openai
+};
+
 export function buildAiProviderModelsRequest(provider: AiProviderConfig): AiProviderHttpRequest {
-  const endpoint = endpointByApiStyle[provider.type];
+  const endpoint = provider.apiStyle ? endpointByRequestStyle[provider.apiStyle] : endpointByApiStyle[provider.type];
+  if (!endpoint) throw new Error("Model list is not available for this API style.");
   const baseUrl = provider.baseUrl?.trim() || endpoint.baseUrl;
   if (!baseUrl) throw new Error("API URL is required.");
 
   return {
     headers: {
-      ...buildAuthHeaders(endpoint.auth, provider.apiKey?.trim() ?? ""),
+      ...buildAuthHeaders(endpoint.auth, readProviderApiKey(provider)),
       ...readAiProviderCustomHeaders(provider)
     },
     method: "GET",
@@ -134,15 +147,16 @@ function missingAiProviderTransport(): never {
 }
 
 export function parseAiProviderModels(provider: AiProviderConfig, body: unknown): AiProviderModel[] {
-  const records = readModelRecords(provider.type, body);
+  const apiStyle = provider.apiStyle ?? provider.type;
+  const records = readModelRecords(apiStyle, body);
   const seenIds = new Set<string>();
   const models: AiProviderModel[] = [];
 
   for (const record of records) {
-    const id = readModelId(provider.type, record);
+    const id = readModelId(apiStyle, record);
     if (!id || seenIds.has(id)) continue;
 
-    const capabilities = inferModelCapabilities(provider.type, record, id);
+    const capabilities = inferModelCapabilities(apiStyle, record, id);
     if (capabilities.length === 0) continue;
 
     seenIds.add(id);
@@ -150,7 +164,7 @@ export function parseAiProviderModels(provider: AiProviderConfig, body: unknown)
       capabilities,
       enabled: true,
       id,
-      name: readModelName(provider.type, record, id)
+      name: readModelName(apiStyle, record, id)
     }));
   }
 
@@ -166,7 +180,11 @@ function buildAuthHeaders(auth: ProviderEndpoint["auth"], apiKey: string): Recor
   return { Authorization: `Bearer ${apiKey}` };
 }
 
-function readModelRecords(apiStyle: AiProviderApiStyle, body: unknown): Record<string, unknown>[] {
+function readProviderApiKey(provider: AiProviderConfig) {
+  return providerRequiresApiKey(provider) ? provider.apiKey?.trim() ?? "" : "";
+}
+
+function readModelRecords(apiStyle: AiProviderApiStyle | AiProviderRequestStyle, body: unknown): Record<string, unknown>[] {
   if (Array.isArray(body)) return body.filter(isRecord);
   if (!isRecord(body)) return [];
 
@@ -177,7 +195,7 @@ function readModelRecords(apiStyle: AiProviderApiStyle, body: unknown): Record<s
   return [];
 }
 
-function readModelId(apiStyle: AiProviderApiStyle, record: Record<string, unknown>) {
+function readModelId(apiStyle: AiProviderApiStyle | AiProviderRequestStyle, record: Record<string, unknown>) {
   const id = typeof record.id === "string" ? record.id : undefined;
   const name = typeof record.name === "string" ? record.name : undefined;
 
@@ -186,7 +204,7 @@ function readModelId(apiStyle: AiProviderApiStyle, record: Record<string, unknow
   return id ?? name;
 }
 
-function readModelName(apiStyle: AiProviderApiStyle, record: Record<string, unknown>, id: string) {
+function readModelName(apiStyle: AiProviderApiStyle | AiProviderRequestStyle, record: Record<string, unknown>, id: string) {
   if (typeof record.displayName === "string") return record.displayName;
   if (typeof record.display_name === "string") return record.display_name;
   if (typeof record.name === "string" && !(apiStyle === "google" && record.name.startsWith("models/"))) return record.name;
@@ -195,7 +213,7 @@ function readModelName(apiStyle: AiProviderApiStyle, record: Record<string, unkn
 }
 
 // Converts provider-specific model metadata into Markra's internal capability flags.
-function inferModelCapabilities(apiStyle: AiProviderApiStyle, record: Record<string, unknown>, id: string): AiModelCapability[] {
+function inferModelCapabilities(apiStyle: AiProviderApiStyle | AiProviderRequestStyle, record: Record<string, unknown>, id: string): AiModelCapability[] {
   if (apiStyle === "google") return inferGoogleCapabilities(record, id);
   if (apiStyle === "openrouter") return inferOpenRouterCapabilities(record, id);
 

--- a/packages/providers/src/settings.test.ts
+++ b/packages/providers/src/settings.test.ts
@@ -1,0 +1,110 @@
+import { normalizeAiSettings } from "./settings";
+
+describe("AI provider settings", () => {
+  it("normalizes legacy provider types into the new request API styles", () => {
+    const settings = normalizeAiSettings({
+      defaultProviderId: "openai",
+      providers: [
+        {
+          enabled: true,
+          id: "openai",
+          models: [{ enabled: true, id: "gpt-5.5", name: "GPT-5.5" }],
+          name: "OpenAI",
+          type: "openai"
+        },
+        {
+          enabled: true,
+          id: "openrouter",
+          models: [{ enabled: true, id: "openrouter/auto", name: "Auto" }],
+          name: "OpenRouter",
+          type: "openrouter"
+        },
+        {
+          apiStyle: "amazon-bedrock",
+          enabled: false,
+          id: "custom-provider-1",
+          models: [{ enabled: true, id: "anthropic.claude-sonnet-4-5-v1:0", name: "Claude Sonnet" }],
+          name: "Legacy Bedrock Relay",
+          type: "openai-compatible"
+        }
+      ]
+    });
+
+    expect(settings.providers.find((provider) => provider.id === "openai")).toMatchObject({
+      apiStyle: "openai-responses",
+      type: "openai"
+    });
+    expect(settings.providers.find((provider) => provider.id === "openrouter")).toMatchObject({
+      apiStyle: "openai-compatible",
+      type: "openrouter"
+    });
+    expect(settings.providers.find((provider) => provider.id === "custom-provider-1")).toMatchObject({
+      apiStyle: "openai-compatible",
+      type: "openai-compatible"
+    });
+  });
+
+  it("keeps fixed built-in providers on their catalog request style", () => {
+    const settings = normalizeAiSettings({
+      defaultProviderId: "groq",
+      providers: [
+        {
+          apiStyle: "anthropic",
+          enabled: true,
+          id: "groq",
+          models: [{ enabled: true, id: "llama-3.3-70b-versatile", name: "Llama" }],
+          name: "Groq",
+          type: "groq"
+        },
+        {
+          apiStyle: "google",
+          enabled: true,
+          id: "openai",
+          models: [{ enabled: true, id: "gpt-5.5", name: "GPT-5.5" }],
+          name: "OpenAI",
+          type: "openai"
+        },
+        {
+          apiStyle: "amazon-bedrock",
+          enabled: true,
+          id: "custom-provider-1",
+          models: [{ enabled: true, id: "default", name: "Default" }],
+          name: "Custom Provider",
+          type: "openai-compatible"
+        }
+      ]
+    });
+
+    expect(settings.providers.find((provider) => provider.id === "groq")).toMatchObject({
+      apiStyle: "openai-compatible"
+    });
+    expect(settings.providers.find((provider) => provider.id === "openai")).toMatchObject({
+      apiStyle: "openai-responses"
+    });
+    expect(settings.providers.find((provider) => provider.id === "custom-provider-1")).toMatchObject({
+      apiStyle: "openai-compatible"
+    });
+  });
+
+  it("drops stored API keys for providers that do not use keys", () => {
+    const settings = normalizeAiSettings({
+      defaultProviderId: "ollama",
+      providers: [
+        {
+          apiKey: "stale-local-key",
+          baseUrl: "http://localhost:11434/v1",
+          enabled: true,
+          id: "ollama",
+          models: [{ enabled: true, id: "llama3.3", name: "Llama" }],
+          name: "Ollama",
+          type: "ollama"
+        }
+      ]
+    });
+
+    expect(settings.providers.find((provider) => provider.id === "ollama")).toMatchObject({
+      apiKey: "",
+      baseUrl: "http://localhost:11434/v1"
+    });
+  });
+});

--- a/packages/providers/src/settings.ts
+++ b/packages/providers/src/settings.ts
@@ -7,6 +7,8 @@ import {
   staleDefaultModelIdsByProviderId
 } from "./catalog";
 import { enrichAiProviderModelCapabilities, readModelCapabilities } from "./capabilities";
+import { providerRequiresApiKey } from "./auth";
+import { editableRequestStylesForProvider, isAiProviderRequestStyle, requestStyleForProviderType } from "./request-styles";
 import {
   isAiProviderApiStyle,
   type AiProviderConfig,
@@ -42,6 +44,7 @@ export function createCustomAiProvider(index: number): AiProviderConfig {
     id: `custom-provider-${providerNumber}`,
     models: [{ capabilities: ["text"], enabled: true, id: "default", name: "Default model" }],
     name: "Custom Provider",
+    apiStyle: "openai-compatible",
     type: "openai-compatible"
   };
 }
@@ -89,10 +92,18 @@ function normalizeProvider(value: unknown): AiProviderConfig | null {
   if (legacyBuiltInProviderIds.has(providerId)) return null;
 
   const type = isAiProviderApiStyle(value.type) ? value.type : "openai-compatible";
+  const defaultProvider = defaultProviderTemplateForProviderId(providerId);
+  const fallbackApiStyle = defaultProvider?.apiStyle ?? requestStyleForProviderType(type);
+  const editableApiStyles = editableRequestStylesForProvider({ id: providerId, type });
+  const storedApiStyle = isAiProviderRequestStyle(value.apiStyle) ? value.apiStyle : undefined;
+  const canUseStoredApiStyle =
+    editableApiStyles.length > 0 &&
+    storedApiStyle !== undefined &&
+    editableApiStyles.includes(storedApiStyle);
+  const apiStyle = canUseStoredApiStyle ? storedApiStyle : fallbackApiStyle;
   const normalizedStoredModels = Array.isArray(value.models)
     ? value.models.map(normalizeModel).filter((model): model is AiProviderModel => Boolean(model))
     : [];
-  const defaultProvider = defaultProviderTemplateForProviderId(providerId);
   const storedModels = defaultProvider
     ? normalizedStoredModels.map((model) => enrichAiProviderModelCapabilities(providerId, model))
     : normalizedStoredModels;
@@ -114,7 +125,10 @@ function normalizeProvider(value: unknown): AiProviderConfig | null {
       : models[0]?.id;
 
   return {
-    apiKey: typeof value.apiKey === "string" ? value.apiKey : "",
+    apiKey:
+      providerRequiresApiKey({ id: providerId, type }) && typeof value.apiKey === "string"
+        ? value.apiKey
+        : "",
     baseUrl: storedBaseUrl || defaultApiUrlForStoredProvider(providerId, type),
     ...(typeof value.customHeaders === "string" && value.customHeaders.trim() ? { customHeaders: value.customHeaders } : {}),
     defaultModelId,
@@ -122,6 +136,7 @@ function normalizeProvider(value: unknown): AiProviderConfig | null {
     id: providerId,
     models,
     name: value.name,
+    apiStyle,
     type
   };
 }

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -13,7 +13,15 @@ export const aiProviderApiStyles = [
   "ollama"
 ] as const;
 
+export const aiProviderRequestStyles = [
+  "openai-responses",
+  "openai-compatible",
+  "anthropic",
+  "google"
+] as const;
+
 export type AiProviderApiStyle = (typeof aiProviderApiStyles)[number];
+export type AiProviderRequestStyle = (typeof aiProviderRequestStyles)[number];
 export type AiModelCapability = "image" | "reasoning" | "text" | "tools" | "vision" | "web";
 
 export type AiProviderModel = {
@@ -32,6 +40,7 @@ export type AiProviderConfig = {
   id: string;
   models: AiProviderModel[];
   name: string;
+  apiStyle?: AiProviderRequestStyle;
   type: AiProviderApiStyle;
 };
 

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -204,7 +204,7 @@ const messages: LocaleMessages = {
   "settings.ai.configured": "已配置",
   "settings.ai.notConfigured": "未配置",
   "settings.ai.providerLogo": "标志",
-  "settings.ai.apiStyleOpenAiCompatible": "OpenAI 兼容",
+  "settings.ai.apiStyleOpenAiCompatible": "OpenAI compatible",
   "settings.ai.customHeaders": "自定义 Header",
   "settings.ai.customHeadersDescription": "会添加到模型列表和聊天请求。请输入 JSON 对象。",
   "settings.ai.customHeadersEdit": "编辑自定义 Header",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -98,7 +98,7 @@ const messages: LocaleMessages = {
   "settings.ai.configured": "已設定",
   "settings.ai.notConfigured": "未設定",
   "settings.ai.providerLogo": "標誌",
-  "settings.ai.apiStyleOpenAiCompatible": "OpenAI 相容",
+  "settings.ai.apiStyleOpenAiCompatible": "OpenAI compatible",
   "settings.ai.customHeaders": "自訂 Header",
   "settings.ai.customHeadersDescription": "會加入模型列表和聊天請求。請輸入 JSON 物件。",
   "settings.ai.customHeadersEdit": "編輯自訂 Header",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,10 +149,43 @@ importers:
         version: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/ai:
     dependencies:
+      '@ai-sdk/alibaba':
+        specifier: 1.0.23
+        version: 1.0.23(zod@4.4.3)
+      '@ai-sdk/anthropic':
+        specifier: 3.0.78
+        version: 3.0.78(zod@4.4.3)
+      '@ai-sdk/azure':
+        specifier: 3.0.65
+        version: 3.0.65(zod@4.4.3)
+      '@ai-sdk/deepseek':
+        specifier: 2.0.35
+        version: 2.0.35(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: 3.0.75
+        version: 3.0.75(zod@4.4.3)
+      '@ai-sdk/groq':
+        specifier: 3.0.39
+        version: 3.0.39(zod@4.4.3)
+      '@ai-sdk/mistral':
+        specifier: 3.0.37
+        version: 3.0.37(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: 3.0.64
+        version: 3.0.64(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: 2.0.47
+        version: 2.0.47(zod@4.4.3)
+      '@ai-sdk/togetherai':
+        specifier: 2.0.51
+        version: 2.0.51(zod@4.4.3)
+      '@ai-sdk/xai':
+        specifier: 3.0.91
+        version: 3.0.91(zod@4.4.3)
       '@mariozechner/pi-agent-core':
         specifier: 0.73.0
         version: 0.73.0(ws@8.20.0)(zod@4.4.3)
@@ -168,6 +201,9 @@ importers:
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
+      ai:
+        specifier: 6.0.184
+        version: 6.0.184(zod@4.4.3)
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
@@ -186,7 +222,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/editor:
     dependencies:
@@ -223,7 +259,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/markdown:
     dependencies:
@@ -245,7 +281,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/providers:
     dependencies:
@@ -261,7 +297,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/shared:
     devDependencies:
@@ -279,7 +315,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
   packages/ui:
     devDependencies:
@@ -312,12 +348,94 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
 
 packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-sdk/alibaba@1.0.23':
+    resolution: {integrity: sha512-IH1vuFCJZacj8UPMrOPCdesFNv86hf6/c/0h19OfeoW4zHeBpW9ssCKUbQ+V68EBZto5aEDr/SnRn1pIuGvgfA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/anthropic@3.0.78':
+    resolution: {integrity: sha512-0OY12G20cUt6iU6htpEA1491Oz++NVxZxlmWGX4B7rSbeZ5pnDmOu6YtW9BKzdZlNx5Gn23i6WMxyZFoMKNcgA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/azure@3.0.65':
+    resolution: {integrity: sha512-i8KdHakLrlBuX4D6pk+AIMSUaj2ZgxcsyKmgrRhZmR+wdunNZf0sh0rjd7LLCItHSPfMk4BWIAeW656R0wJlvg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/deepseek@2.0.35':
+    resolution: {integrity: sha512-9DhYurbAvcurOEGN6u2myYDybrrzGfcrkG8hwmFjwTrePW6KCMggm0YxP7e8RkLYcQKqCEMgFlyEB4BM6EmiKg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.115':
+    resolution: {integrity: sha512-xonmGfN9pt54WdKqMzWe68BRYS3rsYvraBzioyA0gfNcecHs8Ir5qk/X8grJSyZ95hghjWiOphrK6bAc11E6SA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.75':
+    resolution: {integrity: sha512-XAm31ftiOrzlb8NjDzT7kw0xw+4lmgFdGFn1QKM73nXFFKyN1kWLESBV75UGNfjXP8X1YJ0YydnMVqO0jaPghw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/groq@3.0.39':
+    resolution: {integrity: sha512-BZAr6DjCbzWQ0Qn1/TSsHo/bmCt4JaAMb4A7HCSUZBQCAcOjne/03D0sVjHnQhUC3TpwcmYiv7tHAviK7BluRw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mistral@3.0.37':
+    resolution: {integrity: sha512-KkdaMjs4C2y+vrZWJE990E3ZxBFiOTHQ94ZlquuIttpphcqJTMxNoIpnKT/4UzMVWXL0BUEE2vs+1UEVXkN8Kg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.47':
+    resolution: {integrity: sha512-Enm5UlL0zUCrW3792opk5h7hRWxZOZzDe6eQYVFqX9LUOGGCe1h8MZWAGim765nwzgnjlpeYOsuzZmLtRsTPlg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.64':
+    resolution: {integrity: sha512-epO4iS6QwktaY2PF6uBcPnDTJ3BxPOfsGS7/OEtBe3GtNj7C8h8gMDVtIe5K8W16HNDbn0tbR4dcQfpfs+XVFg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/togetherai@2.0.51':
+    resolution: {integrity: sha512-rwITuQuu3Vqo/mpKQ01+e16YwsMtvCLIkSpuejj1KNgduDtYlCbE4bDocYY/H8rkYtTldSpi31CEDUVt7H4iSw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/xai@3.0.91':
+    resolution: {integrity: sha512-7zhOCe7hoLfJ5VMTLejzAjBuhaBWIakfd6ZBeQBveshP+DKAPTbl08wTVqnjRLqP1Dw2zN2oT3eyz1EtiFzyBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -900,6 +1018,10 @@ packages:
 
   '@ocavue/utils@1.6.0':
     resolution: {integrity: sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -1610,6 +1732,10 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1684,6 +1810,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@6.0.184:
+    resolution: {integrity: sha512-j//zHkKvj5ra27l8izHco8cj1g1Pr7vx1ZK+hrzrkHvndgIRmdfZKOb6+RAPpvbk42qGIsuYvlYbGlVAu3erNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2069,6 +2201,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2222,6 +2358,9 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -3108,6 +3247,94 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ai-sdk/alibaba@1.0.23(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.47(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/anthropic@3.0.78(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/azure@3.0.65(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai': 3.0.64(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/deepseek@2.0.35(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.115(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/google@3.0.75(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/groq@3.0.39(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/mistral@3.0.37(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@2.0.47(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@3.0.64(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/togetherai@2.0.51(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.47(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/xai@3.0.91(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.47(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -4396,6 +4623,8 @@ snapshots:
 
   '@ocavue/utils@1.6.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.127.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -5140,6 +5369,8 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -5241,6 +5472,14 @@ snapshots:
   '@vue/shared@3.5.33': {}
 
   agent-base@7.1.4: {}
+
+  ai@6.0.184(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.115(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
 
   ansi-regex@5.0.1: {}
 
@@ -5617,6 +5856,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventsource-parser@3.0.8: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -5806,6 +6047,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
+
+  json-schema@0.4.0: {}
 
   jsonc-parser@3.3.1: {}
 
@@ -6868,7 +7111,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.4
 
-  vitest@4.1.5(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4))
@@ -6891,6 +7134,7 @@ snapshots:
       vite: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.10.0
       jsdom: 29.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Switch AI generation to the Vercel AI SDK streaming path, with response text, reasoning, sources, tool calls, and errors normalized back into Markra's existing event model.
- Tighten API style handling:
  - OpenAI can choose only `OpenAI Responses` or `OpenAI Compatible`.
  - Custom providers can choose supported API styles only; unsupported Amazon Bedrock is no longer exposed.
  - Legacy custom-provider settings saved with `amazon-bedrock` normalize back to `OpenAI Compatible`.
  - Built-in vendor providers use their catalog/default style internally and do not show the API style field or header label when it is not editable.
  - Invalid saved styles for fixed built-in providers are normalized away.
- Clarify provider package ownership by moving request-style policy out of `types.ts` into `request-styles.ts`, and exposing `editableRequestStylesForProvider` instead of a UI-shaped selectable helper.
- Add provider auth policy so Ollama does not show, require, store, or send API keys, while still showing as configured when its local API URL is set.
- Add provider-specific SDK clients for OpenAI Responses, OpenAI Compatible, Anthropic, Google, Mistral, Groq, xAI, Azure OpenAI, DeepSeek, Together.ai, and Alibaba/Qwen.
- Keep fallbacks and compatibility behavior for existing settings, including legacy custom-compatible providers.
- Surface upstream errors directly in the chat bubble instead of returning the generic empty-text message.
- Remove stale Markra MCP server config entries from local Codex config files.

## Validation
- `pnpm --filter @markra/providers test -- request-styles.test.ts settings.test.ts` (36 tests passed)
- `pnpm --filter @markra/providers typecheck:test`
- `pnpm --filter @markra/providers build`
- `pnpm --filter @markra/ai test -- chat-adapters.test.ts chat-completion.test.ts` (178 tests passed)
- `pnpm --filter @markra/ai typecheck:test`
- `pnpm --filter @markra/ai build`
- `pnpm --filter @markra/desktop test -- AiProviderConnectionSection.test.tsx` (Vitest ran the desktop suite: 691 tests passed; existing jsdom `window.scrollBy` warnings remain)
- `pnpm --filter @markra/desktop build` (passed, including chunk verification; existing large chunk warning remains)
- `git diff --check HEAD~1..HEAD`

## Notes / Risk
- Bedrock is intentionally not exposed as a supported API style until Markra has dedicated region/credential settings and request support.
- OpenRouter remains on the OpenAI-compatible route; there is no official Vercel provider package in use here.
- Thinking and native web search still depend on the existing adapter behavior and provider support.
- The added provider SDK packages increase dependency surface; the current desktop build and chunk verification pass, but bundle size should stay on our watchlist.
