### PR TITLE
build(web): add Vercel deployment config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @markra/web build",
+  "outputDirectory": "apps/web/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a root `vercel.json` for deploying the standalone web runtime app from this pnpm monorepo
- configure Vercel to install workspace dependencies, build `@markra/web`, and publish `apps/web/dist`
- add a SPA rewrite so browser routes fall back to `index.html`

## Validation
- `pnpm --filter @markra/web build` passed
- `node -e "JSON.parse(require('node:fs').readFileSync('vercel.json','utf8')); console.log('vercel.json valid')"` passed
- `git diff --check HEAD^ HEAD` passed

## Risk
- low: configuration-only change for Vercel; desktop packaging and runtime code are untouched
- Vercel project should use the repository root as the Root Directory so the workspace lockfile and packages are available during install