### PR TITLE
feat(editor): support LaTeX macro definitions

### DIFF
--- a/apps/desktop/src/components/MarkdownExportDocument.test.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.test.tsx
@@ -59,6 +59,39 @@ describe("MarkdownExportDocument", () => {
     expect(bodyHtml).not.toContain("language-math");
   });
 
+  it("applies display math macro definitions before exporting HTML", async () => {
+    const onRendered = vi.fn();
+
+    render(
+      <MarkdownExportDocument
+        onRendered={onRendered}
+        snapshot={{
+          id: 1,
+          kind: "html",
+          markdown: [
+            "$$",
+            String.raw`\newcommand{\RR}{\mathbb{R}}`,
+            String.raw`\newcommand{\vect}[1]{\mathbf{#1}}`,
+            "$$",
+            "",
+            String.raw`The domain is $\RR$.`,
+            "",
+            String.raw`Vector $\vect{x}$.`
+          ].join("\n"),
+          title: "macro-math.md"
+        }}
+      />
+    );
+
+    await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
+
+    const bodyHtml = onRendered.mock.calls[0]?.[0].bodyHtml as string;
+    expect(bodyHtml).toContain('class="mord mathbb">R</span>');
+    expect(bodyHtml).toContain('class="mord mathbf">x</span>');
+    expect(bodyHtml).not.toContain(String.raw`\newcommand`);
+    expect(bodyHtml).not.toContain('style="color:#cc0000;">\\RR');
+  });
+
   it("renders Mermaid code blocks before exporting HTML", async () => {
     const onRendered = vi.fn();
 

--- a/apps/desktop/src/components/MarkdownExportDocument.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.tsx
@@ -1,10 +1,17 @@
 import { Children, cloneElement, isValidElement, useEffect, useRef, type ReactElement, type ReactNode } from "react";
-import { renderToString } from "katex";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import { isMermaidLanguage, mermaidThemeFromElement, renderMermaidToSvg } from "@markra/editor";
+import {
+  createMarkraMathMacros,
+  isMarkraMathMacroDefinitionSource,
+  isMermaidLanguage,
+  mermaidThemeFromElement,
+  renderMarkraMathToString,
+  renderMermaidToSvg,
+  type MarkraMathMacros
+} from "@markra/editor";
 import { parseMarkdownCalloutMarker, type ParsedMarkdownCalloutMarker } from "@markra/shared";
 import type { ExportDocumentFormat } from "../lib/document-export";
 
@@ -38,13 +45,15 @@ function hasMathClass(className: unknown, kind: "display" | "inline") {
   return typeof className === "string" && className.split(/\s+/u).includes(`math-${kind}`);
 }
 
-function renderMathSource(source: string, kind: "display" | "inline") {
-  const html = renderToString(source, {
-    displayMode: kind === "display",
-    output: "htmlAndMathml",
-    strict: "ignore",
-    throwOnError: false
-  });
+function isMathMacroDefinitionMarker(child: ReactNode) {
+  return isValidElement<Record<string, unknown>>(child) && child.props["data-markra-math-macro-definition"] === "";
+}
+
+function renderMathSource(source: string, kind: "display" | "inline", macros: MarkraMathMacros) {
+  const html = renderMarkraMathToString(source, kind, macros);
+  if (isMarkraMathMacroDefinitionSource(source)) {
+    return <span data-markra-math-macro-definition="" hidden />;
+  }
 
   return (
     <span
@@ -218,6 +227,8 @@ export function MarkdownExportDocument({
 
   if (!snapshot) return null;
 
+  const mathMacros = createMarkraMathMacros();
+
   return (
     <section
       aria-hidden="true"
@@ -232,11 +243,11 @@ export function MarkdownExportDocument({
             blockquote: ({ node: _node, ...props }) => renderCalloutBlockquote(props),
             code: ({ node: _node, className, children, ...props }) => {
               if (hasMathClass(className, "inline")) {
-                return renderMathSource(childrenToText(children), "inline");
+                return renderMathSource(childrenToText(children), "inline", mathMacros);
               }
 
               if (hasMathClass(className, "display")) {
-                return renderMathSource(childrenToText(children), "display");
+                return renderMathSource(childrenToText(children), "display", mathMacros);
               }
 
               return <code {...props} className={className}>{children}</code>;
@@ -250,6 +261,7 @@ export function MarkdownExportDocument({
             ),
             pre: ({ node: _node, children, ...props }) => {
               const onlyChild = Children.toArray(children)[0];
+              if (isMathMacroDefinitionMarker(onlyChild)) return null;
               if (
                 isValidElement<{ className?: string }>(onlyChild) &&
                 hasMathClass(onlyChild.props.className, "display")

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1062,6 +1062,28 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
   });
 
+  it("applies display math macro definitions to later formulas", async () => {
+    const macroDefinition = ["$$", String.raw`\newcommand{\RR}{\mathbb{R}}`, "$$"].join("\n");
+    const source = [macroDefinition, "", String.raw`The domain is $\RR$.`].join("\n");
+    const { container } = await renderEditor(source);
+
+    const inlineFormula = container.querySelector<HTMLElement>(".ProseMirror .markra-math-render-inline");
+    const macroFold = container.querySelector<HTMLElement>(".ProseMirror .markra-math-macro-fold");
+
+    expect(inlineFormula).toBeInTheDocument();
+    expect(inlineFormula?.querySelector(".mathbb")).toHaveTextContent("R");
+    expect(macroFold).toBeInTheDocument();
+    expect(macroFold).toHaveTextContent(String.raw`\newcommand`);
+    expect(container.querySelector(".ProseMirror .markra-math-render-display")).not.toBeInTheDocument();
+
+    macroFold?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+
+    const activeMacroSource = Array.from(container.querySelectorAll(".ProseMirror .markra-math-source-active-display"))
+      .map((node) => node.textContent)
+      .join("");
+    expect(activeMacroSource).toContain(String.raw`\newcommand{\RR}{\mathbb{R}}`);
+  });
+
   it("renders multiline display math without treating minus-led rows as lists", async () => {
     const source = [
       "$$",
@@ -1082,6 +1104,21 @@ describe("MarkdownPaper editing", () => {
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain(source);
+  });
+
+  it("renders multiline display math when typed directly", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    typeText(view, "$$");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, String.raw`\int_0^1 x^2 \, dx`);
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "$$");
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-display .katex")).toBeInTheDocument();
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(["$$", String.raw`\int_0^1 x^2 \, dx`, "$$"].join("\n"));
   });
 
   it("renders ordinary paragraph line breaks without requiring explicit br tags", async () => {

--- a/apps/desktop/src/lib/document-export.test.ts
+++ b/apps/desktop/src/lib/document-export.test.ts
@@ -34,6 +34,46 @@ describe("document export helpers", () => {
     expect(html).toContain(".markdown-export {\n    max-width: none;\n    margin: 0;\n    padding: 0;\n  }");
   });
 
+  it("removes rendered pure LaTeX macro definition blocks from standalone documents", () => {
+    const html = buildMarkdownHtmlDocument({
+      bodyHtml: [
+        '<span class="markra-math-render markra-math-render-display">',
+        '<span class="katex"><span class="katex-mathml"><math><semantics>',
+        "<mrow></mrow>",
+        '<annotation encoding="application/x-tex">\\newcommand{\\RR}{\\mathbb{R}} \\newcommand{\\vect}[1]{\\mathbf{#1}}</annotation>',
+        "</semantics></math></span><span class=\"katex-html\"></span></span>",
+        "</span>",
+        "<p>The domain is rendered.</p>"
+      ].join(""),
+      title: "Macro export"
+    });
+
+    expect(html).not.toContain(String.raw`\newcommand`);
+    expect(html).toContain("<p>The domain is rendered.</p>");
+  });
+
+  it("removes inline LaTeX macro definition markers from standalone documents", () => {
+    const html = buildMarkdownHtmlDocument({
+      bodyHtml: [
+        '<p><span data-markra-math-macro-definition="" hidden=""></span></p>',
+        '<p>Text before ',
+        '<span class="markra-math-render markra-math-render-inline">',
+        '<span class="katex"><span class="katex-mathml"><math><semantics>',
+        "<mrow></mrow>",
+        '<annotation encoding="application/x-tex">\\newcommand{\\b}{\\mathbb{b}}</annotation>',
+        "</semantics></math></span><span class=\"katex-html\"></span></span>",
+        "</span>",
+        " text after.</p>"
+      ].join(""),
+      title: "Inline macro export"
+    });
+
+    expect(html).not.toContain(String.raw`\newcommand`);
+    expect(html).not.toContain("data-markra-math-macro-definition");
+    expect(html).not.toContain("<p></p>");
+    expect(html).toContain("<p>Text before  text after.</p>");
+  });
+
   it("creates file URLs for local export assets", () => {
     expect(localFileUrlFromPath("/Users/me/notes/assets/pasted image.png")).toBe(
       "file:///Users/me/notes/assets/pasted%20image.png"

--- a/apps/desktop/src/lib/document-export.ts
+++ b/apps/desktop/src/lib/document-export.ts
@@ -1,4 +1,5 @@
 import katexStyles from "katex/dist/katex.css?raw";
+import { isMarkraMathMacroDefinitionSource } from "@markra/editor";
 
 export type ExportDocumentFormat = "html" | "pdf";
 
@@ -337,6 +338,57 @@ function escapeHtmlText(text: string) {
     .replace(/"/gu, "&quot;");
 }
 
+function renderedMathAnnotationSource(element: Element) {
+  return element.querySelector('annotation[encoding="application/x-tex"]')?.textContent ?? "";
+}
+
+function removeRenderedMathElement(element: Element) {
+  const parent = element.parentElement;
+  element.remove();
+
+  if (!parent || (parent.tagName !== "P" && parent.tagName !== "PRE")) return;
+  if (parent.textContent?.trim()) return;
+  if (parent.querySelector("img, svg, table, code, .markra-math-render, .markra-mermaid-render")) return;
+
+  parent.remove();
+}
+
+function removeRenderedMathMacroDefinitionMarkers(bodyHtml: string) {
+  if (!bodyHtml.includes("data-markra-math-macro-definition")) return bodyHtml;
+  if (typeof document === "undefined") return bodyHtml;
+
+  const template = document.createElement("template");
+  template.innerHTML = bodyHtml;
+
+  for (const marker of Array.from(template.content.querySelectorAll("[data-markra-math-macro-definition]"))) {
+    removeRenderedMathElement(marker);
+  }
+
+  return template.innerHTML;
+}
+
+function removeRenderedMathMacroDefinitions(bodyHtml: string) {
+  if (
+    !bodyHtml.includes("markra-math-render") ||
+    !/\\(?:newcommand|renewcommand|providecommand)/u.test(bodyHtml)
+  ) {
+    return bodyHtml;
+  }
+  if (typeof document === "undefined") return bodyHtml;
+
+  const template = document.createElement("template");
+  template.innerHTML = bodyHtml;
+
+  for (const mathElement of Array.from(template.content.querySelectorAll(".markra-math-render"))) {
+    const source = renderedMathAnnotationSource(mathElement);
+    if (!isMarkraMathMacroDefinitionSource(source)) continue;
+
+    removeRenderedMathElement(mathElement);
+  }
+
+  return template.innerHTML;
+}
+
 function encodeFileUrlPath(path: string) {
   return path
     .split("/")
@@ -382,6 +434,7 @@ export function buildMarkdownHtmlDocument({
   const escapedAuthor = escapeHtmlText(pdfAuthor?.trim() ?? "");
   const escapedFooter = escapeHtmlText(pdfFooter?.trim() ?? "");
   const escapedHeader = escapeHtmlText(pdfHeader?.trim() ?? "");
+  const exportBodyHtml = removeRenderedMathMacroDefinitions(removeRenderedMathMacroDefinitionMarkers(bodyHtml));
   const documentStyles = styles ?? createMarkdownExportStyles({
     pdfFooter,
     pdfHeader,
@@ -407,7 +460,7 @@ export function buildMarkdownHtmlDocument({
     ...(escapedHeader ? [`<header class="markdown-export-page-header">${escapedHeader}</header>`] : []),
     ...(escapedFooter ? [`<footer class="markdown-export-page-footer">${escapedFooter}</footer>`] : []),
     '<main class="markdown-export">',
-    bodyHtml,
+    exportBodyHtml,
     "</main>",
     "</body>",
     "</html>"

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2014,6 +2014,33 @@
     opacity: 0.96;
   }
 
+  .markdown-paper .markra-math-macro-fold {
+    display: inline-flex;
+    max-width: 100%;
+    align-items: center;
+    border: 1px solid color-mix(in srgb, var(--editor-border) 72%, transparent);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--editor-text-primary) 4%, transparent);
+    color: var(--editor-text-secondary);
+    cursor: pointer;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 0.72em;
+    line-height: 1.45;
+    padding: 0.08rem 0.42rem;
+    user-select: none;
+    vertical-align: 0.08em;
+  }
+
+  .markdown-paper .markra-math-macro-fold:hover {
+    border-color: color-mix(in srgb, var(--accent) 42%, var(--editor-border));
+    color: var(--editor-text-primary);
+  }
+
+  .markdown-paper .markra-math-macro-fold:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 64%, transparent);
+    outline-offset: 2px;
+  }
+
   .markdown-paper strong {
     @apply text-(--text-heading) font-[760];
   }

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -3,14 +3,17 @@ import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/ki
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import type { MarkdownNode } from "@milkdown/kit/transformer";
 import { $prose, $remark } from "@milkdown/kit/utils";
-import { renderToString } from "katex";
+import { renderToString, type KatexOptions } from "katex";
 import remarkMath from "remark-math";
 
-type MathRangeKind = "display" | "inline";
+export type MarkraMathKind = "display" | "inline";
+export type MarkraMathMacros = NonNullable<KatexOptions["macros"]>;
 
 type MathRange = {
   from: number;
-  kind: MathRangeKind;
+  isMacroDefinitionOnly?: boolean;
+  kind: MarkraMathKind;
+  renderedHtml?: string;
   source: string;
   tex: string;
   to: number;
@@ -33,6 +36,120 @@ type MathRenderMeta =
 const mathRenderKey = new PluginKey<ActiveMathSource | null>("markra-math-render");
 const transparentCaretAnchorSrc =
   "data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%221%22%20height=%221%22%20viewBox=%220%200%201%201%22/%3E";
+
+export function createMarkraMathMacros(): MarkraMathMacros {
+  return {};
+}
+
+export function renderMarkraMathToString(tex: string, kind: MarkraMathKind, macros = createMarkraMathMacros()) {
+  return renderToString(tex, {
+    displayMode: kind === "display",
+    globalGroup: true,
+    macros,
+    output: "htmlAndMathml",
+    strict: "ignore",
+    throwOnError: false
+  });
+}
+
+function skipMathWhitespace(source: string, index: number) {
+  let cursor = index;
+  while (cursor < source.length && /\s/u.test(source[cursor] ?? "")) cursor += 1;
+  return cursor;
+}
+
+function readMathCommand(source: string, index: number) {
+  if (source[index] !== "\\") return null;
+
+  let cursor = index + 1;
+  while (cursor < source.length && /[a-zA-Z]/u.test(source[cursor] ?? "")) cursor += 1;
+  if (cursor === index + 1 && cursor < source.length) cursor += 1;
+
+  return {
+    command: source.slice(index, cursor),
+    to: cursor
+  };
+}
+
+function readBalancedMathGroup(source: string, index: number, open: "{" | "[", close: "}" | "]") {
+  if (source[index] !== open) return null;
+
+  let depth = 0;
+  for (let cursor = index; cursor < source.length; cursor += 1) {
+    const character = source[cursor];
+    if (character === open && !isEscaped(source, cursor)) {
+      depth += 1;
+      continue;
+    }
+
+    if (character !== close || isEscaped(source, cursor)) continue;
+
+    depth -= 1;
+    if (depth === 0) return cursor + 1;
+  }
+
+  return null;
+}
+
+function readMathMacroNameArgument(source: string, index: number) {
+  const cursor = skipMathWhitespace(source, index);
+  if (source[cursor] === "{") {
+    const groupEnd = readBalancedMathGroup(source, cursor, "{", "}");
+    return groupEnd === null ? null : groupEnd;
+  }
+
+  return readMathCommand(source, cursor)?.to ?? null;
+}
+
+function readOptionalMathMacroArgument(source: string, index: number) {
+  const cursor = skipMathWhitespace(source, index);
+  if (source[cursor] !== "[") return index;
+
+  return readBalancedMathGroup(source, cursor, "[", "]");
+}
+
+function readRequiredMathMacroReplacement(source: string, index: number) {
+  const cursor = skipMathWhitespace(source, index);
+  return readBalancedMathGroup(source, cursor, "{", "}");
+}
+
+function readNewcommandDefinition(source: string, index: number) {
+  const command = readMathCommand(source, index);
+  if (!command || !["\\newcommand", "\\renewcommand", "\\providecommand"].includes(command.command)) return null;
+
+  let cursor = skipMathWhitespace(source, command.to);
+  if (source[cursor] === "*") cursor += 1;
+
+  const macroNameEnd = readMathMacroNameArgument(source, cursor);
+  if (macroNameEnd === null) return null;
+
+  cursor = macroNameEnd;
+
+  const argumentCountEnd = readOptionalMathMacroArgument(source, cursor);
+  if (argumentCountEnd === null) return null;
+  cursor = argumentCountEnd;
+
+  const optionalDefaultEnd = readOptionalMathMacroArgument(source, cursor);
+  if (optionalDefaultEnd === null) return null;
+  cursor = optionalDefaultEnd;
+
+  return readRequiredMathMacroReplacement(source, cursor);
+}
+
+export function isMarkraMathMacroDefinitionSource(tex: string) {
+  let cursor = skipMathWhitespace(tex, 0);
+  let foundDefinition = false;
+
+  while (cursor < tex.length) {
+    const nextCursor = readNewcommandDefinition(tex, cursor);
+    if (nextCursor === null) return false;
+
+    foundDefinition = true;
+    cursor = skipMathWhitespace(tex, nextCursor);
+  }
+
+  return foundDefinition;
+}
 
 type MarkdownPosition = {
   end?: {
@@ -400,13 +517,21 @@ function findNextDisplayMathBlock(state: EditorState): MathRange | null {
   return nextBlockMathRange;
 }
 
-function renderFormula(range: MathRange) {
-  return renderToString(range.tex, {
-    displayMode: range.kind === "display",
-    output: "htmlAndMathml",
-    strict: "ignore",
-    throwOnError: false
-  });
+function renderFormula(range: MathRange, macros?: MarkraMathMacros) {
+  return renderMarkraMathToString(range.tex, range.kind, macros);
+}
+
+function renderMathRange(range: MathRange, macros: MarkraMathMacros): MathRange {
+  try {
+    const renderedHtml = renderFormula(range, macros);
+    return {
+      ...range,
+      isMacroDefinitionOnly: isMarkraMathMacroDefinitionSource(range.tex) && !renderedHtml.includes("#cc0000"),
+      renderedHtml
+    };
+  } catch {
+    return range;
+  }
 }
 
 function mathSourceEditPosition(range: MathRange) {
@@ -434,6 +559,37 @@ function revealMathSource(view: EditorView, range: MathRange) {
 
 function isPlainEnter(event: KeyboardEvent) {
   return event.key === "Enter" && !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey;
+}
+
+function unclosedDisplayMathSourceBeforeCursor(state: EditorState) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock || $from.parent.type.spec.code) return null;
+
+  const textBeforeCursor = $from.parent.textBetween(0, $from.parentOffset, "\n", "\n");
+  const openingMatch = /^\s*\$\$(?!\$)/u.exec(textBeforeCursor);
+  if (!openingMatch) return null;
+
+  const openingIndex = openingMatch[0].lastIndexOf("$$");
+  const closingIndex = findClosingDelimiter(textBeforeCursor, "$$", openingIndex + 2);
+  if (closingIndex !== -1) return null;
+
+  return textBeforeCursor;
+}
+
+function insertUnclosedDisplayMathSourceNewline(view: EditorView, event: KeyboardEvent) {
+  if (!isPlainEnter(event)) return false;
+  if (unclosedDisplayMathSourceBeforeCursor(view.state) === null) return false;
+
+  const hardbreak = view.state.schema.nodes.hardbreak;
+  if (!hardbreak) return false;
+
+  event.preventDefault();
+  view.dispatch(view.state.tr.replaceSelectionWith(hardbreak.create()).scrollIntoView());
+  view.focus();
+  return true;
 }
 
 function insertDisplayMathSourceNewline(view: EditorView, event: KeyboardEvent) {
@@ -567,6 +723,7 @@ function handleMathKeyDown(view: EditorView, event: KeyboardEvent) {
     moveDownToDisplayMath(view, event) ||
     moveDisplayMathSourceLineBoundary(view, event) ||
     insertDisplayMathSourceNewline(view, event) ||
+    insertUnclosedDisplayMathSourceNewline(view, event) ||
     closeActiveMathSource(view, event) ||
     deleteAdjacentMathSource(view, event)
   );
@@ -668,11 +825,45 @@ function createMathWidget(range: MathRange, activePreview = false) {
     }
 
     try {
-      element.innerHTML = renderFormula(range);
+      element.innerHTML = range.renderedHtml ?? renderFormula(range);
     } catch {
       element.classList.add("markra-math-render-invalid");
       element.textContent = range.source;
     }
+
+    return element;
+  };
+}
+
+function createMathMacroDefinitionFoldWidget(range: MathRange) {
+  return (view: EditorView) => {
+    const element = view.dom.ownerDocument.createElement("span");
+    element.className = "markra-math-macro-fold";
+    element.setAttribute("aria-expanded", "false");
+    element.setAttribute("aria-label", "LaTeX macro definitions");
+    element.setAttribute("role", "button");
+    element.tabIndex = 0;
+    element.textContent = String.raw`\newcommand`;
+
+    element.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      revealMathSource(view, range);
+    });
+    element.addEventListener("keydown", (event) => {
+      if (event.key === "Backspace" || event.key === "Delete") {
+        event.preventDefault();
+        event.stopPropagation();
+        deleteMathRange(view, range);
+        return;
+      }
+
+      if (event.key !== "Enter" && event.key !== " ") return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      revealMathSource(view, range);
+    });
 
     return element;
   };
@@ -733,13 +924,14 @@ function createMathCaretAnchorDecoration(range: MathRange) {
 function buildMathDecorations(state: EditorState, activeRange: MathRange | null) {
   const { doc } = state;
   const decorations: Decoration[] = [];
+  const macros = createMarkraMathMacros();
 
   doc.descendants((node, position) => {
     if (!node.isTextblock || node.type.spec.code) return;
 
     const blockStart = position + 1;
     for (const relativeRange of getMathRanges(node.textContent)) {
-      const range = makeAbsoluteRange(relativeRange, blockStart);
+      const range = renderMathRange(makeAbsoluteRange(relativeRange, blockStart), macros);
       const isActive = activeRange?.from === range.from && activeRange.to === range.to;
       decorations.push(
         Decoration.inline(range.from, range.to, {
@@ -763,7 +955,7 @@ function buildMathDecorations(state: EditorState, activeRange: MathRange | null)
       if (isActive) {
         decorations.push(...activeMathTokenDecorations(range));
 
-        if (range.kind === "display") {
+        if (range.kind === "display" && !range.isMacroDefinitionOnly) {
           decorations.push(
             Decoration.widget(range.to, createMathWidget(range, true), {
               ignoreSelection: true,
@@ -772,6 +964,14 @@ function buildMathDecorations(state: EditorState, activeRange: MathRange | null)
             })
           );
         }
+      } else if (range.isMacroDefinitionOnly) {
+        decorations.push(
+          Decoration.widget(range.from, createMathMacroDefinitionFoldWidget(range), {
+            ignoreSelection: true,
+            key: `markra-math-macro-fold-${range.from}-${range.to}`,
+            side: -1
+          })
+        );
       } else {
         decorations.push(
           Decoration.widget(range.from, createMathWidget(range), {


### PR DESCRIPTION
## Summary
- Support document-scoped LaTeX macro definitions shared across editor math rendering and export rendering.
- Fold valid pure macro definition blocks in the editor while keeping them editable.
- Remove pure macro definition math from exported HTML/PDF output while preserving macro expansion in later formulas.

## Why
- Matches Typora-style workflows where documents define reusable LaTeX commands at the top of the file.
- Keeps macro setup out of rendered/exported prose while still surfacing invalid definitions.

## Validation
- `pnpm --filter @markra/desktop test -- MarkdownPaper.test.tsx MarkdownExportDocument.test.tsx document-export.test.ts -t "macro definitions|typed directly|macro definition|macro export"` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed; existing Vite large chunk warning remains.

Closes #105