### PR TITLE
fix(tabs): stabilize drag-to-side splitting

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -2118,6 +2118,61 @@ describe("Markra workspace", () => {
     Reflect.deleteProperty(document, "elementFromPoint");
   });
 
+  it("cancels a side-by-side document group from the grouped tab menu", async () => {
+    const firstPath = "/mock-files/vault/docs/alpha.md";
+    const secondPath = "/mock-files/vault/docs/beta.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "alpha.md", path: firstPath, relativePath: "docs/alpha.md" },
+      { name: "beta.md", path: secondPath, relativePath: "docs/beta.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === firstPath) {
+        return {
+          content: "# Alpha\n\nMain",
+          name: "alpha.md",
+          path: firstPath
+        };
+      }
+
+      return {
+        content: "# Beta\n\nReference",
+        name: "beta.md",
+        path: secondPath
+      };
+    });
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "docs/alpha.md" }));
+    expect(await screen.findByText("Alpha")).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs/beta.md" }));
+    expect(await screen.findByText("Beta")).toBeInTheDocument();
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /alpha\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
+    await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).toBeInTheDocument());
+    expect(container.querySelector(".document-tabs-side-by-side-group")).toBeInTheDocument();
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /alpha\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Cancel side-by-side" }));
+
+    await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).not.toBeInTheDocument());
+    expect(container.querySelector(".document-tabs-side-by-side-group")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /alpha\.md/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /beta\.md/ })).toBeInTheDocument();
+  });
+
   it("keeps a side-by-side tab group while selecting a standalone clean tab", async () => {
     const firstPath = "/mock-files/vault/docs/1.md";
     const secondPath = "/mock-files/vault/docs/2.md";

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -97,6 +97,17 @@ const defaultImageUpload = {
   }
 };
 
+function mockElementFromPoint(element: Element) {
+  const mock = vi.fn(() => element);
+
+  Object.defineProperty(document, "elementFromPoint", {
+    configurable: true,
+    value: mock
+  });
+
+  return mock;
+}
+
 function createStoredEditorPreferences(
   overrides: Partial<Parameters<typeof mockedSaveStoredEditorPreferences>[0]> = {}
 ): Parameters<typeof mockedSaveStoredEditorPreferences>[0] {
@@ -1224,7 +1235,8 @@ describe("Markra workspace", () => {
     expect(container.querySelector(".native-title-slot")).toHaveStyle({
       marginLeft: "56px"
     });
-    expect(container.querySelector(".native-title-slot")).toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".native-title-slot")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".document-tabs-drag-spacer")).toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".native-title-slot")).not.toHaveStyle({ transform: "translateX(110px)" });
     expect(resizeHandle).toHaveAttribute("aria-valuemin", "220");
     expect(resizeHandle).toHaveAttribute("aria-valuemax", "440");
@@ -1986,6 +1998,124 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Close tab third.md" }));
     await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).not.toBeInTheDocument());
     expect(screen.getByRole("tab", { name: /guide\.md/ })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("opens a pointer-dragged active document tab beside the tab it is released on", async () => {
+    const firstPath = "/mock-files/vault/docs/alpha.md";
+    const secondPath = "/mock-files/vault/docs/beta.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "alpha.md", path: firstPath, relativePath: "docs/alpha.md" },
+      { name: "beta.md", path: secondPath, relativePath: "docs/beta.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === firstPath) {
+        return {
+          content: "# Alpha\n\nMain",
+          name: "alpha.md",
+          path: firstPath
+        };
+      }
+
+      return {
+        content: "# Beta\n\nReference",
+        name: "beta.md",
+        path: secondPath
+      };
+    });
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "docs/alpha.md" }));
+    expect(await screen.findByText("Alpha")).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs/beta.md" }));
+    expect(await screen.findByText("Beta")).toBeInTheDocument();
+
+    const alphaTab = screen.getByRole("tab", { name: /alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(alphaTab);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+
+    await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).toBeInTheDocument());
+    const groupedTabs = container.querySelector(".document-tabs-side-by-side-group") as HTMLElement;
+    expect(within(groupedTabs).getByRole("tab", { name: /alpha\.md/ })).toHaveAttribute("aria-selected", "true");
+    expect(within(groupedTabs).getByRole("tab", { name: /beta\.md/ })).toHaveAttribute("aria-selected", "false");
+    expect(await within(container.querySelector(".side-document-pane") as HTMLElement).findByText("Reference")).toBeInTheDocument();
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("opens a pointer-dragged document tab to the side when released over the editor area", async () => {
+    const firstPath = "/mock-files/vault/docs/alpha.md";
+    const secondPath = "/mock-files/vault/docs/beta.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "alpha.md", path: firstPath, relativePath: "docs/alpha.md" },
+      { name: "beta.md", path: secondPath, relativePath: "docs/beta.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === firstPath) {
+        return {
+          content: "# Alpha\n\nReference",
+          name: "alpha.md",
+          path: firstPath
+        };
+      }
+
+      return {
+        content: "# Beta\n\nMain",
+        name: "beta.md",
+        path: secondPath
+      };
+    });
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "docs/alpha.md" }));
+    expect(await screen.findByText("Alpha")).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs/beta.md" }));
+    expect(await screen.findByText("Beta")).toBeInTheDocument();
+
+    const alphaTab = screen.getByRole("tab", { name: /alpha\.md/ });
+    const editorArea = container.querySelector(".editor-content-slot") as HTMLElement;
+    const elementFromPoint = mockElementFromPoint(editorArea);
+
+    fireEvent.pointerDown(alphaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 220, clientY: 220, pointerId: 1 });
+    expect(editorArea).toHaveAttribute("data-document-tab-pointer-drop-target", "true");
+    expect(editorArea.className).not.toContain("data-[document-tab-pointer-drop-target=true]:ring");
+    fireEvent.pointerUp(window, { clientX: 220, clientY: 220, pointerId: 1 });
+
+    await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).toBeInTheDocument());
+    const groupedTabs = container.querySelector(".document-tabs-side-by-side-group") as HTMLElement;
+    expect(within(groupedTabs).getByRole("tab", { name: /beta\.md/ })).toHaveAttribute("aria-selected", "true");
+    expect(within(groupedTabs).getByRole("tab", { name: /alpha\.md/ })).toHaveAttribute("aria-selected", "false");
+    expect(await within(container.querySelector(".side-document-pane") as HTMLElement).findByText("Reference")).toBeInTheDocument();
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
   });
 
   it("keeps a side-by-side tab group while selecting a standalone clean tab", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2363,6 +2363,12 @@ export default function App() {
     splitMode,
     updateActiveAiSelection
   ]);
+  const handleCancelTitlebarSideBySide = useCallback((tabId: string) => {
+    if (!sideDocumentGroup) return;
+    if (sideDocumentGroup.primaryTabId !== tabId && sideDocumentGroup.sideTabId !== tabId) return;
+
+    clearSideDocumentGroup();
+  }, [clearSideDocumentGroup, sideDocumentGroup]);
   const draggedMarkdownTabIdFromEvent = useCallback((event: ReactDragEvent<HTMLElement>) => {
     return event.dataTransfer.getData(markdownTabDragDataType);
   }, []);
@@ -2487,6 +2493,7 @@ export default function App() {
       items={titlebarItems}
       language={appLanguage.language}
       placement="titlebar"
+      onCancelSideBySide={handleCancelTitlebarSideBySide}
       onCloseTab={handleCloseTitlebarTab}
       onNewTab={() => {
         captureActiveDocumentViewState();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type DragEvent as ReactDragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type UIEvent as ReactUIEvent
@@ -24,7 +25,11 @@ import {
 import { MarkdownFileTreeDrawer } from "./components/MarkdownFileTreeDrawer";
 import { MarkdownPaper } from "./components/MarkdownPaper";
 import { MarkdownSourceEditor } from "./components/MarkdownSourceEditor";
-import { MarkdownTabsBar, type MarkdownTabsBarDocumentItem } from "./components/MarkdownTabsBar";
+import {
+  MarkdownTabsBar,
+  markdownTabDragDataType,
+  type MarkdownTabsBarDocumentItem
+} from "./components/MarkdownTabsBar";
 import { NativeTitleBar } from "./components/NativeTitleBar";
 import { QuietStatus } from "./components/QuietStatus";
 import { SideDocumentPane } from "./components/SideDocumentPane";
@@ -278,6 +283,7 @@ export default function App() {
   const [visualDocumentSearchMatches, setVisualDocumentSearchMatches] = useState<SearchRange[]>([]);
   const [splitVisualPanePercent, setSplitVisualPanePercent] = useState(defaultSplitVisualPanePercent);
   const [sideDocumentMainPanePercent, setSideDocumentMainPanePercent] = useState(defaultSideDocumentMainPanePercent);
+  const [editorTabDropTargetActive, setEditorTabDropTargetActive] = useState(false);
   const [visualEditorReadySequence, setVisualEditorReadySequence] = useState(0);
   const [exportSnapshot, setExportSnapshot] = useState<MarkdownExportSnapshot | null>(null);
   const sourceMode = editorMode === "source";
@@ -2326,10 +2332,11 @@ export default function App() {
     };
   }, [editor, restoreAiCommand, updateAiResults]);
 
-  const handleOpenTitlebarTabToSide = useCallback((tabId: string) => {
-    if (!activeTabId || tabId === activeTabId) return;
+  const handleOpenTitlebarTabToSide = useCallback((tabId: string, primaryTabId = activeTabId ?? undefined) => {
+    if (!primaryTabId || tabId === primaryTabId) return;
     const tab = documentTabs.find((candidate) => candidate.id === tabId);
-    if (!tab?.path) return;
+    const primaryTab = documentTabs.find((candidate) => candidate.id === primaryTabId);
+    if (!tab?.path || !primaryTab?.path) return;
 
     captureActiveDocumentViewState();
     setActiveImageFile(null);
@@ -2339,22 +2346,66 @@ export default function App() {
       setEditorMode("visual");
       setActiveEditorSurface("visual");
     }
-    const primaryFilePath = documentTabs.find((candidate) => candidate.id === activeTabId)?.path ?? document.path;
+    if (primaryTabId !== activeTabId) selectMarkdownTab(primaryTabId);
     openSideDocumentGroup({
-      primaryFilePath,
-      primaryTabId: activeTabId,
+      primaryFilePath: primaryTab.path,
+      primaryTabId,
       sideFilePath: tab.path,
       sideTabId: tabId
     });
   }, [
     activeTabId,
     captureActiveDocumentViewState,
-    document.path,
     documentTabs,
     handleAiCommandClose,
     openSideDocumentGroup,
+    selectMarkdownTab,
     splitMode,
     updateActiveAiSelection
+  ]);
+  const draggedMarkdownTabIdFromEvent = useCallback((event: ReactDragEvent<HTMLElement>) => {
+    return event.dataTransfer.getData(markdownTabDragDataType);
+  }, []);
+  const canDropMarkdownTabOnEditor = useCallback((tabId: string) => {
+    if (!editorPreferences.preferences.showDocumentTabs || activeImageFile || !hasOpenDocument || !activeTabId) return false;
+    if (!tabId || tabId === activeTabId || tabId === sideDocumentGroup?.sideTabId) return false;
+
+    const draggedTab = documentTabs.find((tab) => tab.id === tabId);
+    const activeTab = documentTabs.find((tab) => tab.id === activeTabId);
+    return Boolean(draggedTab?.path && activeTab?.path);
+  }, [
+    activeImageFile,
+    activeTabId,
+    documentTabs,
+    editorPreferences.preferences.showDocumentTabs,
+    hasOpenDocument,
+    sideDocumentGroup?.sideTabId
+  ]);
+  const handleEditorContentDragOver = useCallback((event: ReactDragEvent<HTMLDivElement>) => {
+    const draggedTabId = draggedMarkdownTabIdFromEvent(event);
+    if (!canDropMarkdownTabOnEditor(draggedTabId)) return;
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    setEditorTabDropTargetActive(true);
+  }, [canDropMarkdownTabOnEditor, draggedMarkdownTabIdFromEvent]);
+  const handleEditorContentDragLeave = useCallback(() => {
+    setEditorTabDropTargetActive(false);
+  }, []);
+  const handleEditorContentDrop = useCallback((event: ReactDragEvent<HTMLDivElement>) => {
+    const draggedTabId = draggedMarkdownTabIdFromEvent(event);
+    if (!canDropMarkdownTabOnEditor(draggedTabId)) {
+      setEditorTabDropTargetActive(false);
+      return;
+    }
+
+    event.preventDefault();
+    setEditorTabDropTargetActive(false);
+    handleOpenTitlebarTabToSide(draggedTabId);
+  }, [
+    canDropMarkdownTabOnEditor,
+    draggedMarkdownTabIdFromEvent,
+    handleOpenTitlebarTabToSide
   ]);
   const handleSideDocumentChange = useCallback((content: string) => {
     if (!sideDocumentGroup || readOnlyMode) return;
@@ -2529,8 +2580,15 @@ export default function App() {
             style={{ gridTemplateColumns: `minmax(0,1fr) ${aiAgentInset}` }}
           >
             <div
-              className="editor-content-slot relative h-full min-h-0 overflow-hidden"
+              className={`editor-content-slot relative h-full min-h-0 overflow-hidden transition-[box-shadow] duration-150 ease-out ${
+                editorTabDropTargetActive ? "ring-2 ring-(--accent)/30 ring-inset" : ""
+              }`}
               data-document-search-open={documentSearchOpen && documentSearchAvailable ? "true" : undefined}
+              data-document-tab-editor-drop-target="true"
+              data-document-tab-drop-target={editorTabDropTargetActive ? "true" : undefined}
+              onDragLeave={handleEditorContentDragLeave}
+              onDragOver={handleEditorContentDragOver}
+              onDrop={handleEditorContentDrop}
             >
               {documentSearchOpen && documentSearchAvailable ? (
                 <DocumentSearchBar

--- a/apps/desktop/src/components/MarkdownTabsBar.test.tsx
+++ b/apps/desktop/src/components/MarkdownTabsBar.test.tsx
@@ -385,6 +385,45 @@ describe("MarkdownTabsBar", () => {
     expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b");
   });
 
+  it("cancels a side-by-side tab group from the tab actions menu", () => {
+    const onCancelSideBySide = vi.fn();
+    const onCloseTab = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          [
+            {
+              dirty: false,
+              id: "tab-a",
+              name: "Alpha.md",
+              path: "/synthetic/alpha.md"
+            },
+            {
+              dirty: false,
+              id: "tab-b",
+              name: "Beta.md",
+              path: "/synthetic/beta.md"
+            }
+          ]
+        ]}
+        onCancelSideBySide={onCancelSideBySide}
+        onCloseTab={onCloseTab}
+        onNewTab={() => {}}
+        onOpenTabToSide={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /Beta\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Cancel side-by-side" }));
+
+    expect(onCancelSideBySide).toHaveBeenCalledWith("tab-b");
+    expect(onCloseTab).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu", { name: "Beta.md" })).not.toBeInTheDocument();
+  });
+
   it("opens a pointer-dragged markdown tab to the side when released over the active tab", () => {
     const onOpenTabToSide = vi.fn();
 

--- a/apps/desktop/src/components/MarkdownTabsBar.test.tsx
+++ b/apps/desktop/src/components/MarkdownTabsBar.test.tsx
@@ -3,7 +3,18 @@ import { vi } from "vitest";
 import { MarkdownTabsBar } from "./MarkdownTabsBar";
 
 describe("MarkdownTabsBar", () => {
-  it("marks titlebar tab empty space as a window drag region", () => {
+  function mockElementFromPoint(element: Element) {
+    const mock = vi.fn(() => element);
+
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: mock
+    });
+
+    return mock;
+  }
+
+  it("marks only titlebar tab empty space as a window drag region", () => {
     const { container } = render(
       <MarkdownTabsBar
         activeTabId="tab-a"
@@ -23,8 +34,169 @@ describe("MarkdownTabsBar", () => {
     );
 
     expect(screen.getByRole("tablist", { name: "Open documents" })).toBeInTheDocument();
-    expect(container.querySelector(".document-tabs-titlebar")).toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".document-tabs-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(screen.getByRole("tab", { name: /Alpha\.md/ }).closest("[data-tauri-drag-region]")).toBeNull();
     expect(container.querySelector(".document-tabs-drag-spacer")).toHaveAttribute("data-tauri-drag-region");
+  });
+
+  it("keeps document tabs out of native browser dragging so pointer drag owns side-by-side drops", () => {
+    const { container } = render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+
+    expect(betaTab).toHaveAttribute("draggable", "false");
+    expect(betaTab.closest(".group\\/tab")).toHaveAttribute("draggable", "false");
+    expect(container.querySelector("[draggable='true']")).toBeNull();
+  });
+
+  it("marks the page as tab-dragging while a pointer tab drag is active", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(document.body);
+
+    expect(document.documentElement).not.toHaveAttribute("data-document-tab-dragging");
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 22, clientY: 12, pointerId: 1 });
+    expect(document.documentElement).not.toHaveAttribute("data-document-tab-dragging");
+
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    expect(document.documentElement).toHaveAttribute("data-document-tab-dragging", "true");
+
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    expect(document.documentElement).not.toHaveAttribute("data-document-tab-dragging");
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("shows a shadowed tab preview while pointer dragging", () => {
+    const { container } = render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(document.body);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    expect(container.querySelector(".document-tab-drag-preview")).not.toBeInTheDocument();
+
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 32, pointerId: 1 });
+    const preview = container.querySelector(".document-tab-drag-preview") as HTMLElement;
+
+    expect(preview).toBeInTheDocument();
+    expect(preview).toHaveTextContent("Beta.md");
+    expect(preview.className).toContain("shadow-");
+    expect(preview.style.transform).toBe("translate3d(92px, 44px, 0)");
+
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 32, pointerId: 1 });
+    expect(container.querySelector(".document-tab-drag-preview")).not.toBeInTheDocument();
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("clears pointer tab dragging when the window loses focus", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(document.body);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    expect(document.documentElement).toHaveAttribute("data-document-tab-dragging", "true");
+
+    fireEvent.blur(window);
+    expect(document.documentElement).not.toHaveAttribute("data-document-tab-dragging");
+
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    expect(elementFromPoint).toHaveBeenCalledTimes(1);
+    Reflect.deleteProperty(document, "elementFromPoint");
   });
 
   it("renders grouped tab items from nested arrays with separate close buttons", async () => {
@@ -211,5 +383,168 @@ describe("MarkdownTabsBar", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
 
     expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b");
+  });
+
+  it("opens a pointer-dragged markdown tab to the side when released over the active tab", () => {
+    const onOpenTabToSide = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={onOpenTabToSide}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaTab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(alphaTab);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+
+    expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b", "tab-a");
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("uses the pointer drop target tab as the main side-by-side tab", () => {
+    const onOpenTabToSide = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-b"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={onOpenTabToSide}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaTab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(alphaTab);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+
+    expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b", "tab-a");
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("opens a pointer-dragged markdown tab to the side when released over another tab", () => {
+    const onOpenTabToSide = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-b"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={onOpenTabToSide}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaTab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(alphaTab);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+
+    expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b", "tab-a");
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("treats the whole tab item as a pointer side-by-side drop target", () => {
+    const onOpenTabToSide = vi.fn();
+
+    const { container } = render(
+      <MarkdownTabsBar
+        activeTabId="tab-b"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={onOpenTabToSide}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaCloseButton = screen.getByRole("button", { name: "Close tab Alpha.md" });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    const elementFromPoint = mockElementFromPoint(alphaCloseButton);
+
+    expect(alphaCloseButton.closest(".group\\/tab")).toHaveAttribute("data-document-tab-id", "tab-a");
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 20, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 80, clientY: 12, pointerId: 1 });
+    fireEvent.pointerUp(window, { clientX: 80, clientY: 12, pointerId: 1 });
+
+    expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b", "tab-a");
+    expect(elementFromPoint).toHaveBeenCalled();
+    expect(container.querySelector("[data-document-tab-dragging='true']")).toBeNull();
+    Reflect.deleteProperty(document, "elementFromPoint");
   });
 });

--- a/apps/desktop/src/components/MarkdownTabsBar.tsx
+++ b/apps/desktop/src/components/MarkdownTabsBar.tsx
@@ -23,6 +23,7 @@ type MarkdownTabsBarProps = {
   items: MarkdownTabsBarItem[];
   language?: AppLanguage;
   placement?: "editor" | "titlebar";
+  onCancelSideBySide?: (tabId: string) => unknown;
   onCloseTab: (tabId: string) => unknown;
   onNewTab: () => unknown;
   onOpenTabToSide?: (tabId: string, primaryTabId?: string) => unknown;
@@ -58,6 +59,7 @@ export function MarkdownTabsBar({
   items,
   language = "en",
   placement = "editor",
+  onCancelSideBySide,
   onCloseTab,
   onNewTab,
   onOpenTabToSide,
@@ -143,6 +145,9 @@ export function MarkdownTabsBar({
   const contextMenuRightTabIds = contextMenuTabItemIndex >= 0
     ? tabItemGroups.slice(contextMenuTabItemIndex + 1).flatMap((item) => item.map((tab) => tab.id))
     : [];
+  const contextMenuTabIsSideBySide = contextMenuTab
+    ? tabItemGroups.some((item) => item.length > 1 && item.some((tab) => tab.id === contextMenuTab.id))
+    : false;
   const tabCanParticipateInSideBySide = (tab: MarkdownTabsBarDocumentItem | null | undefined) =>
     Boolean(onOpenTabToSide) &&
     Boolean(tab?.path) &&
@@ -564,6 +569,18 @@ export function MarkdownTabsBar({
               >
                 <Columns2 aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
                 <span className="truncate">{label("app.openDocumentToSide")}</span>
+              </Button>
+            ) : null}
+            {onCancelSideBySide && contextMenuTabIsSideBySide ? (
+              <Button
+                className="w-full justify-start rounded-md text-left"
+                size="sm"
+                variant="ghost"
+                role="menuitem"
+                onClick={() => runTabContextMenuAction(() => onCancelSideBySide(contextMenuTab.id))}
+              >
+                <Columns2 aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+                <span className="truncate">{label("app.cancelSideBySideDocuments")}</span>
               </Button>
             ) : null}
             <Button

--- a/apps/desktop/src/components/MarkdownTabsBar.tsx
+++ b/apps/desktop/src/components/MarkdownTabsBar.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent
+} from "react";
 import { Columns2, FileText, ImageIcon, Pencil, Plus, X } from "lucide-react";
 import { Button, IconButton, PopoverSurface } from "@markra/ui";
 import { t, type AppLanguage } from "@markra/shared";
@@ -18,7 +25,7 @@ type MarkdownTabsBarProps = {
   placement?: "editor" | "titlebar";
   onCloseTab: (tabId: string) => unknown;
   onNewTab: () => unknown;
-  onOpenTabToSide?: (tabId: string) => unknown;
+  onOpenTabToSide?: (tabId: string, primaryTabId?: string) => unknown;
   onRenameTab?: (tab: MarkdownTabsBarDocumentItem, name: string) => unknown;
   onSelectTab: (tabId: string) => unknown;
 };
@@ -28,6 +35,23 @@ type TabContextMenuState = {
   x: number;
   y: number;
 };
+
+type PointerTabDragState = {
+  dragging: boolean;
+  startX: number;
+  startY: number;
+  tabId: string;
+};
+
+type PointerTabDragPreview = {
+  tabId: string;
+  x: number;
+  y: number;
+};
+
+export const markdownTabDragDataType = "application/x-markra-document-tab";
+const pointerTabDragThresholdPx = 6;
+const pointerTabDragPreviewOffsetPx = 12;
 
 export function MarkdownTabsBar({
   activeTabId,
@@ -47,6 +71,20 @@ export function MarkdownTabsBar({
   const renameCancelledRef = useRef(false);
   const contextMenuRef = useRef<HTMLDivElement | null>(null);
   const [contextMenu, setContextMenu] = useState<TabContextMenuState | null>(null);
+  const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
+  const [dragOverTabId, setDragOverTabId] = useState<string | null>(null);
+  const [pointerTabDragPreview, setPointerTabDragPreview] = useState<PointerTabDragPreview | null>(null);
+  const pointerTabDragRef = useRef<PointerTabDragState | null>(null);
+  const pointerDragCleanupRef = useRef<(() => unknown) | null>(null);
+  const pointerEditorDropTargetRef = useRef<HTMLElement | null>(null);
+  const suppressClickTabIdRef = useRef<string | null>(null);
+
+  const setPageDocumentTabDragging = () => {
+    document.documentElement.setAttribute("data-document-tab-dragging", "true");
+  };
+  const clearPageDocumentTabDragging = () => {
+    document.documentElement.removeAttribute("data-document-tab-dragging");
+  };
 
   useEffect(() => {
     if (!renameInputRef.current) return;
@@ -74,6 +112,12 @@ export function MarkdownTabsBar({
     };
   }, [contextMenu]);
 
+  useEffect(() => () => {
+    pointerDragCleanupRef.current?.();
+    pointerDragCleanupRef.current = null;
+    clearPageDocumentTabDragging();
+  }, []);
+
   const tabItemGroups = items.map((item) => Array.isArray(item) ? item : [item]);
   const documentItems = tabItemGroups.flatMap((item) => item);
   const sideGroupedTabIds = new Set(
@@ -83,6 +127,10 @@ export function MarkdownTabsBar({
   if (documentItems.length === 0) return null;
 
   const titlebarPlacement = placement === "titlebar";
+  const pointerTabDragPreviewTab = pointerTabDragPreview
+    ? documentItems.find((tab) => tab.id === pointerTabDragPreview.tabId) ?? null
+    : null;
+  const PointerTabDragPreviewIcon = pointerTabDragPreviewTab?.displayKind === "image" ? ImageIcon : FileText;
   const contextMenuTab = contextMenu ? documentItems.find((tab) => tab.id === contextMenu.tabId) ?? null : null;
   const contextMenuTabItemIndex = contextMenuTab
     ? tabItemGroups.findIndex((item) => item.some((tab) => tab.id === contextMenuTab.id))
@@ -95,12 +143,155 @@ export function MarkdownTabsBar({
   const contextMenuRightTabIds = contextMenuTabItemIndex >= 0
     ? tabItemGroups.slice(contextMenuTabItemIndex + 1).flatMap((item) => item.map((tab) => tab.id))
     : [];
-  const contextMenuTabCanOpenToSide =
+  const tabCanParticipateInSideBySide = (tab: MarkdownTabsBarDocumentItem | null | undefined) =>
     Boolean(onOpenTabToSide) &&
-    Boolean(contextMenuTab?.path) &&
-    contextMenuTab?.displayKind !== "image" &&
-    contextMenuTab?.id !== activeTabId &&
-    !sideGroupedTabIds.has(contextMenuTab?.id ?? "");
+    Boolean(tab?.path) &&
+    tab?.displayKind !== "image";
+  const tabCanOpenToSideFromMenu = (tab: MarkdownTabsBarDocumentItem | null | undefined) =>
+    tabCanParticipateInSideBySide(tab) &&
+    tab?.id !== activeTabId &&
+    !sideGroupedTabIds.has(tab?.id ?? "");
+  const tabCanDragToSide = (tab: MarkdownTabsBarDocumentItem | null | undefined) =>
+    tabCanParticipateInSideBySide(tab) && !sideGroupedTabIds.has(tab?.id ?? "");
+  const tabCanAcceptSideDrop = (tab: MarkdownTabsBarDocumentItem | null | undefined) =>
+    tabCanParticipateInSideBySide(tab) && !sideGroupedTabIds.has(tab?.id ?? "");
+  const contextMenuTabCanOpenToSide = tabCanOpenToSideFromMenu(contextMenuTab);
+  const tabAcceptsSideDrop = (targetTab: MarkdownTabsBarDocumentItem, draggedTab: MarkdownTabsBarDocumentItem | null) => {
+    return draggedTab?.id !== targetTab.id && tabCanDragToSide(draggedTab) && tabCanAcceptSideDrop(targetTab);
+  };
+  const clearPointerEditorDropTarget = () => {
+    if (!pointerEditorDropTargetRef.current) return;
+
+    pointerEditorDropTargetRef.current.removeAttribute("data-document-tab-pointer-drop-target");
+    pointerEditorDropTargetRef.current = null;
+  };
+  const setPointerEditorDropTarget = (target: HTMLElement | null) => {
+    if (pointerEditorDropTargetRef.current === target) return;
+
+    clearPointerEditorDropTarget();
+    if (!target) return;
+
+    target.setAttribute("data-document-tab-pointer-drop-target", "true");
+    pointerEditorDropTargetRef.current = target;
+  };
+  const hitTestPointerDropTarget = (event: PointerEvent) => {
+    const target = document.elementFromPoint(event.clientX, event.clientY);
+    const tabTarget = target?.closest<HTMLElement>("[data-document-tab-id]");
+    const editorTarget = target?.closest<HTMLElement>("[data-document-tab-editor-drop-target='true']");
+
+    return {
+      editorTarget,
+      targetTabId: tabTarget?.dataset.documentTabId ?? null
+    };
+  };
+  const updatePointerDropFeedback = (event: PointerEvent, draggedTab: MarkdownTabsBarDocumentItem) => {
+    const { editorTarget, targetTabId } = hitTestPointerDropTarget(event);
+    const targetTab = targetTabId ? documentItems.find((tab) => tab.id === targetTabId) ?? null : null;
+
+    if (targetTab && tabAcceptsSideDrop(targetTab, draggedTab)) {
+      setDragOverTabId(targetTab.id);
+      setPointerEditorDropTarget(null);
+      return;
+    }
+
+    if (editorTarget && draggedTab.id !== activeTabId) {
+      setDragOverTabId(null);
+      setPointerEditorDropTarget(editorTarget);
+      return;
+    }
+
+    setDragOverTabId(null);
+    setPointerEditorDropTarget(null);
+  };
+  const finishPointerTabDrag = (event: PointerEvent | null, commit: boolean) => {
+    const pointerDrag = pointerTabDragRef.current;
+    pointerTabDragRef.current = null;
+    pointerDragCleanupRef.current?.();
+    pointerDragCleanupRef.current = null;
+    clearPageDocumentTabDragging();
+    clearPointerEditorDropTarget();
+    setDraggingTabId(null);
+    setDragOverTabId(null);
+    setPointerTabDragPreview(null);
+
+    if (!pointerDrag?.dragging) return;
+
+    suppressClickTabIdRef.current = pointerDrag.tabId;
+    window.setTimeout(() => {
+      if (suppressClickTabIdRef.current === pointerDrag.tabId) suppressClickTabIdRef.current = null;
+    }, 0);
+    if (!commit || !event) return;
+
+    const draggedTab = documentItems.find((tab) => tab.id === pointerDrag.tabId) ?? null;
+    if (!draggedTab || !tabCanDragToSide(draggedTab)) return;
+
+    const { editorTarget, targetTabId } = hitTestPointerDropTarget(event);
+    const targetTab = targetTabId ? documentItems.find((tab) => tab.id === targetTabId) ?? null : null;
+
+    if (targetTab && tabAcceptsSideDrop(targetTab, draggedTab)) {
+      onOpenTabToSide?.(draggedTab.id, targetTab.id);
+      return;
+    }
+
+    if (editorTarget && draggedTab.id !== activeTabId) onOpenTabToSide?.(draggedTab.id);
+  };
+  const handleWindowPointerMove = (event: PointerEvent) => {
+    const pointerDrag = pointerTabDragRef.current;
+    if (!pointerDrag) return;
+
+    const draggedTab = documentItems.find((tab) => tab.id === pointerDrag.tabId) ?? null;
+    if (!draggedTab || !tabCanDragToSide(draggedTab)) return;
+
+    const movedDistance = Math.hypot(event.clientX - pointerDrag.startX, event.clientY - pointerDrag.startY);
+    if (!pointerDrag.dragging && movedDistance < pointerTabDragThresholdPx) return;
+    if (!pointerDrag.dragging) {
+      pointerTabDragRef.current = {
+        ...pointerDrag,
+        dragging: true
+      };
+      setPageDocumentTabDragging();
+      setDraggingTabId(pointerDrag.tabId);
+    }
+
+    setPointerTabDragPreview({
+      tabId: pointerDrag.tabId,
+      x: event.clientX,
+      y: event.clientY
+    });
+    event.preventDefault();
+    updatePointerDropFeedback(event, draggedTab);
+  };
+  const handleWindowPointerUp = (event: PointerEvent) => {
+    finishPointerTabDrag(event, true);
+  };
+  const handleWindowPointerCancel = (event: PointerEvent) => {
+    finishPointerTabDrag(event, false);
+  };
+  const handleWindowBlur = () => {
+    finishPointerTabDrag(null, false);
+  };
+  const handleTabPointerDown = (event: ReactPointerEvent, tab: MarkdownTabsBarDocumentItem) => {
+    if (event.button !== 0 || !tabCanDragToSide(tab)) return;
+
+    pointerDragCleanupRef.current?.();
+    clearPageDocumentTabDragging();
+    pointerTabDragRef.current = {
+      dragging: false,
+      startX: event.clientX,
+      startY: event.clientY,
+      tabId: tab.id
+    };
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerUp);
+    window.addEventListener("pointercancel", handleWindowPointerCancel);
+    window.addEventListener("blur", handleWindowBlur);
+    pointerDragCleanupRef.current = () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerUp);
+      window.removeEventListener("pointercancel", handleWindowPointerCancel);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  };
   const startRenamingTab = (tab: MarkdownTabsBarDocumentItem) => {
     if (!tab.path || !onRenameTab) return;
 
@@ -148,6 +339,17 @@ export function MarkdownTabsBar({
     setContextMenu(null);
     action();
   };
+  const handlePreventNativeTabDrag = (event: ReactDragEvent) => {
+    event.preventDefault();
+  };
+  const handleSelectTabClick = (tab: MarkdownTabsBarDocumentItem, selectTabId: string) => {
+    if (suppressClickTabIdRef.current === tab.id) {
+      suppressClickTabIdRef.current = null;
+      return;
+    }
+
+    onSelectTab(selectTabId);
+  };
   const renderTabButton = (tab: MarkdownTabsBarDocumentItem, active: boolean, selectTabId = tab.id) => {
     const TabIcon = tab.displayKind === "image" ? ImageIcon : FileText;
     const renaming = tab.id === renamingTabId;
@@ -182,11 +384,15 @@ export function MarkdownTabsBar({
         className={`flex h-full min-w-0 items-center gap-1.5 rounded-l-md px-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) ${
           active ? "text-(--text-heading)" : "text-(--text-secondary)"
         }`}
+        draggable={false}
         type="button"
         role="tab"
         aria-selected={active}
-        onClick={() => onSelectTab(selectTabId)}
+        data-document-tab-id={tab.id}
+        onClick={() => handleSelectTabClick(tab, selectTabId)}
         onDoubleClick={() => startRenamingTab(tab)}
+        onDragStart={handlePreventNativeTabDrag}
+        onPointerDown={(event) => handleTabPointerDown(event, tab)}
       >
         <TabIcon aria-hidden="true" className="shrink-0 opacity-65" size={13} />
         <span className="min-w-0 truncate">{tab.name || "Untitled.md"}</span>
@@ -210,18 +416,25 @@ export function MarkdownTabsBar({
   );
   const renderDocumentTab = (tab: MarkdownTabsBarDocumentItem) => {
     const active = tab.id === activeTabId;
+    const dragged = tab.id === draggingTabId;
+    const sideDropTarget = tab.id === dragOverTabId;
 
     return (
       <div
         className={`group/tab grid h-7 max-w-52 min-w-28 grid-cols-[minmax(0,1fr)_auto] items-center rounded-md border transition-colors duration-150 ease-out ${
           titlebarPlacement ? "" : "mb-1"
         } ${
-          active
+          sideDropTarget
+            ? "border-(--accent) bg-(--bg-active) text-(--text-heading)"
+            : active
             ? "border-(--border-default) bg-(--bg-active) text-(--text-heading)"
             : "border-transparent bg-transparent text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading)"
-        }`}
+        } ${dragged ? "opacity-60" : ""}`}
+        data-document-tab-id={tab.id}
+        draggable={false}
         key={tab.id}
         onContextMenu={(event) => openTabContextMenu(event, tab)}
+        onDragStart={handlePreventNativeTabDrag}
       >
         {renderTabButton(tab, active)}
         {renderCloseTabButton(tab, active)}
@@ -241,14 +454,19 @@ export function MarkdownTabsBar({
       >
         {group.map((tab, tabIndex) => {
           const active = tab.id === activeTabId;
+          const dragged = tab.id === draggingTabId;
+          const sideDropTarget = tab.id === dragOverTabId;
 
           return (
             <div
               className={`group/tab grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center transition-colors duration-150 ease-out ${
                 tabIndex > 0 ? "border-l border-(--border-default)" : ""
-              } ${active ? "bg-(--bg-active)" : "bg-transparent"}`}
+              } ${sideDropTarget || active ? "bg-(--bg-active)" : "bg-transparent"} ${sideDropTarget ? "outline outline-1 outline-(--accent) -outline-offset-1" : ""} ${dragged ? "opacity-60" : ""}`}
+              data-document-tab-id={tab.id}
+              draggable={false}
               key={tab.id}
               onContextMenu={(event) => openTabContextMenu(event, tab)}
+              onDragStart={handlePreventNativeTabDrag}
             >
               {renderTabButton(tab, active, groupPrimaryTabId)}
               {renderCloseTabButton(tab, active, true)}
@@ -261,7 +479,6 @@ export function MarkdownTabsBar({
 
   return (
     <section
-      data-tauri-drag-region={titlebarPlacement ? "true" : undefined}
       className={
         titlebarPlacement
           ? "document-tabs document-tabs-titlebar h-10 min-w-0 w-full bg-transparent"
@@ -293,6 +510,21 @@ export function MarkdownTabsBar({
           />
         ) : null}
       </div>
+      {pointerTabDragPreview && pointerTabDragPreviewTab ? (
+        <div
+          aria-hidden="true"
+          className="document-tab-drag-preview pointer-events-none fixed top-0 left-0 z-50 flex h-7 max-w-52 min-w-28 items-center gap-1.5 rounded-md border border-(--border-default) bg-(--bg-primary)/96 px-2 text-[12px] leading-5 font-[560] text-(--text-heading) shadow-[0_12px_28px_color-mix(in_srgb,var(--text-heading)_18%,transparent)] backdrop-blur-[2px] will-change-transform"
+          style={{
+            transform: `translate3d(${pointerTabDragPreview.x + pointerTabDragPreviewOffsetPx}px, ${pointerTabDragPreview.y + pointerTabDragPreviewOffsetPx}px, 0)`
+          }}
+        >
+          <PointerTabDragPreviewIcon aria-hidden="true" className="shrink-0 opacity-65" size={13} />
+          <span className="min-w-0 truncate">{pointerTabDragPreviewTab.name || "Untitled.md"}</span>
+          {pointerTabDragPreviewTab.dirty ? (
+            <span className="size-1.25 shrink-0 rounded-full bg-(--accent)" aria-hidden="true" />
+          ) : null}
+        </div>
+      ) : null}
       {contextMenu && contextMenuTab ? (
         <div
           ref={contextMenuRef}

--- a/apps/desktop/src/components/NativeTitleBar.test.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.test.tsx
@@ -82,7 +82,9 @@ describe("NativeTitleBar", () => {
 
     expect(screen.queryByRole("heading", { name: "Draft.md" })).not.toBeInTheDocument();
     expect(screen.getByRole("tablist", { name: "Open documents" })).toBeInTheDocument();
-    expect(container.querySelector(".native-title-slot")).toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".native-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".native-title-slot")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(screen.getByRole("tab", { name: "Draft.md" }).closest("[data-tauri-drag-region]")).toBeNull();
     expect(container.querySelector(".native-titlebar")).toHaveClass("bg-(--bg-primary)");
     expect(container.querySelector(".native-titlebar")).not.toHaveClass("border-b");
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
@@ -183,7 +185,7 @@ describe("NativeTitleBar", () => {
 
     expect(container.querySelector(".native-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".document-actions")).not.toHaveAttribute("data-tauri-drag-region");
-    expect(container.querySelector(".native-title-slot")).toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".native-title-slot")).not.toHaveAttribute("data-tauri-drag-region");
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 

--- a/apps/desktop/src/components/NativeTitleBar.tsx
+++ b/apps/desktop/src/components/NativeTitleBar.tsx
@@ -453,7 +453,7 @@ export function NativeTitleBar({
   };
 
   const renderTitleContent = (className: string, style?: CSSProperties) => (
-    <div className={className} style={style} data-tauri-drag-region>
+    <div className={className} style={style}>
       {titleContent}
     </div>
   );
@@ -526,7 +526,7 @@ export function NativeTitleBar({
       className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-8 grid h-10 grid-cols-[164px_minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
       style={titlebarGridStyle}
       aria-label={label("app.windowDragRegion")}
-      data-tauri-drag-region
+      data-tauri-drag-region={titleContent ? undefined : true}
     >
       {renderMarkdownFilesDivider()}
       <div

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -785,6 +785,14 @@
     user-select: none;
   }
 
+  html[data-document-tab-dragging="true"],
+  html[data-document-tab-dragging="true"] body,
+  html[data-document-tab-dragging="true"] * {
+    cursor: grabbing !important;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   .markdown-source-highlight code {
     font-family: inherit;
   }

--- a/apps/desktop/src/styles.test.ts
+++ b/apps/desktop/src/styles.test.ts
@@ -13,6 +13,15 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("%23ffffff");
   });
 
+  it("forces a grabbing cursor during document tab pointer drags", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).toContain('html[data-document-tab-dragging="true"]');
+    expect(styles).toContain('html[data-document-tab-dragging="true"] *');
+    expect(styles).toContain("cursor: grabbing !important");
+    expect(styles).toContain("user-select: none");
+  });
+
   it("includes readable Markdown table styles", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "Andere Tabs schließen",
   "app.closeDocumentTabsToRight": "Tabs rechts schließen",
   "app.openDocumentToSide": "Seitlich öffnen",
+  "app.cancelSideBySideDocuments": "Nebeneinander beenden",
   "app.newDocumentTab": "Neuer Tab",
   "app.toggleMarkdownFiles": "Dateiliste umschalten",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -307,6 +307,7 @@ const messages: BaseLocaleMessages = {
   "app.closeOtherDocumentTabs": "Close other tabs",
   "app.closeDocumentTabsToRight": "Close tabs to the right",
   "app.openDocumentToSide": "Open to side",
+  "app.cancelSideBySideDocuments": "Cancel side-by-side",
   "app.newDocumentTab": "New tab",
   "app.toggleMarkdownFiles": "Toggle file list",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "Cerrar otras pestañas",
   "app.closeDocumentTabsToRight": "Cerrar pestañas a la derecha",
   "app.openDocumentToSide": "Abrir al lado",
+  "app.cancelSideBySideDocuments": "Cancelar vista lado a lado",
   "app.newDocumentTab": "Nueva pestaña",
   "app.toggleMarkdownFiles": "Alternar lista de archivos",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "Fermer les autres onglets",
   "app.closeDocumentTabsToRight": "Fermer les onglets à droite",
   "app.openDocumentToSide": "Ouvrir sur le côté",
+  "app.cancelSideBySideDocuments": "Annuler le côte à côte",
   "app.newDocumentTab": "Nouvel onglet",
   "app.toggleMarkdownFiles": "Afficher ou masquer la liste des fichiers",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "Chiudi altre schede",
   "app.closeDocumentTabsToRight": "Chiudi schede a destra",
   "app.openDocumentToSide": "Apri a lato",
+  "app.cancelSideBySideDocuments": "Annulla affiancamento",
   "app.newDocumentTab": "Nuova scheda",
   "app.toggleMarkdownFiles": "Mostra/nascondi elenco file",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -175,6 +175,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "他のタブを閉じる",
   "app.closeDocumentTabsToRight": "右側のタブを閉じる",
   "app.openDocumentToSide": "横に開く",
+  "app.cancelSideBySideDocuments": "横並びを解除",
   "app.newDocumentTab": "新しいタブ",
   "app.toggleMarkdownFiles": "ファイルリストを切り替え",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "다른 탭 닫기",
   "app.closeDocumentTabsToRight": "오른쪽 탭 닫기",
   "app.openDocumentToSide": "옆에 열기",
+  "app.cancelSideBySideDocuments": "나란히 보기 취소",
   "app.newDocumentTab": "새 탭",
   "app.toggleMarkdownFiles": "파일 목록 전환",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "Fechar outras abas",
   "app.closeDocumentTabsToRight": "Fechar abas à direita",
   "app.openDocumentToSide": "Abrir ao lado",
+  "app.cancelSideBySideDocuments": "Cancelar lado a lado",
   "app.newDocumentTab": "Nova aba",
   "app.toggleMarkdownFiles": "Alternar lista de arquivos",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -167,6 +167,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "Закрыть другие вкладки",
   "app.closeDocumentTabsToRight": "Закрыть вкладки справа",
   "app.openDocumentToSide": "Открыть сбоку",
+  "app.cancelSideBySideDocuments": "Отменить режим рядом",
   "app.newDocumentTab": "Новая вкладка",
   "app.toggleMarkdownFiles": "Показать или скрыть список файлов",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -318,6 +318,7 @@ export type I18nKey =
   | "app.closeOtherDocumentTabs"
   | "app.closeDocumentTabsToRight"
   | "app.openDocumentToSide"
+  | "app.cancelSideBySideDocuments"
   | "app.newDocumentTab"
   | "app.toggleMarkdownFiles"
   | "app.aiAgent"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "关闭其他标签页",
   "app.closeDocumentTabsToRight": "关闭右侧标签页",
   "app.openDocumentToSide": "打开到侧边",
+  "app.cancelSideBySideDocuments": "取消分屏",
   "app.newDocumentTab": "新建标签页",
   "app.toggleMarkdownFiles": "切换文件列表",
   "app.aiAgent": "Markra AI",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -175,6 +175,7 @@ const messages: LocaleMessages = {
   "app.closeOtherDocumentTabs": "關閉其他標籤頁",
   "app.closeDocumentTabsToRight": "關閉右側標籤頁",
   "app.openDocumentToSide": "開啟到側邊",
+  "app.cancelSideBySideDocuments": "取消分屏",
   "app.newDocumentTab": "新增標籤頁",
   "app.toggleMarkdownFiles": "切換檔案列表",
   "app.aiAgent": "Markra AI",


### PR DESCRIPTION
## Summary
- Use a pointer-driven tab drag flow for opening documents to the side, avoiding unreliable native drag behavior in the Tauri titlebar.
- Support releasing a tab over another tab or over the active editor area to create the existing side-by-side document group.
- Treat the whole tab item, including the close-button area, as a side-by-side drop target.
- Clear pointer drag state when the window loses focus so cursor/target feedback cannot get stuck.
- Add a grouped-tab context menu action to cancel side-by-side mode without closing either document.
- Keep tab/titlebar drag regions separated and force a `grabbing` cursor while tab dragging is active.

## Why
Native browser drag could be swallowed by the desktop titlebar flow, so the first drag attempt could show a drag indicator without opening the side pane. The new path keeps the interaction inside Markra and maps the drop directly to the existing “Open to side” behavior. The context menu also gives users an explicit way to leave the side-by-side group.

## Validation
- `pnpm --filter @markra/desktop test -- src/components/MarkdownTabsBar.test.tsx src/App.test.tsx src/styles.test.ts` passed: 860 tests.
- `pnpm --filter @markra/desktop typecheck:test` passed.
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification.

Closes #139
