### PR TITLE
fix(desktop): offset outline navigation below titlebar

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -2045,7 +2045,7 @@ describe("Markra workspace", () => {
     await waitFor(() =>
       expect(scrollTo).toHaveBeenCalledWith({
         behavior: "auto",
-        top: 396
+        top: 356
       })
     );
   });
@@ -2118,7 +2118,7 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "B" }));
 
     await waitFor(() =>
-      expect(scrollTo.mock.calls.map(([options]) => (options as ScrollToOptions).top)).toEqual([376, 0, 376])
+      expect(scrollTo.mock.calls.map(([options]) => (options as ScrollToOptions).top)).toEqual([336, 0, 336])
     );
   });
 

--- a/apps/desktop/src/hooks/useEditorController.test.ts
+++ b/apps/desktop/src/hooks/useEditorController.test.ts
@@ -1,4 +1,4 @@
-import { scrollElementsAboveContainerBottomInset } from "./useEditorController";
+import { scrollElementToContainerTop, scrollElementsAboveContainerBottomInset } from "./useEditorController";
 
 function rect(overrides: Partial<DOMRect> = {}): DOMRect {
   return {
@@ -16,6 +16,30 @@ function rect(overrides: Partial<DOMRect> = {}): DOMRect {
 }
 
 describe("editor controller scrolling", () => {
+  it("keeps outline jumps below the fixed titlebar", () => {
+    const container = document.createElement("div");
+    const target = document.createElement("h2");
+    const scrollTo = vi.fn();
+
+    Object.defineProperty(container, "scrollTop", {
+      configurable: true,
+      value: 100
+    });
+    Object.defineProperty(container, "scrollTo", {
+      configurable: true,
+      value: scrollTo
+    });
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue(rect({ height: 700, top: 0 }));
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue(rect({ height: 48, top: 240 }));
+
+    scrollElementToContainerTop(target, container);
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: "auto",
+      top: 276
+    });
+  });
+
   it("scrolls a selected element above a bottom overlay", () => {
     const container = document.createElement("div");
     const target = document.createElement("span");

--- a/apps/desktop/src/hooks/useEditorController.ts
+++ b/apps/desktop/src/hooks/useEditorController.ts
@@ -20,7 +20,9 @@ import {
 } from "@markra/editor";
 import type { MarkdownOutlineItem } from "@markra/markdown";
 
-const outlineScrollTopOffset = 24;
+const fixedTitlebarHeight = 40;
+const outlineScrollTopMargin = 24;
+const outlineScrollTopOffset = fixedTitlebarHeight + outlineScrollTopMargin;
 const aiCommandSelectionBottomMargin = 24;
 const defaultMarkdownTable = [
   "| Column 1 | Column 2 |",


### PR DESCRIPTION
## Summary
- Increase outline navigation offset to account for the fixed 40px titlebar plus the existing spacing.
- Add regression coverage for outline jumps landing below the titlebar.

## Why
- Outline navigation previously aligned headings too close to the scroll container top, so the fixed titlebar/tab area could cover the target heading.

## Validation
- `pnpm --filter @markra/desktop test -- src/hooks/useEditorController.test.ts` passed, 4 tests.
- `pnpm --filter @markra/desktop typecheck:test` passed.

## Risk
- Low. This only changes the outline jump offset used by the desktop editor controller.