### PR TITLE
fix(release): repair Linux AppImage runtime policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,38 @@ jobs:
           projectPath: ${{ env.DESKTOP_DIR }}
           args: ${{ matrix.args }} --config tauri.updater.conf.json
 
+      - name: Rebuild Linux AppImage library policy
+        if: matrix.os == 'ubuntu-22.04'
+        shell: bash
+        env:
+          APPIMAGE_APPDIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/${{ env.APP_PRODUCT_NAME }}.AppDir
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          appimage_dir="$(dirname "${APPIMAGE_APPDIR}")"
+          appimage_path="$(find "${appimage_dir}" -maxdepth 1 -type f -name '*.AppImage' -print -quit)"
+
+          if [[ -z "${appimage_path}" ]]; then
+            echo "No AppImage artifact found in ${appimage_dir}" >&2
+            exit 1
+          fi
+
+          node .release-scripts/scripts/release/repair-linux-appimage-libraries.mjs "${APPIMAGE_APPDIR}"
+          node .release-scripts/scripts/release/verify-linux-appimage-libraries.mjs "${APPIMAGE_APPDIR}"
+
+          rm -f "${appimage_path}.sig" "${appimage_path}.tar.gz" "${appimage_path}.tar.gz.sig"
+
+          appimagetool="${RUNNER_TEMP}/appimagetool-x86_64.AppImage"
+          curl -fsSL \
+            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+            -o "${appimagetool}"
+          chmod +x "${appimagetool}"
+
+          APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 "${appimagetool}" "${APPIMAGE_APPDIR}" "${appimage_path}"
+          "${DESKTOP_DIR}/node_modules/.bin/tauri" signer sign "${appimage_path}" > "${appimage_path}.sig"
+
       - name: Verify Linux AppImage library policy
         if: matrix.os == 'ubuntu-22.04'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,11 +209,19 @@ jobs:
         id: tauri_build
         uses: tauri-apps/tauri-action@v0.6.0
         env:
+          LINUXDEPLOY_EXCLUDED_LIBRARIES: libwayland-client.so*
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: ${{ env.DESKTOP_DIR }}
           args: ${{ matrix.args }} --config tauri.updater.conf.json
+
+      - name: Verify Linux AppImage library policy
+        if: matrix.os == 'ubuntu-22.04'
+        shell: bash
+        env:
+          APPIMAGE_APPDIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/${{ env.APP_PRODUCT_NAME }}.AppDir
+        run: node .release-scripts/scripts/release/verify-linux-appimage-libraries.mjs
 
       - name: Add macOS open helper to DMG
         if: startsWith(matrix.os, 'macos-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,9 @@ jobs:
           fi
 
           node .release-scripts/scripts/release/repair-linux-appimage-libraries.mjs "${APPIMAGE_APPDIR}"
+          node .release-scripts/scripts/release/repair-linux-appimage-gtk-ime.mjs "${APPIMAGE_APPDIR}"
           node .release-scripts/scripts/release/verify-linux-appimage-libraries.mjs "${APPIMAGE_APPDIR}"
+          node .release-scripts/scripts/release/verify-linux-appimage-gtk-ime.mjs "${APPIMAGE_APPDIR}"
 
           rm -f "${appimage_path}.sig" "${appimage_path}.tar.gz" "${appimage_path}.tar.gz.sig"
 
@@ -253,7 +255,9 @@ jobs:
         shell: bash
         env:
           APPIMAGE_APPDIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/${{ env.APP_PRODUCT_NAME }}.AppDir
-        run: node .release-scripts/scripts/release/verify-linux-appimage-libraries.mjs
+        run: |
+          node .release-scripts/scripts/release/verify-linux-appimage-libraries.mjs
+          node .release-scripts/scripts/release/verify-linux-appimage-gtk-ime.mjs
 
       - name: Add macOS open helper to DMG
         if: startsWith(matrix.os, 'macos-')

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markra/desktop",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1885,7 +1885,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markra"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "dirs",
  "dispatch2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markra"
-version = "0.1.21"
+version = "0.1.22"
 description = "AI-native Markdown editor"
 authors = ["Markra contributors"]
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markra",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "identifier": "dev.markra.app",
   "build": {
     "beforeDevCommand": "pnpm dev --host 127.0.0.1 --port 1420 --strictPort",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markra-workspace",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "AGPL-3.0-only",
   "private": true,
   "packageManager": "pnpm@10.30.3",

--- a/scripts/release/normalize-release-artifacts.test.mjs
+++ b/scripts/release/normalize-release-artifacts.test.mjs
@@ -63,9 +63,14 @@ test("release workflow uses arm64 in Apple Silicon file names while keeping the 
 
 test("release workflow excludes Wayland client from Linux AppImage bundling", () => {
   const buildStep = readReleaseStep("Build and bundle app");
+  const rebuildStep = readReleaseStep("Rebuild Linux AppImage library policy");
   const verifyStep = readReleaseStep("Verify Linux AppImage library policy");
 
   assert.match(buildStep, /LINUXDEPLOY_EXCLUDED_LIBRARIES:\s*libwayland-client\.so\*/);
+  assert.match(rebuildStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
+  assert.match(rebuildStep, /repair-linux-appimage-libraries\.mjs/);
+  assert.match(rebuildStep, /appimagetool-x86_64\.AppImage/);
+  assert.match(rebuildStep, /tauri" signer sign/);
   assert.match(verifyStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
   assert.match(verifyStep, /verify-linux-appimage-libraries\.mjs/);
 });

--- a/scripts/release/normalize-release-artifacts.test.mjs
+++ b/scripts/release/normalize-release-artifacts.test.mjs
@@ -43,12 +43,31 @@ function readReleaseMatrixEntry(name) {
   return next === -1 ? workflow.slice(start) : workflow.slice(start, next);
 }
 
+function readReleaseStep(name) {
+  const workflow = fs.readFileSync(releaseWorkflowPath, "utf8");
+  const start = workflow.indexOf(`- name: ${name}`);
+
+  assert.notEqual(start, -1, `${name} release step should exist`);
+
+  const next = workflow.indexOf("\n      - name:", start + 1);
+  return next === -1 ? workflow.slice(start) : workflow.slice(start, next);
+}
+
 test("release workflow uses arm64 in Apple Silicon file names while keeping the Tauri updater platform", () => {
   const appleSiliconEntry = readReleaseMatrixEntry("macOS (Apple Silicon)");
 
   assert.match(appleSiliconEntry, /asset_arch:\s*arm64/);
   assert.match(appleSiliconEntry, /updater_platform:\s*darwin-aarch64/);
   assert.doesNotMatch(appleSiliconEntry, /asset_arch:\s*aarch64/);
+});
+
+test("release workflow excludes Wayland client from Linux AppImage bundling", () => {
+  const buildStep = readReleaseStep("Build and bundle app");
+  const verifyStep = readReleaseStep("Verify Linux AppImage library policy");
+
+  assert.match(buildStep, /LINUXDEPLOY_EXCLUDED_LIBRARIES:\s*libwayland-client\.so\*/);
+  assert.match(verifyStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
+  assert.match(verifyStep, /verify-linux-appimage-libraries\.mjs/);
 });
 
 test("normalize-release-artifacts adds macOS platform labels to updater and dmg assets", () => {

--- a/scripts/release/normalize-release-artifacts.test.mjs
+++ b/scripts/release/normalize-release-artifacts.test.mjs
@@ -69,10 +69,12 @@ test("release workflow excludes Wayland client from Linux AppImage bundling", ()
   assert.match(buildStep, /LINUXDEPLOY_EXCLUDED_LIBRARIES:\s*libwayland-client\.so\*/);
   assert.match(rebuildStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
   assert.match(rebuildStep, /repair-linux-appimage-libraries\.mjs/);
+  assert.match(rebuildStep, /repair-linux-appimage-gtk-ime\.mjs/);
   assert.match(rebuildStep, /appimagetool-x86_64\.AppImage/);
   assert.match(rebuildStep, /tauri" signer sign/);
   assert.match(verifyStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
   assert.match(verifyStep, /verify-linux-appimage-libraries\.mjs/);
+  assert.match(verifyStep, /verify-linux-appimage-gtk-ime\.mjs/);
 });
 
 test("normalize-release-artifacts adds macOS platform labels to updater and dmg assets", () => {

--- a/scripts/release/repair-linux-appimage-gtk-ime.mjs
+++ b/scripts/release/repair-linux-appimage-gtk-ime.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 const gtkHookRelativePath = path.join("apprun-hooks", "linuxdeploy-plugin-gtk.sh");
 const archGtkModulePath = "/usr/lib/gtk-3.0";
 const hostGtkInputMethodPolicyMarker = "MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES";
+const fcitxXimFallbackMarker = "MARKRA_FCITX_XIM_FALLBACK";
 
 const hostGtkInputMethodPolicy = `# Markra: keep Linux AppImage input methods compatible with host IBus/Fcitx.
 # Tauri's GTK hook is generated on Ubuntu and can point GTK_IM_MODULE_FILE at
@@ -20,6 +21,17 @@ for gtk_im_module_file in "\${${hostGtkInputMethodPolicyMarker}[@]}"; do
     break
   fi
 done`;
+
+const fcitxXimFallbackPolicy = `# Markra: Fcitx GTK immodules can fail to load from AppImage-bundled GTK.
+# Use the XIM fallback that works with host Fcitx on Manjaro/GNOME Wayland.
+if [ "\${XMODIFIERS:-}" = "@im=fcitx" ]; then
+  case "\${GTK_IM_MODULE:-}" in
+    ""|"fcitx"|"fcitx5")
+      export ${fcitxXimFallbackMarker}=1
+      export GTK_IM_MODULE=xim
+      ;;
+  esac
+fi`;
 
 function usage() {
   return [
@@ -66,6 +78,18 @@ function repairGtkInputMethodCache(content) {
   return content.replace(internalCachePattern, hostGtkInputMethodPolicy);
 }
 
+function repairFcitxXimFallback(content) {
+  if (content.includes(fcitxXimFallbackMarker)) {
+    return content;
+  }
+
+  if (content.includes(hostGtkInputMethodPolicy)) {
+    return content.replace(hostGtkInputMethodPolicy, `${hostGtkInputMethodPolicy}\n${fcitxXimFallbackPolicy}`);
+  }
+
+  return `${content.trimEnd()}\n${fcitxXimFallbackPolicy}\n`;
+}
+
 const appDir = process.argv[2] || process.env.APPIMAGE_APPDIR;
 
 if (!appDir) {
@@ -85,7 +109,7 @@ if (!fs.existsSync(gtkHookPath)) {
 }
 
 const originalHook = fs.readFileSync(gtkHookPath, "utf8");
-const repairedHook = repairGtkInputMethodCache(repairGtkPath(originalHook));
+const repairedHook = repairFcitxXimFallback(repairGtkInputMethodCache(repairGtkPath(originalHook)));
 
 if (repairedHook !== originalHook) {
   fs.writeFileSync(gtkHookPath, repairedHook);

--- a/scripts/release/repair-linux-appimage-gtk-ime.mjs
+++ b/scripts/release/repair-linux-appimage-gtk-ime.mjs
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const gtkHookRelativePath = path.join("apprun-hooks", "linuxdeploy-plugin-gtk.sh");
+const archGtkModulePath = "/usr/lib/gtk-3.0";
+const hostGtkInputMethodPolicyMarker = "MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES";
+
+const hostGtkInputMethodPolicy = `# Markra: keep Linux AppImage input methods compatible with host IBus/Fcitx.
+# Tauri's GTK hook is generated on Ubuntu and can point GTK_IM_MODULE_FILE at
+# the AppImage-local immodules.cache, which hides Manjaro/Arch/Fedora host IMEs.
+${hostGtkInputMethodPolicyMarker}=(
+  "/usr/lib/gtk-3.0/3.0.0/immodules.cache"
+  "/usr/lib64/gtk-3.0/3.0.0/immodules.cache"
+  "/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache"
+  "/etc/gtk-3.0/gtk.immodules"
+)
+for gtk_im_module_file in "\${${hostGtkInputMethodPolicyMarker}[@]}"; do
+  if [ -r "$gtk_im_module_file" ]; then
+    export GTK_IM_MODULE_FILE="$gtk_im_module_file"
+    break
+  fi
+done`;
+
+function usage() {
+  return [
+    "Usage: node scripts/release/repair-linux-appimage-gtk-ime.mjs <AppDir>",
+    "",
+    "APPIMAGE_APPDIR may be used instead of the positional argument.",
+  ].join("\n");
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function repairGtkPath(content) {
+  let foundGtkPath = false;
+
+  const repaired = content.replace(/^export GTK_PATH="([^"]*)"$/m, (line, value) => {
+    foundGtkPath = true;
+    const entries = value.split(":").filter(Boolean);
+    if (entries.includes(archGtkModulePath)) return line;
+
+    return `export GTK_PATH="${[...entries, archGtkModulePath].join(":")}"`;
+  });
+
+  if (!foundGtkPath) {
+    fail("GTK_PATH export not found in the Linux AppImage GTK AppRun hook.");
+  }
+
+  return repaired;
+}
+
+function repairGtkInputMethodCache(content) {
+  if (content.includes(hostGtkInputMethodPolicyMarker)) {
+    return content;
+  }
+
+  const internalCachePattern = /^export GTK_IM_MODULE_FILE="\$APPDIR\/[^"]*immodules\.cache"$/m;
+
+  if (!internalCachePattern.test(content)) {
+    fail("GTK_IM_MODULE_FILE AppImage-local cache export not found in the Linux AppImage GTK AppRun hook.");
+  }
+
+  return content.replace(internalCachePattern, hostGtkInputMethodPolicy);
+}
+
+const appDir = process.argv[2] || process.env.APPIMAGE_APPDIR;
+
+if (!appDir) {
+  console.error(usage());
+  process.exit(2);
+}
+
+if (!fs.existsSync(appDir)) {
+  console.error(`AppDir not found: ${appDir}`);
+  process.exit(2);
+}
+
+const gtkHookPath = path.join(appDir, gtkHookRelativePath);
+
+if (!fs.existsSync(gtkHookPath)) {
+  fail(`GTK AppRun hook not found: ${gtkHookPath}`);
+}
+
+const originalHook = fs.readFileSync(gtkHookPath, "utf8");
+const repairedHook = repairGtkInputMethodCache(repairGtkPath(originalHook));
+
+if (repairedHook !== originalHook) {
+  fs.writeFileSync(gtkHookPath, repairedHook);
+  console.log(`Repaired Linux AppImage GTK input method policy in ${gtkHookPath}.`);
+} else {
+  console.log(`Linux AppImage GTK input method policy already repaired in ${gtkHookPath}.`);
+}

--- a/scripts/release/repair-linux-appimage-gtk-ime.test.mjs
+++ b/scripts/release/repair-linux-appimage-gtk-ime.test.mjs
@@ -50,6 +50,8 @@ test("repair-linux-appimage-gtk-ime points GTK input methods at the host module 
   const repairedHook = fs.readFileSync(hookPath, "utf8");
   assert.doesNotMatch(repairedHook, /export GTK_IM_MODULE_FILE="\$APPDIR\//);
   assert.match(repairedHook, /MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES/);
+  assert.match(repairedHook, /MARKRA_FCITX_XIM_FALLBACK/);
+  assert.match(repairedHook, /export GTK_IM_MODULE=xim/);
   assert.match(repairedHook, /\/usr\/lib\/gtk-3\.0\/3\.0\.0\/immodules\.cache/);
   assert.match(repairedHook, /export GTK_PATH="\$APPDIR\/\/usr\/lib\/x86_64-linux-gnu\/gtk-3\.0:\/usr\/lib64\/gtk-3\.0:\/usr\/lib\/x86_64-linux-gnu\/gtk-3\.0:\/usr\/lib\/gtk-3\.0"/);
 });
@@ -63,7 +65,32 @@ test("repair-linux-appimage-gtk-ime is idempotent", () => {
 
   const repairedHook = fs.readFileSync(hookPath, "utf8");
   assert.equal((repairedHook.match(/MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=\(/gu) ?? []).length, 1);
+  assert.equal((repairedHook.match(/MARKRA_FCITX_XIM_FALLBACK=1/gu) ?? []).length, 1);
   assert.equal((repairedHook.match(/\/usr\/lib\/gtk-3\.0/gu) ?? []).length, 2);
+});
+
+test("repair-linux-appimage-gtk-ime adds the Fcitx XIM fallback to previously repaired hooks", () => {
+  const appDir = makeTempDir();
+  const hookPath = writeGtkHook(appDir, `#! /usr/bin/env bash
+export GTK_PATH="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib/gtk-3.0"
+MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=(
+  "/usr/lib/gtk-3.0/3.0.0/immodules.cache"
+)
+for gtk_im_module_file in "\${MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES[@]}"; do
+  if [ -r "$gtk_im_module_file" ]; then
+    export GTK_IM_MODULE_FILE="$gtk_im_module_file"
+    break
+  fi
+done
+`);
+
+  const result = runRepair(appDir);
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const repairedHook = fs.readFileSync(hookPath, "utf8");
+  assert.match(repairedHook, /MARKRA_FCITX_XIM_FALLBACK=1/);
+  assert.match(repairedHook, /export GTK_IM_MODULE=xim/);
 });
 
 test("repair-linux-appimage-gtk-ime fails when the GTK AppRun hook is missing", () => {

--- a/scripts/release/repair-linux-appimage-gtk-ime.test.mjs
+++ b/scripts/release/repair-linux-appimage-gtk-ime.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "markra-appimage-ime-repair-"));
+}
+
+function writeFile(filePath, content = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function writeGtkHook(appDir, content) {
+  const hookPath = path.join(appDir, "apprun-hooks", "linuxdeploy-plugin-gtk.sh");
+  writeFile(hookPath, content);
+  return hookPath;
+}
+
+function runRepair(appDir) {
+  return spawnSync(process.execPath, ["scripts/release/repair-linux-appimage-gtk-ime.mjs", appDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+const tauriGtkHook = `#! /usr/bin/env bash
+export APPDIR="\${APPDIR:-"\$(dirname "\$(realpath "$0")")"}"
+export GTK_EXE_PREFIX="$APPDIR//usr"
+export GTK_PATH="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0"
+export GTK_IM_MODULE_FILE="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache"
+export GDK_PIXBUF_MODULE_FILE="$APPDIR//usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+`;
+
+test("repair-linux-appimage-gtk-ime points GTK input methods at the host module cache", () => {
+  const appDir = makeTempDir();
+  const hookPath = writeGtkHook(appDir, tauriGtkHook);
+
+  const result = runRepair(appDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Repaired Linux AppImage GTK input method policy/);
+
+  const repairedHook = fs.readFileSync(hookPath, "utf8");
+  assert.doesNotMatch(repairedHook, /export GTK_IM_MODULE_FILE="\$APPDIR\//);
+  assert.match(repairedHook, /MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES/);
+  assert.match(repairedHook, /\/usr\/lib\/gtk-3\.0\/3\.0\.0\/immodules\.cache/);
+  assert.match(repairedHook, /export GTK_PATH="\$APPDIR\/\/usr\/lib\/x86_64-linux-gnu\/gtk-3\.0:\/usr\/lib64\/gtk-3\.0:\/usr\/lib\/x86_64-linux-gnu\/gtk-3\.0:\/usr\/lib\/gtk-3\.0"/);
+});
+
+test("repair-linux-appimage-gtk-ime is idempotent", () => {
+  const appDir = makeTempDir();
+  const hookPath = writeGtkHook(appDir, tauriGtkHook);
+
+  assert.equal(runRepair(appDir).status, 0);
+  assert.equal(runRepair(appDir).status, 0);
+
+  const repairedHook = fs.readFileSync(hookPath, "utf8");
+  assert.equal((repairedHook.match(/MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=\(/gu) ?? []).length, 1);
+  assert.equal((repairedHook.match(/\/usr\/lib\/gtk-3\.0/gu) ?? []).length, 2);
+});
+
+test("repair-linux-appimage-gtk-ime fails when the GTK AppRun hook is missing", () => {
+  const appDir = makeTempDir();
+  writeFile(path.join(appDir, "usr", "bin", "markra"));
+
+  const result = runRepair(appDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /GTK AppRun hook not found/);
+});

--- a/scripts/release/repair-linux-appimage-libraries.mjs
+++ b/scripts/release/repair-linux-appimage-libraries.mjs
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const forbiddenLibraryPrefixes = ["libwayland-client.so"];
+
+function usage() {
+  return [
+    "Usage: node scripts/release/repair-linux-appimage-libraries.mjs <AppDir>",
+    "",
+    "APPIMAGE_APPDIR may be used instead of the positional argument.",
+  ].join("\n");
+}
+
+function walkFiles(root) {
+  const pending = [root];
+  const files = [];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    const stat = fs.lstatSync(current);
+
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(current)) {
+        pending.push(path.join(current, entry));
+      }
+      continue;
+    }
+
+    files.push(current);
+  }
+
+  return files;
+}
+
+function isForbiddenLibrary(filePath) {
+  const basename = path.basename(filePath);
+  return forbiddenLibraryPrefixes.some((prefix) => basename.startsWith(prefix));
+}
+
+const appDir = process.argv[2] || process.env.APPIMAGE_APPDIR;
+
+if (!appDir) {
+  console.error(usage());
+  process.exit(2);
+}
+
+if (!fs.existsSync(appDir)) {
+  console.error(`AppDir not found: ${appDir}`);
+  process.exit(2);
+}
+
+const forbiddenLibraries = walkFiles(appDir).filter(isForbiddenLibrary).sort();
+
+for (const filePath of forbiddenLibraries) {
+  fs.rmSync(filePath, { force: true });
+}
+
+if (forbiddenLibraries.length === 0) {
+  console.log(`No forbidden AppImage libraries to remove in ${appDir}.`);
+} else {
+  console.log(`Removed ${forbiddenLibraries.length} forbidden AppImage library file(s):`);
+  for (const filePath of forbiddenLibraries) {
+    console.log(`- ${filePath}`);
+  }
+}

--- a/scripts/release/repair-linux-appimage-libraries.test.mjs
+++ b/scripts/release/repair-linux-appimage-libraries.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "markra-appimage-repair-"));
+}
+
+function writeFile(filePath, content = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function runRepair(appDir) {
+  return spawnSync(process.execPath, ["scripts/release/repair-linux-appimage-libraries.mjs", appDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+test("repair-linux-appimage-libraries removes bundled Wayland client libraries", () => {
+  const appDir = makeTempDir();
+  const libraryPath = path.join(appDir, "usr", "lib", "libwayland-client.so.0");
+  writeFile(libraryPath);
+  writeFile(path.join(appDir, "usr", "lib", "libgtk-3.so.0"));
+
+  const result = runRepair(appDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Removed 1 forbidden AppImage librar/);
+  assert.equal(fs.existsSync(libraryPath), false);
+  assert.equal(fs.existsSync(path.join(appDir, "usr", "lib", "libgtk-3.so.0")), true);
+});
+
+test("repair-linux-appimage-libraries succeeds when there is nothing to remove", () => {
+  const appDir = makeTempDir();
+  writeFile(path.join(appDir, "usr", "bin", "markra"));
+
+  const result = runRepair(appDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No forbidden AppImage libraries to remove/);
+});

--- a/scripts/release/verify-linux-appimage-gtk-ime.mjs
+++ b/scripts/release/verify-linux-appimage-gtk-ime.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 const gtkHookRelativePath = path.join("apprun-hooks", "linuxdeploy-plugin-gtk.sh");
 const hostGtkInputMethodPolicyMarker = "MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES";
+const fcitxXimFallbackMarker = "MARKRA_FCITX_XIM_FALLBACK";
 const archGtkModulePath = "/usr/lib/gtk-3.0";
 const archGtkInputMethodCache = "/usr/lib/gtk-3.0/3.0.0/immodules.cache";
 
@@ -58,6 +59,10 @@ if (!content.includes(archGtkInputMethodCache)) {
 
 if (!gtkPathEntries.includes(archGtkModulePath)) {
   errors.push(`GTK_PATH must include ${archGtkModulePath} for Arch and Manjaro GTK modules.`);
+}
+
+if (!content.includes(fcitxXimFallbackMarker) || !/^ *export GTK_IM_MODULE=xim$/m.test(content)) {
+  errors.push("Fcitx XIM fallback is missing from the Linux AppImage GTK AppRun hook.");
 }
 
 if (errors.length > 0) {

--- a/scripts/release/verify-linux-appimage-gtk-ime.mjs
+++ b/scripts/release/verify-linux-appimage-gtk-ime.mjs
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const gtkHookRelativePath = path.join("apprun-hooks", "linuxdeploy-plugin-gtk.sh");
+const hostGtkInputMethodPolicyMarker = "MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES";
+const archGtkModulePath = "/usr/lib/gtk-3.0";
+const archGtkInputMethodCache = "/usr/lib/gtk-3.0/3.0.0/immodules.cache";
+
+function usage() {
+  return [
+    "Usage: node scripts/release/verify-linux-appimage-gtk-ime.mjs <AppDir>",
+    "",
+    "APPIMAGE_APPDIR may be used instead of the positional argument.",
+  ].join("\n");
+}
+
+function readGtkPathEntries(content) {
+  const match = content.match(/^export GTK_PATH="([^"]*)"$/m);
+  if (!match) return [];
+
+  return match[1].split(":").filter(Boolean);
+}
+
+const appDir = process.argv[2] || process.env.APPIMAGE_APPDIR;
+
+if (!appDir) {
+  console.error(usage());
+  process.exit(2);
+}
+
+if (!fs.existsSync(appDir)) {
+  console.error(`AppDir not found: ${appDir}`);
+  process.exit(2);
+}
+
+const gtkHookPath = path.join(appDir, gtkHookRelativePath);
+
+if (!fs.existsSync(gtkHookPath)) {
+  console.error(`GTK AppRun hook not found: ${gtkHookPath}`);
+  process.exit(1);
+}
+
+const content = fs.readFileSync(gtkHookPath, "utf8");
+const errors = [];
+const gtkPathEntries = readGtkPathEntries(content);
+
+if (/^export GTK_IM_MODULE_FILE="\$APPDIR\//m.test(content)) {
+  errors.push("GTK_IM_MODULE_FILE points inside the AppImage instead of a host GTK input method cache.");
+}
+
+if (!content.includes(hostGtkInputMethodPolicyMarker)) {
+  errors.push("Host GTK input method cache discovery block is missing.");
+}
+
+if (!content.includes(archGtkInputMethodCache)) {
+  errors.push(`Host GTK input method cache candidates must include ${archGtkInputMethodCache}.`);
+}
+
+if (!gtkPathEntries.includes(archGtkModulePath)) {
+  errors.push(`GTK_PATH must include ${archGtkModulePath} for Arch and Manjaro GTK modules.`);
+}
+
+if (errors.length > 0) {
+  console.error("Linux AppImage GTK input method policy failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Linux AppImage GTK input method policy looks host-compatible in ${gtkHookPath}.`);

--- a/scripts/release/verify-linux-appimage-gtk-ime.test.mjs
+++ b/scripts/release/verify-linux-appimage-gtk-ime.test.mjs
@@ -41,6 +41,14 @@ for gtk_im_module_file in "\${MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES[@]}"; 
     break
   fi
 done
+if [ "\${XMODIFIERS:-}" = "@im=fcitx" ]; then
+  case "\${GTK_IM_MODULE:-}" in
+    ""|"fcitx"|"fcitx5")
+      export MARKRA_FCITX_XIM_FALLBACK=1
+      export GTK_IM_MODULE=xim
+      ;;
+  esac
+fi
 `);
 
   const result = runVerify(appDir);
@@ -74,4 +82,19 @@ MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=(
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /\/usr\/lib\/gtk-3\.0/);
+});
+
+test("verify-linux-appimage-gtk-ime rejects hooks without the Fcitx XIM fallback", () => {
+  const appDir = makeTempDir();
+  writeGtkHook(appDir, `#! /usr/bin/env bash
+export GTK_PATH="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib/gtk-3.0"
+MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=(
+  "/usr/lib/gtk-3.0/3.0.0/immodules.cache"
+)
+`);
+
+  const result = runVerify(appDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Fcitx XIM fallback/);
 });

--- a/scripts/release/verify-linux-appimage-gtk-ime.test.mjs
+++ b/scripts/release/verify-linux-appimage-gtk-ime.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "markra-appimage-ime-policy-"));
+}
+
+function writeFile(filePath, content = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function writeGtkHook(appDir, content) {
+  writeFile(path.join(appDir, "apprun-hooks", "linuxdeploy-plugin-gtk.sh"), content);
+}
+
+function runVerify(appDir) {
+  return spawnSync(process.execPath, ["scripts/release/verify-linux-appimage-gtk-ime.mjs", appDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+test("verify-linux-appimage-gtk-ime accepts a hook that uses host GTK input method caches", () => {
+  const appDir = makeTempDir();
+  writeGtkHook(appDir, `#! /usr/bin/env bash
+export GTK_PATH="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib/gtk-3.0"
+MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=(
+  "/usr/lib/gtk-3.0/3.0.0/immodules.cache"
+)
+for gtk_im_module_file in "\${MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES[@]}"; do
+  if [ -r "$gtk_im_module_file" ]; then
+    export GTK_IM_MODULE_FILE="$gtk_im_module_file"
+    break
+  fi
+done
+`);
+
+  const result = runVerify(appDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Linux AppImage GTK input method policy looks host-compatible/);
+});
+
+test("verify-linux-appimage-gtk-ime rejects AppImage-local GTK input method caches", () => {
+  const appDir = makeTempDir();
+  writeGtkHook(appDir, `#! /usr/bin/env bash
+export GTK_PATH="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0"
+export GTK_IM_MODULE_FILE="$APPDIR//usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache"
+`);
+
+  const result = runVerify(appDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /GTK_IM_MODULE_FILE points inside the AppImage/);
+});
+
+test("verify-linux-appimage-gtk-ime rejects hooks without the Arch GTK module path", () => {
+  const appDir = makeTempDir();
+  writeGtkHook(appDir, `#! /usr/bin/env bash
+MARKRA_SYSTEM_GTK_IM_MODULE_FILE_CANDIDATES=(
+  "/usr/lib/gtk-3.0/3.0.0/immodules.cache"
+)
+`);
+
+  const result = runVerify(appDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /\/usr\/lib\/gtk-3\.0/);
+});

--- a/scripts/release/verify-linux-appimage-libraries.mjs
+++ b/scripts/release/verify-linux-appimage-libraries.mjs
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const forbiddenLibraryPrefixes = ["libwayland-client.so"];
+
+function usage() {
+  return [
+    "Usage: node scripts/release/verify-linux-appimage-libraries.mjs <AppDir>",
+    "",
+    "APPIMAGE_APPDIR may be used instead of the positional argument.",
+  ].join("\n");
+}
+
+function walkFiles(root) {
+  const pending = [root];
+  const files = [];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    const stat = fs.lstatSync(current);
+
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(current)) {
+        pending.push(path.join(current, entry));
+      }
+      continue;
+    }
+
+    files.push(current);
+  }
+
+  return files;
+}
+
+function isForbiddenLibrary(filePath) {
+  const basename = path.basename(filePath);
+  return forbiddenLibraryPrefixes.some((prefix) => basename.startsWith(prefix));
+}
+
+const appDir = process.argv[2] || process.env.APPIMAGE_APPDIR;
+
+if (!appDir) {
+  console.error(usage());
+  process.exit(2);
+}
+
+if (!fs.existsSync(appDir)) {
+  console.error(`AppDir not found: ${appDir}`);
+  process.exit(2);
+}
+
+const forbiddenLibraries = walkFiles(appDir).filter(isForbiddenLibrary).sort();
+
+if (forbiddenLibraries.length > 0) {
+  console.error("Forbidden Linux AppImage libraries were bundled:");
+  for (const filePath of forbiddenLibraries) {
+    console.error(`- ${filePath}`);
+  }
+  console.error("");
+  console.error("Keep libwayland-client on the host system to avoid Wayland/Mesa ABI conflicts.");
+  process.exit(1);
+}
+
+console.log(`No forbidden AppImage libraries found in ${appDir}.`);

--- a/scripts/release/verify-linux-appimage-libraries.test.mjs
+++ b/scripts/release/verify-linux-appimage-libraries.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "markra-appimage-policy-"));
+}
+
+function writeFile(filePath, content = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function runVerify(appDir, env = {}) {
+  return spawnSync(process.execPath, ["scripts/release/verify-linux-appimage-libraries.mjs", appDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}
+
+test("verify-linux-appimage-libraries accepts AppDirs without bundled Wayland client libraries", () => {
+  const appDir = makeTempDir();
+  writeFile(path.join(appDir, "usr", "lib", "libgtk-3.so.0"));
+
+  const result = runVerify(appDir);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No forbidden AppImage libraries found/);
+});
+
+test("verify-linux-appimage-libraries rejects bundled Wayland client library variants", () => {
+  const appDir = makeTempDir();
+  const libraryPath = path.join(appDir, "usr", "lib", "libwayland-client.so.0.24.0");
+  writeFile(libraryPath);
+
+  const result = runVerify(appDir);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /libwayland-client\.so\.0\.24\.0/);
+});
+
+test("verify-linux-appimage-libraries can read the AppDir path from the environment", () => {
+  const appDir = makeTempDir();
+  writeFile(path.join(appDir, "usr", "bin", "markra"));
+
+  const result = spawnSync(process.execPath, ["scripts/release/verify-linux-appimage-libraries.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      APPIMAGE_APPDIR: appDir,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No forbidden AppImage libraries found/);
+});


### PR DESCRIPTION
## Summary
- exclude bundled `libwayland-client.so*` from Linux AppImages and verify the AppDir before publishing
- repair the generated GTK AppRun hook so Linux AppImages use host GTK input method caches, including Manjaro/Arch GTK module paths
- add an AppImage Fcitx compatibility fallback that switches host Fcitx sessions to `GTK_IM_MODULE=xim`, matching the command the reporter confirmed works
- rebuild and re-sign the AppImage after applying the release-time policies
- bump the prerelease build to `v0.1.22`

## Why
- fixes the Wayland/Mesa ABI conflict reported in #83
- fixes Linux Chinese input method failures reported in #93, where `fcitx5-gtk` is installed but AppImage direct GTK immodule loading fails while XIM fallback works

## Validation
- `pnpm test:release` passed: 27 tests
- Release workflow succeeded: https://github.com/murongg/markra/actions/runs/26074530317
- Linux release job confirmed `Removed 1 forbidden AppImage library file(s)`
- Linux release job confirmed `Repaired Linux AppImage GTK input method policy` and `Linux AppImage GTK input method policy looks host-compatible`
- Public prerelease updated for user testing: https://github.com/murongg/markra/releases/tag/v0.1.22
- User confirmed #83 AppImage display issue is fixed in v0.1.22
- User confirmed #93 Chinese input works in the rebuilt v0.1.22 AppImage without manual environment variables

## Risk
- AppImage-only runtime policy change; deb/rpm assets are still produced unchanged by the normal Tauri bundling path
- the Fcitx fallback only applies when `XMODIFIERS=@im=fcitx` and `GTK_IM_MODULE` is empty, `fcitx`, or `fcitx5`; IBus remains untouched

Closes #83
Closes #93
