### PR TITLE
feat(editor): support frontmatter blocks

### DIFF
--- a/apps/desktop/src/components/MarkdownPaper.test.tsx
+++ b/apps/desktop/src/components/MarkdownPaper.test.tsx
@@ -748,6 +748,138 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain(source);
   });
 
+  it.each([
+    {
+      label: "YAML",
+      source: [
+        "---",
+        'title: "Mock post"',
+        "pubDate: 2026-01-02T03:04:05+08:00",
+        "---",
+        "",
+        "# Body"
+      ].join("\n")
+    },
+    {
+      label: "TOML",
+      source: [
+        "+++",
+        '"title" = "Mock post"',
+        '"pubDate" = "2026-01-02T03:04:05+08:00"',
+        "+++",
+        "",
+        "# Body"
+      ].join("\n")
+    },
+    {
+      label: "JSON",
+      source: [
+        "{",
+        '  "title": "Mock post",',
+        '  "pubDate": "2026-01-02T03:04:05+08:00"',
+        "}",
+        "",
+        "# Body"
+      ].join("\n")
+    }
+  ])("preserves $label frontmatter as a dedicated editor block", async ({ source }) => {
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(view.state.doc.child(0).type.name).toBe("frontmatter");
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it("preserves JSON frontmatter with blank lines inside the object", async () => {
+    const source = [
+      "{",
+      '  "title": "Mock post",',
+      "",
+      '  "description": "Draft metadata"',
+      "}",
+      "",
+      "# Body"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(view.state.doc.child(0).type.name).toBe("frontmatter");
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it("preserves JSON frontmatter with nested objects and braces inside strings", async () => {
+    const source = [
+      "{",
+      '  "title": "Mock {post}",',
+      '  "draft": true,',
+      '  "meta": {',
+      '    "description": "Synthetic } metadata"',
+      "  }",
+      "}",
+      "",
+      "# Body"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(view.state.doc.child(0).type.name).toBe("frontmatter");
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it.each([
+    {
+      label: "empty YAML",
+      source: ["---", "---", "", "# Body"].join("\n")
+    },
+    {
+      label: "empty TOML",
+      source: ["+++", "+++", "", "# Body"].join("\n")
+    },
+    {
+      label: "empty JSON",
+      source: ["{}", "", "# Body"].join("\n")
+    }
+  ])("preserves $label frontmatter", async ({ source }) => {
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(view.state.doc.child(0).type.name).toBe("frontmatter");
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it.each([
+    {
+      label: "malformed JSON object",
+      source: ["{", '  "title": "Mock post",', "}", "", "# Body"].join("\n")
+    },
+    {
+      label: "top-level JSON array",
+      source: ["[", '  "not metadata"', "]", "", "# Body"].join("\n")
+    },
+    {
+      label: "non-leading YAML block",
+      source: ["# Intro", "", "---", "title: nope", "---"].join("\n")
+    },
+    {
+      label: "inline JSON prose",
+      source: '{"title":"Mock post"} is ordinary text'
+    },
+    {
+      label: "fenced JSON code block",
+      source: ["```json", '{"title":"Mock post"}', "```", "", "# Body"].join("\n")
+    }
+  ])("does not promote $label to frontmatter", async ({ source }) => {
+    const { view } = await renderEditor(source);
+    let hasFrontmatter = false;
+
+    view.state.doc.descendants((node) => {
+      hasFrontmatter = node.type.name === "frontmatter";
+      return !hasFrontmatter;
+    });
+
+    expect(hasFrontmatter).toBe(false);
+  });
+
   it("renders Mermaid code blocks as folded diagrams and reveals source for editing", async () => {
     const source = ["```mermaid", "flowchart TD", "  A --> B", "```", "", "After"].join("\n");
     const { container, editor, view } = await renderEditor(source);

--- a/apps/desktop/src/components/MarkdownPaperSurface.tsx
+++ b/apps/desktop/src/components/MarkdownPaperSurface.tsx
@@ -15,6 +15,8 @@ import {
   markraCalloutSerializerPlugin,
   markraClipboardImagePluginWithOptions,
   markraCodeBlockPlugin,
+  markraFrontmatterRemarkPlugin,
+  markraFrontmatterSchema,
   markraHeadingLevelPlugin,
   markraHeadingTogglePlugin,
   markraListTogglePlugin,
@@ -257,8 +259,10 @@ function MilkdownEditorSurface({
         .use(markraReadOnlyTransactionGuard(readOnlyRef))
         .use(listener)
         .use(history)
+        .use(markraFrontmatterRemarkPlugin)
         .use(markraMathRemarkPlugin)
         .use(markraCommonmark)
+        .use(markraFrontmatterSchema)
         .use(markraGfm)
         .use(markraCalloutSerializerPlugin);
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,6 +22,7 @@
     "lowlight": "3.3.0",
     "mermaid": "11.15.0",
     "prosemirror-tables": "1.8.5",
+    "remark-frontmatter": "5.0.0",
     "remark-math": "6.0.0"
   },
   "devDependencies": {

--- a/packages/editor/src/frontmatter.ts
+++ b/packages/editor/src/frontmatter.ts
@@ -1,0 +1,250 @@
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import type { MarkdownNode } from "@milkdown/kit/transformer";
+import { $nodeSchema, $remark } from "@milkdown/kit/utils";
+import remarkFrontmatter from "remark-frontmatter";
+
+type MarkraFrontmatterKind = "json" | "toml" | "yaml";
+
+type MarkdownPosition = {
+  end?: {
+    offset?: number;
+  };
+  start?: {
+    offset?: number;
+  };
+};
+
+type FrontmatterMarkdownNode = MarkdownNode & {
+  kind?: unknown;
+  position?: MarkdownPosition;
+  value?: unknown;
+};
+
+type MarkdownSerializerState = {
+  enter: (name: string) => () => unknown;
+};
+
+const frontmatterKinds = ["json", "toml", "yaml"] satisfies MarkraFrontmatterKind[];
+
+function frontmatterKindFromValue(value: unknown): MarkraFrontmatterKind {
+  return frontmatterKinds.includes(value as MarkraFrontmatterKind) ? value as MarkraFrontmatterKind : "yaml";
+}
+
+function findJsonObjectEnd(markdown: string, start: number) {
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+
+  for (let index = start; index < markdown.length; index += 1) {
+    const character = markdown[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (character === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (character === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (character === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (character !== "}") continue;
+
+    depth -= 1;
+    if (depth === 0) return index + 1;
+  }
+
+  return null;
+}
+
+function looksLikeJsonFrontmatter(source: string) {
+  const trimmed = source.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return false;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return Boolean(parsed && typeof parsed === "object" && !Array.isArray(parsed));
+  } catch {
+    return false;
+  }
+}
+
+function readLeadingJsonFrontmatter(markdown: string) {
+  const start = markdown.charCodeAt(0) === 0xfeff ? 1 : 0;
+  if (markdown[start] !== "{") return null;
+
+  const end = findJsonObjectEnd(markdown, start);
+  if (end === null) return null;
+
+  let after = end;
+  while (markdown[after] === " " || markdown[after] === "\t") after += 1;
+  if (after < markdown.length && markdown[after] !== "\n" && markdown[after] !== "\r") return null;
+
+  const source = markdown.slice(start, end);
+  if (!looksLikeJsonFrontmatter(source)) return null;
+
+  return {
+    end,
+    source,
+    start
+  };
+}
+
+function markdownNodeStart(node: FrontmatterMarkdownNode) {
+  return node.position?.start?.offset;
+}
+
+function markdownNodeEnd(node: FrontmatterMarkdownNode) {
+  return node.position?.end?.offset;
+}
+
+function transformJsonFrontmatter(tree: MarkdownNode, markdown: string) {
+  if (!Array.isArray(tree.children)) return;
+
+  const frontmatter = readLeadingJsonFrontmatter(markdown);
+  if (!frontmatter) return;
+
+  let deleteCount = 0;
+  let startIndex = -1;
+
+  for (let index = 0; index < tree.children.length; index += 1) {
+    const child = tree.children[index] as FrontmatterMarkdownNode;
+    const childStart = markdownNodeStart(child);
+    const childEnd = markdownNodeEnd(child);
+    if (typeof childStart !== "number" || typeof childEnd !== "number") continue;
+    if (childEnd <= frontmatter.start) continue;
+    if (childStart >= frontmatter.end) break;
+    if (childStart < frontmatter.start || childEnd > frontmatter.end) return;
+
+    if (startIndex === -1) startIndex = index;
+    deleteCount += 1;
+  }
+
+  if (startIndex === -1 || deleteCount === 0) return;
+
+  tree.children.splice(startIndex, deleteCount, {
+    kind: "json",
+    type: "markraFrontmatter",
+    value: frontmatter.source
+  });
+}
+
+function serializeJsonFrontmatter(node: FrontmatterMarkdownNode, _parent: MarkdownNode | undefined, state: MarkdownSerializerState) {
+  const exit = state.enter("markraFrontmatter");
+  const value = typeof node.value === "string" ? node.value : "";
+  exit();
+  return value;
+}
+
+function markraFrontmatterRemark(this: { data: () => { toMarkdownExtensions?: unknown[] } }) {
+  remarkFrontmatter.call(this, ["yaml", "toml"]);
+
+  const data = this.data();
+  if (!Array.isArray(data.toMarkdownExtensions)) {
+    data.toMarkdownExtensions = [];
+  }
+
+  data.toMarkdownExtensions.push({
+    handlers: {
+      markraFrontmatter: serializeJsonFrontmatter
+    }
+  });
+
+  return (tree: unknown, file: { value?: unknown }) => {
+    transformJsonFrontmatter(tree as MarkdownNode, String(file.value ?? ""));
+  };
+}
+
+export const markraFrontmatterRemarkPlugin = $remark<"markraFrontmatterRemark", undefined>(
+  "markraFrontmatterRemark",
+  () => markraFrontmatterRemark
+);
+
+export const markraFrontmatterSchema = $nodeSchema("frontmatter", () => ({
+  attrs: {
+    kind: {
+      default: "yaml",
+      validate: "string"
+    }
+  },
+  code: true,
+  content: "text*",
+  defining: true,
+  group: "block",
+  marks: "",
+  parseDOM: [{
+    getAttrs: (dom) => {
+      if (!(dom instanceof HTMLElement)) return false;
+
+      return {
+        kind: frontmatterKindFromValue(dom.dataset.frontmatterKind)
+      };
+    },
+    preserveWhitespace: "full",
+    tag: 'pre[data-type="frontmatter"]'
+  }],
+  parseMarkdown: {
+    match: (node) => ["markraFrontmatter", "toml", "yaml"].includes(String(node.type)),
+    runner: (state, node: FrontmatterMarkdownNode, type) => {
+      const kind = node.type === "yaml" || node.type === "toml"
+        ? node.type
+        : frontmatterKindFromValue(node.kind);
+
+      state.openNode(type, { kind });
+      if (typeof node.value === "string" && node.value.length > 0) {
+        state.addText(node.value);
+      }
+      state.closeNode();
+    }
+  },
+  toDOM: (node: ProseNode) => {
+    const kind = frontmatterKindFromValue(node.attrs.kind);
+
+    return [
+      "pre",
+      {
+        class: "markra-frontmatter",
+        "data-frontmatter-kind": kind,
+        "data-type": "frontmatter"
+      },
+      [
+        "code",
+        {
+          "data-frontmatter-kind": kind
+        },
+        0
+      ]
+    ];
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === "frontmatter",
+    runner: (state, node) => {
+      const kind = frontmatterKindFromValue(node.attrs.kind);
+      const value = node.textContent;
+
+      if (kind === "json") {
+        state.addNode("markraFrontmatter", undefined, value, { kind });
+        return;
+      }
+
+      state.addNode(kind, undefined, value);
+    }
+  }
+}));

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -3,6 +3,7 @@ export * from "./block-drag.ts";
 export * from "./callout.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
+export * from "./frontmatter.ts";
 export * from "./heading-level.ts";
 export * from "./heading-toggle.ts";
 export * from "./input-rules.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       prosemirror-tables:
         specifier: 1.8.5
         version: 1.8.5
+      remark-frontmatter:
+        specifier: 5.0.0
+        version: 5.0.0
       remark-math:
         specifier: 6.0.0
         version: 6.0.0
@@ -2219,6 +2222,9 @@ packages:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2231,6 +2237,10 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -2507,6 +2517,9 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -2560,6 +2573,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -2852,6 +2868,9 @@ packages:
 
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -5873,6 +5892,10 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -5881,6 +5904,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  format@0.2.2: {}
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -6182,6 +6207,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6370,6 +6406,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -6817,6 +6860,15 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Add an editor frontmatter block for YAML, TOML, and leading JSON metadata.
- Preserve frontmatter through Milkdown parse/serialize instead of rewriting it as ordinary Markdown.
- Add regression coverage for empty frontmatter, nested JSON, blank lines, and non-frontmatter false positives.

## Why
Users need a small metadata section at the top of Markdown documents without Markra auto-formatting it into native Markdown blocks.

## Validation
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop test` passed, 47 files / 844 tests
- `pnpm --filter @markra/desktop build` passed

## Risk
- JSON frontmatter has no explicit delimiter, so detection is intentionally limited to a leading valid object followed by a newline or EOF.
- This PR preserves and edits existing frontmatter blocks; it does not add a visual-mode command for creating new frontmatter yet.

Closes #132
