### PR TITLE
feat(desktop): support file tree drag moves

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,8 +17,8 @@ use image_upload::{upload_s3_image, upload_webdav_image};
 use markdown_files::{
     create_markdown_tree_file, create_markdown_tree_folder, delete_markdown_template_file,
     delete_markdown_tree_file, export_pdf_file, list_markdown_files_for_path,
-    open_markdown_file_in_new_window, open_markdown_folder_in_new_window, open_markdown_path,
-    read_markdown_file, read_markdown_image_file, read_markdown_template_file,
+    move_markdown_tree_file, open_markdown_file_in_new_window, open_markdown_folder_in_new_window,
+    open_markdown_path, read_markdown_file, read_markdown_image_file, read_markdown_template_file,
     rename_markdown_tree_file, resolve_markdown_path, save_clipboard_image, write_markdown_file,
     write_markdown_template_file,
 };
@@ -103,6 +103,7 @@ pub fn run() {
             create_markdown_tree_folder,
             install_application_menu,
             rename_markdown_tree_file,
+            move_markdown_tree_file,
             delete_markdown_tree_file,
             open_markdown_file_in_new_window,
             open_markdown_folder_in_new_window,

--- a/apps/desktop/src-tauri/src/markdown_files.rs
+++ b/apps/desktop/src-tauri/src/markdown_files.rs
@@ -938,6 +938,36 @@ fn canonical_markdown_tree_entry(root: &Path, path: &Path) -> Result<PathBuf, St
     Err("Path is not a Markdown file, supported image asset, or folder".to_string())
 }
 
+fn canonical_movable_markdown_tree_entry(root: &Path, path: &Path) -> Result<PathBuf, String> {
+    let canonical_path = path.canonicalize().map_err(|error| error.to_string())?;
+
+    canonical_path
+        .strip_prefix(root)
+        .map_err(|_| "File is outside the current Markdown folder".to_string())?;
+
+    if canonical_path == root {
+        return Err("Cannot move the current Markdown folder root".to_string());
+    }
+
+    if canonical_path.is_dir()
+        || (canonical_path.is_file()
+            && (is_markdown_tree_file(&canonical_path)
+                || is_markdown_tree_asset_file(&canonical_path)))
+    {
+        return Ok(canonical_path);
+    }
+
+    Err("Path is not a Markdown file, supported image asset, or folder".to_string())
+}
+
+fn markdown_tree_entry_kind(path: &Path) -> Result<MarkdownFolderEntryKind, String> {
+    if path.is_dir() {
+        return Ok(MarkdownFolderEntryKind::Folder);
+    }
+
+    markdown_tree_file_kind(path)
+}
+
 fn ensure_markdown_tree_parent(root: &Path, parent: &Path) -> Result<(), String> {
     let canonical_parent = parent.canonicalize().map_err(|error| error.to_string())?;
     canonical_parent
@@ -1218,6 +1248,40 @@ pub(crate) fn rename_markdown_tree_file(
     fs::rename(&source_path, &target_path).map_err(|error| error.to_string())?;
 
     markdown_folder_file(&root, &target_path, markdown_tree_file_kind(&target_path)?)
+}
+
+#[tauri::command]
+pub(crate) fn move_markdown_tree_file(
+    root_path: String,
+    path: String,
+    target_parent_path: Option<String>,
+) -> Result<MarkdownFolderFile, String> {
+    let root_path = PathBuf::from(root_path);
+    let root = canonical_markdown_tree_root(&root_path)?;
+    let source_path = canonical_movable_markdown_tree_entry(&root, &PathBuf::from(path))?;
+    let target_parent = markdown_tree_target_parent(&root, target_parent_path)?;
+    let source_name = source_path
+        .file_name()
+        .ok_or_else(|| "File name is invalid".to_string())?;
+    let target_path = target_parent.join(source_name);
+
+    ensure_markdown_tree_parent(&root, &target_parent)?;
+
+    if source_path.is_dir()
+        && (target_parent == source_path || target_parent.starts_with(&source_path))
+    {
+        return Err("Cannot move a folder into itself".to_string());
+    }
+
+    if target_path.exists() && target_path != source_path {
+        return Err("File already exists".to_string());
+    }
+
+    if target_path != source_path {
+        fs::rename(&source_path, &target_path).map_err(|error| error.to_string())?;
+    }
+
+    markdown_folder_file(&root, &target_path, markdown_tree_entry_kind(&target_path)?)
 }
 
 #[tauri::command]
@@ -1967,6 +2031,142 @@ mod tests {
         .is_err());
 
         fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn moves_markdown_tree_files_and_folders_inside_the_root() {
+        let root = std::env::temp_dir().join(format!(
+            "markra-tree-move-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after epoch")
+                .as_nanos()
+        ));
+
+        let docs = root.join("docs");
+        let archive = root.join("archive");
+        fs::create_dir_all(&docs).expect("source folder should be created");
+        fs::create_dir_all(&archive).expect("target folder should be created");
+        fs::write(docs.join("guide.md"), "# Guide").expect("markdown file should be created");
+        fs::write(docs.join("notes.md"), "# Notes")
+            .expect("nested markdown file should be created");
+        let canonical_root = root
+            .canonicalize()
+            .expect("test folder should have a canonical path");
+
+        let moved_file = move_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            docs.join("guide.md").to_string_lossy().to_string(),
+            Some(archive.to_string_lossy().to_string()),
+        )
+        .expect("markdown file should move into the target folder");
+
+        assert_markdown_folder_file(
+            &moved_file,
+            MarkdownFolderEntryKind::File,
+            &canonical_root.join("archive").join("guide.md"),
+            "archive/guide.md",
+        );
+        assert!(!docs.join("guide.md").exists());
+        assert_eq!(
+            fs::read_to_string(archive.join("guide.md"))
+                .expect("moved markdown file should be readable"),
+            "# Guide"
+        );
+
+        let moved_folder = move_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            docs.to_string_lossy().to_string(),
+            Some(archive.to_string_lossy().to_string()),
+        )
+        .expect("markdown folder should move into the target folder");
+
+        assert_markdown_folder_file(
+            &moved_folder,
+            MarkdownFolderEntryKind::Folder,
+            &canonical_root.join("archive").join("docs"),
+            "archive/docs",
+        );
+        assert!(!docs.exists());
+        assert_eq!(
+            fs::read_to_string(archive.join("docs").join("notes.md"))
+                .expect("nested moved markdown file should be readable"),
+            "# Notes"
+        );
+
+        let moved_back_to_root = move_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            archive.join("guide.md").to_string_lossy().to_string(),
+            None,
+        )
+        .expect("markdown file should move back to the root");
+
+        assert_markdown_folder_file(
+            &moved_back_to_root,
+            MarkdownFolderEntryKind::File,
+            &canonical_root.join("guide.md"),
+            "guide.md",
+        );
+        assert!(!archive.join("guide.md").exists());
+        assert_eq!(
+            fs::read_to_string(root.join("guide.md"))
+                .expect("root moved markdown file should be readable"),
+            "# Guide"
+        );
+
+        fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn rejects_invalid_markdown_tree_moves() {
+        let root = std::env::temp_dir().join(format!(
+            "markra-tree-move-boundary-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after epoch")
+                .as_nanos()
+        ));
+        let sibling = root.with_file_name(format!(
+            "{}-sibling",
+            root.file_name()
+                .and_then(|name| name.to_str())
+                .expect("root should have a file name")
+        ));
+
+        let docs = root.join("docs");
+        let child = docs.join("child");
+        let archive = root.join("archive");
+        fs::create_dir_all(&child).expect("nested source folder should be created");
+        fs::create_dir_all(&archive).expect("target folder should be created");
+        fs::create_dir_all(&sibling).expect("sibling folder should be created");
+        fs::write(docs.join("guide.md"), "# Guide").expect("markdown file should be created");
+        fs::write(archive.join("guide.md"), "# Existing")
+            .expect("conflicting file should be created");
+        fs::write(sibling.join("outside.md"), "# Outside").expect("outside file should be created");
+
+        assert!(move_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            sibling.join("outside.md").to_string_lossy().to_string(),
+            Some(archive.to_string_lossy().to_string())
+        )
+        .is_err());
+        assert!(move_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            docs.to_string_lossy().to_string(),
+            Some(child.to_string_lossy().to_string())
+        )
+        .is_err());
+        assert!(move_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            docs.join("guide.md").to_string_lossy().to_string(),
+            Some(archive.to_string_lossy().to_string())
+        )
+        .is_err());
+        assert!(docs.join("guide.md").exists());
+        assert!(sibling.join("outside.md").exists());
+
+        fs::remove_dir_all(root).expect("test tree should be removed");
+        fs::remove_dir_all(sibling).expect("sibling tree should be removed");
     }
 
     #[test]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -71,6 +71,7 @@ import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath
 import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
 import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
+import { replaceMovedPath } from "./lib/path-move";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
 import { openNativeExternalUrl, openSettingsWindow } from "./lib/tauri";
 import { aiAgentWebSearchAvailable, type AiDiffResult, type AiEditIntent, type AiSelectionContext } from "@markra/ai";
@@ -358,6 +359,7 @@ export default function App() {
     createFile: createMarkdownTreeFile,
     createFolder: createMarkdownTreeFolder,
     deleteFile: deleteMarkdownTreeFile,
+    moveFile: moveMarkdownTreeFile,
     open: fileTreeOpen,
     openFolderPath,
     openMarkdownFolder,
@@ -416,6 +418,7 @@ export default function App() {
     openTreeMarkdownFile,
     outlineItems,
     replaceOpenDocumentFile,
+    replaceMovedOpenDocumentFile,
     saveCurrentDocument,
     saveMarkdownTab,
     selectMarkdownTab,
@@ -1423,6 +1426,33 @@ export default function App() {
     ));
     setActiveImageFile((currentFile) => currentFile?.path === previousPath ? renamedFile : currentFile);
   }, [persistSideDocumentGroupPathUpdate, replaceOpenDocumentFile]);
+  const applyMovedTreeFile = useCallback((
+    previousFile: NativeMarkdownFolderFile,
+    movedFile: NativeMarkdownFolderFile
+  ) => {
+    const moveFolderFile = (file: NativeMarkdownFolderFile): NativeMarkdownFolderFile => {
+      const nextPath = replaceMovedPath(file.path, previousFile.path, movedFile.path);
+      if (nextPath === file.path) return file;
+
+      return {
+        ...file,
+        name: file.path === previousFile.path ? movedFile.name : file.name,
+        path: nextPath,
+        relativePath: replaceMovedPath(file.relativePath, previousFile.relativePath, movedFile.relativePath)
+      };
+    };
+
+    replaceMovedOpenDocumentFile(previousFile.path, movedFile);
+    persistSideDocumentGroupPathUpdate({
+      nextPath: movedFile.path,
+      previousPath: previousFile.path
+    });
+    setImageTabs((currentTabs) => currentTabs.map((tab) => {
+      const movedTab = moveFolderFile(tab);
+      return movedTab === tab ? tab : createImageDocumentTab(movedTab);
+    }));
+    setActiveImageFile((currentFile) => currentFile ? moveFolderFile(currentFile) : currentFile);
+  }, [persistSideDocumentGroupPathUpdate, replaceMovedOpenDocumentFile]);
   const handleCreateMarkdownTreeFolder = useCallback(async (folderName: string, parentPath: string | null = null) => {
     try {
       await createMarkdownTreeFolder(folderName, parentPath);
@@ -1438,6 +1468,17 @@ export default function App() {
       // Keep the existing tree state if the native rename fails.
     }
   }, [applyRenamedTreeFile, renameMarkdownTreeFile]);
+  const handleMoveMarkdownTreeFile = useCallback(async (
+    file: NativeMarkdownFolderFile,
+    targetParentPath: string | null
+  ) => {
+    try {
+      const movedFile = await moveMarkdownTreeFile(file, targetParentPath);
+      if (movedFile) applyMovedTreeFile(file, movedFile);
+    } catch {
+      // Keep the existing tree state if the native move fails.
+    }
+  }, [applyMovedTreeFile, moveMarkdownTreeFile]);
   const handleDeleteMarkdownTreeFile = useCallback(async (file: NativeMarkdownFolderFile) => {
     const fileIsFolder = file.kind === "folder";
     const confirmed = await confirmNativeMarkdownFileDelete(file.name, {
@@ -2396,6 +2437,7 @@ export default function App() {
               onCreateFile={handleCreateMarkdownTreeFile}
               onCreateFolder={handleCreateMarkdownTreeFolder}
               onDeleteFile={handleDeleteMarkdownTreeFile}
+              onMoveFile={handleMoveMarkdownTreeFile}
               onOpenFile={handleOpenTreeFile}
               onOpenFileToSide={
                 editorPreferences.preferences.showDocumentTabs

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -14,6 +14,12 @@ const markdownFiles = [
   { name: "deploy.md", path: "/vault/deploy/deploy.md", relativePath: "deploy/deploy.md" }
 ];
 
+async function settleFileTreeDrag() {
+  await new Promise((resolve) => {
+    window.setTimeout(resolve, 60);
+  });
+}
+
 describe("MarkdownFileTreeDrawer", () => {
   beforeEach(() => {
     mockedShowNativeMarkdownFileTreeContextMenu.mockReset();
@@ -644,6 +650,74 @@ describe("MarkdownFileTreeDrawer", () => {
     }
   });
 
+  it("starts root create actions inside the current file parent folder", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-21T09:30:00"));
+    const createFile = vi.fn();
+    const createFolder = vi.fn();
+
+    try {
+      const { rerender } = render(
+        <MarkdownFileTreeDrawer
+          currentPath="/vault/deploy/deploy.md"
+          files={markdownFiles}
+          open
+          outlineItems={[]}
+          rootPath="/vault"
+          rootName="Obsidian Vault"
+          onCreateFile={createFile}
+          onCreateFolder={createFolder}
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+      const newFileInput = screen.getByRole("textbox", { name: "New file name" });
+      fireEvent.change(newFileInput, { target: { value: "Sprint note" } });
+      fireEvent.keyDown(newFileInput, { key: "Enter" });
+
+      expect(createFile).toHaveBeenCalledWith("Sprint note", "/vault/deploy");
+
+      rerender(
+        <MarkdownFileTreeDrawer
+          currentPath="/vault/deploy/deploy.md"
+          files={markdownFiles}
+          open
+          outlineItems={[]}
+          rootPath="/vault"
+          rootName="Obsidian Vault"
+          onCreateFile={createFile}
+          onCreateFolder={createFolder}
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Daily note" }));
+      const templateInput = screen.getByRole("textbox", { name: "New file name" });
+      fireEvent.keyDown(templateInput, { key: "Enter" });
+
+      expect(createFile).toHaveBeenLastCalledWith(
+        "2026-05-21",
+        "/vault/deploy",
+        expect.stringContaining("# 2026-05-21")
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "New Folder" }));
+      const newFolderInput = screen.getByRole("textbox", { name: "New folder name" });
+      fireEvent.change(newFolderInput, { target: { value: "Research" } });
+      fireEvent.keyDown(newFolderInput, { key: "Enter" });
+
+      expect(createFolder).toHaveBeenCalledWith("Research", "/vault/deploy");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("starts a markdown file from a custom template", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-21T09:30:00"));
@@ -896,6 +970,372 @@ describe("MarkdownFileTreeDrawer", () => {
     fireEvent.keyDown(newFolderInput, { key: "Enter" });
 
     expect(createFolder).toHaveBeenCalledWith("Research", "/vault/deploy");
+  });
+
+  it("moves folders onto other folders and nested files back to the root", async () => {
+    const moveFile = vi.fn();
+
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[
+          ...markdownFiles,
+          { kind: "folder", name: "archive", path: "/vault/archive", relativePath: "archive" }
+        ]}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onMoveFile={moveFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const deployFolder = screen.getByRole("button", { name: "deploy" });
+    const archiveFolder = screen.getByRole("button", { name: "archive" });
+    vi.spyOn(deployFolder, "getBoundingClientRect").mockReturnValue({
+      bottom: 32,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 0,
+      width: 260,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(archiveFolder, "getBoundingClientRect").mockReturnValue({
+      bottom: 64,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 32,
+      width: 260,
+      x: 0,
+      y: 32,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(deployFolder, { button: 0, clientX: 20, clientY: 16 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 28 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 48 });
+    fireEvent.mouseUp(document, { clientX: 24, clientY: 48 });
+    await settleFileTreeDrag();
+
+    expect(moveFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "folder",
+        path: "/vault/deploy",
+        relativePath: "deploy"
+      }),
+      "/vault/archive"
+    );
+
+    fireEvent.click(deployFolder);
+    const nestedFile = screen.getByRole("button", { name: "deploy/deploy.md" });
+    const scroll = container.querySelector(".file-tree-scroll") as HTMLElement;
+    vi.spyOn(nestedFile, "getBoundingClientRect").mockReturnValue({
+      bottom: 96,
+      height: 32,
+      left: 20,
+      right: 260,
+      top: 64,
+      width: 240,
+      x: 20,
+      y: 64,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(scroll, "getBoundingClientRect").mockReturnValue({
+      bottom: 260,
+      height: 220,
+      left: 0,
+      right: 260,
+      top: 40,
+      width: 260,
+      x: 0,
+      y: 40,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(nestedFile, { button: 0, clientX: 40, clientY: 80 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 44, clientY: 120 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 44, clientY: 180 });
+    fireEvent.mouseUp(document, { clientX: 44, clientY: 180 });
+    await settleFileTreeDrag();
+
+    expect(moveFile).toHaveBeenLastCalledWith(
+      markdownFiles[2],
+      null
+    );
+  });
+
+  it("moves files and folders with pointer dragging in the file tree", async () => {
+    const moveFile = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[
+          ...markdownFiles,
+          { kind: "folder", name: "archive", path: "/vault/archive", relativePath: "archive" }
+        ]}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onMoveFile={moveFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const deployFolder = screen.getByRole("button", { name: "deploy" });
+    const awsFile = screen.getByRole("button", { name: "AWS.md" });
+    vi.spyOn(awsFile, "getBoundingClientRect").mockReturnValue({
+      bottom: 72,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 40,
+      width: 260,
+      x: 0,
+      y: 40,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(deployFolder, "getBoundingClientRect").mockReturnValue({
+      bottom: 32,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 0,
+      width: 260,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(awsFile, { button: 0, clientX: 20, clientY: 56 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 42 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 16 });
+
+    expect(screen.getByTestId("file-tree-drag-overlay")).toHaveTextContent("AWS.md");
+    expect(deployFolder).toHaveClass("bg-(--bg-active)");
+
+    fireEvent.mouseUp(document, { clientX: 24, clientY: 16 });
+    await settleFileTreeDrag();
+
+    expect(moveFile).toHaveBeenCalledWith(markdownFiles[1], "/vault/deploy");
+  });
+
+  it("moves a file into an expanded folder when dropped over its child list", async () => {
+    const moveFile = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onMoveFile={moveFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const deployFolder = screen.getByRole("button", { name: "deploy" });
+    fireEvent.click(deployFolder);
+
+    const deployChildren = screen.getByRole("group", { name: "deploy children" });
+    const awsFile = screen.getByRole("button", { name: "AWS.md" });
+    vi.spyOn(awsFile, "getBoundingClientRect").mockReturnValue({
+      bottom: 128,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 96,
+      width: 260,
+      x: 0,
+      y: 96,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(deployChildren, "getBoundingClientRect").mockReturnValue({
+      bottom: 92,
+      height: 60,
+      left: 20,
+      right: 260,
+      top: 32,
+      width: 240,
+      x: 20,
+      y: 32,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(awsFile, { button: 0, clientX: 20, clientY: 112 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 36, clientY: 96 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 36, clientY: 72 });
+
+    expect(deployFolder).toHaveClass("bg-(--bg-active)");
+    expect(deployChildren).toHaveClass("bg-(--bg-active)");
+
+    fireEvent.mouseUp(document, { clientX: 36, clientY: 72 });
+    await settleFileTreeDrag();
+
+    expect(moveFile).toHaveBeenCalledWith(markdownFiles[1], "/vault/deploy");
+  });
+
+  it("does not move items into their current parent or themselves", async () => {
+    const moveFile = vi.fn();
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onMoveFile={moveFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const deployFolder = screen.getByRole("button", { name: "deploy" });
+    const awsFile = screen.getByRole("button", { name: "AWS.md" });
+    const scroll = container.querySelector(".file-tree-scroll") as HTMLElement;
+    vi.spyOn(awsFile, "getBoundingClientRect").mockReturnValue({
+      bottom: 72,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 40,
+      width: 260,
+      x: 0,
+      y: 40,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(scroll, "getBoundingClientRect").mockReturnValue({
+      bottom: 260,
+      height: 220,
+      left: 0,
+      right: 260,
+      top: 40,
+      width: 260,
+      x: 0,
+      y: 40,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(awsFile, { button: 0, clientX: 20, clientY: 56 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 100 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 180 });
+    fireEvent.mouseUp(document, { clientX: 24, clientY: 180 });
+    await settleFileTreeDrag();
+
+    fireEvent.click(deployFolder);
+    const deployChildren = screen.getByRole("group", { name: "deploy children" });
+    vi.spyOn(deployFolder, "getBoundingClientRect").mockReturnValue({
+      bottom: 32,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 0,
+      width: 260,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(deployChildren, "getBoundingClientRect").mockReturnValue({
+      bottom: 92,
+      height: 60,
+      left: 20,
+      right: 260,
+      top: 32,
+      width: 240,
+      x: 20,
+      y: 32,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(deployFolder, { button: 0, clientX: 20, clientY: 16 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 36, clientY: 44 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 36, clientY: 72 });
+    fireEvent.mouseUp(document, { clientX: 36, clientY: 72 });
+    await settleFileTreeDrag();
+
+    expect(moveFile).not.toHaveBeenCalled();
+  });
+
+  it("uses the innermost expanded child list as the drop target", async () => {
+    const moveFile = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[
+          ...markdownFiles,
+          { kind: "folder", name: "child", path: "/vault/deploy/child", relativePath: "deploy/child" },
+          { name: "inside.md", path: "/vault/deploy/child/inside.md", relativePath: "deploy/child/inside.md" }
+        ]}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onMoveFile={moveFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "deploy" }));
+    fireEvent.click(screen.getByRole("button", { name: "child" }));
+
+    const deployChildren = screen.getByRole("group", { name: "deploy children" });
+    const childChildren = screen.getByRole("group", { name: "child children" });
+    const awsFile = screen.getByRole("button", { name: "AWS.md" });
+    vi.spyOn(awsFile, "getBoundingClientRect").mockReturnValue({
+      bottom: 180,
+      height: 32,
+      left: 0,
+      right: 260,
+      top: 148,
+      width: 260,
+      x: 0,
+      y: 148,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(deployChildren, "getBoundingClientRect").mockReturnValue({
+      bottom: 140,
+      height: 108,
+      left: 20,
+      right: 260,
+      top: 32,
+      width: 240,
+      x: 20,
+      y: 32,
+      toJSON: () => ({})
+    } as DOMRect);
+    vi.spyOn(childChildren, "getBoundingClientRect").mockReturnValue({
+      bottom: 120,
+      height: 56,
+      left: 40,
+      right: 260,
+      top: 64,
+      width: 220,
+      x: 40,
+      y: 64,
+      toJSON: () => ({})
+    } as DOMRect);
+
+    fireEvent.mouseDown(awsFile, { button: 0, clientX: 20, clientY: 164 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 60, clientY: 132 });
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 60, clientY: 88 });
+    fireEvent.mouseUp(document, { clientX: 60, clientY: 88 });
+    await settleFileTreeDrag();
+
+    expect(moveFile).toHaveBeenCalledWith(markdownFiles[1], "/vault/deploy/child");
   });
 
   it("opens a folder context menu with a delete action for that folder", () => {

--- a/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
+++ b/apps/desktop/src/components/MarkdownFileTreeDrawer.tsx
@@ -6,8 +6,26 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
-  type ReactNode
+  type ReactNode,
+  type SyntheticEvent
 } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  type DraggableAttributes,
+  type DraggableSyntheticListeners,
+  type UniqueIdentifier
+} from "@dnd-kit/core";
 import {
   ArrowDownAZ,
   ArrowUpDown,
@@ -33,6 +51,7 @@ import { clampNumber, t, type AppLanguage } from "@markra/shared";
 import { IconButton } from "@markra/ui";
 import type { MarkdownOutlineItem } from "@markra/markdown";
 import type { NativeMarkdownFolderFile } from "../lib/tauri";
+import { normalizeMovedPath } from "../lib/path-move";
 import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
 import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
 import type { RecentMarkdownFolder } from "../lib/settings/app-settings";
@@ -67,6 +86,7 @@ type MarkdownFileTreeDrawerProps = {
   onOpenRecentFolder?: (folder: RecentMarkdownFolder) => unknown | Promise<unknown>;
   onOpenSettings?: () => unknown | Promise<unknown>;
   onRemoveRecentFolder?: (folder: RecentMarkdownFolder) => unknown | Promise<unknown>;
+  onMoveFile?: (file: NativeMarkdownFolderFile, targetParentPath: string | null) => unknown | Promise<unknown>;
   onRenameFile?: (file: NativeMarkdownFolderFile, fileName: string) => unknown | Promise<unknown>;
   onResize?: (width: number) => unknown;
   onResizeEnd?: () => unknown;
@@ -99,6 +119,29 @@ type FileTreeSortDirection = "ascending" | "descending";
 type FileTreeSort = {
   direction: FileTreeSortDirection;
   key: FileTreeSortKey;
+};
+type FileTreeDragData = {
+  file: NativeMarkdownFolderFile;
+};
+type FileTreeDropData = {
+  targetParentPath: string | null;
+};
+type FileTreeDragSourceRenderProps = {
+  attributes: Partial<Omit<DraggableAttributes, "aria-pressed" | "role">>;
+  isDragging: boolean;
+  listeners: Record<string, (event: SyntheticEvent<HTMLElement>) => unknown>;
+  setNodeRef: (element: HTMLElement | null) => undefined;
+};
+type FileTreeDragSourceProps = {
+  children: (props: FileTreeDragSourceRenderProps) => ReactNode;
+  disabled?: boolean;
+  file: NativeMarkdownFolderFile;
+};
+type FileTreeDropTargetProps = {
+  children: (props: { setNodeRef: (element: HTMLElement | null) => undefined }) => ReactNode;
+  disabled?: boolean;
+  id: UniqueIdentifier;
+  targetParentPath: string | null;
 };
 
 const emptyMarkdownTemplates: readonly MarkdownTemplate[] = [];
@@ -167,6 +210,166 @@ function parentPathFromPath(path: string) {
   if (lastSeparatorIndex < 0) return null;
   if (lastSeparatorIndex === 0) return path.slice(0, 1);
   return path.slice(0, lastSeparatorIndex);
+}
+
+function fileTreeDragId(file: NativeMarkdownFolderFile) {
+  return `file-tree-drag:${file.path}`;
+}
+
+function fileTreeDropId(name: string) {
+  return `file-tree-drop:${name}`;
+}
+
+function fileTreeFolderDropId(path: string | null | undefined) {
+  return fileTreeDropId(path ?? "__missing__");
+}
+
+function fileTreeFolderChildrenDropId(path: string | null | undefined) {
+  return fileTreeDropId(`children:${path ?? "__missing__"}`);
+}
+
+function fileTreeRootDropId(name: string) {
+  return fileTreeDropId(`root:${name}`);
+}
+
+function fileTreeDragData(value: unknown): FileTreeDragData | null {
+  const data = value as Partial<FileTreeDragData> | null | undefined;
+  return data?.file ? { file: data.file } : null;
+}
+
+function fileTreeDropData(value: unknown): FileTreeDropData | null {
+  const data = value as Partial<FileTreeDropData> | null | undefined;
+  if (!data || !("targetParentPath" in data)) return null;
+  return { targetParentPath: data.targetParentPath ?? null };
+}
+
+const fileTreeCollisionDetection: CollisionDetection = (args) => {
+  const collisions = pointerWithin(args);
+  const folderCollisions = collisions.filter((collision) => {
+    const dropData = fileTreeDropData(collision.data?.droppableContainer.data.current);
+    return dropData?.targetParentPath !== null;
+  });
+
+  if (folderCollisions.length === 0) return collisions;
+
+  return [...folderCollisions].sort((left, right) => {
+    const leftRect = left.data?.droppableContainer.rect.current;
+    const rightRect = right.data?.droppableContainer.rect.current;
+    const leftArea = leftRect ? leftRect.width * leftRect.height : Number.MAX_SAFE_INTEGER;
+    const rightArea = rightRect ? rightRect.width * rightRect.height : Number.MAX_SAFE_INTEGER;
+
+    return leftArea - rightArea;
+  });
+};
+
+function combineNodeRefs<T extends HTMLElement>(
+  ...setNodeRefs: ((element: T | null) => unknown)[]
+) {
+  return (element: T | null) => {
+    setNodeRefs.forEach((setNodeRef) => {
+      setNodeRef(element);
+    });
+    return undefined;
+  };
+}
+
+function fileTreeDraggableAttributes(
+  attributes: DraggableAttributes,
+  disabled: boolean
+): FileTreeDragSourceRenderProps["attributes"] {
+  if (disabled) return {};
+
+  return {
+    "aria-describedby": attributes["aria-describedby"],
+    "aria-disabled": attributes["aria-disabled"],
+    "aria-roledescription": attributes["aria-roledescription"],
+    tabIndex: attributes.tabIndex
+  };
+}
+
+function fileTreeDraggableListeners(
+  listeners: DraggableSyntheticListeners,
+  disabled: boolean
+): FileTreeDragSourceRenderProps["listeners"] {
+  if (disabled) return {};
+
+  return Object.fromEntries(
+    Object.entries(listeners ?? {}).map(([eventName, listener]) => {
+      const dragListener = listener as (event: SyntheticEvent<HTMLElement>) => unknown;
+
+      return [
+        eventName,
+        (event: SyntheticEvent<HTMLElement>) => dragListener(event)
+      ];
+    })
+  );
+}
+
+function FileTreeDragSource({
+  children,
+  disabled = false,
+  file
+}: FileTreeDragSourceProps) {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef
+  } = useDraggable({
+    id: fileTreeDragId(file),
+    data: { file } satisfies FileTreeDragData,
+    disabled
+  });
+
+  return children({
+    attributes: fileTreeDraggableAttributes(attributes, disabled),
+    isDragging,
+    listeners: fileTreeDraggableListeners(listeners, disabled),
+    setNodeRef: (element) => {
+      setNodeRef(element);
+      return undefined;
+    }
+  });
+}
+
+function FileTreeDropTarget({
+  children,
+  disabled = false,
+  id,
+  targetParentPath
+}: FileTreeDropTargetProps) {
+  const { setNodeRef } = useDroppable({
+    id,
+    data: { targetParentPath } satisfies FileTreeDropData,
+    disabled
+  });
+
+  return children({
+    setNodeRef: (element) => {
+      setNodeRef(element);
+      return undefined;
+    }
+  });
+}
+
+function FileTreeDragOverlay({
+  file
+}: {
+  file: NativeMarkdownFolderFile | null;
+}) {
+  if (!file) return null;
+
+  const FileIcon = file.kind === "folder" ? Folder : file.kind === "asset" ? ImageIcon : FileText;
+
+  return (
+    <div
+      className="grid h-8 min-w-44 max-w-72 grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 rounded-md border border-(--border-default) bg-(--bg-primary) px-2 text-[13px] leading-none text-(--text-heading) opacity-80 shadow-[0_12px_28px_color-mix(in_srgb,var(--text-heading)_18%,transparent)]"
+      data-testid="file-tree-drag-overlay"
+    >
+      <FileIcon aria-hidden="true" className="shrink-0" size={15} />
+      <span className="min-w-0 truncate">{file.relativePath}</span>
+    </div>
+  );
 }
 
 function buildMarkdownFileTree(
@@ -285,6 +488,8 @@ const maxOutlineHeightPercent = 72;
 const outlineResizeKeyboardStepPercent = 5;
 const outlineResizeFallbackHeight = 320;
 const fileTreeContextRowSelectionClassName = "select-none [-webkit-user-select:none]";
+const fileTreeDropTargetClassName = "bg-(--bg-active) text-(--text-heading)";
+const fileTreeDropListTargetClassName = "rounded-sm bg-(--bg-active)";
 
 export function MarkdownFileTreeDrawer({
   currentPath,
@@ -309,6 +514,7 @@ export function MarkdownFileTreeDrawer({
   onOpenRecentFolder,
   onOpenSettings = () => {},
   onRemoveRecentFolder,
+  onMoveFile,
   onRenameFile,
   onResize,
   onResizeEnd,
@@ -341,6 +547,15 @@ export function MarkdownFileTreeDrawer({
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameFileName, setRenameFileName] = useState("");
+  const [dragOverTargetPath, setDragOverTargetPath] = useState<string | null>(null);
+  const [activeDragFile, setActiveDragFile] = useState<NativeMarkdownFolderFile | null>(null);
+  const fileTreeDndSensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 4
+      }
+    })
+  );
   const fileTreeSort = useMemo(
     () => ({ direction: fileTreeSortDirection, key: fileTreeSortKey }) satisfies FileTreeSort,
     [fileTreeSortDirection, fileTreeSortKey]
@@ -364,6 +579,19 @@ export function MarkdownFileTreeDrawer({
   const folderActionsAvailable = fileCreationAvailable || folderCreationAvailable;
   const folderExpansionAvailable = folderPaths.length > 0;
   const allFoldersExpanded = folderExpansionAvailable && folderPaths.every((folderPath) => expandedFolders.has(folderPath));
+  const dragMoveAvailable = folderOpen && Boolean(onMoveFile);
+  const activeCreateParentPath = useMemo(() => {
+    const normalizedRootPath = rootPath ? normalizeMovedPath(rootPath) : null;
+    const currentParentPath = currentPath ? parentPathFromPath(currentPath) : null;
+    if (!normalizedRootPath || !currentParentPath) return null;
+
+    const normalizedParentPath = normalizeMovedPath(currentParentPath);
+    if (normalizedParentPath === normalizedRootPath || normalizedParentPath.startsWith(`${normalizedRootPath}/`)) {
+      return currentParentPath;
+    }
+
+    return null;
+  }, [currentPath, rootPath]);
   const recentFolderChoices = recentFolders.slice(0, 5);
   const recentFolderAreaVisible = recentFolderChoices.length > 0 && Boolean(onOpenRecentFolder);
   const filePanelVisible = folderOpen;
@@ -586,6 +814,59 @@ export function MarkdownFileTreeDrawer({
       language,
       file
     ).catch(() => {});
+  };
+
+  const dragTargetKey = (targetParentPath: string | null) => targetParentPath ?? "__root__";
+
+  const canMoveFileToParent = (file: NativeMarkdownFolderFile, targetParentPath: string | null) => {
+    const normalizedTargetParentPath = normalizeCreateParentPath(targetParentPath);
+    const targetPath = normalizedTargetParentPath ?? rootPath;
+    if (!targetPath) return false;
+
+    const normalizedFilePath = normalizeMovedPath(file.path);
+    const normalizedTargetPath = normalizeMovedPath(targetPath);
+    const normalizedCurrentParentPath = file.path ? normalizeMovedPath(parentPathFromPath(file.path) ?? "") : "";
+
+    if (normalizedCurrentParentPath === normalizedTargetPath) return false;
+    if (file.kind !== "folder") return true;
+    if (normalizedTargetPath === normalizedFilePath) return false;
+    return !normalizedTargetPath.startsWith(`${normalizedFilePath}/`);
+  };
+
+  const clearFileTreeDrag = () => {
+    setDragOverTargetPath(null);
+    setActiveDragFile(null);
+  };
+
+  const handleFileTreeDragStart = (event: DragStartEvent) => {
+    const dragData = fileTreeDragData(event.active.data.current);
+    if (!dragData) {
+      clearFileTreeDrag();
+      return;
+    }
+
+    setActiveDragFile(dragData.file);
+  };
+
+  const handleFileTreeDragOver = (event: DragOverEvent) => {
+    const dragData = fileTreeDragData(event.active.data.current);
+    const dropData = fileTreeDropData(event.over?.data.current);
+    if (!dragData || !dropData || !canMoveFileToParent(dragData.file, dropData.targetParentPath)) {
+      setDragOverTargetPath(null);
+      return;
+    }
+
+    setDragOverTargetPath(dragTargetKey(dropData.targetParentPath));
+  };
+
+  const handleFileTreeDragEnd = (event: DragEndEvent) => {
+    const dragData = fileTreeDragData(event.active.data.current);
+    const dropData = fileTreeDropData(event.over?.data.current);
+    clearFileTreeDrag();
+    if (!dragData || !dropData || !onMoveFile) return;
+    if (!canMoveFileToParent(dragData.file, dropData.targetParentPath)) return;
+
+    Promise.resolve(onMoveFile(dragData.file, normalizeCreateParentPath(dropData.targetParentPath))).catch(() => {});
   };
 
   const resizeDrawer = (nextWidth: number | null) => {
@@ -829,12 +1110,15 @@ export function MarkdownFileTreeDrawer({
     depth = 0,
     treeLabel = label("app.markdownFiles"),
     parentPath: string | null = null
-  ) => (
-    <ol
-      className={depth === 0 ? "m-0 list-none p-0" : "ml-5 list-none border-l border-(--border-default) p-0"}
-      role={depth === 0 ? "tree" : "group"}
-      aria-label={treeLabel}
-    >
+  ) => {
+    const listDropTarget = parentPath !== null && dragOverTargetPath === dragTargetKey(parentPath);
+    const nodeList = (setNodeRef?: (element: HTMLOListElement | null) => undefined) => (
+      <ol
+        ref={setNodeRef}
+        className={depth === 0 ? "m-0 list-none p-0" : `ml-5 list-none border-l border-(--border-default) p-0 ${listDropTarget ? fileTreeDropListTargetClassName : ""}`}
+        role={depth === 0 ? "tree" : "group"}
+        aria-label={treeLabel}
+      >
       {renderCreateRows(parentPath, depth)}
       {nodes.map((node) => {
         const rowIndentClass = "pl-8";
@@ -844,24 +1128,47 @@ export function MarkdownFileTreeDrawer({
           const expanded = searchQuery.trim().length > 0 ||
             expandedFolders.has(node.relativePath) ||
             ((creatingFile || creatingFolder) && creatingAtParentPath(node.path, depth + 1));
+          const folderFile = folderNodeAsFile(node);
+          const dropTarget = dragOverTargetPath === dragTargetKey(node.path);
+          const folderRowStateClassName = dropTarget
+            ? fileTreeDropTargetClassName
+            : "bg-transparent hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)";
 
           return (
             <li key={node.relativePath}>
-              <button
-                className={`relative flex h-8 w-full cursor-pointer items-center gap-1 border-0 bg-transparent py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
-                type="button"
-                aria-expanded={expanded}
-                onContextMenu={(event) => openContextMenu(event, folderNodeAsFile(node), node.path)}
-                onClick={() => toggleFolder(node.relativePath)}
+              <FileTreeDropTarget
+                disabled={!dragMoveAvailable || !node.path}
+                id={fileTreeFolderDropId(node.path)}
+                targetParentPath={node.path}
               >
-                {expanded ? (
-                  <ChevronDown aria-hidden="true" className="shrink-0" size={13} />
-                ) : (
-                  <ChevronRight aria-hidden="true" className="shrink-0" size={13} />
+                {(dropTargetProps) => (
+                  <FileTreeDragSource disabled={!dragMoveAvailable} file={folderFile}>
+                    {(dragSource) => (
+                      <button
+                        ref={combineNodeRefs<HTMLButtonElement>(
+                          dropTargetProps.setNodeRef,
+                          dragSource.setNodeRef
+                        )}
+                        className={`relative flex h-8 w-full cursor-pointer touch-none items-center gap-1 border-0 py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) focus-visible:outline-none ${folderRowStateClassName} ${dragSource.isDragging ? "opacity-70" : ""} ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
+                        type="button"
+                        aria-expanded={expanded}
+                        onContextMenu={(event) => openContextMenu(event, folderFile, node.path)}
+                        onClick={() => toggleFolder(node.relativePath)}
+                        {...dragSource.attributes}
+                        {...dragSource.listeners}
+                      >
+                        {expanded ? (
+                          <ChevronDown aria-hidden="true" className="shrink-0" size={13} />
+                        ) : (
+                          <ChevronRight aria-hidden="true" className="shrink-0" size={13} />
+                        )}
+                        <Folder aria-hidden="true" className="shrink-0" size={16} />
+                        <span className="min-w-0 truncate">{node.name}</span>
+                      </button>
+                    )}
+                  </FileTreeDragSource>
                 )}
-                <Folder aria-hidden="true" className="shrink-0" size={16} />
-                <span className="min-w-0 truncate">{node.name}</span>
-              </button>
+              </FileTreeDropTarget>
               {expanded ? renderNodes(node.children, depth + 1, `${node.name} children`, node.path) : null}
             </li>
           );
@@ -902,26 +1209,46 @@ export function MarkdownFileTreeDrawer({
                 />
               </div>
             ) : (
-              <button
-                className={`relative grid h-8 w-full cursor-pointer grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 border-0 bg-transparent py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-[current=page]:border-l-[3px] aria-[current=page]:border-(--text-secondary) aria-[current=page]:bg-(--bg-active) aria-[current=page]:text-(--text-heading) ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
-                type="button"
-                aria-current={active ? "page" : undefined}
-                aria-label={node.relativePath}
-                title={node.file.path}
-                onContextMenu={(event) => openContextMenu(event, node.file)}
-                onClick={() => {
-                  onOpenFile(node.file);
-                }}
-              >
-                <FileIcon aria-hidden="true" className="shrink-0" size={15} />
-                <span className="min-w-0 truncate">{node.name}</span>
-              </button>
+              <FileTreeDragSource disabled={!dragMoveAvailable} file={node.file}>
+                {(dragSource) => (
+                  <button
+                    ref={dragSource.setNodeRef}
+                    className={`relative grid h-8 w-full cursor-pointer touch-none grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 border-0 bg-transparent py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-[current=page]:border-l-[3px] aria-[current=page]:border-(--text-secondary) aria-[current=page]:bg-(--bg-active) aria-[current=page]:text-(--text-heading) ${dragSource.isDragging ? "opacity-70" : ""} ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
+                    type="button"
+                    aria-current={active ? "page" : undefined}
+                    aria-label={node.relativePath}
+                    title={node.file.path}
+                    onContextMenu={(event) => openContextMenu(event, node.file)}
+                    onClick={() => {
+                      onOpenFile(node.file);
+                    }}
+                    {...dragSource.attributes}
+                    {...dragSource.listeners}
+                  >
+                    <FileIcon aria-hidden="true" className="shrink-0" size={15} />
+                    <span className="min-w-0 truncate">{node.name}</span>
+                  </button>
+                )}
+              </FileTreeDragSource>
             )}
           </li>
         );
       })}
-    </ol>
-  );
+      </ol>
+    );
+
+    if (depth === 0 || !parentPath) return nodeList();
+
+    return (
+      <FileTreeDropTarget
+        disabled={!dragMoveAvailable}
+        id={fileTreeFolderChildrenDropId(parentPath)}
+        targetParentPath={parentPath}
+      >
+        {(dropTargetProps) => nodeList(dropTargetProps.setNodeRef)}
+      </FileTreeDropTarget>
+    );
+  };
 
   const renderOutline = () => (
     outlineItems.length > 0 ? (
@@ -1159,14 +1486,31 @@ export function MarkdownFileTreeDrawer({
               className={`markdown-file-tree-files flex min-h-0 flex-col ${outlineOpen ? "min-h-24" : "flex-1"}`}
               style={filePanelStyle}
             >
+              <DndContext
+                collisionDetection={fileTreeCollisionDetection}
+                sensors={fileTreeDndSensors}
+                onDragCancel={clearFileTreeDrag}
+                onDragEnd={handleFileTreeDragEnd}
+                onDragOver={handleFileTreeDragOver}
+                onDragStart={handleFileTreeDragStart}
+              >
               <div className="flex h-9 shrink-0 items-center gap-1 px-4 text-[13px] text-(--text-secondary)">
-                <div
-                  className={`flex min-w-0 flex-1 items-center gap-1 ${fileTreeContextRowSelectionClassName}`}
-                  onContextMenu={(event) => openContextMenu(event)}
+                <FileTreeDropTarget
+                  disabled={!dragMoveAvailable}
+                  id={fileTreeRootDropId("header")}
+                  targetParentPath={null}
                 >
-                  <Folder aria-hidden="true" size={16} />
-                  <span className="min-w-0 truncate">{rootName}</span>
-                </div>
+                  {(rootDropTarget) => (
+                    <div
+                      ref={rootDropTarget.setNodeRef}
+                      className={`flex min-w-0 flex-1 items-center gap-1 rounded-sm ${dragOverTargetPath === dragTargetKey(null) ? fileTreeDropTargetClassName : ""} ${fileTreeContextRowSelectionClassName}`}
+                      onContextMenu={(event) => openContextMenu(event)}
+                    >
+                      <Folder aria-hidden="true" size={16} />
+                      <span className="min-w-0 truncate">{rootName}</span>
+                    </div>
+                  )}
+                </FileTreeDropTarget>
                 <div className="relative">
                   <IconButton
                     className="rounded-md"
@@ -1256,12 +1600,12 @@ export function MarkdownFileTreeDrawer({
                         {fileCreationAvailable ? renderCreateMenuItem(
                           label("app.newMarkdownFile"),
                           <FileText size={13} />,
-                          () => startCreatingFile()
+                          () => startCreatingFile(activeCreateParentPath)
                         ) : null}
                         {folderCreationAvailable ? renderCreateMenuItem(
                           label("app.newMarkdownFolder"),
                           <Folder size={13} />,
-                          () => startCreatingFolder()
+                          () => startCreatingFolder(activeCreateParentPath)
                         ) : null}
                         {fileCreationAvailable ? (
                           <>
@@ -1275,7 +1619,7 @@ export function MarkdownFileTreeDrawer({
                                 className="flex h-7 w-full items-center gap-2 border-0 bg-transparent px-2.5 text-left text-[12px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none"
                                 role="menuitem"
                                 type="button"
-                                onClick={() => startCreatingFile(null, template)}
+                                onClick={() => startCreatingFile(activeCreateParentPath, template)}
                               >
                                 <span className="flex w-3.5 justify-center" aria-hidden="true">
                                   <LayoutTemplate size={13} />
@@ -1291,19 +1635,32 @@ export function MarkdownFileTreeDrawer({
                 ) : null}
               </div>
 
-              <div
-                className="file-tree-scroll min-h-0 flex-1 overflow-y-auto overscroll-none pb-4"
-                onMouseDown={cancelFileTreeInputsFromBlankArea}
-                onContextMenu={(event) => openContextMenu(event)}
+              <FileTreeDropTarget
+                disabled={!dragMoveAvailable}
+                id={fileTreeRootDropId("scroll")}
+                targetParentPath={null}
               >
-                {tree.length > 0 || creatingFile || creatingFolder ? (
-                  renderNodes(tree)
-                ) : (
-                  <p className="m-0 px-4 py-3 text-[12px] text-(--text-secondary)">
-                    {label("app.noMarkdownFiles")}
-                  </p>
+                {(rootDropTarget) => (
+                  <div
+                    ref={rootDropTarget.setNodeRef}
+                    className={`file-tree-scroll min-h-0 flex-1 overflow-y-auto overscroll-none pb-4 ${dragOverTargetPath === dragTargetKey(null) ? fileTreeDropTargetClassName : ""}`}
+                    onMouseDown={cancelFileTreeInputsFromBlankArea}
+                    onContextMenu={(event) => openContextMenu(event)}
+                  >
+                    {tree.length > 0 || creatingFile || creatingFolder ? (
+                      renderNodes(tree)
+                    ) : (
+                      <p className="m-0 px-4 py-3 text-[12px] text-(--text-secondary)">
+                        {label("app.noMarkdownFiles")}
+                      </p>
+                    )}
+                  </div>
                 )}
-              </div>
+              </FileTreeDropTarget>
+              <DragOverlay dropAnimation={null}>
+                <FileTreeDragOverlay file={activeDragFile} />
+              </DragOverlay>
+              </DndContext>
             </section>
           ) : null}
 

--- a/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownDocument.test.tsx
@@ -696,6 +696,57 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("updates open tree document paths when their containing folder is moved", async () => {
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
+      content: path.endsWith("guide.md") ? "# Guide" : "# Notes",
+      name: path.endsWith("guide.md") ? "guide.md" : "notes.md",
+      path
+    }));
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/docs/guide.md",
+        relativePath: "docs/guide.md"
+      });
+    });
+    await act(async () => {
+      await result.current.openTreeMarkdownFileInBackground({
+        name: "notes.md",
+        path: "/mock-files/docs/notes.md",
+        relativePath: "docs/notes.md"
+      });
+    });
+
+    act(() => {
+      expect(result.current.replaceMovedOpenDocumentFile("/mock-files/docs", {
+        kind: "folder",
+        name: "docs",
+        path: "/mock-files/archive/docs",
+        relativePath: "archive/docs"
+      })).toBe(true);
+    });
+
+    expect(result.current.document).toMatchObject({
+      name: "guide.md",
+      path: "/mock-files/archive/docs/guide.md"
+    });
+    expect(result.current.tabs.map((tab) => tab.path)).toEqual([
+      "/mock-files/archive/docs/guide.md",
+      "/mock-files/archive/docs/notes.md"
+    ]);
+  });
+
   it("skips a restored folder workspace when the folder no longer opens", async () => {
     const onTreeRootFromFolderPath = vi.fn(async () => null);
     mockedGetStoredWorkspaceState.mockResolvedValue({

--- a/apps/desktop/src/hooks/useMarkdownDocument.ts
+++ b/apps/desktop/src/hooks/useMarkdownDocument.ts
@@ -23,6 +23,7 @@ import {
   type NativeMarkdownFile,
   type NativeMarkdownFolderFile
 } from "../lib/tauri";
+import { normalizeMovedPath, replaceMovedPath } from "../lib/path-move";
 import { setNativeWindowTitle } from "../lib/tauri";
 import { pathNameFromPath, type DocumentState } from "@markra/shared";
 
@@ -168,13 +169,9 @@ function isEquivalentEditorMarkdown(left: string, right: string) {
   return comparableMarkdown(left) === comparableMarkdown(right);
 }
 
-function normalizeDocumentPath(path: string) {
-  return path.replace(/\\/gu, "/").replace(/\/+$/u, "");
-}
-
 function isDeletedDocumentPath(documentPath: string, deletedPath: string) {
-  const normalizedDocumentPath = normalizeDocumentPath(documentPath);
-  const normalizedDeletedPath = normalizeDocumentPath(deletedPath);
+  const normalizedDocumentPath = normalizeMovedPath(documentPath);
+  const normalizedDeletedPath = normalizeMovedPath(deletedPath);
 
   return normalizedDocumentPath === normalizedDeletedPath || normalizedDocumentPath.startsWith(`${normalizedDeletedPath}/`);
 }
@@ -723,6 +720,45 @@ export function useMarkdownDocument({
     return true;
   }, [registerWindowRestoreState, setActiveDocument]);
 
+  const replaceMovedOpenDocumentFile = useCallback((previousPath: string, file: NativeMarkdownFolderFile) => {
+    const movedPathFor = (path: string | null) => (path ? replaceMovedPath(path, previousPath, file.path) : path);
+    const affected =
+      tabsRef.current.some((tab) => tab.path !== null && movedPathFor(tab.path) !== tab.path) ||
+      (documentRef.current.path !== null && movedPathFor(documentRef.current.path) !== documentRef.current.path);
+    if (!affected) return false;
+
+    const current = documentRef.current;
+    if (current.path !== null) {
+      const nextPath = movedPathFor(current.path);
+      if (nextPath !== current.path) {
+        setActiveDocument({
+          ...current,
+          name: current.path === previousPath ? file.name : current.name,
+          path: nextPath
+        });
+      }
+    }
+
+    const nextTabs = tabsRef.current.map((tab) => {
+      const nextPath = movedPathFor(tab.path);
+      if (nextPath === tab.path) return tab;
+
+      return {
+        ...tab,
+        name: tab.path === previousPath ? file.name : tab.name,
+        path: nextPath
+      };
+    });
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
+    persistWorkspaceState({
+      filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
+      openFilePaths: openFilePathsFromTabs(nextTabs)
+    });
+    return true;
+  }, [registerWindowRestoreState, setActiveDocument]);
+
   const detachDeletedDocumentFile = useCallback((path: string) => {
     const currentTabs = tabsRef.current;
     const deletedTab = currentTabs.find((tab) => tab.path !== null && isDeletedDocumentPath(tab.path, path));
@@ -1223,6 +1259,7 @@ export function useMarkdownDocument({
     openTreeMarkdownFile,
     outlineItems,
     replaceOpenDocumentFile,
+    replaceMovedOpenDocumentFile,
     saveCurrentDocument,
     saveMarkdownTab,
     selectMarkdownTab,

--- a/apps/desktop/src/hooks/useMarkdownFileTree.test.tsx
+++ b/apps/desktop/src/hooks/useMarkdownFileTree.test.tsx
@@ -4,6 +4,7 @@ import {
   createNativeMarkdownTreeFolder,
   deleteNativeMarkdownTreeFile,
   listNativeMarkdownFilesForPath,
+  moveNativeMarkdownTreeFile,
   openNativeMarkdownFolder,
   renameNativeMarkdownTreeFile,
   watchNativeMarkdownTree
@@ -23,6 +24,7 @@ vi.mock("../lib/tauri", () => ({
   createNativeMarkdownTreeFolder: vi.fn(),
   deleteNativeMarkdownTreeFile: vi.fn(),
   listNativeMarkdownFilesForPath: vi.fn(),
+  moveNativeMarkdownTreeFile: vi.fn(),
   openNativeMarkdownFolder: vi.fn(),
   renameNativeMarkdownTreeFile: vi.fn(),
   watchNativeMarkdownTree: vi.fn()
@@ -44,6 +46,7 @@ const mockedCreateNativeMarkdownTreeFile = vi.mocked(createNativeMarkdownTreeFil
 const mockedCreateNativeMarkdownTreeFolder = vi.mocked(createNativeMarkdownTreeFolder);
 const mockedDeleteNativeMarkdownTreeFile = vi.mocked(deleteNativeMarkdownTreeFile);
 const mockedListNativeMarkdownFilesForPath = vi.mocked(listNativeMarkdownFilesForPath);
+const mockedMoveNativeMarkdownTreeFile = vi.mocked(moveNativeMarkdownTreeFile);
 const mockedOpenNativeMarkdownFolder = vi.mocked(openNativeMarkdownFolder);
 const mockedRenameNativeMarkdownTreeFile = vi.mocked(renameNativeMarkdownTreeFile);
 const mockedWatchNativeMarkdownTree = vi.mocked(watchNativeMarkdownTree);
@@ -114,6 +117,16 @@ function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) 
       </button>
       <button
         type="button"
+        onClick={() =>
+          tree.moveFile(
+            { name: "readme.md", path: "/vault/readme.md", relativePath: "readme.md" },
+            "/vault/docs"
+          )}
+      >
+        Move
+      </button>
+      <button
+        type="button"
         onClick={() => tree.deleteFile({ name: "renamed.md", path: "/vault/renamed.md", relativePath: "renamed.md" })}
       >
         Delete
@@ -138,6 +151,7 @@ describe("useMarkdownFileTree", () => {
     mockedCreateNativeMarkdownTreeFolder.mockReset();
     mockedDeleteNativeMarkdownTreeFile.mockReset();
     mockedListNativeMarkdownFilesForPath.mockReset();
+    mockedMoveNativeMarkdownTreeFile.mockReset();
     mockedOpenNativeMarkdownFolder.mockReset();
     mockedRenameNativeMarkdownTreeFile.mockReset();
     mockedWatchNativeMarkdownTree.mockReset();
@@ -166,6 +180,11 @@ describe("useMarkdownFileTree", () => {
       name: "renamed.md",
       path: "/vault/renamed.md",
       relativePath: "renamed.md"
+    });
+    mockedMoveNativeMarkdownTreeFile.mockResolvedValue({
+      name: "readme.md",
+      path: "/vault/docs/readme.md",
+      relativePath: "docs/readme.md"
     });
     mockedSaveStoredWorkspaceState.mockResolvedValue(undefined);
     mockedWatchNativeMarkdownTree.mockResolvedValue(() => {});
@@ -388,7 +407,7 @@ describe("useMarkdownFileTree", () => {
     expect(screen.getByTestId("layout-class")).toHaveTextContent("transition-[grid-template-columns]");
   });
 
-  it("creates folders, creates files, renames files, and deletes files through native markdown tree operations", async () => {
+  it("creates folders, creates files, moves files, renames files, and deletes files through native markdown tree operations", async () => {
     mockedOpenNativeMarkdownFolder.mockResolvedValue({
       path: "/vault",
       name: "vault"
@@ -423,6 +442,11 @@ describe("useMarkdownFileTree", () => {
     fireEvent.click(screen.getByRole("button", { name: "Rename" }));
     await waitFor(() =>
       expect(mockedRenameNativeMarkdownTreeFile).toHaveBeenCalledWith("/vault", "/vault/readme.md", "renamed.md")
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+    await waitFor(() =>
+      expect(mockedMoveNativeMarkdownTreeFile).toHaveBeenCalledWith("/vault", "/vault/readme.md", "/vault/docs")
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));

--- a/apps/desktop/src/hooks/useMarkdownFileTree.ts
+++ b/apps/desktop/src/hooks/useMarkdownFileTree.ts
@@ -13,6 +13,7 @@ import {
   createNativeMarkdownTreeFolder,
   deleteNativeMarkdownTreeFile,
   listNativeMarkdownFilesForPath,
+  moveNativeMarkdownTreeFile,
   openNativeMarkdownFolder,
   renameNativeMarkdownTreeFile,
   watchNativeMarkdownTree,
@@ -207,6 +208,14 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     return renamedFile;
   }, [refresh, sourcePath]);
 
+  const moveFile = useCallback(async (file: NativeMarkdownFolderFile, targetParentPath: string | null = null) => {
+    if (!sourcePath) return null;
+
+    const movedFile = await moveNativeMarkdownTreeFile(sourcePath, file.path, normalizeTreeParentPath(targetParentPath));
+    await refresh(sourcePath);
+    return movedFile;
+  }, [refresh, sourcePath]);
+
   const deleteFile = useCallback(async (file: NativeMarkdownFolderFile) => {
     if (!sourcePath) return false;
 
@@ -315,6 +324,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     openFolderPath,
     openRecentFolder,
     removeRecentFolder,
+    moveFile,
     rootNameForDocument,
     refresh,
     setRootFromMarkdownFilePath,

--- a/apps/desktop/src/hooks/useSideBySideTabs.test.tsx
+++ b/apps/desktop/src/hooks/useSideBySideTabs.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useSideBySideTabs } from "./useSideBySideTabs";
 import type { MarkdownTabsBarDocumentItem } from "../components/MarkdownTabsBar";
 import type { MarkdownDocumentTab } from "./useMarkdownDocument";
@@ -78,5 +78,45 @@ describe("useSideBySideTabs", () => {
     );
     expect(result.current.sideDocumentOpen).toBe(true);
     expect(loadStoredWorkspaceState).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists side-by-side paths when a containing folder moves", () => {
+    const persistSideDocumentGroup = vi.fn();
+    const docsTab = documentTab("file:/vault/docs/1.md", "/vault/docs/1.md");
+    const nestedTab = documentTab("file:/vault/docs/nested/2.md", "/vault/docs/nested/2.md");
+    const { result } = renderHook(() =>
+      useSideBySideTabs({
+        ...baseOptions,
+        documentTabs: [docsTab, nestedTab],
+        documentTabsEnabled: true,
+        loadStoredWorkspaceState: vi.fn(async () => ({
+          openFilePaths: [],
+          sideBySideGroup: null
+        })),
+        persistSideDocumentGroup,
+        titlebarTabs: [docsTab, nestedTab]
+      })
+    );
+
+    act(() => {
+      result.current.openSideDocumentGroup({
+        primaryFilePath: docsTab.path,
+        primaryTabId: docsTab.id,
+        sideFilePath: nestedTab.path,
+        sideTabId: nestedTab.id
+      });
+    });
+
+    act(() => {
+      result.current.persistSideDocumentGroupPathUpdate({
+        previousPath: "/vault/docs",
+        nextPath: "/vault/archive/docs"
+      });
+    });
+
+    expect(persistSideDocumentGroup).toHaveBeenLastCalledWith({
+      primaryFilePath: "/vault/archive/docs/1.md",
+      sideFilePath: "/vault/archive/docs/nested/2.md"
+    });
   });
 });

--- a/apps/desktop/src/hooks/useSideBySideTabs.ts
+++ b/apps/desktop/src/hooks/useSideBySideTabs.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { MarkdownTabsBarDocumentItem, MarkdownTabsBarItem } from "../components/MarkdownTabsBar";
+import { replaceMovedPath } from "../lib/path-move";
 import type { StoredWorkspaceSideBySideGroup, StoredWorkspaceState } from "../lib/settings/app-settings";
 import type { MarkdownDocumentTab } from "./useMarkdownDocument";
 
@@ -93,7 +94,7 @@ export function useSideBySideTabs({
     const resolveUpdatedPath = (tab: MarkdownTabsBarDocumentItem | undefined) => {
       if (!tab?.path) return null;
       if (update.tabId && tab.id === update.tabId) return update.nextPath;
-      if (update.previousPath && tab.path === update.previousPath) return update.nextPath;
+      if (update.previousPath) return replaceMovedPath(tab.path, update.previousPath, update.nextPath);
       return tab.path;
     };
     const primaryFilePath = resolveUpdatedPath(primaryTab);

--- a/apps/desktop/src/lib/path-move.ts
+++ b/apps/desktop/src/lib/path-move.ts
@@ -1,0 +1,19 @@
+export function normalizeMovedPath(path: string) {
+  return path.replace(/\\/gu, "/").replace(/\/+$/u, "");
+}
+
+function nativePathSeparator(path: string) {
+  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+}
+
+export function replaceMovedPath(path: string, previousPath: string, nextPath: string) {
+  const normalizedPath = normalizeMovedPath(path);
+  const normalizedPreviousPath = normalizeMovedPath(previousPath);
+
+  if (normalizedPath === normalizedPreviousPath) return nextPath;
+  if (!normalizedPath.startsWith(`${normalizedPreviousPath}/`)) return path;
+
+  const separator = nativePathSeparator(nextPath);
+  const suffix = normalizedPath.slice(normalizedPreviousPath.length + 1).split("/").join(separator);
+  return `${nextPath.replace(/[\\/]+$/u, "")}${separator}${suffix}`;
+}

--- a/apps/desktop/src/lib/tauri/file.test.ts
+++ b/apps/desktop/src/lib/tauri/file.test.ts
@@ -13,6 +13,7 @@ import {
   installNativeMarkdownFileDrop,
   listenNativeOpenedMarkdownPaths,
   listNativeMarkdownFilesForPath,
+  moveNativeMarkdownTreeFile,
   takeNativeOpenedMarkdownPaths,
   openNativeMarkdownFolder,
   openNativeMarkdownFile,
@@ -344,12 +345,13 @@ describe("native file access", () => {
     });
   });
 
-  it("creates folders, creates files, renames files, and deletes files through Tauri commands", async () => {
+  it("creates folders, creates files, moves files, renames files, and deletes files through Tauri commands", async () => {
     mockedInvoke
       .mockResolvedValueOnce({ kind: "folder", path: "/mock-files/Research", relativePath: "Research" })
       .mockResolvedValueOnce({ kind: "folder", path: "/mock-files/docs/Sprint", relativePath: "docs/Sprint" })
       .mockResolvedValueOnce({ path: "/mock-files/Daily note.md", relativePath: "Daily note.md" })
       .mockResolvedValueOnce({ path: "/mock-files/Template note.md", relativePath: "Template note.md" })
+      .mockResolvedValueOnce({ path: "/mock-files/docs/readme.md", relativePath: "docs/readme.md" })
       .mockResolvedValueOnce({ path: "/mock-files/Renamed.md", relativePath: "Renamed.md" })
       .mockResolvedValueOnce(undefined);
 
@@ -372,6 +374,11 @@ describe("native file access", () => {
     });
     await createNativeMarkdownTreeFile(mockFolderPath, "Template note", {
       contents: "# Template note\n\nFrom template."
+    });
+    await expect(moveNativeMarkdownTreeFile(mockFolderPath, mockReadmePath, "/mock-files/docs")).resolves.toEqual({
+      name: "readme.md",
+      path: "/mock-files/docs/readme.md",
+      relativePath: "docs/readme.md"
     });
     await expect(renameNativeMarkdownTreeFile(mockFolderPath, mockReadmePath, "Renamed.md")).resolves.toEqual({
       name: "Renamed.md",
@@ -401,12 +408,17 @@ describe("native file access", () => {
       rootPath: mockFolderPath,
       contents: "# Template note\n\nFrom template."
     });
-    expect(mockedInvoke).toHaveBeenNthCalledWith(5, "rename_markdown_tree_file", {
+    expect(mockedInvoke).toHaveBeenNthCalledWith(5, "move_markdown_tree_file", {
+      path: mockReadmePath,
+      rootPath: mockFolderPath,
+      targetParentPath: "/mock-files/docs"
+    });
+    expect(mockedInvoke).toHaveBeenNthCalledWith(6, "rename_markdown_tree_file", {
       fileName: "Renamed.md",
       path: mockReadmePath,
       rootPath: mockFolderPath
     });
-    expect(mockedInvoke).toHaveBeenNthCalledWith(6, "delete_markdown_tree_file", {
+    expect(mockedInvoke).toHaveBeenNthCalledWith(7, "delete_markdown_tree_file", {
       path: "/mock-files/Renamed.md",
       rootPath: mockFolderPath
     });

--- a/apps/desktop/src/lib/tauri/file.ts
+++ b/apps/desktop/src/lib/tauri/file.ts
@@ -411,6 +411,20 @@ export async function renameNativeMarkdownTreeFile(
   return markdownFolderFileFromResponse(file);
 }
 
+export async function moveNativeMarkdownTreeFile(
+  rootPath: string,
+  path: string,
+  targetParentPath: string | null = null
+): Promise<NativeMarkdownFolderFile> {
+  const file = await invoke<MarkdownFolderFileResponse>("move_markdown_tree_file", {
+    path,
+    rootPath,
+    targetParentPath: normalizeNativeParentPath(targetParentPath)
+  });
+
+  return markdownFolderFileFromResponse(file);
+}
+
 export async function deleteNativeMarkdownTreeFile(rootPath: string, path: string) {
   await invoke("delete_markdown_tree_file", {
     path,


### PR DESCRIPTION
## Summary
- Add a native move command for Markdown tree files, image assets, and folders with root-boundary, descendant, and conflict checks.
- Let the file tree use pointer-based dragging with a visible drag overlay; files and folders can drop onto folder rows, expanded child lists, or the root.
- Highlight the active drop target with shared folder-row and child-list background feedback.
- Keep open document/image/side-by-side paths in sync after moves.
- Make root-level New actions default to the active file's parent folder when a folder root is open.

## Edge Cases Checked
- Dropping a root-level item back onto the root is ignored instead of firing a no-op move.
- Dropping a folder onto its own expanded child list is ignored.
- Nested expanded child lists choose the innermost folder as the move target.
- Native moves support `targetParentPath = null` for moving back to the vault root.

## Validation
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml markdown_tree --lib` passed.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml markdown_files --lib` passed.
- `pnpm --filter @markra/desktop test -- MarkdownFileTreeDrawer.test.tsx useMarkdownFileTree.test.tsx useMarkdownDocument.test.tsx useSideBySideTabs.test.tsx file.test.ts --runInBand` passed.
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check` passed.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed; Vite still reports the existing large-chunk warning.

Closes #117