### PR TITLE
fix(desktop): restore update-restarted windows

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod menu_labels;
 mod opened_files;
 mod watcher;
 mod web_http;
+mod window_state;
 mod windows;
 
 use ai_http::{request_ai_provider_json, request_native_chat, request_native_chat_stream};
@@ -36,6 +37,10 @@ use watcher::{
     MarkdownFileWatcherState, MarkdownTreeWatcherState,
 };
 use web_http::{download_web_image, request_web_resource};
+use window_state::{
+    list_editor_window_restore_states, remove_editor_window_restore_state,
+    set_editor_window_restore_state, EditorWindowRestoreState,
+};
 use windows::{
     apply_main_window_chrome, apply_webview_window_chrome, apply_window_event_chrome,
     open_blank_editor_window, open_settings_window, spawn_blank_editor_window,
@@ -49,6 +54,7 @@ pub fn run() {
         .manage(MarkdownTreeWatcherState::default())
         .manage(OpenedMarkdownPathsState::default())
         .manage(NativeMenuTargetState::default())
+        .manage(EditorWindowRestoreState::default())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
@@ -69,6 +75,7 @@ pub fn run() {
         .on_window_event(|window, event| {
             remember_native_menu_window_from_event(window, event);
             apply_window_event_chrome(window, event);
+            remove_editor_window_restore_state(window, event);
         })
         .menu(create_application_menu)
         .on_menu_event(|app, event| {
@@ -119,7 +126,9 @@ pub fn run() {
             unwatch_markdown_file,
             watch_markdown_tree,
             unwatch_markdown_tree,
-            take_opened_markdown_paths
+            take_opened_markdown_paths,
+            set_editor_window_restore_state,
+            list_editor_window_restore_states
         ])
         .build(tauri::generate_context!())
         .expect("error while building Markra")

--- a/apps/desktop/src-tauri/src/window_state.rs
+++ b/apps/desktop/src-tauri/src/window_state.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tauri::Manager;
+
+#[derive(Default)]
+pub(crate) struct EditorWindowRestoreState(Mutex<HashMap<String, EditorWindowRestoreEntry>>);
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EditorWindowRestoreEntry {
+    pub(crate) file_path: Option<String>,
+    pub(crate) label: String,
+    pub(crate) open_file_paths: Vec<String>,
+}
+
+fn normalize_optional_path(path: Option<String>) -> Option<String> {
+    path.and_then(|path| {
+        let trimmed = path.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn normalize_open_file_paths(paths: Vec<String>) -> Vec<String> {
+    let mut seen_paths = std::collections::HashSet::new();
+    let mut normalized_paths = Vec::new();
+
+    for path in paths {
+        let trimmed = path.trim();
+        if trimmed.is_empty() || seen_paths.contains(trimmed) {
+            continue;
+        }
+
+        seen_paths.insert(trimmed.to_string());
+        normalized_paths.push(trimmed.to_string());
+    }
+
+    normalized_paths
+}
+
+fn editor_window_restore_entry(
+    label: String,
+    file_path: Option<String>,
+    open_file_paths: Vec<String>,
+) -> Option<EditorWindowRestoreEntry> {
+    let file_path = normalize_optional_path(file_path);
+    let mut open_file_paths = normalize_open_file_paths(open_file_paths);
+
+    if let Some(path) = &file_path {
+        if !open_file_paths.contains(path) {
+            open_file_paths.push(path.clone());
+        }
+    }
+
+    if file_path.is_none() && open_file_paths.is_empty() {
+        return None;
+    }
+
+    Some(EditorWindowRestoreEntry {
+        file_path,
+        label,
+        open_file_paths,
+    })
+}
+
+#[tauri::command]
+pub(crate) fn set_editor_window_restore_state(
+    window: tauri::Window,
+    state: tauri::State<'_, EditorWindowRestoreState>,
+    file_path: Option<String>,
+    open_file_paths: Vec<String>,
+) {
+    let label = window.label().to_string();
+    let mut entries = state
+        .0
+        .lock()
+        .expect("editor window restore state poisoned");
+
+    if let Some(entry) = editor_window_restore_entry(label.clone(), file_path, open_file_paths) {
+        entries.insert(label, entry);
+    } else {
+        entries.remove(&label);
+    }
+}
+
+#[tauri::command]
+pub(crate) fn list_editor_window_restore_states(
+    state: tauri::State<'_, EditorWindowRestoreState>,
+) -> Vec<EditorWindowRestoreEntry> {
+    let mut entries = state
+        .0
+        .lock()
+        .expect("editor window restore state poisoned")
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
+
+    entries.sort_by(|left, right| left.label.cmp(&right.label));
+    entries
+}
+
+pub(crate) fn remove_editor_window_restore_state<R>(
+    window: &tauri::Window<R>,
+    event: &tauri::WindowEvent,
+) where
+    R: tauri::Runtime,
+{
+    if !matches!(event, tauri::WindowEvent::Destroyed) {
+        return;
+    }
+
+    let state = window.state::<EditorWindowRestoreState>();
+    let mut entries = state
+        .0
+        .lock()
+        .expect("editor window restore state poisoned");
+    entries.remove(window.label());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_editor_window_restore_entries() {
+        let entry = editor_window_restore_entry(
+            "markra-editor-1".to_string(),
+            Some(" /mock-files/active.md ".to_string()),
+            vec![
+                "/mock-files/notes.md".to_string(),
+                " ".to_string(),
+                "/mock-files/notes.md".to_string(),
+            ],
+        )
+        .expect("entry should be retained");
+
+        assert_eq!(
+            entry,
+            EditorWindowRestoreEntry {
+                file_path: Some("/mock-files/active.md".to_string()),
+                label: "markra-editor-1".to_string(),
+                open_file_paths: vec![
+                    "/mock-files/notes.md".to_string(),
+                    "/mock-files/active.md".to_string()
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn drops_empty_editor_window_restore_entries() {
+        assert_eq!(
+            editor_window_restore_entry("main".to_string(), Some(" ".to_string()), vec![]),
+            None
+        );
+    }
+}

--- a/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
@@ -1,9 +1,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useMarkdownDocument } from "./useMarkdownDocument";
 import {
+  openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
   readNativeMarkdownFile,
   saveNativeMarkdownFile,
+  setNativeEditorWindowRestoreState,
   watchNativeMarkdownFile
 } from "../lib/tauri";
 import {
@@ -25,13 +27,16 @@ vi.mock("../lib/tauri", () => ({
   openNativeMarkdownPath: vi.fn(),
   readNativeMarkdownFile: vi.fn(),
   saveNativeMarkdownFile: vi.fn(),
+  setNativeEditorWindowRestoreState: vi.fn(),
   setNativeWindowTitle: vi.fn(),
   watchNativeMarkdownFile: vi.fn()
 }));
 
+const mockedOpenNativeMarkdownFileInNewWindow = vi.mocked(openNativeMarkdownFileInNewWindow);
 const mockedOpenNativeMarkdownPath = vi.mocked(openNativeMarkdownPath);
 const mockedReadNativeMarkdownFile = vi.mocked(readNativeMarkdownFile);
 const mockedSaveNativeMarkdownFile = vi.mocked(saveNativeMarkdownFile);
+const mockedSetNativeEditorWindowRestoreState = vi.mocked(setNativeEditorWindowRestoreState);
 const mockedWatchNativeMarkdownFile = vi.mocked(watchNativeMarkdownFile);
 const mockedConsumeWelcomeDocumentState = vi.mocked(consumeWelcomeDocumentState);
 const mockedGetStoredWorkspaceState = vi.mocked(getStoredWorkspaceState);
@@ -41,8 +46,10 @@ describe("useMarkdownDocument", () => {
   beforeEach(() => {
     window.history.pushState({}, "", "/");
     mockedOpenNativeMarkdownPath.mockReset();
+    mockedOpenNativeMarkdownFileInNewWindow.mockReset();
     mockedReadNativeMarkdownFile.mockReset();
     mockedSaveNativeMarkdownFile.mockReset();
+    mockedSetNativeEditorWindowRestoreState.mockReset();
     mockedWatchNativeMarkdownFile.mockReset();
     mockedConsumeWelcomeDocumentState.mockReset();
     mockedGetStoredWorkspaceState.mockReset();
@@ -62,6 +69,7 @@ describe("useMarkdownDocument", () => {
       name: "saved.md",
       path: "/mock-files/saved.md"
     });
+    mockedSetNativeEditorWindowRestoreState.mockResolvedValue(undefined);
   });
 
   it("does not ask to discard an untouched blank document when the editor still exposes stale markdown", async () => {
@@ -837,5 +845,82 @@ describe("useMarkdownDocument", () => {
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(notesPath);
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("restores additional editor windows from the saved update-restart snapshot", async () => {
+    const firstPath = "/mock-files/vault/first.md";
+    const secondPath = "/mock-files/vault/second.md";
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-window-restore",
+      filePath: null,
+      fileTreeOpen: false,
+      folderName: null,
+      folderPath: null,
+      openFilePaths: [],
+      openWindows: [
+        {
+          filePath: firstPath,
+          label: "main",
+          openFilePaths: [firstPath]
+        },
+        {
+          filePath: secondPath,
+          label: "markra-editor-1",
+          openFilePaths: [secondPath]
+        }
+      ]
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# First",
+      name: "first.md",
+      path: firstPath
+    });
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.document.name).toBe("first.md"));
+
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(firstPath);
+    expect(mockedOpenNativeMarkdownFileInNewWindow).toHaveBeenCalledWith(secondPath);
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({ openWindows: [] });
+    expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("registers the current editor window restore state when a markdown file opens", async () => {
+    const filePath = "/mock-files/vault/current.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "file",
+      file: {
+        content: "# Current",
+        name: "current.md",
+        path: filePath
+      }
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openMarkdownFile();
+    });
+
+    expect(mockedSetNativeEditorWindowRestoreState).toHaveBeenCalledWith({
+      filePath,
+      openFilePaths: [filePath]
+    });
   });
 });

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -4,7 +4,8 @@ import {
   consumeWelcomeDocumentState,
   createAiAgentSessionId,
   getStoredWorkspaceState,
-  saveStoredWorkspaceState
+  saveStoredWorkspaceState,
+  type StoredWorkspaceWindow
 } from "../lib/settings/app-settings";
 import { getMarkdownOutline, getWordCount } from "@markra/markdown";
 import {
@@ -14,6 +15,7 @@ import {
   readNativeMarkdownFile,
   resolveNativeMarkdownPath,
   saveNativeMarkdownFile,
+  setNativeEditorWindowRestoreState,
   listenNativeOpenedMarkdownPaths,
   takeNativeOpenedMarkdownPaths,
   watchNativeMarkdownFile,
@@ -101,6 +103,10 @@ function restoreFilePathsFromWorkspace(openFilePaths: readonly string[], filePat
   if (activeFilePath && !paths.includes(activeFilePath)) paths.push(activeFilePath);
 
   return paths;
+}
+
+function activeFilePathFromWindowRestore(window: StoredWorkspaceWindow) {
+  return window.filePath ?? window.openFilePaths.at(-1) ?? null;
 }
 
 function activeFilePathFromTabs(tabs: readonly MarkdownDocumentTab[], activeTabId: string | null) {
@@ -282,6 +288,10 @@ export function useMarkdownDocument({
     return isCurrentMarkdownEquivalent?.(markdown);
   }, [editorReady, isCurrentMarkdownEquivalent]);
 
+  const registerWindowRestoreState = useCallback((filePath: string | null, openFilePaths: string[]) => {
+    setNativeEditorWindowRestoreState({ filePath, openFilePaths }).catch(() => {});
+  }, []);
+
   const setActiveDocument = useCallback((nextDocument: DocumentState) => {
     documentRef.current = nextDocument;
     setDocument(nextDocument);
@@ -431,16 +441,18 @@ export function useMarkdownDocument({
       const tab = createDocumentTab(nextDocument, createUntitledTabId());
       const nextTabs = [...tabsRef.current, tab];
       setActiveTabState(nextTabs, tab.id);
+      registerWindowRestoreState(activeFilePathFromTabs(nextTabs, tab.id), openFilePathsFromTabs(nextTabs));
       persistWorkspaceState({
         filePath: null,
         openFilePaths: openFilePathsFromTabs(nextTabs)
       });
     } else {
       setActiveDocument(nextDocument);
+      registerWindowRestoreState(null, []);
       persistWorkspaceState({ filePath: null, openFilePaths: [] });
     }
     return true;
-  }, [createUntitledTabId, documentTabsEnabled, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]);
+  }, [createUntitledTabId, documentTabsEnabled, registerWindowRestoreState, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]);
 
   const createBlankDocument = useCallback(() => {
     if (documentTabsEnabled) return Promise.resolve(resetToBlankDocument());
@@ -474,8 +486,9 @@ export function useMarkdownDocument({
     setActiveTabId(null);
     setDocument(nextDocument);
     documentRef.current = nextDocument;
+    registerWindowRestoreState(null, []);
     if (options.persistWorkspace !== false) persistWorkspaceState({ filePath: null, openFilePaths: [] });
-  }, []);
+  }, [registerWindowRestoreState]);
 
   const applyNativeMarkdownFile = useCallback(
     (file: NativeMarkdownFile, updateTreeRoot = true, preferredSessionId?: string | null) => {
@@ -522,6 +535,7 @@ export function useMarkdownDocument({
       }
 
       if (updateTreeRoot) onTreeRootFromFilePath(file.path);
+      registerWindowRestoreState(file.path, nextOpenFilePaths);
       persistWorkspaceState({
         aiAgentSessionId: sessionId,
         filePath: file.path,
@@ -529,7 +543,7 @@ export function useMarkdownDocument({
         ...(updateTreeRoot ? { folderName: null, folderPath: null } : {})
       });
     },
-    [documentTabsEnabled, onTreeRootFromFilePath, resolveWorkspaceSessionId, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]
+    [documentTabsEnabled, onTreeRootFromFilePath, registerWindowRestoreState, resolveWorkspaceSessionId, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]
   );
 
   const loadNativeMarkdownPath = useCallback(
@@ -587,6 +601,7 @@ export function useMarkdownDocument({
       }
 
       if (updateTreeRoot && activeFile) onTreeRootFromFilePath(activeFile.path);
+      registerWindowRestoreState(activeFile?.path ?? null, files.map((file) => file.path));
       persistWorkspaceState({
         aiAgentSessionId: sessionId,
         filePath: activeFile?.path ?? null,
@@ -595,7 +610,7 @@ export function useMarkdownDocument({
       });
       return true;
     },
-    [documentTabsEnabled, onTreeRootFromFilePath, resolveWorkspaceSessionId, setActiveDocument, setActiveTabState]
+    [documentTabsEnabled, onTreeRootFromFilePath, registerWindowRestoreState, resolveWorkspaceSessionId, setActiveDocument, setActiveTabState]
   );
 
   const openMarkdownFile = useCallback(async (options: OpenMarkdownFileOptions = {}) => {
@@ -662,6 +677,7 @@ export function useMarkdownDocument({
 
         tabsRef.current = nextTabs;
         setTabs(nextTabs);
+        registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
         persistWorkspaceState({
           filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
           openFilePaths: openFilePathsFromTabs(nextTabs)
@@ -672,7 +688,7 @@ export function useMarkdownDocument({
         return null;
       }
     },
-    [syncActiveDocumentFromEditor]
+    [registerWindowRestoreState, syncActiveDocumentFromEditor]
   );
 
   const replaceOpenDocumentFile = useCallback((previousPath: string, file: NativeMarkdownFolderFile) => {
@@ -699,12 +715,13 @@ export function useMarkdownDocument({
     });
     tabsRef.current = nextTabs;
     setTabs(nextTabs);
+    registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
     persistWorkspaceState({
       filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
     return true;
-  }, [setActiveDocument]);
+  }, [registerWindowRestoreState, setActiveDocument]);
 
   const detachDeletedDocumentFile = useCallback((path: string) => {
     const currentTabs = tabsRef.current;
@@ -743,8 +760,9 @@ export function useMarkdownDocument({
       filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
+    registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
     return true;
-  }, [documentTabsEnabled, setActiveDocument, setActiveTabState]);
+  }, [documentTabsEnabled, registerWindowRestoreState, setActiveDocument, setActiveTabState]);
 
   const saveCurrentDocument = useCallback(
     async (saveAs = false) => {
@@ -775,6 +793,7 @@ export function useMarkdownDocument({
         ))
         : [savedFile.path];
       if (saveAs || current.path === null) onTreeRootFromFilePath(savedFile.path);
+      registerWindowRestoreState(savedFile.path, nextOpenFilePaths);
       persistWorkspaceState({
         filePath: savedFile.path,
         openFilePaths: nextOpenFilePaths,
@@ -782,7 +801,7 @@ export function useMarkdownDocument({
       });
       return savedFile;
     },
-    [currentMarkdown, documentTabsEnabled, onTreeRootFromFilePath, setActiveDocument]
+    [currentMarkdown, documentTabsEnabled, onTreeRootFromFilePath, registerWindowRestoreState, setActiveDocument]
   );
 
   const saveMarkdownTab = useCallback(
@@ -821,6 +840,7 @@ export function useMarkdownDocument({
       }
 
       if (saveAs || tab.path === null) onTreeRootFromFilePath(savedFile.path);
+      registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
       persistWorkspaceState({
         filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
         openFilePaths: openFilePathsFromTabs(nextTabs),
@@ -828,7 +848,7 @@ export function useMarkdownDocument({
       });
       return savedFile;
     },
-    [currentMarkdown, onTreeRootFromFilePath, syncActiveDocumentFromEditor]
+    [currentMarkdown, onTreeRootFromFilePath, registerWindowRestoreState, syncActiveDocumentFromEditor]
   );
 
   const handleSaveClick = useCallback(() => {
@@ -841,12 +861,13 @@ export function useMarkdownDocument({
     if (!tab) return false;
 
     setActiveTabState(tabsRef.current, tab.id);
+    registerWindowRestoreState(tab.path, openFilePathsFromTabs(tabsRef.current));
     persistWorkspaceState({
       filePath: tab.path,
       openFilePaths: openFilePathsFromTabs(tabsRef.current)
     });
     return true;
-  }, [setActiveTabState, syncActiveDocumentFromEditor]);
+  }, [registerWindowRestoreState, setActiveTabState, syncActiveDocumentFromEditor]);
 
   const closeMarkdownTab = useCallback(async (tabId: string) => {
     syncActiveDocumentFromEditor();
@@ -867,12 +888,13 @@ export function useMarkdownDocument({
         : nextTabs.find((candidate) => candidate.id === activeTabIdRef.current) ?? null;
 
     setActiveTabState(nextTabs, nextActiveTab?.id ?? null);
+    registerWindowRestoreState(nextActiveTab?.path ?? null, openFilePathsFromTabs(nextTabs));
     persistWorkspaceState({
       filePath: nextActiveTab?.path ?? null,
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
     return true;
-  }, [confirmDiscardUnsavedChanges, hasDiscardableTabChanges, setActiveTabState, syncActiveDocumentFromEditor]);
+  }, [confirmDiscardUnsavedChanges, hasDiscardableTabChanges, registerWindowRestoreState, setActiveTabState, syncActiveDocumentFromEditor]);
 
   const handleDroppedMarkdownPath = useCallback(
     async (target: NativeMarkdownDroppedTarget) => {
@@ -1028,11 +1050,28 @@ export function useMarkdownDocument({
         try {
           const workspace = await getStoredWorkspaceState();
           const sessionId = workspace.aiAgentSessionId ?? createAiAgentSessionId();
-          let restoreFilePaths = restoreFilePathsFromWorkspace(
-            workspace.openFilePaths,
-            workspace.filePath,
-            documentTabsEnabled
-          );
+          const restoreWindows = workspace.openWindows ?? [];
+          const primaryRestoreWindow = restoreWindows[0] ?? null;
+          const primaryRestoreWindowFilePath = primaryRestoreWindow
+            ? activeFilePathFromWindowRestore(primaryRestoreWindow)
+            : null;
+          let restoreFilePaths = primaryRestoreWindow
+            ? restoreFilePathsFromWorkspace(
+              primaryRestoreWindow.openFilePaths,
+              primaryRestoreWindowFilePath,
+              documentTabsEnabled
+            )
+            : restoreFilePathsFromWorkspace(
+              workspace.openFilePaths,
+              workspace.filePath,
+              documentTabsEnabled
+            );
+          const activeRestoreFilePath = primaryRestoreWindow ? primaryRestoreWindowFilePath : workspace.filePath;
+          const additionalRestoreWindowFilePaths = normalizeOpenFilePaths(
+            restoreWindows
+              .slice(1)
+              .map(activeFilePathFromWindowRestore)
+          ).filter((path) => !restoreFilePaths.includes(path));
 
           assignWorkspaceSessionId(sessionId);
 
@@ -1063,12 +1102,22 @@ export function useMarkdownDocument({
           if (restoreFilePaths.length > 0) {
             const restoredFiles = await restoreNativeMarkdownFiles(
               restoreFilePaths,
-              workspace.filePath,
+              activeRestoreFilePath,
               !restoredWorkspace,
               sessionId
             );
             if (!active) return;
             if (restoredFiles) restoredWorkspace = true;
+          }
+
+          for (const path of additionalRestoreWindowFilePaths) {
+            await openNativeMarkdownFileInNewWindow(path);
+            if (!active) return;
+            restoredWorkspace = true;
+          }
+
+          if (restoreWindows.length > 0) {
+            persistWorkspaceState({ openWindows: [] });
           }
 
           if (workspace.aiAgentSessionId !== sessionId) {

--- a/apps/desktop/src/lib/settings/app-settings.test.ts
+++ b/apps/desktop/src/lib/settings/app-settings.test.ts
@@ -809,6 +809,27 @@ describe("app settings", () => {
         "/mock-files/vault/README.md",
         "/mock-files/vault/notes.md"
       ],
+      openWindows: [
+        {
+          filePath: "/mock-files/vault/README.md",
+          label: "main",
+          openFilePaths: [
+            "/mock-files/vault/notes.md",
+            "/mock-files/vault/README.md",
+            "/mock-files/vault/notes.md"
+          ]
+        },
+        {
+          filePath: " ",
+          label: "blank-window",
+          openFilePaths: []
+        },
+        {
+          filePath: "/mock-files/vault/archive.md",
+          label: "main",
+          openFilePaths: ["/mock-files/vault/archive.md"]
+        }
+      ],
       sideBySideGroup: {
         primaryFilePath: "/mock-files/vault/README.md",
         sideFilePath: "/mock-files/vault/notes.md"
@@ -824,6 +845,16 @@ describe("app settings", () => {
       openFilePaths: [
         "/mock-files/vault/notes.md",
         "/mock-files/vault/README.md"
+      ],
+      openWindows: [
+        {
+          filePath: "/mock-files/vault/README.md",
+          label: "main",
+          openFilePaths: [
+            "/mock-files/vault/notes.md",
+            "/mock-files/vault/README.md"
+          ]
+        }
       ],
       sideBySideGroup: {
         primaryFilePath: "/mock-files/vault/README.md",
@@ -870,6 +901,7 @@ describe("app settings", () => {
         "/mock-files/vault/README.md",
         "/mock-files/vault/notes.md"
       ],
+      openWindows: [],
       sideBySideGroup: {
         primaryFilePath: "/mock-files/vault/README.md",
         sideFilePath: "/mock-files/vault/notes.md"
@@ -908,7 +940,8 @@ describe("app settings", () => {
       openFilePaths: [
         "/mock-files/vault/README.md",
         "/mock-files/vault/notes.md"
-      ]
+      ],
+      openWindows: []
     });
     expect(store.save).toHaveBeenCalledTimes(1);
   });
@@ -933,7 +966,8 @@ describe("app settings", () => {
       fileTreeOpen: true,
       folderName: "vault",
       folderPath: "/mock-files/vault",
-      openFilePaths: ["/mock-files/vault/README.md"]
+      openFilePaths: ["/mock-files/vault/README.md"],
+      openWindows: []
     });
   });
 

--- a/apps/desktop/src/lib/settings/app-settings.ts
+++ b/apps/desktop/src/lib/settings/app-settings.ts
@@ -138,7 +138,13 @@ export type StoredWorkspaceState = {
   folderName: string | null;
   folderPath: string | null;
   openFilePaths: string[];
+  openWindows?: StoredWorkspaceWindow[];
   sideBySideGroup?: StoredWorkspaceSideBySideGroup | null;
+};
+export type StoredWorkspaceWindow = {
+  filePath: string | null;
+  label: string;
+  openFilePaths: string[];
 };
 export type StoredWorkspaceSideBySideGroup = {
   primaryFilePath: string;
@@ -285,7 +291,8 @@ export const defaultWorkspaceState: StoredWorkspaceState = {
   fileTreeOpen: false,
   folderName: null,
   folderPath: null,
-  openFilePaths: []
+  openFilePaths: [],
+  openWindows: []
 };
 
 function loadSettingsStore() {
@@ -1115,6 +1122,7 @@ export function normalizeWorkspaceState(value: unknown): StoredWorkspaceState {
     folderName: normalizeNullableString(workspace.folderName),
     folderPath: normalizeNullableString(workspace.folderPath),
     openFilePaths,
+    openWindows: normalizeWorkspaceWindows(workspace.openWindows),
     ...(persistedSideBySideGroup ? { sideBySideGroup: persistedSideBySideGroup } : {})
   };
 }
@@ -1134,6 +1142,35 @@ function normalizeWorkspaceOpenFilePaths(value: unknown) {
   });
 
   return paths;
+}
+
+function normalizeWorkspaceWindows(value: unknown): StoredWorkspaceWindow[] {
+  if (!Array.isArray(value)) return [];
+
+  const seenLabels = new Set<string>();
+  const windows: StoredWorkspaceWindow[] = [];
+
+  value.forEach((item) => {
+    if (typeof item !== "object" || item === null) return;
+
+    const candidate = item as Partial<StoredWorkspaceWindow>;
+    const label = normalizeNullableString(candidate.label);
+    if (!label || seenLabels.has(label)) return;
+
+    const filePath = normalizeNullableString(candidate.filePath);
+    const openFilePaths = normalizeWorkspaceOpenFilePaths(candidate.openFilePaths);
+    if (filePath && !openFilePaths.includes(filePath)) openFilePaths.push(filePath);
+    if (!filePath && openFilePaths.length === 0) return;
+
+    seenLabels.add(label);
+    windows.push({
+      filePath,
+      label,
+      openFilePaths
+    });
+  });
+
+  return windows;
 }
 
 function normalizeWorkspaceSideBySideGroup(value: unknown): StoredWorkspaceSideBySideGroup | null {

--- a/apps/desktop/src/lib/tauri/updater.test.ts
+++ b/apps/desktop/src/lib/tauri/updater.test.ts
@@ -1,5 +1,7 @@
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { saveStoredWorkspaceState } from "../settings/app-settings";
+import { listNativeEditorWindowRestoreStates } from "./window";
 import { checkNativeAppUpdate } from "./updater";
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
@@ -10,13 +12,27 @@ vi.mock("@tauri-apps/plugin-process", () => ({
   relaunch: vi.fn()
 }));
 
+vi.mock("../settings/app-settings", () => ({
+  saveStoredWorkspaceState: vi.fn()
+}));
+
+vi.mock("./window", () => ({
+  listNativeEditorWindowRestoreStates: vi.fn()
+}));
+
 const mockedCheck = vi.mocked(check);
 const mockedRelaunch = vi.mocked(relaunch);
+const mockedSaveStoredWorkspaceState = vi.mocked(saveStoredWorkspaceState);
+const mockedListNativeEditorWindowRestoreStates = vi.mocked(listNativeEditorWindowRestoreStates);
 
 describe("native app updater", () => {
   beforeEach(() => {
     mockedCheck.mockReset();
     mockedRelaunch.mockReset();
+    mockedSaveStoredWorkspaceState.mockReset();
+    mockedListNativeEditorWindowRestoreStates.mockReset();
+    mockedListNativeEditorWindowRestoreStates.mockResolvedValue([]);
+    mockedSaveStoredWorkspaceState.mockResolvedValue(undefined);
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
@@ -110,6 +126,47 @@ describe("native app updater", () => {
 
     await update?.restart();
 
+    expect(mockedRelaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the registered editor window restore snapshot before relaunching", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mockedListNativeEditorWindowRestoreStates.mockResolvedValue([
+      {
+        filePath: "/mock-files/first.md",
+        label: "main",
+        openFilePaths: ["/mock-files/first.md"]
+      },
+      {
+        filePath: "/mock-files/second.md",
+        label: "markra-editor-1",
+        openFilePaths: ["/mock-files/second.md"]
+      }
+    ]);
+    mockedCheck.mockResolvedValue({
+      currentVersion: "0.0.6",
+      downloadAndInstall: vi.fn(),
+      rawJson: {},
+      version: "0.0.7"
+    } as unknown as Awaited<ReturnType<typeof check>>);
+
+    const update = await checkNativeAppUpdate();
+    await update?.restart();
+
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      openWindows: [
+        {
+          filePath: "/mock-files/first.md",
+          label: "main",
+          openFilePaths: ["/mock-files/first.md"]
+        },
+        {
+          filePath: "/mock-files/second.md",
+          label: "markra-editor-1",
+          openFilePaths: ["/mock-files/second.md"]
+        }
+      ]
+    });
     expect(mockedRelaunch).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/lib/tauri/updater.ts
+++ b/apps/desktop/src/lib/tauri/updater.ts
@@ -1,5 +1,7 @@
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { saveStoredWorkspaceState } from "../settings/app-settings";
+import { listNativeEditorWindowRestoreStates } from "./window";
 
 const localUpdaterProxyUrls = [
   "http://127.0.0.1:7890",
@@ -62,6 +64,15 @@ function emitProgress({
   });
 }
 
+async function persistEditorWindowRestoreSnapshot() {
+  try {
+    const openWindows = await listNativeEditorWindowRestoreStates();
+    await saveStoredWorkspaceState({ openWindows });
+  } catch {
+    // Relaunching for an installed update should not be blocked by opportunistic restore state.
+  }
+}
+
 export async function checkNativeAppUpdate(): Promise<NativeAppUpdate | null> {
   if (!isTauriRuntime()) return null;
 
@@ -96,7 +107,10 @@ export async function checkNativeAppUpdate(): Promise<NativeAppUpdate | null> {
         }
       });
     },
-    restart: relaunch,
+    async restart() {
+      await persistEditorWindowRestoreSnapshot();
+      await relaunch();
+    },
     version: update.version
   };
 }

--- a/apps/desktop/src/lib/tauri/window.test.ts
+++ b/apps/desktop/src/lib/tauri/window.test.ts
@@ -1,7 +1,10 @@
+import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   closeNativeWindow,
+  listNativeEditorWindowRestoreStates,
   minimizeNativeWindow,
+  setNativeEditorWindowRestoreState,
   toggleNativeWindowMaximized
 } from "./window";
 
@@ -14,6 +17,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 }));
 
 const mockedGetCurrentWindow = vi.mocked(getCurrentWindow);
+const mockedInvoke = vi.mocked(invoke);
 
 describe("native window actions", () => {
   beforeEach(() => {
@@ -22,6 +26,7 @@ describe("native window actions", () => {
       value: {}
     });
     mockedGetCurrentWindow.mockReset();
+    mockedInvoke.mockReset();
   });
 
   afterEach(() => {
@@ -63,5 +68,43 @@ describe("native window actions", () => {
     await toggleNativeWindowMaximized();
 
     expect(mockedGetCurrentWindow).not.toHaveBeenCalled();
+  });
+
+  it("registers the current editor window restore state in Tauri", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await setNativeEditorWindowRestoreState({
+      filePath: "/mock-files/notes.md",
+      openFilePaths: ["/mock-files/notes.md"]
+    });
+
+    expect(mockedInvoke).toHaveBeenCalledWith("set_editor_window_restore_state", {
+      filePath: "/mock-files/notes.md",
+      openFilePaths: ["/mock-files/notes.md"]
+    });
+  });
+
+  it("lists normalized editor window restore states from Tauri", async () => {
+    mockedInvoke.mockResolvedValue([
+      {
+        filePath: " /mock-files/first.md ",
+        label: "main",
+        openFilePaths: [" /mock-files/first.md ", " "]
+      },
+      {
+        filePath: null,
+        label: "empty",
+        openFilePaths: []
+      }
+    ]);
+
+    await expect(listNativeEditorWindowRestoreStates()).resolves.toEqual([
+      {
+        filePath: "/mock-files/first.md",
+        label: "main",
+        openFilePaths: ["/mock-files/first.md"]
+      }
+    ]);
+    expect(mockedInvoke).toHaveBeenCalledWith("list_editor_window_restore_states");
   });
 });

--- a/apps/desktop/src/lib/tauri/window.ts
+++ b/apps/desktop/src/lib/tauri/window.ts
@@ -1,5 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
 
+export type NativeEditorWindowRestoreState = {
+  filePath: string | null;
+  label: string;
+  openFilePaths: string[];
+};
+
+export type SetNativeEditorWindowRestoreStateInput = {
+  filePath: string | null;
+  openFilePaths: string[];
+};
+
 export function openSettingsWindow() {
   return invoke("open_settings_window");
 }
@@ -31,6 +42,53 @@ async function getCurrentNativeWindow() {
 
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
   return getCurrentWindow();
+}
+
+function normalizeNativeEditorWindowRestoreStates(value: unknown): NativeEditorWindowRestoreState[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((item) => {
+    if (typeof item !== "object" || item === null) return [];
+
+    const candidate = item as Partial<NativeEditorWindowRestoreState>;
+    const label = candidate.label?.trim();
+    const trimmedFilePath = typeof candidate.filePath === "string" ? candidate.filePath.trim() : "";
+    const filePath = trimmedFilePath
+      ? trimmedFilePath
+      : null;
+    const openFilePaths = Array.isArray(candidate.openFilePaths)
+      ? candidate.openFilePaths.flatMap((path) => {
+        if (typeof path !== "string") return [];
+
+        const trimmedPath = path.trim();
+        return trimmedPath ? [trimmedPath] : [];
+      })
+      : [];
+
+    if (!label || (!filePath && openFilePaths.length === 0)) return [];
+
+    return [{
+      filePath,
+      label,
+      openFilePaths
+    }];
+  });
+}
+
+export async function setNativeEditorWindowRestoreState(input: SetNativeEditorWindowRestoreStateInput) {
+  if (!("__TAURI_INTERNALS__" in window)) {
+    return;
+  }
+
+  await invoke("set_editor_window_restore_state", input);
+}
+
+export async function listNativeEditorWindowRestoreStates() {
+  if (!("__TAURI_INTERNALS__" in window)) {
+    return [];
+  }
+
+  return normalizeNativeEditorWindowRestoreStates(await invoke("list_editor_window_restore_states"));
 }
 
 export async function closeNativeWindow() {

--- a/apps/desktop/src/test/app-harness.tsx
+++ b/apps/desktop/src/test/app-harness.tsx
@@ -19,6 +19,7 @@ import {
   saveNativeHtmlFile,
   saveNativeMarkdownFile,
   saveNativePdfFile,
+  setNativeEditorWindowRestoreState,
   showNativeMarkdownFileTreeContextMenu,
   installNativeMarkdownFileDrop,
   listNativeMarkdownFilesForPath,
@@ -120,6 +121,7 @@ vi.mock("../lib/tauri", () => ({
   saveNativeHtmlFile: vi.fn(),
   saveNativeMarkdownFile: vi.fn(),
   saveNativePdfFile: vi.fn(),
+  setNativeEditorWindowRestoreState: vi.fn(),
   showNativeMarkdownFileTreeContextMenu: vi.fn(),
   uploadNativeS3Image: vi.fn(),
   uploadNativeWebDavImage: vi.fn(),
@@ -474,6 +476,7 @@ export const mockedResolveNativeMarkdownPath = vi.mocked(resolveNativeMarkdownPa
 export const mockedSaveNativeHtmlFile = vi.mocked(saveNativeHtmlFile);
 export const mockedSaveNativeMarkdownFile = vi.mocked(saveNativeMarkdownFile);
 export const mockedSaveNativePdfFile = vi.mocked(saveNativePdfFile);
+export const mockedSetNativeEditorWindowRestoreState = vi.mocked(setNativeEditorWindowRestoreState);
 export const mockedShowNativeMarkdownFileTreeContextMenu = vi.mocked(showNativeMarkdownFileTreeContextMenu);
 export const mockedInstallNativeMarkdownFileDrop = vi.mocked(installNativeMarkdownFileDrop);
 export const mockedListNativeMarkdownFilesForPath = vi.mocked(listNativeMarkdownFilesForPath);
@@ -630,6 +633,7 @@ export function installAppTestHarness() {
     mockedRenameNativeMarkdownTreeFile.mockReset();
     mockedSaveNativeMarkdownFile.mockReset();
     mockedShowNativeMarkdownFileTreeContextMenu.mockReset();
+    mockedSetNativeEditorWindowRestoreState.mockReset();
     mockedListNativeMarkdownFilesForPath.mockReset();
     mockedTakeNativeOpenedMarkdownPaths.mockReset();
     mockedWatchNativeMarkdownFile.mockReset();
@@ -725,6 +729,7 @@ export function installAppTestHarness() {
       path: "/mock-files/Untitled.pdf"
     });
     mockedShowNativeMarkdownFileTreeContextMenu.mockResolvedValue(undefined);
+    mockedSetNativeEditorWindowRestoreState.mockResolvedValue(undefined);
     mockedListenAppAiSettingsChanged.mockResolvedValue(() => {});
     mockedListenAppCustomThemeCssChanged.mockResolvedValue(() => {});
     mockedListenAppEditorPreferencesChanged.mockResolvedValue(() => {});


### PR DESCRIPTION
## Summary
- Capture live editor window restore state in Tauri so update relaunches can persist all open editor windows.
- Restore the primary window from the saved update snapshot and reopen additional Markdown file windows on startup.
- Normalize the saved window snapshot in settings and add focused JS/Rust coverage.

## Why
The previous workspace persistence was shared by every editor window, so the last window to update state overwrote the rest. After an in-app update restart, only that last window was restored.

## Validation
- `pnpm --filter @markra/desktop test -- apps/desktop/src/lib/tauri/window.test.ts apps/desktop/src/hooks/useMarkdownDocument.test.tsx apps/desktop/src/lib/tauri/updater.test.ts apps/desktop/src/lib/settings/app-settings.test.ts` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/desktop build` passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib` passed

## Risk
- Low to medium: touches startup restore and updater relaunch paths, with compatibility kept for existing workspace state.

Closes #109
