### PR TITLE
ci(release): limit Windows prerelease bundles to NSIS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,19 @@ jobs:
           fs.writeFileSync(path.join(desktopDir, "tauri.updater.conf.json"), `${JSON.stringify(updaterConfig, null, 2)}\n`);
           NODE
 
+      - name: Resolve Tauri build args
+        id: tauri_args
+        shell: bash
+        env:
+          ASSET_PLATFORM: ${{ matrix.asset_platform }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          TAURI_BUILD_ARGS: ${{ matrix.args }}
+        run: |
+          set -euo pipefail
+
+          tauri_args="$(node .release-scripts/scripts/release/resolve-tauri-build-args.mjs)"
+          echo "args=${tauri_args}" >> "${GITHUB_OUTPUT}"
+
       - name: Build and bundle app
         id: tauri_build
         uses: tauri-apps/tauri-action@v0.6.0
@@ -214,7 +227,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: ${{ env.DESKTOP_DIR }}
-          args: ${{ matrix.args }} --config tauri.updater.conf.json
+          args: ${{ steps.tauri_args.outputs.args }} --config tauri.updater.conf.json
 
       - name: Rebuild Linux AppImage library policy
         if: matrix.os == 'ubuntu-22.04'

--- a/scripts/release/resolve-tauri-build-args.mjs
+++ b/scripts/release/resolve-tauri-build-args.mjs
@@ -1,0 +1,26 @@
+function readEnv(name) {
+  return process.env[name]?.trim() || "";
+}
+
+function splitArgs(value) {
+  return value.split(/\s+/).filter(Boolean);
+}
+
+function hasBundleOverride(args) {
+  return args.some((arg) => arg === "--bundles" || arg === "-b" || arg.startsWith("--bundles="));
+}
+
+function isPrereleaseTag(tag) {
+  const version = tag.replace(/^v/u, "");
+  return version.includes("-");
+}
+
+const args = splitArgs(readEnv("TAURI_BUILD_ARGS"));
+const platform = readEnv("ASSET_PLATFORM");
+const releaseTag = readEnv("RELEASE_TAG");
+
+if (platform === "windows" && isPrereleaseTag(releaseTag) && !hasBundleOverride(args)) {
+  args.push("--bundles", "nsis");
+}
+
+process.stdout.write(`${args.join(" ")}\n`);

--- a/scripts/release/resolve-tauri-build-args.test.mjs
+++ b/scripts/release/resolve-tauri-build-args.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function runResolveArgs(env) {
+  return spawnSync(process.execPath, ["scripts/release/resolve-tauri-build-args.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}
+
+test("resolve-tauri-build-args limits Windows prerelease bundles to NSIS", () => {
+  const result = runResolveArgs({
+    ASSET_PLATFORM: "windows",
+    RELEASE_TAG: "v0.6.0-beta.1",
+    TAURI_BUILD_ARGS: "--target x86_64-pc-windows-msvc",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "--target x86_64-pc-windows-msvc --bundles nsis");
+});
+
+test("resolve-tauri-build-args keeps Windows stable release bundles unchanged", () => {
+  const result = runResolveArgs({
+    ASSET_PLATFORM: "windows",
+    RELEASE_TAG: "v0.6.0",
+    TAURI_BUILD_ARGS: "--target x86_64-pc-windows-msvc",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "--target x86_64-pc-windows-msvc");
+});
+
+test("resolve-tauri-build-args keeps non-Windows prerelease bundles unchanged", () => {
+  const result = runResolveArgs({
+    ASSET_PLATFORM: "macos",
+    RELEASE_TAG: "v0.6.0-beta.1",
+    TAURI_BUILD_ARGS: "--target aarch64-apple-darwin",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "--target aarch64-apple-darwin");
+});


### PR DESCRIPTION
## Summary
- Add a release helper that appends `--bundles nsis` for Windows prerelease tags.
- Wire the release workflow to resolve Tauri build args before bundling.
- Keep stable Windows releases unchanged so MSI artifacts are still produced for normal releases.

## Why
Windows MSI bundling rejects prerelease versions like `0.6.0-beta.1` because the MSI prerelease identifier must be numeric-only. Limiting Windows prerelease builds to NSIS keeps beta tags like `v0.6.0-beta.1` usable without changing stable release packaging.

## Validation
- `node --test scripts/release/resolve-tauri-build-args.test.mjs` passed
- `pnpm test:release` passed
- `ASSET_PLATFORM=windows RELEASE_TAG=v0.6.0-beta.1 TAURI_BUILD_ARGS='--target x86_64-pc-windows-msvc' node scripts/release/resolve-tauri-build-args.mjs` outputs `--target x86_64-pc-windows-msvc --bundles nsis`
- `git diff --check` passed
- Workflow YAML parsed successfully with Ruby `YAML.load_file`

## Risk
- Windows prerelease releases will not include MSI artifacts; stable Windows releases still use the existing full bundle target set.
