### PR TITLE
fix(desktop): restore workspace document tabs

### DIFF
--- a/apps/desktop/src/App.ai.test.tsx
+++ b/apps/desktop/src/App.ai.test.tsx
@@ -243,7 +243,8 @@ describe("Markra AI workspace", () => {
       filePath: mockNativePath,
       fileTreeOpen: false,
       folderName: null,
-      folderPath: null
+      folderPath: null,
+      openFilePaths: [mockNativePath]
     });
     mockedReadNativeMarkdownFile.mockResolvedValue({
       content: "Original text",
@@ -278,7 +279,8 @@ describe("Markra AI workspace", () => {
       filePath: mockNativePath,
       fileTreeOpen: false,
       folderName: null,
-      folderPath: null
+      folderPath: null,
+      openFilePaths: [mockNativePath]
     });
     mockedReadNativeMarkdownFile.mockResolvedValue({
       content: "Original text",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -278,7 +278,8 @@ describe("Markra workspace", () => {
       filePath: mockNativePath,
       fileTreeOpen: false,
       folderName: null,
-      folderPath: null
+      folderPath: null,
+      openFilePaths: [mockNativePath]
     });
     mockedReadNativeMarkdownFile.mockResolvedValue({
       content: "# Restored file\n\nBack from last launch.",
@@ -301,7 +302,8 @@ describe("Markra workspace", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: mockFolderPath
+      folderPath: mockFolderPath,
+      openFilePaths: []
     });
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([
       { name: "index.md", path: "/mock-files/vault/index.md", relativePath: "index.md" },
@@ -330,7 +332,8 @@ describe("Markra workspace", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "deleted-notes",
-      folderPath: "/mock-files/deleted-notes"
+      folderPath: "/mock-files/deleted-notes",
+      openFilePaths: []
     });
     mockedListNativeMarkdownFilesForPath.mockRejectedValue(new Error("Markdown folder no longer exists"));
 
@@ -353,7 +356,8 @@ describe("Markra workspace", () => {
       filePath: nestedFilePath,
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: mockFolderPath
+      folderPath: mockFolderPath,
+      openFilePaths: [nestedFilePath]
     });
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([
       { name: "a.md", path: nestedFilePath, relativePath: "docs/deep/a.md" }
@@ -1147,7 +1151,8 @@ describe("Markra workspace", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: mockFolderPath
+      folderPath: mockFolderPath,
+      openFilePaths: []
     });
   });
 
@@ -1180,7 +1185,8 @@ describe("Markra workspace", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "notes",
-      folderPath: "/mock-files/notes"
+      folderPath: "/mock-files/notes",
+      openFilePaths: []
     });
   });
 
@@ -1396,7 +1402,10 @@ describe("Markra workspace", () => {
     expect(screen.queryByText("Native file")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "mock-files" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Markdown" })).toBeDisabled();
-    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({ filePath: null });
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      filePath: null,
+      openFilePaths: []
+    });
   });
 
   it("previews an image asset from the current folder tree and returns to markdown files", async () => {
@@ -2412,7 +2421,8 @@ describe("Markra workspace", () => {
       filePath: mockNativePath,
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: mockFolderPath
+      folderPath: mockFolderPath,
+      openFilePaths: [mockNativePath]
     });
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([
       { name: "native.md", path: mockNativePath, relativePath: "native.md" }

--- a/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
@@ -51,7 +51,8 @@ describe("useMarkdownDocument", () => {
       filePath: null,
       fileTreeOpen: false,
       folderName: null,
-      folderPath: null
+      folderPath: null,
+      openFilePaths: []
     });
     mockedSaveStoredWorkspaceState.mockResolvedValue(undefined);
   });
@@ -608,7 +609,8 @@ describe("useMarkdownDocument", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "notes",
-      folderPath: "/mock-files/deleted-notes"
+      folderPath: "/mock-files/deleted-notes",
+      openFilePaths: []
     });
 
     const { result } = renderHook(() =>
@@ -633,7 +635,8 @@ describe("useMarkdownDocument", () => {
       expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
         fileTreeOpen: false,
         folderName: null,
-        folderPath: null
+        folderPath: null,
+        openFilePaths: []
       })
     );
     expect(result.current.document).toMatchObject({
@@ -643,6 +646,110 @@ describe("useMarkdownDocument", () => {
       open: true,
       path: null
     });
+    expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("does not restore document tabs from a deleted folder workspace", async () => {
+    const guidePath = "/mock-files/deleted-notes/guide.md";
+    const notesPath = "/mock-files/deleted-notes/notes.md";
+    const onTreeRootFromFolderPath = vi.fn(async () => null);
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-deleted-folder-tabs",
+      filePath: notesPath,
+      fileTreeOpen: true,
+      folderName: "deleted-notes",
+      folderPath: "/mock-files/deleted-notes",
+      openFilePaths: [guidePath, notesPath]
+    });
+    mockedReadNativeMarkdownFile.mockRejectedValue(new Error("Markdown file no longer exists"));
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath,
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() =>
+      expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+        fileTreeOpen: false,
+        folderName: null,
+        folderPath: null,
+        openFilePaths: []
+      })
+    );
+
+    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+    expect(result.current.tabs).toEqual([expect.objectContaining({
+      name: "Untitled.md",
+      path: null
+    })]);
+    expect(result.current.document).toMatchObject({
+      content: "",
+      dirty: false,
+      name: "Untitled.md",
+      open: true,
+      path: null
+    });
+  });
+
+  it("restores open markdown document tabs from the last workspace", async () => {
+    const guidePath = "/mock-files/vault/guide.md";
+    const notesPath = "/mock-files/vault/notes.md";
+    const onTreeRootFromFolderPath = vi.fn(async () => ({ name: "vault", path: "/mock-files/vault" }));
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-tabs",
+      filePath: notesPath,
+      fileTreeOpen: true,
+      folderName: "vault",
+      folderPath: "/mock-files/vault",
+      openFilePaths: [guidePath, notesPath]
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === guidePath) {
+        return {
+          content: "# Guide",
+          name: "guide.md",
+          path
+        };
+      }
+
+      return {
+        content: "# Notes",
+        name: "notes.md",
+        path
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath,
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.tabs.map((tab) => tab.name)).toEqual(["guide.md", "notes.md"]));
+
+    expect(result.current.document).toMatchObject({
+      content: "# Notes",
+      dirty: false,
+      name: "notes.md",
+      open: true,
+      path: notesPath
+    });
+    expect(result.current.tabs.map((tab) => tab.path)).toEqual([guidePath, notesPath]);
+    expect(result.current.activeTabId).toBe(`file:${notesPath}`);
+    expect(onTreeRootFromFolderPath).toHaveBeenCalledWith("/mock-files/vault", "vault", "session-tabs", false);
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(notesPath);
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -73,6 +73,40 @@ function fileTabId(path: string) {
   return `file:${path}`;
 }
 
+function normalizeOpenFilePaths(paths: readonly (string | null | undefined)[]) {
+  const seenPaths = new Set<string>();
+  const normalizedPaths: string[] = [];
+
+  paths.forEach((item) => {
+    const path = item?.trim();
+    if (!path || seenPaths.has(path)) return;
+
+    seenPaths.add(path);
+    normalizedPaths.push(path);
+  });
+
+  return normalizedPaths;
+}
+
+function openFilePathsFromTabs(tabs: readonly MarkdownDocumentTab[]) {
+  return normalizeOpenFilePaths(tabs.map((tab) => tab.open ? tab.path : null));
+}
+
+function restoreFilePathsFromWorkspace(openFilePaths: readonly string[], filePath: string | null, documentTabsEnabled: boolean) {
+  if (!documentTabsEnabled) return filePath ? [filePath] : [];
+
+  const paths = normalizeOpenFilePaths(openFilePaths);
+  const activeFilePath = filePath?.trim() ?? "";
+
+  if (activeFilePath && !paths.includes(activeFilePath)) paths.push(activeFilePath);
+
+  return paths;
+}
+
+function activeFilePathFromTabs(tabs: readonly MarkdownDocumentTab[], activeTabId: string | null) {
+  return tabs.find((tab) => tab.id === activeTabId)?.path ?? null;
+}
+
 function isPristineUntitledDocument(document: DocumentState) {
   return document.open && document.path === null && document.content === "" && !document.dirty && document.revision === 0;
 }
@@ -373,12 +407,16 @@ export function useMarkdownDocument({
     if (documentTabsEnabled) {
       syncActiveDocumentFromEditor();
       const tab = createDocumentTab(nextDocument, createUntitledTabId());
-      setActiveTabState([...tabsRef.current, tab], tab.id);
+      const nextTabs = [...tabsRef.current, tab];
+      setActiveTabState(nextTabs, tab.id);
+      persistWorkspaceState({
+        filePath: null,
+        openFilePaths: openFilePathsFromTabs(nextTabs)
+      });
     } else {
       setActiveDocument(nextDocument);
+      persistWorkspaceState({ filePath: null, openFilePaths: [] });
     }
-
-    persistWorkspaceState({ filePath: null });
     return true;
   }, [createUntitledTabId, documentTabsEnabled, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]);
 
@@ -414,7 +452,7 @@ export function useMarkdownDocument({
     setActiveTabId(null);
     setDocument(nextDocument);
     documentRef.current = nextDocument;
-    if (options.persistWorkspace !== false) persistWorkspaceState({ filePath: null });
+    if (options.persistWorkspace !== false) persistWorkspaceState({ filePath: null, openFilePaths: [] });
   }, []);
 
   const applyNativeMarkdownFile = useCallback(
@@ -431,25 +469,32 @@ export function useMarkdownDocument({
         revision: documentRef.current.revision + 1
       };
 
+      let nextOpenFilePaths = [file.path];
+
       if (documentTabsEnabled) {
         syncActiveDocumentFromEditor();
         const currentTabs = tabsRef.current;
         const existingTab = currentTabs.find((tab) => tab.path === file.path);
+        let nextTabs: MarkdownDocumentTab[];
+        let nextActiveTabId: string;
 
         if (existingTab) {
-          setActiveTabState(currentTabs, existingTab.id);
+          nextTabs = currentTabs;
+          nextActiveTabId = existingTab.id;
         } else {
           const activeTabIsPristine = currentTabs.some((tab) =>
             tab.id === activeTabIdRef.current && isPristineUntitledDocument(documentFromTab(tab))
           );
           const nextTabId = activeTabIsPristine && activeTabIdRef.current ? activeTabIdRef.current : fileTabId(file.path);
           const nextTab = createDocumentTab(nextDocument, nextTabId);
-          const nextTabs = activeTabIsPristine
+          nextTabs = activeTabIsPristine
             ? currentTabs.map((tab) => tab.id === activeTabIdRef.current ? nextTab : tab)
             : [...currentTabs, nextTab];
-
-          setActiveTabState(nextTabs, nextTab.id);
+          nextActiveTabId = nextTab.id;
         }
+
+        setActiveTabState(nextTabs, nextActiveTabId);
+        nextOpenFilePaths = openFilePathsFromTabs(nextTabs);
       } else {
         setActiveDocument(nextDocument);
       }
@@ -458,6 +503,7 @@ export function useMarkdownDocument({
       persistWorkspaceState({
         aiAgentSessionId: sessionId,
         filePath: file.path,
+        openFilePaths: nextOpenFilePaths,
         ...(updateTreeRoot ? { folderName: null, folderPath: null } : {})
       });
     },
@@ -470,6 +516,64 @@ export function useMarkdownDocument({
       applyNativeMarkdownFile(file, updateTreeRoot, preferredSessionId);
     },
     [applyNativeMarkdownFile]
+  );
+
+  const restoreNativeMarkdownFiles = useCallback(
+    async (paths: string[], activeFilePath: string | null, updateTreeRoot = true, preferredSessionId?: string | null) => {
+      const files: NativeMarkdownFile[] = [];
+
+      for (const path of paths) {
+        try {
+          files.push(await readNativeMarkdownFile(path));
+        } catch {
+          // Missing or moved files should not block restoring the rest of the workspace.
+        }
+      }
+
+      if (files.length === 0) return false;
+
+      const sessionId = updateTreeRoot
+        ? resolveWorkspaceSessionId(preferredSessionId)
+        : resolveWorkspaceSessionId(preferredSessionId ?? workspaceSessionIdRef.current);
+      const activeFile =
+        files.find((file) => file.path === activeFilePath) ??
+        files.at(-1) ??
+        null;
+
+      if (documentTabsEnabled) {
+        const nextTabs = files.map((file) =>
+          createDocumentTab({
+            path: file.path,
+            name: file.name,
+            content: file.content,
+            dirty: false,
+            open: true,
+            revision: documentRef.current.revision + 1
+          }, fileTabId(file.path))
+        );
+
+        setActiveTabState(nextTabs, activeFile ? fileTabId(activeFile.path) : nextTabs[0]?.id ?? null);
+      } else if (activeFile) {
+        setActiveDocument({
+          path: activeFile.path,
+          name: activeFile.name,
+          content: activeFile.content,
+          dirty: false,
+          open: true,
+          revision: documentRef.current.revision + 1
+        });
+      }
+
+      if (updateTreeRoot && activeFile) onTreeRootFromFilePath(activeFile.path);
+      persistWorkspaceState({
+        aiAgentSessionId: sessionId,
+        filePath: activeFile?.path ?? null,
+        openFilePaths: files.map((file) => file.path),
+        ...(updateTreeRoot ? { folderName: null, folderPath: null } : {})
+      });
+      return true;
+    },
+    [documentTabsEnabled, onTreeRootFromFilePath, resolveWorkspaceSessionId, setActiveDocument, setActiveTabState]
   );
 
   const openMarkdownFile = useCallback(async (options: OpenMarkdownFileOptions = {}) => {
@@ -525,20 +629,21 @@ export function useMarkdownDocument({
       });
     }
 
-    setTabs((currentTabs) => {
-      const nextTabs = currentTabs.map((tab) => {
-        if (tab.path !== previousPath) return tab;
+    const nextTabs = tabsRef.current.map((tab) => {
+      if (tab.path !== previousPath) return tab;
 
-        return {
-          ...tab,
-          name: file.name,
-          path: file.path
-        };
-      });
-      tabsRef.current = nextTabs;
-      return nextTabs;
+      return {
+        ...tab,
+        name: file.name,
+        path: file.path
+      };
     });
-    persistWorkspaceState({ filePath: file.path });
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    persistWorkspaceState({
+      filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
+      openFilePaths: openFilePathsFromTabs(nextTabs)
+    });
     return true;
   }, [setActiveDocument]);
 
@@ -575,7 +680,10 @@ export function useMarkdownDocument({
       setActiveDocument(nextDocument);
     }
 
-    persistWorkspaceState({ filePath: null });
+    persistWorkspaceState({
+      filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
+      openFilePaths: openFilePathsFromTabs(nextTabs)
+    });
     return true;
   }, [documentTabsEnabled, setActiveDocument, setActiveTabState]);
 
@@ -602,13 +710,19 @@ export function useMarkdownDocument({
       };
 
       setActiveDocument(nextDocument);
+      const nextOpenFilePaths = documentTabsEnabled
+        ? openFilePathsFromTabs(tabsRef.current.map((tab) =>
+          tab.id === activeTabIdRef.current ? createDocumentTab(nextDocument, tab.id) : tab
+        ))
+        : [savedFile.path];
       if (saveAs || current.path === null) onTreeRootFromFilePath(savedFile.path);
       persistWorkspaceState({
         filePath: savedFile.path,
+        openFilePaths: nextOpenFilePaths,
         ...(saveAs || current.path === null ? { folderName: null, folderPath: null } : {})
       });
     },
-    [currentMarkdown, onTreeRootFromFilePath, setActiveDocument]
+    [currentMarkdown, documentTabsEnabled, onTreeRootFromFilePath, setActiveDocument]
   );
 
   const handleSaveClick = useCallback(() => {
@@ -621,7 +735,10 @@ export function useMarkdownDocument({
     if (!tab) return false;
 
     setActiveTabState(tabsRef.current, tab.id);
-    persistWorkspaceState({ filePath: tab.path });
+    persistWorkspaceState({
+      filePath: tab.path,
+      openFilePaths: openFilePathsFromTabs(tabsRef.current)
+    });
     return true;
   }, [setActiveTabState, syncActiveDocumentFromEditor]);
 
@@ -644,7 +761,10 @@ export function useMarkdownDocument({
         : nextTabs.find((candidate) => candidate.id === activeTabIdRef.current) ?? null;
 
     setActiveTabState(nextTabs, nextActiveTab?.id ?? null);
-    persistWorkspaceState({ filePath: nextActiveTab?.path ?? null });
+    persistWorkspaceState({
+      filePath: nextActiveTab?.path ?? null,
+      openFilePaths: openFilePathsFromTabs(nextTabs)
+    });
     return true;
   }, [confirmDiscardUnsavedChanges, hasDiscardableTabChanges, setActiveTabState, syncActiveDocumentFromEditor]);
 
@@ -802,6 +922,11 @@ export function useMarkdownDocument({
         try {
           const workspace = await getStoredWorkspaceState();
           const sessionId = workspace.aiAgentSessionId ?? createAiAgentSessionId();
+          let restoreFilePaths = restoreFilePathsFromWorkspace(
+            workspace.openFilePaths,
+            workspace.filePath,
+            documentTabsEnabled
+          );
 
           assignWorkspaceSessionId(sessionId);
 
@@ -810,7 +935,7 @@ export function useMarkdownDocument({
               workspace.folderPath,
               workspace.folderName ?? workspace.folderPath,
               sessionId,
-              !workspace.filePath
+              restoreFilePaths.length === 0
             );
             if (!active) return;
 
@@ -818,25 +943,26 @@ export function useMarkdownDocument({
               persistWorkspaceState({
                 fileTreeOpen: false,
                 folderName: null,
-                folderPath: null
+                folderPath: null,
+                openFilePaths: []
               });
+              restoreFilePaths = [];
               restoredWorkspace = true;
             } else {
-              if (!workspace.filePath) clearOpenDocument({ persistWorkspace: false });
+              if (restoreFilePaths.length === 0) clearOpenDocument({ persistWorkspace: false });
               restoredWorkspace = true;
             }
           }
 
-          if (workspace.filePath) {
-            try {
-              const file = await readNativeMarkdownFile(workspace.filePath);
-              if (!active) return;
-
-              applyNativeMarkdownFile(file, !restoredWorkspace, sessionId);
-              restoredWorkspace = true;
-            } catch {
-              // A deleted or moved file should not block the normal launch fallback.
-            }
+          if (restoreFilePaths.length > 0) {
+            const restoredFiles = await restoreNativeMarkdownFiles(
+              restoreFilePaths,
+              workspace.filePath,
+              !restoredWorkspace,
+              sessionId
+            );
+            if (!active) return;
+            if (restoredFiles) restoredWorkspace = true;
           }
 
           if (workspace.aiAgentSessionId !== sessionId) {
@@ -868,12 +994,13 @@ export function useMarkdownDocument({
       active = false;
     };
   }, [
-    applyNativeMarkdownFile,
     assignWorkspaceSessionId,
     clearOpenDocument,
+    documentTabsEnabled,
     nativeOpenedPathsReady,
     onTreeRootFromFolderPath,
     preferencesReady,
+    restoreNativeMarkdownFiles,
     resolveWorkspaceSessionId,
     restoreWorkspaceOnStartup,
     setActiveDocument

--- a/apps/desktop/src/hooks/useMarkdownFileTree.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownFileTree.test.tsx
@@ -190,7 +190,8 @@ describe("useMarkdownFileTree", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: "/vault"
+      folderPath: "/vault",
+      openFilePaths: []
     });
     expect(mockedSaveStoredRecentMarkdownFolder).toHaveBeenCalledWith({
       name: "vault",

--- a/apps/desktop/src/hooks/useMarkdownFileTree.ts
+++ b/apps/desktop/src/hooks/useMarkdownFileTree.ts
@@ -142,7 +142,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     // Opening a folder replaces the startup workspace, so clear the previous file path in the same write.
     persistWorkspaceState({
       aiAgentSessionId: sessionId,
-      ...(clearFilePath ? { filePath: null } : {}),
+      ...(clearFilePath ? { filePath: null, openFilePaths: [] } : {}),
       fileTreeOpen: true,
       folderName,
       folderPath: path

--- a/apps/desktop/src/lib/settings/app-settings.test.ts
+++ b/apps/desktop/src/lib/settings/app-settings.test.ts
@@ -802,7 +802,13 @@ describe("app settings", () => {
       filePath: "/mock-files/vault/README.md",
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: "/mock-files/vault"
+      folderPath: "/mock-files/vault",
+      openFilePaths: [
+        "/mock-files/vault/notes.md",
+        " ",
+        "/mock-files/vault/README.md",
+        "/mock-files/vault/notes.md"
+      ]
     });
 
     await expect(getStoredWorkspaceState()).resolves.toEqual({
@@ -810,7 +816,11 @@ describe("app settings", () => {
       filePath: "/mock-files/vault/README.md",
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: "/mock-files/vault"
+      folderPath: "/mock-files/vault",
+      openFilePaths: [
+        "/mock-files/vault/notes.md",
+        "/mock-files/vault/README.md"
+      ]
     });
 
     expect(store.get).toHaveBeenCalledWith("workspace");
@@ -822,11 +832,16 @@ describe("app settings", () => {
       filePath: null,
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: "/mock-files/vault"
+      folderPath: "/mock-files/vault",
+      openFilePaths: ["/mock-files/vault/notes.md"]
     });
 
     await saveStoredWorkspaceState({
-      filePath: "/mock-files/vault/README.md"
+      filePath: "/mock-files/vault/README.md",
+      openFilePaths: [
+        "/mock-files/vault/README.md",
+        "/mock-files/vault/notes.md"
+      ]
     });
 
     expect(store.set).toHaveBeenCalledWith("workspace", {
@@ -834,7 +849,11 @@ describe("app settings", () => {
       filePath: "/mock-files/vault/README.md",
       fileTreeOpen: true,
       folderName: "vault",
-      folderPath: "/mock-files/vault"
+      folderPath: "/mock-files/vault",
+      openFilePaths: [
+        "/mock-files/vault/README.md",
+        "/mock-files/vault/notes.md"
+      ]
     });
     expect(store.save).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/lib/settings/app-settings.ts
+++ b/apps/desktop/src/lib/settings/app-settings.ts
@@ -137,6 +137,7 @@ export type StoredWorkspaceState = {
   fileTreeOpen: boolean;
   folderName: string | null;
   folderPath: string | null;
+  openFilePaths: string[];
 };
 export type RecentMarkdownFolder = {
   name: string;
@@ -278,7 +279,8 @@ export const defaultWorkspaceState: StoredWorkspaceState = {
   filePath: null,
   fileTreeOpen: false,
   folderName: null,
-  folderPath: null
+  folderPath: null,
+  openFilePaths: []
 };
 
 function loadSettingsStore() {
@@ -1097,8 +1099,26 @@ export function normalizeWorkspaceState(value: unknown): StoredWorkspaceState {
     filePath: normalizeNullableString(workspace.filePath),
     fileTreeOpen: typeof workspace.fileTreeOpen === "boolean" ? workspace.fileTreeOpen : false,
     folderName: normalizeNullableString(workspace.folderName),
-    folderPath: normalizeNullableString(workspace.folderPath)
+    folderPath: normalizeNullableString(workspace.folderPath),
+    openFilePaths: normalizeWorkspaceOpenFilePaths(workspace.openFilePaths)
   };
+}
+
+function normalizeWorkspaceOpenFilePaths(value: unknown) {
+  if (!Array.isArray(value)) return [];
+
+  const seenPaths = new Set<string>();
+  const paths: string[] = [];
+
+  value.forEach((item) => {
+    const path = normalizeNullableString(item);
+    if (!path || seenPaths.has(path)) return;
+
+    seenPaths.add(path);
+    paths.push(path);
+  });
+
+  return paths;
 }
 
 function aiAgentSessionStorePath(sessionId: string | null) {

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -877,7 +877,8 @@ export function installAppTestHarness() {
       filePath: null,
       fileTreeOpen: false,
       folderName: null,
-      folderPath: null
+      folderPath: null,
+      openFilePaths: []
     });
     mockedResetWelcomeDocumentState.mockResolvedValue(undefined);
     mockedSaveStoredAiAgentPreferences.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- Persist the full set of open Markdown document tab paths in workspace settings.
- Restore saved workspace tabs on app launch while keeping the last active tab selected.
- Clear saved tab paths when a restored folder is missing or when opening a folder-only workspace.

## Why
- The restore-on-startup setting only saved `filePath`, so Markra could restore the file tree but not the rest of the previously open document tabs.

## Validation
- `pnpm --filter @markra/desktop test -- src/hooks/useMarkdownDocument.test.tsx src/hooks/useMarkdownFileTree.test.tsx src/lib/settings/app-settings.test.ts src/App.test.tsx src/App.ai.test.tsx` passed, 44 test files / 713 tests.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed, including `verify:chunks`; Vite still reports the existing large chunk warning.

## Risk
- Workspace settings gain a backward-compatible `openFilePaths` array; older settings normalize to an empty list.
- Missing files are skipped during tab restore, and a deleted workspace folder clears saved folder/tab restore state.

Closes #97