### PR TITLE
fix(desktop): keep titlebar tabs clear of AI panel

### DIFF
--- a/apps/desktop/src/components/NativeTitleBar.test.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.test.tsx
@@ -95,7 +95,7 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".native-title-slot")).not.toHaveStyle({ transform: "translateX(110px)" });
   });
 
-  it("keeps macOS titlebar tabs between the sidebar and AI panel", () => {
+  it("keeps macOS titlebar tabs clear of transformed actions before the AI panel", () => {
     const { container } = render(
       <NativeTitleBar
         aiAgentOpen
@@ -120,7 +120,7 @@ describe("NativeTitleBar", () => {
 
     expect(container.querySelector(".native-title-slot")).toHaveStyle({
       marginLeft: "124px",
-      marginRight: "220px"
+      marginRight: "384px"
     });
   });
 

--- a/apps/desktop/src/components/NativeTitleBar.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.tsx
@@ -506,7 +506,7 @@ export function NativeTitleBar({
   const titleTransform = titleOffset === 0 ? undefined : `translateX(${titleOffset}px)`;
   const titleContentSlotStyle: CSSProperties = {
     ...(editorLeftInset > titlebarSideSlotWidth ? { marginLeft: editorLeftInset - titlebarSideSlotWidth } : {}),
-    ...(editorRightInset > titlebarSideSlotWidth ? { marginRight: editorRightInset - titlebarSideSlotWidth } : {})
+    ...(editorRightInset > 0 ? { marginRight: editorRightInset } : {})
   };
   const titleSlotStyle: CSSProperties = {
     transform: titleTransform,


### PR DESCRIPTION
## Summary
- Reserve the full AI panel inset for macOS titlebar tab content.
- Update titlebar coverage so tabs stay clear of transformed titlebar actions before the AI panel.

## Why
- When the AI panel opens, right-side titlebar actions are translated left before the panel. The previous tab slot only subtracted the fixed side slot from the AI inset, so many tabs could slide under those actions and get clipped.

## Validation
- `pnpm --dir apps/desktop test -- src/components/NativeTitleBar.test.tsx src/components/MarkdownTabsBar.test.tsx` passed.
- `pnpm --filter @markra/desktop build` passed.

## Risk
- Low. The change only adjusts the titlebar content margin when the AI panel is open and document tabs are rendered in the native titlebar.
