### PR TITLE
fix(editor): keep dollar amounts out of math rendering

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1097,6 +1097,17 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
   });
 
+  it("keeps dollar-prefixed amounts as plain markdown text", async () => {
+    const source = "Invoice options: $1000、 $100";
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-inline")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
+    expect(view.state.doc.textContent).toBe(source);
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(source);
+  });
+
   it("applies display math macro definitions to later formulas", async () => {
     const macroDefinition = ["$$", String.raw`\newcommand{\RR}{\mathbb{R}}`, "$$"].join("\n");
     const source = [macroDefinition, "", String.raw`The domain is $\RR$.`].join("\n");

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -359,6 +359,28 @@ function findClosingDelimiter(text: string, delimiter: "$" | "$$", from: number)
   return -1;
 }
 
+function readCurrencyAmountEnd(text: string, dollarIndex: number) {
+  if (!/\d/u.test(text[dollarIndex + 1] ?? "")) return null;
+
+  let cursor = dollarIndex + 1;
+  while (cursor < text.length && /[\d,.]/u.test(text[cursor] ?? "")) cursor += 1;
+  return cursor;
+}
+
+function hasMathOperatorSyntax(text: string) {
+  return /[\\=+\-*/^_{}<>]/u.test(text);
+}
+
+function looksLikeCurrencyAmountSpill(text: string, openingIndex: number, closingIndex: number) {
+  const amountEnd = readCurrencyAmountEnd(text, openingIndex);
+  if (amountEnd === null || amountEnd >= closingIndex) return false;
+
+  const textBetweenAmountAndClosing = text.slice(amountEnd, closingIndex);
+  if (hasMathOperatorSyntax(textBetweenAmountAndClosing)) return false;
+
+  return /[\s\p{P}]/u.test(text[amountEnd] ?? "");
+}
+
 function getMathRanges(text: string) {
   const ranges: MathRange[] = [];
   let index = 0;
@@ -399,6 +421,11 @@ function getMathRanges(text: string) {
 
     const closingIndex = findClosingDelimiter(text, "$", index + 1);
     if (closingIndex === -1) {
+      index += 1;
+      continue;
+    }
+
+    if (looksLikeCurrencyAmountSpill(text, index, closingIndex)) {
       index += 1;
       continue;
     }


### PR DESCRIPTION
## Summary
- Prevent dollar-prefixed amounts such as `$1000、 $100` from being folded into inline KaTeX.
- Add a MarkdownPaper regression test for plain currency text.

## Why
- The inline math scanner paired separate currency dollar signs and treated the text between them as formula source.

## Validation
- `pnpm --filter @markra/desktop test -- MarkdownPaper.test.tsx --runInBand` passed: 46 test files, 800 tests.
- `pnpm --filter @markra/editor build` passed.

## Risk
- Low. The change only skips single-dollar math candidates that begin as a currency amount and spill into punctuation or whitespace before the closing dollar.