### PR TITLE
feat(desktop): add document search and replace

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -3357,6 +3357,161 @@ describe("Markra workspace", () => {
     expect(await screen.findByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
   });
 
+  it("opens document search from the keyboard shortcut", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    expect(fireEvent.keyDown(window, { key: "f", metaKey: true })).toBe(false);
+
+    expect(screen.getByRole("search", { name: "Find in document" })).toBeInTheDocument();
+    const searchInput = screen.getByRole("searchbox", { name: "Find in document" });
+    expect(searchInput).toHaveFocus();
+    expect(searchInput).toHaveAttribute("autocomplete", "off");
+    expect(searchInput).toHaveAttribute("autocapitalize", "none");
+    expect(searchInput).toHaveAttribute("autocorrect", "off");
+    expect(searchInput).toHaveAttribute("spellcheck", "false");
+    expect(container.querySelector(".editor-content-slot")).toHaveAttribute("data-document-search-open", "true");
+  });
+
+  it("does not open the AI command when visual document search focuses a match", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    fireEvent.change(screen.getByRole("searchbox", { name: "Find in document" }), {
+      target: { value: "Welcome" }
+    });
+
+    await waitFor(() => expect(container.querySelector(".markra-search-match-current")).toBeInTheDocument());
+    await settleEditorUpdates();
+
+    expect(screen.queryByRole("dialog", { name: "AI writing command" })).not.toBeInTheDocument();
+  });
+
+  it("does not scroll the visual editor while typing a document search query", async () => {
+    const { container } = renderApp();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView
+    });
+
+    try {
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+      fireEvent.change(screen.getByRole("searchbox", { name: "Find in document" }), {
+        target: { value: "Welcome" }
+      });
+
+      await waitFor(() => expect(container.querySelector(".markra-search-match-current")).toBeInTheDocument());
+      await settleEditorUpdates();
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(container.querySelector(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Next match" }));
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    } finally {
+      if (originalScrollIntoView) {
+        HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+      }
+    }
+  });
+
+  it("does not count hidden display math source as a visual document search match", async () => {
+    mockOpenMarkdownFile({
+      content: [
+        "# c",
+        "",
+        "$$",
+        String.raw`\begin{aligned}`,
+        String.raw`z &= csa \\`,
+        String.raw`z &= csb`,
+        String.raw`\end{aligned}`,
+        "$$"
+      ].join("\n"),
+      name: "math.md",
+      path: mockNativePath
+    });
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByText("c")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    fireEvent.change(screen.getByRole("searchbox", { name: "Find in document" }), {
+      target: { value: "csa" }
+    });
+
+    await waitFor(() => expect(screen.getByText("0/0")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror .markra-search-match-current")).not.toBeInTheDocument();
+  });
+
+  it("clears finalized image source editing when document search opens", async () => {
+    mockOpenMarkdownFile({
+      content: "Intro\n\n![Screenshot](assets/pasted-image.png)\n\nContent",
+      name: "native.md",
+      path: mockNativePath
+    });
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByText("Content")).toBeInTheDocument();
+
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+    expect(image).toBeInTheDocument();
+    expect(fireEvent.mouseDown(image!)).toBe(false);
+
+    const sourceInput = await waitFor(() => {
+      const input = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
+      expect(input).toBeInTheDocument();
+      return input!;
+    });
+    await waitFor(() => expect(sourceInput).toHaveFocus());
+    expect(image?.closest(".markra-image-node")).toHaveClass("markra-image-node-selected");
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+
+    expect(screen.getByRole("searchbox", { name: "Find in document" })).toHaveFocus();
+    await waitFor(() =>
+      expect(container.querySelector(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument()
+    );
+    expect(image?.closest(".markra-image-node")).not.toHaveClass("markra-image-node-selected");
+  });
+
+  it("replaces the current source-mode document search match", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "s", altKey: true, metaKey: true });
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+
+    fireEvent.keyDown(window, { key: "f", altKey: true, metaKey: true });
+    fireEvent.change(screen.getByRole("searchbox", { name: "Find in document" }), {
+      target: { value: "Welcome" }
+    });
+    const replaceInput = screen.getByRole("textbox", { name: "Replace" });
+    expect(replaceInput).toHaveAttribute("autocomplete", "off");
+    expect(replaceInput).toHaveAttribute("autocapitalize", "none");
+    expect(replaceInput).toHaveAttribute("autocorrect", "off");
+    expect(replaceInput).toHaveAttribute("spellcheck", "false");
+    fireEvent.change(screen.getByRole("textbox", { name: "Replace" }), {
+      target: { value: "Hello" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+
+    expect((sourceEditor as HTMLTextAreaElement).value).toContain("# Hello to Markra");
+  });
+
   it("toggles read-only mode from the keyboard shortcut and marks the status area", async () => {
     const { container } = renderApp();
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -14,6 +14,7 @@ import { AppToaster } from "./components/AppToaster";
 import { AiCommandBar } from "./components/AiCommandBar";
 import { AiAgentPanel } from "./components/AiAgentPanel";
 import { AiSelectionToolbar } from "./components/AiSelectionToolbar";
+import { DocumentSearchBar } from "./components/DocumentSearchBar";
 import { ImagePreview } from "./components/ImagePreview";
 import {
   MarkdownExportDocument,
@@ -54,7 +55,16 @@ import {
   useNativeMenuHandlers,
   useNativeMenus
 } from "./hooks/useNativeBindings";
-import { aiTranslationLanguageName, clampNumber, debug, t, type I18nKey } from "@markra/shared";
+import {
+  aiTranslationLanguageName,
+  clampNumber,
+  debug,
+  findSearchRanges,
+  normalizeSearchIndex,
+  t,
+  type I18nKey,
+  type SearchRange
+} from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
@@ -189,6 +199,16 @@ function aiCommandTextSelection(selection: AiSelectionContext | null | undefined
   return selection;
 }
 
+function replaceTextRange(content: string, range: SearchRange, replacement: string) {
+  return `${content.slice(0, range.from)}${replacement}${content.slice(range.to)}`;
+}
+
+function replaceTextRanges(content: string, ranges: SearchRange[], replacement: string) {
+  return [...ranges]
+    .sort((left, right) => right.from - left.from)
+    .reduce((nextContent, range) => replaceTextRange(nextContent, range, replacement), content);
+}
+
 function restoreElementScrollTop(element: HTMLElement, scrollTop: number) {
   try {
     element.scrollTop = scrollTop;
@@ -225,6 +245,14 @@ export default function App() {
   const [editorMode, setEditorMode] = useState<EditorMode>("visual");
   const [activeEditorSurface, setActiveEditorSurface] = useState<EditorSurface>("visual");
   const [readOnlyMode, setReadOnlyMode] = useState(false);
+  const [documentSearchOpen, setDocumentSearchOpen] = useState(false);
+  const [documentSearchReplaceOpen, setDocumentSearchReplaceOpen] = useState(false);
+  const [documentSearchQuery, setDocumentSearchQuery] = useState("");
+  const [documentSearchReplacement, setDocumentSearchReplacement] = useState("");
+  const [documentSearchCaseSensitive, setDocumentSearchCaseSensitive] = useState(false);
+  const [documentSearchActiveIndex, setDocumentSearchActiveIndex] = useState(0);
+  const [documentSearchRevealRevision, setDocumentSearchRevealRevision] = useState(0);
+  const [visualDocumentSearchMatches, setVisualDocumentSearchMatches] = useState<SearchRange[]>([]);
   const [splitVisualPanePercent, setSplitVisualPanePercent] = useState(defaultSplitVisualPanePercent);
   const [sideDocumentMainPanePercent, setSideDocumentMainPanePercent] = useState(defaultSideDocumentMainPanePercent);
   const [visualEditorReadySequence, setVisualEditorReadySequence] = useState(0);
@@ -241,6 +269,7 @@ export default function App() {
   const pendingSplitVisualPanePercentRef = useRef(defaultSplitVisualPanePercent);
   const pendingSideDocumentMainPanePercentRef = useRef(defaultSideDocumentMainPanePercent);
   const sourceToVisualSyncingRef = useRef(false);
+  const lastDocumentSearchRevealRevisionRef = useRef(0);
   const documentRevisionRef = useRef(0);
   const visualEditorReadyRevisionRef = useRef<number | null>(null);
   const sourceScrollRef = useRef<HTMLElement | null>(null);
@@ -283,13 +312,18 @@ export default function App() {
   }, [editorPreferences.preferences.markdownTemplates]);
 
   const editor = useEditorController();
+  const findEditorSearchMatches = editor.findSearchMatches;
   const getEditorCurrentMarkdown = editor.getCurrentMarkdown;
   const handleMilkdownEditorReady = editor.handleEditorReady;
   const insertEditorMarkdownSnippet = editor.insertMarkdownSnippet;
   const insertEditorMarkdownTable = editor.insertMarkdownTable;
   const isEditorCurrentMarkdownEquivalent = editor.isCurrentMarkdownEquivalent;
+  const replaceAllEditorSearchMatches = editor.replaceAllSearchMatches;
   const replaceEditorMarkdown = editor.replaceMarkdown;
+  const replaceEditorSearchMatch = editor.replaceSearchMatch;
+  const revealEditorSearchMatch = editor.revealSearchMatch;
   const runEditorShortcut = editor.runEditorShortcut;
+  const showEditorSearchMatches = editor.showSearchMatches;
   const readCurrentMarkdownForDocument = useCallback((fallbackContent: string) => {
     if (sourceSurfaceActive) return fallbackContent;
 
@@ -392,6 +426,36 @@ export default function App() {
   documentRevisionRef.current = document.revision;
   const workspaceKey = document.path ?? fileTree.sourcePath ?? null;
   const hasOpenDocument = document.open;
+  const documentSearchAvailable = hasOpenDocument && !activeImageFile;
+  const documentSearchSurface: EditorSurface = sourceSurfaceActive ? "source" : "visual";
+  const sourceDocumentSearchMatches = useMemo(
+    () =>
+      documentSearchOpen && documentSearchSurface === "source"
+        ? findSearchRanges(document.content, documentSearchQuery, {
+            caseSensitive: documentSearchCaseSensitive
+          })
+        : [],
+    [
+      document.content,
+      documentSearchCaseSensitive,
+      documentSearchOpen,
+      documentSearchQuery,
+      documentSearchSurface
+    ]
+  );
+  const documentSearchMatches =
+    documentSearchSurface === "source" ? sourceDocumentSearchMatches : visualDocumentSearchMatches;
+  const documentSearchMatchCount = documentSearchMatches.length;
+  const normalizedDocumentSearchActiveIndex = normalizeSearchIndex(
+    documentSearchActiveIndex,
+    documentSearchMatchCount
+  );
+  const activeDocumentSearchMatch =
+    normalizedDocumentSearchActiveIndex >= 0
+      ? documentSearchMatches[normalizedDocumentSearchActiveIndex] ?? null
+      : null;
+  const visibleSourceDocumentSearchMatches =
+    documentSearchOpen && documentSearchSurface === "source" ? sourceDocumentSearchMatches : [];
   const activeAiAgentSessionId = workspaceSessionId ?? aiAgentSessionId;
   const aiResult = aiResults.at(-1) ?? null;
   const activeEditorContentWidth = editorContentWidth;
@@ -1701,6 +1765,145 @@ export default function App() {
     runEditorShortcut(...args);
     syncVisualMarkdownAfterEditorCommand();
   }, [readOnlyMode, runEditorShortcut, syncVisualMarkdownAfterEditorCommand]);
+  const handleDocumentSearchOpen = useCallback(() => {
+    if (!documentSearchAvailable) return;
+
+    setDocumentSearchOpen(true);
+    setDocumentSearchReplaceOpen(false);
+    setDocumentSearchActiveIndex(0);
+  }, [documentSearchAvailable]);
+  const handleDocumentReplaceOpen = useCallback(() => {
+    if (!documentSearchAvailable) return;
+
+    setDocumentSearchOpen(true);
+    setDocumentSearchReplaceOpen(true);
+    setDocumentSearchActiveIndex(0);
+  }, [documentSearchAvailable]);
+  const handleDocumentSearchClose = useCallback(() => {
+    setDocumentSearchOpen(false);
+    setDocumentSearchReplaceOpen(false);
+    setDocumentSearchActiveIndex(0);
+  }, []);
+  const handleDocumentSearchQueryChange = useCallback((query: string) => {
+    setDocumentSearchQuery(query);
+    setDocumentSearchActiveIndex(0);
+  }, []);
+  const handleDocumentSearchCaseSensitiveChange = useCallback((caseSensitive: boolean) => {
+    setDocumentSearchCaseSensitive(caseSensitive);
+    setDocumentSearchActiveIndex(0);
+  }, []);
+  const navigateDocumentSearch = useCallback((direction: 1 | -1) => {
+    if (documentSearchMatchCount <= 0) return;
+
+    setDocumentSearchActiveIndex((current) =>
+      normalizeSearchIndex((current < 0 ? 0 : current) + direction, documentSearchMatchCount)
+    );
+    setDocumentSearchRevealRevision((current) => current + 1);
+  }, [documentSearchMatchCount]);
+  const handleDocumentSearchNext = useCallback(() => {
+    navigateDocumentSearch(1);
+  }, [navigateDocumentSearch]);
+  const handleDocumentSearchPrevious = useCallback(() => {
+    navigateDocumentSearch(-1);
+  }, [navigateDocumentSearch]);
+  const handleDocumentReplace = useCallback(() => {
+    if (readOnlyMode || !activeDocumentSearchMatch) return;
+
+    if (documentSearchSurface === "source") {
+      handleSourceMarkdownChange(replaceTextRange(document.content, activeDocumentSearchMatch, documentSearchReplacement));
+      return;
+    }
+
+    replaceEditorSearchMatch(activeDocumentSearchMatch, documentSearchReplacement);
+  }, [
+    activeDocumentSearchMatch,
+    document.content,
+    documentSearchReplacement,
+    documentSearchSurface,
+    handleSourceMarkdownChange,
+    replaceEditorSearchMatch,
+    readOnlyMode
+  ]);
+  const handleDocumentReplaceAll = useCallback(() => {
+    if (readOnlyMode || documentSearchMatches.length === 0) return;
+
+    if (documentSearchSurface === "source") {
+      handleSourceMarkdownChange(replaceTextRanges(document.content, documentSearchMatches, documentSearchReplacement));
+      setDocumentSearchActiveIndex(0);
+      return;
+    }
+
+    replaceAllEditorSearchMatches(documentSearchMatches, documentSearchReplacement);
+    setDocumentSearchActiveIndex(0);
+  }, [
+    document.content,
+    documentSearchMatches,
+    documentSearchReplacement,
+    documentSearchSurface,
+    handleSourceMarkdownChange,
+    replaceAllEditorSearchMatches,
+    readOnlyMode
+  ]);
+  useEffect(() => {
+    if (documentSearchAvailable) return;
+
+    setDocumentSearchOpen(false);
+    setDocumentSearchReplaceOpen(false);
+  }, [documentSearchAvailable]);
+  useEffect(() => {
+    if (!documentSearchOpen || !documentSearchAvailable || documentSearchSurface !== "visual") {
+      setVisualDocumentSearchMatches([]);
+      return;
+    }
+
+    setVisualDocumentSearchMatches(
+      findEditorSearchMatches(documentSearchQuery, {
+        caseSensitive: documentSearchCaseSensitive
+      })
+    );
+  }, [
+    document.revision,
+    documentSearchAvailable,
+    documentSearchCaseSensitive,
+    documentSearchOpen,
+    documentSearchQuery,
+    documentSearchSurface,
+    findEditorSearchMatches,
+    visualEditorReadySequence
+  ]);
+  useEffect(() => {
+    const nextIndex = normalizeSearchIndex(documentSearchActiveIndex, documentSearchMatchCount);
+    if (nextIndex !== documentSearchActiveIndex) setDocumentSearchActiveIndex(nextIndex);
+  }, [documentSearchActiveIndex, documentSearchMatchCount]);
+  useEffect(() => {
+    if (!documentSearchOpen || documentSearchSurface !== "visual") {
+      showEditorSearchMatches([], -1, { suppressEditorChrome: false });
+      return;
+    }
+
+    showEditorSearchMatches(visualDocumentSearchMatches, normalizedDocumentSearchActiveIndex, {
+      suppressEditorChrome: true
+    });
+  }, [
+    documentSearchOpen,
+    documentSearchSurface,
+    normalizedDocumentSearchActiveIndex,
+    showEditorSearchMatches,
+    visualDocumentSearchMatches
+  ]);
+  useEffect(() => {
+    if (!documentSearchOpen || documentSearchSurface !== "visual") return;
+    if (documentSearchRevealRevision === lastDocumentSearchRevealRevisionRef.current) return;
+
+    lastDocumentSearchRevealRevisionRef.current = documentSearchRevealRevision;
+    revealEditorSearchMatch(activeDocumentSearchMatch);
+  }, [
+    activeDocumentSearchMatch,
+    documentSearchOpen,
+    documentSearchRevealRevision,
+    documentSearchSurface,
+    revealEditorSearchMatch
+  ]);
   useEffect(() => {
     exportContextRef.current = {
       activeImageFile: Boolean(activeImageFile),
@@ -1924,6 +2127,8 @@ export default function App() {
     exportPdf: exportPdfDocument,
     markdownShortcuts: editorPreferences.preferences.markdownShortcuts,
     openDocument: handleOpenMarkdownFile,
+    openDocumentReplace: handleDocumentReplaceOpen,
+    openDocumentSearch: handleDocumentSearchOpen,
     openFolder: handleOpenMarkdownFolder,
     saveDocument: handleSaveDocument,
     saveDocumentAs,
@@ -2214,7 +2419,31 @@ export default function App() {
             className={editorAgentLayoutClassName}
             style={{ gridTemplateColumns: `minmax(0,1fr) ${aiAgentInset}` }}
           >
-            <div className="editor-content-slot relative h-full min-h-0 overflow-hidden">
+            <div
+              className="editor-content-slot relative h-full min-h-0 overflow-hidden"
+              data-document-search-open={documentSearchOpen && documentSearchAvailable ? "true" : undefined}
+            >
+              {documentSearchOpen && documentSearchAvailable ? (
+                <DocumentSearchBar
+                  activeIndex={normalizedDocumentSearchActiveIndex}
+                  caseSensitive={documentSearchCaseSensitive}
+                  language={appLanguage.language}
+                  matchCount={documentSearchMatchCount}
+                  query={documentSearchQuery}
+                  readOnly={readOnlyMode}
+                  replaceOpen={documentSearchReplaceOpen}
+                  replacement={documentSearchReplacement}
+                  onCaseSensitiveChange={handleDocumentSearchCaseSensitiveChange}
+                  onClose={handleDocumentSearchClose}
+                  onNext={handleDocumentSearchNext}
+                  onPrevious={handleDocumentSearchPrevious}
+                  onQueryChange={handleDocumentSearchQueryChange}
+                  onReplace={handleDocumentReplace}
+                  onReplaceAll={handleDocumentReplaceAll}
+                  onReplaceOpenChange={setDocumentSearchReplaceOpen}
+                  onReplacementChange={setDocumentSearchReplacement}
+                />
+              ) : null}
               {activeImageFile ? (
                 <ImagePreview
                   alt={activeImageFile.name}
@@ -2296,6 +2525,8 @@ export default function App() {
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                           onScroll={handleSourcePaneScroll}
                           readOnly={readOnlyMode}
+                          searchActiveIndex={normalizedDocumentSearchActiveIndex}
+                          searchMatches={visibleSourceDocumentSearchMatches}
                           scrollRef={sourceScrollRef}
                           topInset="titlebar"
                         />
@@ -2315,6 +2546,8 @@ export default function App() {
                       onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                       onScroll={handleSourcePaneScroll}
                       readOnly={readOnlyMode}
+                      searchActiveIndex={normalizedDocumentSearchActiveIndex}
+                      searchMatches={visibleSourceDocumentSearchMatches}
                       scrollRef={sourceScrollRef}
                       topInset="titlebar"
                     />

--- a/apps/desktop/src/components/DocumentSearchBar.tsx
+++ b/apps/desktop/src/components/DocumentSearchBar.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useRef, type KeyboardEvent } from "react";
+import { CaseSensitive, ChevronDown, ChevronUp, Replace, Search, X } from "lucide-react";
+import { t, type AppLanguage } from "@markra/shared";
+
+type DocumentSearchBarProps = {
+  activeIndex: number;
+  caseSensitive: boolean;
+  language?: AppLanguage;
+  matchCount: number;
+  query: string;
+  readOnly?: boolean;
+  replaceOpen: boolean;
+  replacement: string;
+  onCaseSensitiveChange: (caseSensitive: boolean) => unknown;
+  onClose: () => unknown;
+  onNext: () => unknown;
+  onPrevious: () => unknown;
+  onQueryChange: (query: string) => unknown;
+  onReplace: () => unknown;
+  onReplaceAll: () => unknown;
+  onReplaceOpenChange: (open: boolean) => unknown;
+  onReplacementChange: (replacement: string) => unknown;
+};
+
+const labels: Record<string, {
+  caseSensitive: string;
+  close: string;
+  findInDocument: string;
+  next: string;
+  previous: string;
+  replace: string;
+  replaceAll: string;
+  replacePlaceholder: string;
+  toggleReplace: string;
+}> = {
+  en: {
+    caseSensitive: "Case sensitive",
+    close: "Close search",
+    findInDocument: "Find in document",
+    next: "Next match",
+    previous: "Previous match",
+    replace: "Replace",
+    replaceAll: "All",
+    replacePlaceholder: "Replace",
+    toggleReplace: "Show replace"
+  },
+  "zh-CN": {
+    caseSensitive: "区分大小写",
+    close: "关闭搜索",
+    findInDocument: "文档内搜索",
+    next: "下一个匹配",
+    previous: "上一个匹配",
+    replace: "替换",
+    replaceAll: "全部",
+    replacePlaceholder: "替换为",
+    toggleReplace: "显示替换"
+  },
+  "zh-TW": {
+    caseSensitive: "區分大小寫",
+    close: "關閉搜尋",
+    findInDocument: "文件內搜尋",
+    next: "下一個相符項目",
+    previous: "上一個相符項目",
+    replace: "取代",
+    replaceAll: "全部",
+    replacePlaceholder: "取代為",
+    toggleReplace: "顯示取代"
+  }
+};
+
+function documentSearchLabels(language: AppLanguage) {
+  return labels[language] ?? labels.en;
+}
+
+export function DocumentSearchBar({
+  activeIndex,
+  caseSensitive,
+  language = "en",
+  matchCount,
+  query,
+  readOnly = false,
+  replaceOpen,
+  replacement,
+  onCaseSensitiveChange,
+  onClose,
+  onNext,
+  onPrevious,
+  onQueryChange,
+  onReplace,
+  onReplaceAll,
+  onReplaceOpenChange,
+  onReplacementChange
+}: DocumentSearchBarProps) {
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const label = documentSearchLabels(language);
+  const activeLabel = matchCount > 0 && activeIndex >= 0 ? `${activeIndex + 1}/${matchCount}` : `0/${matchCount}`;
+
+  useEffect(() => {
+    searchInputRef.current?.focus();
+    searchInputRef.current?.select();
+  }, []);
+
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+
+    if (event.key !== "Enter") return;
+
+    event.preventDefault();
+    if (event.shiftKey) {
+      onPrevious();
+    } else {
+      onNext();
+    }
+  };
+
+  const handleReplacementKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+
+    if (event.key !== "Enter") return;
+
+    event.preventDefault();
+    onReplace();
+  };
+
+  const navigationDisabled = matchCount === 0;
+  const replaceDisabled = readOnly || matchCount === 0;
+
+  return (
+    <div
+      className="document-search-bar absolute right-4 top-12 z-40 flex w-[min(calc(100%-2rem),460px)] flex-col gap-2 rounded-md border border-(--border-strong) bg-(--bg-secondary)/96 p-2 text-[12px] text-(--text-primary) shadow-[0_14px_42px_rgba(0,0,0,0.14)] backdrop-blur-sm"
+      role="search"
+      aria-label={label.findInDocument}
+    >
+      <div className="flex min-w-0 items-center gap-1.5">
+        <Search aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+        <input
+          className="h-8 min-w-0 flex-1 rounded-sm border border-(--border-default) bg-(--bg-primary) px-2 text-[12px] text-(--text-heading) outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-(--text-secondary) focus:border-(--accent) focus:shadow-[0_0_0_2px_var(--accent-soft)]"
+          aria-label={label.findInDocument}
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect="off"
+          placeholder={t(language, "app.searchPlaceholder")}
+          ref={searchInputRef}
+          spellCheck={false}
+          type="search"
+          value={query}
+          onChange={(event) => onQueryChange(event.currentTarget.value)}
+          onKeyDown={handleSearchKeyDown}
+        />
+        <span className="w-12 shrink-0 text-center tabular-nums text-(--text-secondary)">{activeLabel}</span>
+        <button
+          className="document-search-icon-button"
+          aria-label={label.previous}
+          disabled={navigationDisabled}
+          type="button"
+          onClick={onPrevious}
+        >
+          <ChevronUp aria-hidden="true" size={14} />
+        </button>
+        <button
+          className="document-search-icon-button"
+          aria-label={label.next}
+          disabled={navigationDisabled}
+          type="button"
+          onClick={onNext}
+        >
+          <ChevronDown aria-hidden="true" size={14} />
+        </button>
+        <button
+          className="document-search-icon-button"
+          aria-label={label.caseSensitive}
+          aria-pressed={caseSensitive}
+          type="button"
+          onClick={() => onCaseSensitiveChange(!caseSensitive)}
+        >
+          <CaseSensitive aria-hidden="true" size={14} />
+        </button>
+        <button
+          className="document-search-icon-button"
+          aria-label={label.toggleReplace}
+          aria-pressed={replaceOpen}
+          type="button"
+          onClick={() => onReplaceOpenChange(!replaceOpen)}
+        >
+          <Replace aria-hidden="true" size={14} />
+        </button>
+        <button
+          className="document-search-icon-button"
+          aria-label={label.close}
+          type="button"
+          onClick={onClose}
+        >
+          <X aria-hidden="true" size={14} />
+        </button>
+      </div>
+      {replaceOpen ? (
+        <div className="flex min-w-0 items-center gap-1.5 pl-[20px]">
+          <input
+            className="h-8 min-w-0 flex-1 rounded-sm border border-(--border-default) bg-(--bg-primary) px-2 text-[12px] text-(--text-heading) outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-(--text-secondary) focus:border-(--accent) focus:shadow-[0_0_0_2px_var(--accent-soft)] disabled:cursor-not-allowed disabled:opacity-55"
+            aria-label={label.replacePlaceholder}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            disabled={readOnly}
+            placeholder={label.replacePlaceholder}
+            spellCheck={false}
+            value={replacement}
+            onChange={(event) => onReplacementChange(event.currentTarget.value)}
+            onKeyDown={handleReplacementKeyDown}
+          />
+          <button
+            className="document-search-text-button"
+            disabled={replaceDisabled}
+            type="button"
+            onClick={onReplace}
+          >
+            {label.replace}
+          </button>
+          <button
+            className="document-search-text-button"
+            disabled={replaceDisabled}
+            type="button"
+            onClick={onReplaceAll}
+          >
+            {label.replaceAll}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -27,10 +27,13 @@ import {
   clearAiSelectionHold,
   confirmAiEditorResultApplied,
   defaultMarkdownShortcuts,
+  findSearchMatchesInDoc,
+  findVisibleSearchMatchesInState,
   mermaidThemeFromElement,
   scrollAiEditorPreviewIntoView,
   showAiEditorPreview,
   showAiSelectionHold,
+  updateSearchDecorations,
   type MarkdownShortcutMap
 } from "@markra/editor";
 import {
@@ -164,6 +167,23 @@ function findLastTextBlockCursor(view: EditorView) {
     if (!node.isTextblock) return true;
 
     position = nodePosition + 1;
+    return true;
+  });
+
+  if (position === null) {
+    throw new Error("Could not find text block in editor.");
+  }
+
+  return position;
+}
+
+function findLastTextBlockEndCursor(view: EditorView) {
+  let position: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (!node.isTextblock) return true;
+
+    position = nodePosition + 1 + node.content.size;
     return true;
   });
 
@@ -612,6 +632,21 @@ afterAll(async () => {
 });
 
 describe("MarkdownPaper editing", () => {
+  it("renders exact visual search highlights without width normalization", async () => {
+    const { container, view } = await renderEditor("alpha, beta，gamma, delta");
+
+    const commaMatches = findSearchMatchesInDoc(view.state.doc, ",");
+    const fullWidthCommaMatches = findSearchMatchesInDoc(view.state.doc, "，");
+
+    expect(commaMatches.map((match) => view.state.doc.textBetween(match.from, match.to))).toEqual([",", ","]);
+    expect(fullWidthCommaMatches.map((match) => view.state.doc.textBetween(match.from, match.to))).toEqual(["，"]);
+
+    updateSearchDecorations(view, commaMatches, 0);
+
+    expect(container.querySelectorAll(".markra-search-match")).toHaveLength(2);
+    expect(container.querySelector(".markra-search-match-current")).toHaveTextContent(",");
+  });
+
   it("keeps the writing surface from macOS-style scroll dragging", async () => {
     const { container } = await renderEditor();
 
@@ -1160,6 +1195,85 @@ describe("MarkdownPaper editing", () => {
     expect(selectionParent).toHaveClass("markra-math-source-hidden-display");
     expect(nativeCaretAnchor).toBeInTheDocument();
     expect(nativeCaretAnchor).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
+  });
+
+  it("suppresses the display math caret anchor while visual document search is active", async () => {
+    const source = [
+      "# c",
+      "",
+      "112",
+      "",
+      "$$",
+      String.raw`\begin{aligned}`,
+      String.raw`b &= a \\`,
+      String.raw`-y &= b \\`,
+      String.raw`z &= csa \\`,
+      String.raw`z &= csb`,
+      String.raw`\end{aligned}`,
+      "$$"
+    ].join("\n");
+    const { container, view } = await renderEditor(source);
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    await waitFor(() =>
+      expect(container.querySelector(".ProseMirror img.markra-math-caret-anchor")).toBeInTheDocument()
+    );
+
+    const matches = findSearchMatchesInDoc(view.state.doc, "c");
+    expect(matches.length).toBeGreaterThan(0);
+
+    updateSearchDecorations(view, matches, 0, { suppressEditorChrome: true });
+    await waitFor(() =>
+      expect(container.querySelector(".ProseMirror img.markra-math-caret-anchor")).not.toBeInTheDocument()
+    );
+
+    updateSearchDecorations(view, [], -1, { suppressEditorChrome: false });
+    await waitFor(() =>
+      expect(container.querySelector(".ProseMirror img.markra-math-caret-anchor")).toBeInTheDocument()
+    );
+  });
+
+  it("does not expose hidden display math source when the query matches formula text", async () => {
+    const source = [
+      "# c",
+      "",
+      "$$",
+      String.raw`\begin{aligned}`,
+      String.raw`z &= csa \\`,
+      String.raw`z &= csb`,
+      String.raw`\end{aligned}`,
+      "$$"
+    ].join("\n");
+    const { container, view } = await renderEditor(source);
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    await waitFor(() =>
+      expect(container.querySelector(".ProseMirror img.markra-math-caret-anchor")).toBeInTheDocument()
+    );
+
+    const matches = findSearchMatchesInDoc(view.state.doc, "csa");
+    expect(matches).toHaveLength(1);
+
+    updateSearchDecorations(view, matches, 0, { suppressEditorChrome: true });
+
+    expect(container.querySelector(".ProseMirror .markra-math-source-hidden-display")).toBeInTheDocument();
+    expect(
+      container.querySelector(".ProseMirror .markra-math-source-hidden-display .markra-search-match")
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector(".ProseMirror .markra-math-source-hidden-display.markra-search-match")
+    ).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-search-match-current")).not.toBeInTheDocument();
+  });
+
+  it("omits visual search matches that overlap hidden display math source", async () => {
+    const source = "Visible $$ E = mc^2 $$";
+    const { view } = await renderEditor(source);
+
+    const allMatches = findSearchMatchesInDoc(view.state.doc, "Visible $$");
+    expect(allMatches).toHaveLength(1);
+
+    expect(findVisibleSearchMatchesInState(view.state, "Visible $$")).toHaveLength(0);
   });
 
   it("reveals math source for editing when a rendered formula is clicked", async () => {

--- a/apps/desktop/src/components/MarkdownPaperSurface.tsx
+++ b/apps/desktop/src/components/MarkdownPaperSurface.tsx
@@ -21,10 +21,12 @@ import {
   markraLinkImageLivePlugin,
   markraLiveMarkdownPlugin,
   markraMarkdownShortcuts,
+  markraMathCaretAnchorSuppressionPlugin,
   markraMathPlugin,
   markraMathRemarkPlugin,
   markraMathSourcePlugin,
   markraRawHtmlPlugin,
+  markraSearchPlugin,
   markraSlashCommands,
   markraTableControlsPlugin,
   normalizeHeadingSourceDocument,
@@ -266,9 +268,11 @@ function MilkdownEditorSurface({
         .use(markraMathSourcePlugin)
         .use(markraMarkdownShortcuts(normalizedMarkdownShortcuts))
         .use(markraCodeBlockPlugin)
+        .use(markraMathCaretAnchorSuppressionPlugin)
         .use(markraMathPlugin)
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)
+        .use(markraSearchPlugin())
         .use(markraBlockDragPlugin(blockDragLabels))
         .use(markraHeadingTogglePlugin(headingToggleLabels))
         .use(markraListTogglePlugin(listToggleLabels))

--- a/apps/desktop/src/components/MarkdownSourceEditor.test.tsx
+++ b/apps/desktop/src/components/MarkdownSourceEditor.test.tsx
@@ -49,4 +49,19 @@ describe("MarkdownSourceEditor", () => {
     expect(container.querySelector(".markdown-source-token-callout")).toHaveTextContent("[!TIP]");
     expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
   });
+
+  it("renders exact search highlights in source mode", () => {
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="alpha, beta，gamma"
+        searchMatches={[{ from: 5, to: 6 }]}
+        searchActiveIndex={0}
+        onChange={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".markra-source-search-match")).toHaveTextContent(",");
+    expect(container.querySelector(".markra-source-search-match-current")).toHaveTextContent(",");
+    expect(container.querySelector(".markra-source-search-match")).not.toHaveTextContent("，");
+  });
 });

--- a/apps/desktop/src/components/MarkdownSourceEditor.tsx
+++ b/apps/desktop/src/components/MarkdownSourceEditor.tsx
@@ -1,5 +1,14 @@
-import { Fragment, type CSSProperties, type ChangeEvent, type ReactNode, type Ref, type UIEvent } from "react";
-import { parseMarkdownCalloutMarker, t, type AppLanguage } from "@markra/shared";
+import {
+  Fragment,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ChangeEvent,
+  type ReactNode,
+  type Ref,
+  type UIEvent
+} from "react";
+import { parseMarkdownCalloutMarker, t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
   editorContentWidthPixels,
   editorCustomContentWidthMax,
@@ -24,6 +33,8 @@ type MarkdownSourceEditorProps = {
   onContentWidthResizeStart?: () => unknown;
   onScroll?: (event: UIEvent<HTMLElement>) => unknown;
   readOnly?: boolean;
+  searchActiveIndex?: number;
+  searchMatches?: SearchRange[];
   scrollRef?: Ref<HTMLElement>;
   topInset?: "none" | "tabs" | "titlebar";
 };
@@ -159,6 +170,48 @@ function markdownInlineTokenClassName(token: string) {
   return "markdown-source-token-emphasis";
 }
 
+function renderSourceSearchHighlights(content: string, matches: SearchRange[] = [], activeIndex = -1) {
+  if (matches.length === 0) return null;
+
+  const nodes: ReactNode[] = [];
+  let offset = 0;
+
+  matches.forEach((match, index) => {
+    const from = Math.max(0, Math.min(content.length, match.from));
+    const to = Math.max(from, Math.min(content.length, match.to));
+    if (to <= from) return;
+
+    if (from > offset) {
+      nodes.push(
+        <span className="markra-source-search-transparent" key={`text-${offset}`}>
+          {content.slice(offset, from)}
+        </span>
+      );
+    }
+
+    nodes.push(
+      <span
+        className={`markra-source-search-match ${index === activeIndex ? "markra-source-search-match-current" : ""}`}
+        data-markra-source-search-current={index === activeIndex ? "true" : undefined}
+        key={`match-${from}-${to}-${index}`}
+      >
+        {content.slice(from, to)}
+      </span>
+    );
+    offset = to;
+  });
+
+  if (offset < content.length) {
+    nodes.push(
+      <span className="markra-source-search-transparent" key={`text-${offset}`}>
+        {content.slice(offset)}
+      </span>
+    );
+  }
+
+  return nodes;
+}
+
 export function MarkdownSourceEditor({
   autoFocus = false,
   bodyFontSize = 16,
@@ -175,9 +228,13 @@ export function MarkdownSourceEditor({
   onContentWidthResizeStart,
   onScroll,
   readOnly = false,
+  searchActiveIndex = -1,
+  searchMatches = [],
   scrollRef,
   topInset = "titlebar"
 }: MarkdownSourceEditorProps) {
+  const sourceLayerRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const paperStyle = {
     fontSize: `${bodyFontSize}px`,
@@ -195,6 +252,17 @@ export function MarkdownSourceEditor({
       : topInset === "titlebar"
         ? "pt-14 max-[900px]:pt-10"
         : "pt-6 max-[900px]:pt-5";
+
+  useEffect(() => {
+    const activeMatch = searchMatches[searchActiveIndex];
+    if (!activeMatch) return;
+
+    textareaRef.current?.setSelectionRange(activeMatch.from, activeMatch.to);
+    const currentMatch = sourceLayerRef.current?.querySelector('[data-markra-source-search-current="true"]');
+    if (currentMatch instanceof HTMLElement && typeof currentMatch.scrollIntoView === "function") {
+      currentMatch.scrollIntoView({ block: "center", inline: "nearest" });
+    }
+  }, [searchActiveIndex, searchMatches]);
 
   return (
     <section
@@ -218,18 +286,27 @@ export function MarkdownSourceEditor({
           onResizeEnd={onContentWidthResizeEnd}
           onResizeStart={onContentWidthResizeStart}
         />
-        <div className="markdown-source-layer relative min-h-[calc(100vh-176px)]">
+        <div className="markdown-source-layer relative min-h-[calc(100vh-176px)]" ref={sourceLayerRef}>
           <pre
             className="markdown-source-highlight pointer-events-none m-0 min-h-[calc(100vh-176px)] whitespace-pre-wrap wrap-break-word border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal"
             aria-hidden="true"
           >
             <code>{renderMarkdownSourceHighlight(content)}</code>
           </pre>
+          {searchMatches.length > 0 ? (
+            <pre
+              className="markra-source-search-layer pointer-events-none absolute inset-0 m-0 min-h-[calc(100vh-176px)] whitespace-pre-wrap wrap-break-word border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal"
+              aria-hidden="true"
+            >
+              <code>{renderSourceSearchHighlights(content, searchMatches, searchActiveIndex)}</code>
+            </pre>
+          ) : null}
           <textarea
             className="markdown-source-input absolute inset-0 block h-full min-h-full w-full resize-none overflow-hidden border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal text-transparent outline-none placeholder:text-(--text-secondary) focus:outline-none"
             aria-label={t(language, "app.markdownSource")}
             autoFocus={autoFocus}
             readOnly={readOnly}
+            ref={textareaRef}
             spellCheck={false}
             value={content}
             onChange={handleChange}

--- a/apps/desktop/src/hooks/useEditorController.ts
+++ b/apps/desktop/src/hooks/useEditorController.ts
@@ -11,14 +11,18 @@ import {
   clearAiEditorPreview,
   confirmAiEditorResultApplied,
   listAiEditorPreviewResults,
+  findVisibleSearchMatchesInState,
   normalizeHeadingSourceDocument,
   scrollAiEditorPreviewIntoView,
+  scrollSearchMatchIntoView,
   serializeLinkImageLiveMarkdown,
   showAiEditorPreview,
   showAiSelectionHold,
+  updateSearchDecorations,
   type AiEditorPreviewLabels
 } from "@markra/editor";
 import type { MarkdownOutlineItem } from "@markra/markdown";
+import type { SearchRange } from "@markra/shared";
 
 const fixedTitlebarHeight = 40;
 const outlineScrollTopMargin = 24;
@@ -459,6 +463,82 @@ export function useEditorController() {
     []
   );
 
+  const findSearchMatches = useCallback((query: string, options: { caseSensitive?: boolean } = {}) => {
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return [];
+
+      return findVisibleSearchMatchesInState(view.state, query, options);
+    } catch {
+      return [];
+    }
+  }, []);
+
+  const showSearchMatches = useCallback((
+    matches: SearchRange[],
+    activeIndex: number,
+    options: { suppressEditorChrome?: boolean } = {}
+  ) => {
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return;
+
+      updateSearchDecorations(view, matches, activeIndex, options);
+    } catch {
+      // Search decoration is a transient affordance; failing to draw it should not interrupt editing.
+    }
+  }, []);
+
+  const revealSearchMatch = useCallback((match: SearchRange | null | undefined) => {
+    if (!match) return false;
+
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return false;
+
+      return scrollSearchMatchIntoView(view);
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const replaceSearchMatch = useCallback((match: SearchRange | null | undefined, replacement: string) => {
+    if (!match) return false;
+
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return false;
+
+      view.dispatch(
+        view.state.tr
+          .insertText(replacement, match.from, match.to)
+          .scrollIntoView()
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const replaceAllSearchMatches = useCallback((matches: SearchRange[], replacement: string) => {
+    if (matches.length === 0) return false;
+
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return false;
+
+      const transaction = [...matches]
+        .sort((left, right) => right.from - left.from)
+        .reduce((tr, match) => tr.insertText(replacement, match.from, match.to), view.state.tr)
+        .scrollIntoView();
+
+      view.dispatch(transaction);
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
   const insertMarkdownSnippet = useCallback((open: string, close: string, placeholder: string) => {
     const editor = editorRef.current;
     if (!editor) return;
@@ -673,6 +753,7 @@ export function useEditorController() {
     clearAiPreview,
     clearAiSelection,
     confirmAiResultApplied,
+    findSearchMatches,
     getDocumentEndPosition,
     getHeadingAnchors,
     getCurrentMarkdown,
@@ -686,10 +767,14 @@ export function useEditorController() {
     insertMarkdownTable,
     listAiPreviews,
     previewAiResult,
+    replaceAllSearchMatches,
     replaceMarkdown,
+    replaceSearchMatch,
+    revealSearchMatch,
     runEditorShortcut,
     scrollAiSelectionAboveCommand,
     scrollToAiPreview,
-    selectOutlineItem
+    selectOutlineItem,
+    showSearchMatches
   };
 }

--- a/apps/desktop/src/hooks/useNativeBindings.test.tsx
+++ b/apps/desktop/src/hooks/useNativeBindings.test.tsx
@@ -243,4 +243,40 @@ describe("useApplicationShortcuts", () => {
 
     expect(closeDocument).toHaveBeenCalledTimes(1);
   });
+
+  it("intercepts the default document search shortcut", () => {
+    const openDocumentSearch = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openDocumentSearch
+      })
+    );
+
+    const handled = fireEvent.keyDown(window, {
+      key: "f",
+      metaKey: true
+    });
+
+    expect(handled).toBe(false);
+    expect(openDocumentSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens replace from the document search shortcut with Alt", () => {
+    const openDocumentReplace = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openDocumentReplace
+      })
+    );
+
+    fireEvent.keyDown(window, {
+      key: "f",
+      altKey: true,
+      metaKey: true
+    });
+
+    expect(openDocumentReplace).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/hooks/useNativeBindings.ts
+++ b/apps/desktop/src/hooks/useNativeBindings.ts
@@ -50,6 +50,8 @@ type ApplicationShortcutOptions = {
   exportPdf?: () => unknown | Promise<unknown>;
   markdownShortcuts?: MarkdownShortcutMap;
   openDocument: () => unknown | Promise<unknown>;
+  openDocumentReplace?: () => unknown | Promise<unknown>;
+  openDocumentSearch?: () => unknown | Promise<unknown>;
   openFolder: () => unknown | Promise<unknown>;
   saveDocument: () => unknown | Promise<unknown>;
   saveDocumentAs: () => unknown | Promise<unknown>;
@@ -283,6 +285,8 @@ export function useApplicationShortcuts({
   exportPdf,
   markdownShortcuts,
   openDocument,
+  openDocumentReplace,
+  openDocumentSearch,
   openFolder,
   saveDocument,
   saveDocumentAs,
@@ -319,10 +323,18 @@ export function useApplicationShortcuts({
         return;
       }
 
-      if (event.altKey) return;
-
       const key = event.key.toLowerCase();
-      if (key === "s" && event.shiftKey) {
+      if (key === "f" && !event.shiftKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.altKey) {
+          openDocumentReplace?.();
+        } else {
+          openDocumentSearch?.();
+        }
+      } else if (event.altKey) {
+        return;
+      } else if (key === "s" && event.shiftKey) {
         event.preventDefault();
         saveDocumentAs();
       } else if (key === "w" && !event.shiftKey && closeDocument) {
@@ -356,6 +368,8 @@ export function useApplicationShortcuts({
     closeDocument,
     normalizedMarkdownShortcuts,
     openDocument,
+    openDocumentReplace,
+    openDocumentSearch,
     openFolder,
     saveDocument,
     saveDocumentAs,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -604,6 +604,33 @@
     @apply px-2.5 py-2 text-[12px] leading-5 font-[560] text-(--text-secondary);
   }
 
+  .document-search-icon-button {
+    @apply flex size-8 shrink-0 items-center justify-center rounded-sm border border-transparent bg-transparent text-(--text-secondary) outline-none transition-[background-color,color,border-color] duration-150 ease-out;
+  }
+
+  .document-search-icon-button:hover,
+  .document-search-icon-button:focus-visible,
+  .document-search-icon-button[aria-pressed="true"] {
+    @apply border-(--border-default) bg-(--bg-active) text-(--text-heading);
+  }
+
+  .document-search-icon-button:disabled {
+    @apply cursor-not-allowed opacity-40;
+  }
+
+  .document-search-text-button {
+    @apply h-8 shrink-0 rounded-sm border border-(--border-default) bg-(--bg-primary) px-2.5 text-[12px] leading-5 font-[620] text-(--text-heading) outline-none transition-[background-color,border-color,color] duration-150 ease-out;
+  }
+
+  .document-search-text-button:hover,
+  .document-search-text-button:focus-visible {
+    @apply border-(--border-strong) bg-(--bg-active);
+  }
+
+  .document-search-text-button:disabled {
+    @apply cursor-not-allowed opacity-45;
+  }
+
   .markdown-paper,
   .markdown-source-paper {
     --editor-text-cursor: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http://www.w3.org/2000/svg%27%20width%3D%2724%27%20height%3D%2724%27%20viewBox%3D%270%200%2024%2024%27%3E%3Cpath%20d%3D%27M12%204v16M8.5%204h7M8.5%2020h7%27%20fill%3D%27none%27%20stroke%3D%27%23ffffff%27%20stroke-width%3D%274%27%20stroke-linecap%3D%27round%27/%3E%3Cpath%20d%3D%27M12%204v16M8.5%204h7M8.5%2020h7%27%20fill%3D%27none%27%20stroke%3D%27%231a1c1e%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%3C/svg%3E") 12 12, text;
@@ -771,6 +798,26 @@
   .markdown-source-input::selection {
     background: color-mix(in srgb, var(--accent) 22%, transparent);
     -webkit-text-fill-color: transparent;
+  }
+
+  .markra-source-search-transparent {
+    color: transparent;
+  }
+
+  .markra-source-search-match,
+  .markra-search-match {
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--accent) 16%, transparent);
+  }
+
+  .markra-source-search-match {
+    color: transparent;
+  }
+
+  .markra-source-search-match-current,
+  .markra-search-match-current {
+    background: color-mix(in srgb, var(--accent) 30%, transparent);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
   }
 
   .markdown-source-token-muted {
@@ -2595,6 +2642,31 @@
   .markdown-paper::selection,
   .markdown-paper *::selection {
     background: color-mix(in srgb, var(--accent) 20%, transparent);
+  }
+
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper,
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper *,
+  .editor-content-slot[data-document-search-open="true"] .markdown-source-paper,
+  .editor-content-slot[data-document-search-open="true"] .markdown-source-paper * {
+    caret-color: transparent !important;
+  }
+
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper::selection,
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper *::selection,
+  .editor-content-slot[data-document-search-open="true"] .markdown-source-paper::selection,
+  .editor-content-slot[data-document-search-open="true"] .markdown-source-paper *::selection {
+    background: transparent;
+  }
+
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper .markra-math-caret-anchor,
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper .markra-image-node-source-row {
+    display: none !important;
+  }
+
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper .markra-image-node.markra-image-node-selected,
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper .ProseMirror-selectednode {
+    outline: none !important;
+    box-shadow: none !important;
   }
 
   .ai-command-thinking-text {

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -101,6 +101,21 @@ describe("editor stylesheet", () => {
     expect(imageSelectionStyles).not.toContain("outline-none");
   });
 
+  it("suppresses editor selection chrome while document search is open", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const searchChromeStart = styles.indexOf(".editor-content-slot[data-document-search-open=\"true\"]");
+    const searchChromeEnd = styles.indexOf(".ai-command-thinking-text");
+    const searchChromeStyles = styles.slice(searchChromeStart, searchChromeEnd);
+
+    expect(searchChromeStart).toBeGreaterThanOrEqual(0);
+    expect(searchChromeEnd).toBeGreaterThan(searchChromeStart);
+    expect(searchChromeStyles).toContain("caret-color: transparent");
+    expect(searchChromeStyles).toContain(".markra-math-caret-anchor");
+    expect(searchChromeStyles).toContain(".markra-image-node.markra-image-node-selected");
+    expect(searchChromeStyles).toContain(".ProseMirror-selectednode");
+    expect(searchChromeStyles).toContain(".markra-image-node-source-row");
+  });
+
   it("lets AI insert previews inherit the current Markdown block typography", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -12,6 +12,7 @@ export * from "./mermaid.ts";
 export * from "./math.ts";
 export * from "./raw-html.ts";
 export * from "./selection-hold.ts";
+export * from "./search.ts";
 export * from "./shortcuts.ts";
 export * from "./slash-commands.ts";
 export * from "./table-controls.ts";

--- a/packages/editor/src/link-image/images.ts
+++ b/packages/editor/src/link-image/images.ts
@@ -242,6 +242,7 @@ export function createFinalizedImageNodeView(
   source.addEventListener("input", syncSource);
   source.addEventListener("change", syncSource);
   source.addEventListener("keydown", moveToParagraphAfterImage);
+  source.addEventListener("blur", hideSource);
 
   return {
     dom,
@@ -268,6 +269,7 @@ export function createFinalizedImageNodeView(
       source.removeEventListener("input", syncSource);
       source.removeEventListener("change", syncSource);
       source.removeEventListener("keydown", moveToParagraphAfterImage);
+      source.removeEventListener("blur", hideSource);
     }
   };
 }

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -1,5 +1,5 @@
 import type { Node as ProseNode } from "@milkdown/kit/prose/model";
-import { Plugin, PluginKey, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
+import { Plugin, PluginKey, TextSelection, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import type { MarkdownNode } from "@milkdown/kit/transformer";
 import { $prose, $remark } from "@milkdown/kit/utils";
@@ -19,6 +19,11 @@ type MathRange = {
   to: number;
 };
 
+export type MarkraHiddenMathSourceRange = {
+  from: number;
+  to: number;
+};
+
 type ActiveMathSource = {
   from: number;
   to: number;
@@ -34,8 +39,13 @@ type MathRenderMeta =
     };
 
 const mathRenderKey = new PluginKey<ActiveMathSource | null>("markra-math-render");
+const mathCaretAnchorSuppressionKey = new PluginKey<boolean>("markra-math-caret-anchor-suppression");
 const transparentCaretAnchorSrc =
   "data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%221%22%20height=%221%22%20viewBox=%220%200%201%201%22/%3E";
+
+type MathCaretAnchorSuppressionMeta = {
+  suppressed: boolean;
+};
 
 export function createMarkraMathMacros(): MarkraMathMacros {
   return {};
@@ -50,6 +60,16 @@ export function renderMarkraMathToString(tex: string, kind: MarkraMathKind, macr
     strict: "ignore",
     throwOnError: false
   });
+}
+
+export function setMathCaretAnchorSuppressedMeta(transaction: Transaction, suppressed: boolean) {
+  return transaction.setMeta(mathCaretAnchorSuppressionKey, {
+    suppressed
+  } satisfies MathCaretAnchorSuppressionMeta);
+}
+
+export function setMathCaretAnchorSuppressed(view: EditorView, suppressed: boolean) {
+  view.dispatch(setMathCaretAnchorSuppressedMeta(view.state.tr, suppressed));
 }
 
 function skipMathWhitespace(source: string, index: number) {
@@ -456,6 +476,30 @@ function getActiveMathSource(state: EditorState): MathRange | null {
 
 function getEditableMathRange(state: EditorState) {
   return getActiveMathSource(state) ?? findActiveMathRange(state);
+}
+
+export function findHiddenDisplayMathSourceRanges(state: EditorState): MarkraHiddenMathSourceRange[] {
+  const ranges: MarkraHiddenMathSourceRange[] = [];
+  const activeRange = getEditableMathRange(state);
+
+  state.doc.descendants((node, position) => {
+    if (!node.isTextblock || node.type.spec.code) return;
+
+    const blockStart = position + 1;
+    for (const relativeRange of getMathRanges(node.textContent)) {
+      if (relativeRange.kind !== "display") continue;
+
+      const range = makeAbsoluteRange(relativeRange, blockStart);
+      if (activeRange?.from === range.from && activeRange.to === range.to) continue;
+
+      ranges.push({
+        from: range.from,
+        to: range.to
+      });
+    }
+  });
+
+  return ranges;
 }
 
 function findAdjacentMathRange(state: EditorState, direction: "backward" | "forward") {
@@ -923,6 +967,7 @@ function createMathCaretAnchorDecoration(range: MathRange) {
 
 function buildMathDecorations(state: EditorState, activeRange: MathRange | null) {
   const { doc } = state;
+  const caretAnchorSuppressed = mathCaretAnchorSuppressionKey.getState(state) ?? false;
   const decorations: Decoration[] = [];
   const macros = createMarkraMathMacros();
 
@@ -981,7 +1026,7 @@ function buildMathDecorations(state: EditorState, activeRange: MathRange | null)
           })
         );
 
-        if (range.kind === "display" && selectionIsAtMathRangeEnd(state, range)) {
+        if (range.kind === "display" && !caretAnchorSuppressed && selectionIsAtMathRangeEnd(state, range)) {
           decorations.push(createMathCaretAnchorDecoration(range));
         }
       }
@@ -990,6 +1035,21 @@ function buildMathDecorations(state: EditorState, activeRange: MathRange | null)
 
   return DecorationSet.create(doc, decorations);
 }
+
+export const markraMathCaretAnchorSuppressionPlugin = $prose(() => {
+  return new Plugin<boolean>({
+    key: mathCaretAnchorSuppressionKey,
+    state: {
+      init: () => false,
+      apply(transaction, previous) {
+        const meta = transaction.getMeta(mathCaretAnchorSuppressionKey) as MathCaretAnchorSuppressionMeta | undefined;
+        if (typeof meta?.suppressed === "boolean") return meta.suppressed;
+
+        return previous;
+      }
+    }
+  });
+});
 
 export const markraMathPlugin = $prose(() => {
   return new Plugin({

--- a/packages/editor/src/search.ts
+++ b/packages/editor/src/search.ts
@@ -1,0 +1,203 @@
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, type EditorState } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+import { findSearchRanges, type SearchRange } from "@markra/shared";
+import { findHiddenDisplayMathSourceRanges, setMathCaretAnchorSuppressedMeta } from "./math.ts";
+
+type TextSegment = {
+  end: number;
+  from: number;
+  start: number;
+};
+
+type SearchState = {
+  activeIndex: number;
+  decorations: DecorationSet;
+  matches: SearchRange[];
+};
+
+type SearchMeta = {
+  activeIndex: number;
+  matches: SearchRange[];
+};
+
+type SearchDecorationOptions = {
+  suppressEditorChrome?: boolean;
+};
+
+const emptySearchState: SearchState = {
+  activeIndex: -1,
+  decorations: DecorationSet.empty,
+  matches: []
+};
+
+const searchKey = new PluginKey<SearchState>("markra-search");
+const currentSearchMatchSelector = "[data-markra-search-current=\"true\"]";
+
+export function findSearchMatchesInDoc(
+  doc: ProseNode,
+  query: string,
+  options: { caseSensitive?: boolean } = {}
+): SearchRange[] {
+  if (!query) return [];
+
+  const matches: SearchRange[] = [];
+
+  doc.descendants((node, position) => {
+    if (!node.isTextblock) return true;
+
+    const segments: TextSegment[] = [];
+    let text = "";
+
+    node.descendants((child, offset) => {
+      if (!child.isText || !child.text) return true;
+
+      const start = text.length;
+      text += child.text;
+      segments.push({
+        end: text.length,
+        from: position + 1 + offset,
+        start
+      });
+
+      return true;
+    });
+
+    for (const range of findSearchRanges(text, query, options)) {
+      const from = positionForTextOffset(segments, range.from);
+      const to = positionForTextOffset(segments, range.to);
+      if (from !== null && to !== null && from < to) {
+        matches.push({ from, to });
+      }
+    }
+
+    return false;
+  });
+
+  return matches;
+}
+
+export function findVisibleSearchMatchesInState(
+  state: EditorState,
+  query: string,
+  options: { caseSensitive?: boolean } = {}
+): SearchRange[] {
+  const matches = findSearchMatchesInDoc(state.doc, query, options);
+  if (matches.length === 0) return matches;
+
+  const hiddenDisplayMathSourceRanges = findHiddenDisplayMathSourceRanges(state);
+  if (hiddenDisplayMathSourceRanges.length === 0) return matches;
+
+  return matches.filter((match) => !rangeOverlapsHiddenDisplayMathSource(match, hiddenDisplayMathSourceRanges));
+}
+
+export function markraSearchPlugin() {
+  return $prose(() => new Plugin<SearchState>({
+    key: searchKey,
+    props: {
+      decorations(state) {
+        return searchKey.getState(state)?.decorations ?? DecorationSet.empty;
+      }
+    },
+    state: {
+      init() {
+        return emptySearchState;
+      },
+      apply(transaction, previous, _oldState, newState) {
+        const meta = transaction.getMeta(searchKey) as SearchMeta | undefined;
+        if (!meta) {
+          const matches = mapSearchRanges(previous.matches, transaction.mapping);
+          return {
+            activeIndex: previous.activeIndex,
+            decorations: buildSearchDecorations(newState, matches, previous.activeIndex),
+            matches
+          };
+        }
+
+        return {
+          activeIndex: meta.activeIndex,
+          decorations: buildSearchDecorations(newState, meta.matches, meta.activeIndex),
+          matches: meta.matches
+        };
+      }
+    }
+  }));
+}
+
+export function updateSearchDecorations(
+  view: EditorView,
+  matches: SearchRange[],
+  activeIndex: number,
+  options: SearchDecorationOptions = {}
+) {
+  const transaction = setMathCaretAnchorSuppressedMeta(
+    view.state.tr.setMeta(searchKey, {
+      activeIndex,
+      matches
+    } satisfies SearchMeta),
+    Boolean(options.suppressEditorChrome)
+  );
+
+  view.dispatch(transaction);
+}
+
+export function scrollSearchMatchIntoView(view: EditorView) {
+  const currentMatch = view.dom.querySelector(currentSearchMatchSelector);
+  if (!(currentMatch instanceof HTMLElement) || typeof currentMatch.scrollIntoView !== "function") return false;
+
+  currentMatch.scrollIntoView({
+    block: "center",
+    inline: "nearest"
+  });
+  return true;
+}
+
+function buildSearchDecorations(state: EditorState, matches: SearchRange[], activeIndex: number) {
+  if (matches.length === 0) return DecorationSet.empty;
+
+  const hiddenDisplayMathSourceRanges = findHiddenDisplayMathSourceRanges(state);
+
+  return DecorationSet.create(
+    state.doc,
+    matches.flatMap((match, index) => {
+      if (rangeOverlapsHiddenDisplayMathSource(match, hiddenDisplayMathSourceRanges)) return [];
+
+      const current = index === activeIndex;
+      return [Decoration.inline(match.from, match.to, current
+        ? {
+            class: "markra-search-match markra-search-match-current",
+            "data-markra-search-current": "true"
+          }
+        : {
+            class: "markra-search-match"
+          })];
+    })
+  );
+}
+
+function mapSearchRanges(matches: SearchRange[], mapping: Parameters<DecorationSet["map"]>[0]) {
+  return matches.flatMap((match) => {
+    const from = mapping.map(match.from, 1);
+    const to = mapping.map(match.to, -1);
+
+    return from < to ? [{ from, to }] : [];
+  });
+}
+
+function rangeOverlapsHiddenDisplayMathSource(
+  match: SearchRange,
+  hiddenDisplayMathSourceRanges: SearchRange[]
+) {
+  return hiddenDisplayMathSourceRanges.some((range) => match.from < range.to && range.from < match.to);
+}
+
+function positionForTextOffset(segments: TextSegment[], offset: number) {
+  for (const segment of segments) {
+    if (offset >= segment.start && offset <= segment.end) {
+      return segment.from + offset - segment.start;
+    }
+  }
+
+  return null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./number.ts";
 export * from "./path.ts";
 export * from "./record.ts";
 export * from "./runtime.ts";
+export * from "./search.ts";
 export * from "./string.ts";
 export * from "./text.ts";
 export * from "./url.ts";

--- a/packages/shared/src/search.test.ts
+++ b/packages/shared/src/search.test.ts
@@ -1,0 +1,28 @@
+import { findSearchRanges } from "./search";
+
+describe("document search", () => {
+  it("matches punctuation exactly without width normalization", () => {
+    const text = "alpha, beta，gamma, delta";
+
+    expect(findSearchRanges(text, ",")).toEqual([
+      { from: 5, to: 6 },
+      { from: 17, to: 18 }
+    ]);
+    expect(findSearchRanges(text, "，")).toEqual([{ from: 11, to: 12 }]);
+  });
+
+  it("supports case-sensitive matching", () => {
+    const text = "Markra markra MARKRA";
+
+    expect(findSearchRanges(text, "markra")).toEqual([
+      { from: 0, to: 6 },
+      { from: 7, to: 13 },
+      { from: 14, to: 20 }
+    ]);
+    expect(findSearchRanges(text, "markra", { caseSensitive: true })).toEqual([{ from: 7, to: 13 }]);
+  });
+
+  it("keeps original offsets when case folding changes string length", () => {
+    expect(findSearchRanges("İ, exact", ",")).toEqual([{ from: 1, to: 2 }]);
+  });
+});

--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -1,0 +1,42 @@
+export type SearchRange = {
+  from: number;
+  to: number;
+};
+
+type SearchOptions = {
+  caseSensitive?: boolean;
+};
+
+export function findSearchRanges(text: string, query: string, options: SearchOptions = {}): SearchRange[] {
+  if (!query) return [];
+
+  const ranges: SearchRange[] = [];
+  const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
+  let from = 0;
+
+  while (from <= text.length - query.length) {
+    const candidate = text.slice(from, from + query.length);
+    const matches = options.caseSensitive
+      ? candidate === query
+      : candidate.toLocaleLowerCase() === needle;
+
+    if (matches) {
+      ranges.push({
+        from,
+        to: from + query.length
+      });
+      from += Math.max(1, query.length);
+      continue;
+    }
+
+    from += 1;
+  }
+
+  return ranges;
+}
+
+export function normalizeSearchIndex(index: number, count: number) {
+  if (count <= 0) return -1;
+
+  return ((index % count) + count) % count;
+}


### PR DESCRIPTION
## Summary
- Add an in-app document search and replace bar for the desktop editor.
- Intercept native `Mod+F` / `Mod+Alt+F` search shortcuts so WebView/browser search is not used.
- Highlight exact literal matches in source and visual editor surfaces, with replace-current and replace-all support.
- Prevent search from triggering AI selection UI, system input correction UI, automatic scroll jumps while typing, lingering image source selection UI, or formula-related hidden editor chrome.
- Exclude hidden display math source from visual-mode search counts/highlights; source mode still searches the raw Markdown text.

## Why
Windows WebView native search can match punctuation too loosely and invoke browser-native behavior. Markra now owns the document search flow so punctuation matching, replacement, and editor UI behavior stay predictable.

## Validation
- `pnpm --filter @markra/desktop exec vitest run src/App.test.tsx -t "document search"` passed, 6 tests
- `pnpm --filter @markra/desktop exec vitest run src/components/MarkdownPaper.test.tsx -t "search"` passed, 3 tests
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/shared test -- search.test.ts` passed, 19 tests
- `pnpm --filter @markra/desktop build` passed
- `git diff --check` passed

## Notes
- The unrelated restored-tabs switching bug is split into #118.
- The desktop test run still prints the existing jsdom `Window's scrollBy()` warning.
- The desktop build still prints the existing large chunk warning.

Closes #113
Closes #114
