### PR TITLE
feat(editor): support Hugo math delimiters

### DIFF
--- a/apps/desktop/src/components/MarkdownExportDocument.test.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.test.tsx
@@ -59,6 +59,40 @@ describe("MarkdownExportDocument", () => {
     expect(bodyHtml).not.toContain("language-math");
   });
 
+  it("renders Hugo-style inline and display math before exporting HTML", async () => {
+    const onRendered = vi.fn();
+
+    render(
+      <MarkdownExportDocument
+        onRendered={onRendered}
+        snapshot={{
+          id: 1,
+          kind: "pdf",
+          markdown: [
+            String.raw`Inline \(x^2\) formula.`,
+            "",
+            String.raw`\[`,
+            String.raw`\begin{aligned}`,
+            String.raw`x &= a \\`,
+            String.raw`- y &= b`,
+            String.raw`\end{aligned}`,
+            String.raw`\]`
+          ].join("\n"),
+          title: "hugo-math.md"
+        }}
+      />
+    );
+
+    await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
+
+    const bodyHtml = onRendered.mock.calls[0]?.[0].bodyHtml as string;
+    expect(bodyHtml).toContain("markra-math-render-inline");
+    expect(bodyHtml).toContain("markra-math-render-display");
+    expect(bodyHtml).toContain("katex");
+    expect(bodyHtml).not.toContain("<ul>");
+    expect(bodyHtml).not.toContain("language-math");
+  });
+
   it("applies display math macro definitions before exporting HTML", async () => {
     const onRendered = vi.fn();
 

--- a/apps/desktop/src/components/MarkdownExportDocument.tsx
+++ b/apps/desktop/src/components/MarkdownExportDocument.tsx
@@ -8,6 +8,7 @@ import {
   isMarkraMathMacroDefinitionSource,
   isMermaidLanguage,
   mermaidThemeFromElement,
+  remarkHugoMath,
   renderMarkraMathToString,
   renderMermaidToSvg,
   type MarkraMathMacros
@@ -241,7 +242,7 @@ export function MarkdownExportDocument({
     >
       <article className="markdown-paper markdown-export-paper" ref={articleRef}>
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
+          remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkHugoMath]}
           components={{
             a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
             blockquote: ({ node: _node, ...props }) =>

--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -1104,6 +1104,35 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
   });
 
+  it("renders Hugo-style inline and display math formulas while preserving markdown source", async () => {
+    const inlineFormula = String.raw`\(a^2 + b^2 = c^2\)`;
+    const displayFormula = [
+      String.raw`\[`,
+      String.raw`\begin{aligned}`,
+      String.raw`x &= a \\`,
+      String.raw`- y &= b`,
+      String.raw`\end{aligned}`,
+      String.raw`\]`
+    ].join("\n");
+    const source = [`Where ${inlineFormula}.`, "", displayFormula].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-inline .katex")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-math-render-display .katex")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror ul")).not.toBeInTheDocument();
+    const hiddenMathSource = Array.from(container.querySelectorAll(".ProseMirror .markra-math-source-hidden"))
+      .map((node) => node.textContent)
+      .join("");
+    expect(hiddenMathSource).toContain(inlineFormula);
+    expect(hiddenMathSource).toContain(String.raw`\begin{aligned}`);
+    expect(hiddenMathSource).toContain("- y &= b");
+    expect(hiddenMathSource).toContain(String.raw`\]`);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(`Where ${inlineFormula}.`);
+    expect(serializeMarkdown(view.state.doc)).toContain(displayFormula);
+  });
+
   it("keeps dollar-prefixed amounts as plain markdown text", async () => {
     const source = "Invoice options: $1000、 $100";
     const { container, editor, view } = await renderEditor(source);
@@ -1172,6 +1201,23 @@ describe("MarkdownPaper editing", () => {
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain(["$$", String.raw`\int_0^1 x^2 \, dx`, "$$"].join("\n"));
+  });
+
+  it("renders Hugo-style multiline display math when typed directly", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    typeText(view, String.raw`\[`);
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, String.raw`\int_0^1 x^2 \, dx`);
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, String.raw`\]`);
+
+    expect(container.querySelector(".ProseMirror .markra-math-render-display .katex")).toBeInTheDocument();
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(
+      [String.raw`\[`, String.raw`\int_0^1 x^2 \, dx`, String.raw`\]`].join("\n")
+    );
   });
 
   it("renders ordinary paragraph line breaks without requiring explicit br tags", async () => {

--- a/packages/editor/src/hugo-math.ts
+++ b/packages/editor/src/hugo-math.ts
@@ -1,0 +1,430 @@
+import type { MarkdownNode } from "@milkdown/kit/transformer";
+
+type HugoMathKind = "display" | "inline";
+type MicromarkCode = number | null;
+type MicromarkStateResult = MicromarkState | unknown;
+type MicromarkState = (code: MicromarkCode) => MicromarkStateResult;
+type MicromarkToken = {
+  type: string;
+};
+type MicromarkEffects = {
+  attempt: (construct: MicromarkConstruct, ok: MicromarkState, nok: MicromarkState) => MicromarkState;
+  consume: (code: MicromarkCode) => unknown;
+  enter: (type: string) => MicromarkToken;
+  exit: (type: string) => unknown;
+};
+type MicromarkConstruct = {
+  concrete?: boolean;
+  name: string;
+  partial?: boolean;
+  previous?: (code: MicromarkCode) => boolean;
+  tokenize: (effects: MicromarkEffects, ok: MicromarkState, nok: MicromarkState) => MicromarkState;
+};
+type HugoMathCompileContext = {
+  buffer: () => unknown;
+  config: {
+    enter: {
+      data: (this: HugoMathCompileContext, token: unknown) => unknown;
+    };
+    exit: {
+      data: (this: HugoMathCompileContext, token: unknown) => unknown;
+    };
+  };
+  data: Record<string, unknown>;
+  enter: (node: MarkdownNode, token: unknown) => unknown;
+  exit: (token: unknown) => unknown;
+  resume: () => string;
+  stack: MarkdownNode[];
+};
+
+type MathMarkdownNode = MarkdownNode & {
+  data?: unknown;
+  value?: string;
+};
+
+type RemarkProcessorData = {
+  fromMarkdownExtensions?: unknown[];
+  micromarkExtensions?: unknown[];
+};
+
+const micromarkCodes = {
+  backslash: 92,
+  carriageReturn: -5,
+  carriageReturnLineFeed: -3,
+  horizontalTab: -2,
+  leftParenthesis: 40,
+  leftSquareBracket: 91,
+  lineFeed: -4,
+  rightParenthesis: 41,
+  rightSquareBracket: 93,
+  space: 32,
+  virtualSpace: -1
+} as const;
+const micromarkTypes = {
+  lineEnding: "lineEnding",
+  linePrefix: "linePrefix",
+  whitespace: "whitespace"
+} as const;
+const hugoMathFlowType = "markraHugoMathFlow";
+const hugoMathFlowDataType = "markraHugoMathFlowValue";
+const hugoMathFlowFenceType = "markraHugoMathFlowFence";
+const hugoMathFlowSequenceType = "markraHugoMathFlowFenceSequence";
+const hugoMathFlowInsideKey = "markraHugoMathFlowInside";
+const hugoMathTextType = "markraHugoMathText";
+const hugoMathTextDataType = "markraHugoMathTextData";
+const hugoMathTextSequenceType = "markraHugoMathTextSequence";
+
+function isMicromarkLineEnding(code: MicromarkCode) {
+  return (
+    code === micromarkCodes.carriageReturn ||
+    code === micromarkCodes.lineFeed ||
+    code === micromarkCodes.carriageReturnLineFeed
+  );
+}
+
+function isMicromarkSpace(code: MicromarkCode) {
+  return (
+    code === micromarkCodes.horizontalTab ||
+    code === micromarkCodes.space ||
+    code === micromarkCodes.virtualSpace
+  );
+}
+
+function markraHugoMathPrevious(code: MicromarkCode) {
+  return code !== micromarkCodes.backslash;
+}
+
+function consumeMicromarkSpace(
+  effects: MicromarkEffects,
+  ok: MicromarkState,
+  type: string,
+  max?: number
+): MicromarkState {
+  let size = 0;
+
+  return start;
+
+  function start(code: MicromarkCode): MicromarkStateResult {
+    if (!isMicromarkSpace(code) || (typeof max === "number" && size >= max)) return ok(code);
+
+    effects.enter(type);
+    return space(code);
+  }
+
+  function space(code: MicromarkCode): MicromarkStateResult {
+    if (isMicromarkSpace(code) && (typeof max !== "number" || size < max)) {
+      effects.consume(code);
+      size += 1;
+      return space;
+    }
+
+    effects.exit(type);
+    return ok(code);
+  }
+}
+
+function createMathMarkdownData(kind: HugoMathKind, value: string) {
+  return kind === "display"
+    ? {
+        hChildren: [
+          {
+            children: [{ type: "text", value }],
+            properties: { className: ["language-math", "math-display"] },
+            tagName: "code",
+            type: "element"
+          }
+        ],
+        hName: "pre"
+      }
+    : {
+        hChildren: [{ type: "text", value }],
+        hName: "code",
+        hProperties: {
+          className: ["language-math", "math-inline"]
+        }
+      };
+}
+
+function markraHugoMathFlow(): MicromarkConstruct {
+  return {
+    concrete: true,
+    name: hugoMathFlowType,
+    tokenize(effects, ok, nok) {
+      return start;
+
+      function start(code: MicromarkCode): MicromarkStateResult {
+        if (code !== micromarkCodes.backslash) return nok(code);
+
+        effects.enter(hugoMathFlowType);
+        effects.enter(hugoMathFlowFenceType);
+        effects.enter(hugoMathFlowSequenceType);
+        effects.consume(code);
+        return openingDelimiter;
+      }
+
+      function openingDelimiter(code: MicromarkCode): MicromarkStateResult {
+        if (code !== micromarkCodes.leftSquareBracket) return nok(code);
+
+        effects.consume(code);
+        effects.exit(hugoMathFlowSequenceType);
+        return consumeMicromarkSpace(effects, openingLineEnd, micromarkTypes.whitespace);
+      }
+
+      function openingLineEnd(code: MicromarkCode): MicromarkStateResult {
+        if (code === null) {
+          effects.exit(hugoMathFlowFenceType);
+          effects.exit(hugoMathFlowType);
+          return ok(code);
+        }
+
+        if (!isMicromarkLineEnding(code)) return nok(code);
+
+        effects.exit(hugoMathFlowFenceType);
+        return beforeContent(code);
+      }
+
+      function beforeContent(code: MicromarkCode): MicromarkStateResult {
+        if (code === null) {
+          effects.exit(hugoMathFlowType);
+          return ok(code);
+        }
+
+        if (isMicromarkLineEnding(code)) {
+          effects.enter(micromarkTypes.lineEnding);
+          effects.consume(code);
+          effects.exit(micromarkTypes.lineEnding);
+          return lineStart;
+        }
+
+        return lineStart(code);
+      }
+
+      function lineStart(code: MicromarkCode): MicromarkStateResult {
+        return effects.attempt(
+          {
+            name: `${hugoMathFlowType}ClosingFence`,
+            partial: true,
+            tokenize: tokenizeHugoMathFlowClosingFence
+          },
+          after,
+          contentStart
+        )(code);
+      }
+
+      function contentStart(code: MicromarkCode): MicromarkStateResult {
+        if (code === null) return after(code);
+        if (isMicromarkLineEnding(code)) return beforeContent(code);
+
+        effects.enter(hugoMathFlowDataType);
+        return contentChunk(code);
+      }
+
+      function contentChunk(code: MicromarkCode): MicromarkStateResult {
+        if (code === null || isMicromarkLineEnding(code)) {
+          effects.exit(hugoMathFlowDataType);
+          return beforeContent(code);
+        }
+
+        effects.consume(code);
+        return contentChunk;
+      }
+
+      function after(code: MicromarkCode): MicromarkStateResult {
+        effects.exit(hugoMathFlowType);
+        return ok(code);
+      }
+    }
+  };
+}
+
+function tokenizeHugoMathFlowClosingFence(
+  effects: MicromarkEffects,
+  ok: MicromarkState,
+  nok: MicromarkState
+): MicromarkState {
+  return consumeMicromarkSpace(effects, beforeSequenceClose, micromarkTypes.linePrefix, 3);
+
+  function beforeSequenceClose(code: MicromarkCode): MicromarkStateResult {
+    if (code !== micromarkCodes.backslash) return nok(code);
+
+    effects.enter(hugoMathFlowFenceType);
+    effects.enter(hugoMathFlowSequenceType);
+    effects.consume(code);
+    return sequenceClose;
+  }
+
+  function sequenceClose(code: MicromarkCode): MicromarkStateResult {
+    if (code !== micromarkCodes.rightSquareBracket) return nok(code);
+
+    effects.consume(code);
+    effects.exit(hugoMathFlowSequenceType);
+    return consumeMicromarkSpace(effects, afterSequenceClose, micromarkTypes.whitespace);
+  }
+
+  function afterSequenceClose(code: MicromarkCode): MicromarkStateResult {
+    if (code === null || isMicromarkLineEnding(code)) {
+      effects.exit(hugoMathFlowFenceType);
+      return ok(code);
+    }
+
+    return nok(code);
+  }
+}
+
+function markraHugoMathText(): MicromarkConstruct {
+  return {
+    name: hugoMathTextType,
+    previous: markraHugoMathPrevious,
+    tokenize(effects, ok, nok) {
+      let closingCode: typeof micromarkCodes.rightParenthesis | typeof micromarkCodes.rightSquareBracket;
+      let sequenceToken: MicromarkToken;
+
+      return start;
+
+      function start(code: MicromarkCode): MicromarkStateResult {
+        if (code !== micromarkCodes.backslash) return nok(code);
+
+        effects.enter(hugoMathTextType);
+        effects.enter(hugoMathTextSequenceType);
+        effects.consume(code);
+        return openingDelimiter;
+      }
+
+      function openingDelimiter(code: MicromarkCode): MicromarkStateResult {
+        if (code === micromarkCodes.leftParenthesis) {
+          closingCode = micromarkCodes.rightParenthesis;
+        } else if (code === micromarkCodes.leftSquareBracket) {
+          closingCode = micromarkCodes.rightSquareBracket;
+        } else {
+          return nok(code);
+        }
+
+        effects.consume(code);
+        effects.exit(hugoMathTextSequenceType);
+        return between;
+      }
+
+      function between(code: MicromarkCode): MicromarkStateResult {
+        if (code === null) return nok(code);
+
+        if (code === micromarkCodes.backslash) {
+          sequenceToken = effects.enter(hugoMathTextSequenceType);
+          effects.consume(code);
+          return closingDelimiter;
+        }
+
+        if (isMicromarkLineEnding(code)) {
+          effects.enter(micromarkTypes.lineEnding);
+          effects.consume(code);
+          effects.exit(micromarkTypes.lineEnding);
+          return between;
+        }
+
+        effects.enter(hugoMathTextDataType);
+        return data(code);
+      }
+
+      function data(code: MicromarkCode): MicromarkStateResult {
+        if (code === null || code === micromarkCodes.backslash || isMicromarkLineEnding(code)) {
+          effects.exit(hugoMathTextDataType);
+          return between(code);
+        }
+
+        effects.consume(code);
+        return data;
+      }
+
+      function closingDelimiter(code: MicromarkCode): MicromarkStateResult {
+        if (code === closingCode) {
+          effects.consume(code);
+          effects.exit(hugoMathTextSequenceType);
+          effects.exit(hugoMathTextType);
+          return ok;
+        }
+
+        sequenceToken.type = hugoMathTextDataType;
+        return data(code);
+      }
+    }
+  };
+}
+
+export function markraHugoMathSyntax() {
+  return {
+    flow: {
+      [micromarkCodes.backslash]: markraHugoMathFlow()
+    },
+    text: {
+      [micromarkCodes.backslash]: markraHugoMathText()
+    }
+  };
+}
+
+export function markraHugoMathFromMarkdown() {
+  return {
+    enter: {
+      [hugoMathFlowType]: function enterHugoMathFlow(this: HugoMathCompileContext, token: unknown) {
+        this.enter(
+          {
+            data: createMathMarkdownData("display", ""),
+            meta: null,
+            type: "math",
+            value: ""
+          },
+          token
+        );
+      },
+      [hugoMathTextType]: function enterHugoMathText(this: HugoMathCompileContext, token: unknown) {
+        this.enter(
+          {
+            data: createMathMarkdownData("inline", ""),
+            type: "inlineMath",
+            value: ""
+          },
+          token
+        );
+        this.buffer();
+      }
+    },
+    exit: {
+      [hugoMathFlowDataType]: function exitHugoMathFlowData(this: HugoMathCompileContext, token: unknown) {
+        this.config.enter.data.call(this, token);
+        this.config.exit.data.call(this, token);
+      },
+      [hugoMathFlowFenceType]: function exitHugoMathFlowFence(this: HugoMathCompileContext) {
+        if (this.data[hugoMathFlowInsideKey]) return;
+
+        this.buffer();
+        this.data[hugoMathFlowInsideKey] = true;
+      },
+      [hugoMathFlowType]: function exitHugoMathFlow(this: HugoMathCompileContext, token: unknown) {
+        const data = this.resume().replace(/^(\r?\n|\r)|(\r?\n|\r)$/gu, "");
+        const node = this.stack[this.stack.length - 1] as MathMarkdownNode;
+        this.exit(token);
+        node.value = data;
+        node.data = createMathMarkdownData("display", data);
+        this.data[hugoMathFlowInsideKey] = undefined;
+      },
+      [hugoMathTextDataType]: function exitHugoMathTextData(this: HugoMathCompileContext, token: unknown) {
+        this.config.enter.data.call(this, token);
+        this.config.exit.data.call(this, token);
+      },
+      [hugoMathTextType]: function exitHugoMathText(this: HugoMathCompileContext, token: unknown) {
+        const data = this.resume();
+        const node = this.stack[this.stack.length - 1] as MathMarkdownNode;
+        this.exit(token);
+        node.value = data;
+        node.data = createMathMarkdownData("inline", data);
+      }
+    }
+  };
+}
+
+export function remarkHugoMath(this: { data: () => RemarkProcessorData }) {
+  const data = this.data();
+  const micromarkExtensions = data.micromarkExtensions ?? (data.micromarkExtensions = []);
+  const fromMarkdownExtensions = data.fromMarkdownExtensions ?? (data.fromMarkdownExtensions = []);
+
+  micromarkExtensions.push(markraHugoMathSyntax());
+  fromMarkdownExtensions.push(markraHugoMathFromMarkdown());
+}

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -5,6 +5,9 @@ import type { MarkdownNode } from "@milkdown/kit/transformer";
 import { $prose, $remark } from "@milkdown/kit/utils";
 import { renderToString, type KatexOptions } from "katex";
 import remarkMath from "remark-math";
+import { remarkHugoMath } from "./hugo-math.ts";
+
+export { remarkHugoMath } from "./hugo-math.ts";
 
 export type MarkraMathKind = "display" | "inline";
 export type MarkraMathMacros = NonNullable<KatexOptions["macros"]>;
@@ -195,6 +198,12 @@ type MarkdownSerializerState = {
   enter: (name: string) => () => unknown;
 };
 
+type RemarkProcessorData = {
+  fromMarkdownExtensions?: unknown[];
+  micromarkExtensions?: unknown[];
+  toMarkdownExtensions?: unknown[];
+};
+
 function mathSourceFromPosition(markdown: string, node: MathMarkdownNode, fallback: string) {
   const start = node.position?.start?.offset;
   const end = node.position?.end?.offset;
@@ -291,6 +300,42 @@ function isDisplayMathSource(source: string) {
   return ranges.length === 1 && ranges[0]?.kind === "display" && ranges[0].from === 0 && ranges[0].to === source.length;
 }
 
+function isHugoMathRange(range: MathRange) {
+  return range.source.startsWith("\\(") || range.source.startsWith("\\[");
+}
+
+function serializeMarkdownSourceSegment(source: string, state: MarkdownSerializerState, info: MarkdownSerializerInfo) {
+  if (!source) return "";
+
+  return state.containerPhrasing(
+    {
+      children: sourceToInlineMarkdownNodes(source),
+      type: "paragraph"
+    },
+    info
+  );
+}
+
+function serializeHugoMathAwareParagraphSource(
+  source: string,
+  state: MarkdownSerializerState,
+  info: MarkdownSerializerInfo
+) {
+  const ranges = getMathRanges(source);
+  if (!ranges.some(isHugoMathRange)) return null;
+
+  let cursor = 0;
+  let value = "";
+  for (const range of ranges) {
+    value += serializeMarkdownSourceSegment(source.slice(cursor, range.from), state, info);
+    value += range.source;
+    cursor = range.to;
+  }
+
+  value += serializeMarkdownSourceSegment(source.slice(cursor), state, info);
+  return value;
+}
+
 function serializeMathAwareParagraph(
   node: MarkdownNode,
   _parent: MarkdownNode | undefined,
@@ -302,13 +347,16 @@ function serializeMathAwareParagraph(
 
   const exit = state.enter("paragraph");
   const subexit = state.enter("phrasing");
-  const value = state.containerPhrasing(node, info);
+  const value =
+    source === null
+      ? state.containerPhrasing(node, info)
+      : serializeHugoMathAwareParagraphSource(source, state, info) ?? state.containerPhrasing(node, info);
   subexit();
   exit();
   return value;
 }
 
-function remarkMathParseOnly(this: { data: () => { toMarkdownExtensions?: unknown[] } }) {
+function remarkMathParseOnly(this: { data: () => RemarkProcessorData }) {
   const dataBeforeMath = this.data();
   const toMarkdownExtensionCount = dataBeforeMath.toMarkdownExtensions?.length ?? 0;
 
@@ -316,6 +364,8 @@ function remarkMathParseOnly(this: { data: () => { toMarkdownExtensions?: unknow
   remarkMath.call(this);
 
   const dataAfterMath = this.data();
+  remarkHugoMath.call(this);
+
   if (!Array.isArray(dataAfterMath.toMarkdownExtensions)) return;
 
   dataAfterMath.toMarkdownExtensions.splice(toMarkdownExtensionCount);
@@ -359,6 +409,15 @@ function findClosingDelimiter(text: string, delimiter: "$" | "$$", from: number)
   return -1;
 }
 
+function findClosingBracketMathDelimiter(text: string, delimiter: "\\)" | "\\]", from: number) {
+  for (let index = from; index < text.length - 1; index += 1) {
+    if (text[index] !== "\\" || isEscaped(text, index)) continue;
+    if (text.startsWith(delimiter, index)) return index;
+  }
+
+  return -1;
+}
+
 function readCurrencyAmountEnd(text: string, dollarIndex: number) {
   if (!/\d/u.test(text[dollarIndex + 1] ?? "")) return null;
 
@@ -386,6 +445,52 @@ function getMathRanges(text: string) {
   let index = 0;
 
   while (index < text.length) {
+    if (text.startsWith("\\(", index) && !isEscaped(text, index)) {
+      const closingIndex = findClosingBracketMathDelimiter(text, "\\)", index + 2);
+      if (closingIndex === -1) {
+        index += 2;
+        continue;
+      }
+
+      const to = closingIndex + 2;
+      const tex = text.slice(index + 2, closingIndex).trim();
+      if (tex) {
+        ranges.push({
+          from: index,
+          kind: "inline",
+          source: text.slice(index, to),
+          tex,
+          to
+        });
+      }
+
+      index = to;
+      continue;
+    }
+
+    if (text.startsWith("\\[", index) && !isEscaped(text, index)) {
+      const closingIndex = findClosingBracketMathDelimiter(text, "\\]", index + 2);
+      if (closingIndex === -1) {
+        index += 2;
+        continue;
+      }
+
+      const to = closingIndex + 2;
+      const tex = text.slice(index + 2, closingIndex).trim();
+      if (tex) {
+        ranges.push({
+          from: index,
+          kind: "display",
+          source: text.slice(index, to),
+          tex,
+          to
+        });
+      }
+
+      index = to;
+      continue;
+    }
+
     if (text[index] !== "$" || isEscaped(text, index)) {
       index += 1;
       continue;
@@ -605,8 +710,13 @@ function renderMathRange(range: MathRange, macros: MarkraMathMacros): MathRange 
   }
 }
 
+function mathDelimiterLength(range: MathRange) {
+  if (range.source.startsWith("$$") || range.source.startsWith("\\(") || range.source.startsWith("\\[")) return 2;
+  return 1;
+}
+
 function mathSourceEditPosition(range: MathRange) {
-  const delimiterLength = range.kind === "display" ? 2 : 1;
+  const delimiterLength = mathDelimiterLength(range);
   const sourceAfterDelimiter = range.source.slice(delimiterLength);
   const firstContentOffset = sourceAfterDelimiter.search(/\S/u);
   const fallbackPosition = range.from + delimiterLength;
@@ -640,11 +750,15 @@ function unclosedDisplayMathSourceBeforeCursor(state: EditorState) {
   if (!$from.parent.isTextblock || $from.parent.type.spec.code) return null;
 
   const textBeforeCursor = $from.parent.textBetween(0, $from.parentOffset, "\n", "\n");
-  const openingMatch = /^\s*\$\$(?!\$)/u.exec(textBeforeCursor);
+  const openingMatch = /^\s*(\$\$(?!\$)|\\\[)/u.exec(textBeforeCursor);
   if (!openingMatch) return null;
 
-  const openingIndex = openingMatch[0].lastIndexOf("$$");
-  const closingIndex = findClosingDelimiter(textBeforeCursor, "$$", openingIndex + 2);
+  const openingDelimiter = openingMatch[1];
+  const openingIndex = openingMatch[0].lastIndexOf(openingDelimiter);
+  const closingIndex =
+    openingDelimiter === "$$"
+      ? findClosingDelimiter(textBeforeCursor, "$$", openingIndex + 2)
+      : findClosingBracketMathDelimiter(textBeforeCursor, "\\]", openingIndex + 2);
   if (closingIndex !== -1) return null;
 
   return textBeforeCursor;
@@ -942,7 +1056,7 @@ function createMathMacroDefinitionFoldWidget(range: MathRange) {
 
 function activeMathTokenDecorations(range: MathRange) {
   const decorations: Decoration[] = [];
-  const delimiterLength = range.kind === "display" ? 2 : 1;
+  const delimiterLength = mathDelimiterLength(range);
 
   decorations.push(
     Decoration.inline(range.from, range.from + delimiterLength, {


### PR DESCRIPTION
## Summary
- Add Hugo-style math parsing for `\(...\)` inline formulas and `\[...\]` display formulas.
- Preserve Hugo math source during editor serialization and rendered editor interactions.
- Reuse the Hugo math parser in HTML/PDF export so formulas render before export.
- Cover display formulas whose contents include Markdown-looking rows such as `- y &= b`.

## Why
Hugo recognizes `\(...\)` and `\[...\]` math delimiters, but Markra previously only handled dollar-delimited math. Those backslash delimiters could be treated as ordinary Markdown escapes, which removed the source delimiters and let display formula content be parsed as Markdown lists.

## Validation
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop test src/components/MarkdownExportDocument.test.tsx` passed, 8 tests
- `pnpm --filter @markra/desktop test src/components/MarkdownPaper.test.tsx` passed, 208 tests
- `git diff --check` passed

## Risk
- The new parser is scoped to math delimiter handling and is exercised in both editor and export tests.
- Full workspace `pnpm test` was not run locally.

Closes #131
