### PR TITLE
fix(editor): keep intraword underscores literal

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -4874,6 +4874,39 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("clears inline formatting after deleting finalized markdown marks", async () => {
+    const cases = [
+      { markdown: "_2_", selectors: ["em"] },
+      { markdown: "**2**", selectors: ["strong"] },
+      { markdown: "___2___", selectors: ["strong", "em"] },
+      { markdown: "~~2~~", selectors: ["del"] },
+      { markdown: "`2`", selectors: ["code"] }
+    ];
+
+    for (const { markdown, selectors } of cases) {
+      const { container, view } = await renderEditor();
+
+      typeText(view, markdown);
+      expect(pressEnter(view)).toBe(true);
+
+      for (const selector of selectors) {
+        expect(container.querySelector(`.ProseMirror ${selector}`)).toHaveTextContent("2");
+      }
+
+      selectText(view, 1, 2);
+      view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+      typeText(view, "plain");
+
+      for (const selector of selectors) {
+        expect(container.querySelector(`.ProseMirror ${selector}`)).not.toBeInTheDocument();
+      }
+
+      expect(container.querySelector(".ProseMirror")?.textContent).toBe("plain");
+    }
+
+    await settleMarkdownListener();
+  });
+
   it("renders ==text== highlight syntax only when the extension is enabled", async () => {
     const enabled = await renderEditor("", {
       extendedSyntax: {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -4341,6 +4341,26 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps intraword underscores in identifiers as plain text", async () => {
+    const { container, view } = await renderEditor("user_info_data user__meta__data");
+
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("user_info_data user__meta__data");
+    expect(container.querySelector(".ProseMirror .markra-live-mark-emphasis")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-live-mark-strong")).not.toBeInTheDocument();
+    expectHiddenMarkdownDelimiters(container, 0);
+
+    moveCursor(view, findTextPosition(view, "user__meta__data", "user__meta__data".length));
+    typeText(view, " mock_value_name mock__token__name");
+
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe(
+      "user_info_data user__meta__data mock_value_name mock__token__name"
+    );
+    expect(container.querySelector(".ProseMirror .markra-live-mark-emphasis")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-live-mark-strong")).not.toBeInTheDocument();
+    expectHiddenMarkdownDelimiters(container, 0);
+    await settleMarkdownListener();
+  });
+
   it("supports inline markdown formatting shortcuts", async () => {
     const strong = await renderEditor();
     typeText(strong.view, "bold");

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -4907,6 +4907,34 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps inline formatting when editing inside remaining finalized marks", async () => {
+    const cases = [
+      { markdown: "_bold_", selector: "em" },
+      { markdown: "**bold**", selector: "strong" },
+      { markdown: "~~bold~~", selector: "del" },
+      { markdown: "`bold`", selector: "code" }
+    ];
+
+    for (const { markdown, selector } of cases) {
+      const { container, view } = await renderEditor();
+
+      typeText(view, markdown);
+      expect(pressEnter(view)).toBe(true);
+
+      selectText(view, findTextPosition(view, "ol"), findTextPosition(view, "ol", "ol".length));
+      view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+      typeText(view, "OO");
+
+      const markedText = Array.from(container.querySelectorAll(`.ProseMirror ${selector}`))
+        .map((node) => node.textContent ?? "")
+        .join("");
+      expect(markedText).toBe("bOOd");
+      expect(container.querySelector(".ProseMirror")?.textContent).toBe("bOOd");
+    }
+
+    await settleMarkdownListener();
+  });
+
   it("renders ==text== highlight syntax only when the extension is enabled", async () => {
     const enabled = await renderEditor("", {
       extendedSyntax: {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -4722,6 +4722,31 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps live closing delimiters visible after deleting adjacent plain text", async () => {
+    const cases = [
+      { markdown: "*a*a", marker: "*", kind: "emphasis" },
+      { markdown: "**a**a", marker: "**", kind: "strong" },
+      { markdown: "~~a~~a", marker: "~~", kind: "strikethrough" },
+      { markdown: "`a`a", marker: "`", kind: "inlineCode" }
+    ];
+
+    for (const { markdown, marker, kind } of cases) {
+      const { container, view } = await renderEditor();
+
+      typeText(view, markdown);
+
+      expectMarkdownDelimiters(container, 0);
+      expect(pressBackspace(view)).toBe(true);
+
+      expectLiveMark(container, kind, "a");
+      expectMarkdownDelimiterText(container, marker);
+      expect(container.querySelector(".ProseMirror p")?.textContent).toBe(markdown.slice(0, -1));
+      expect(view.state.selection.from).toBe(findLastTextBlockEndCursor(view));
+    }
+
+    await settleMarkdownListener();
+  });
+
   it("moves the cursor over live markdown delimiters as a single visible step", async () => {
     const { view } = await renderEditor();
 

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -179,6 +179,36 @@ function clearManagedStoredMarks(state: EditorState, markTypes: MarkType[]) {
   return state.tr.setStoredMarks(nextMarks);
 }
 
+function deleteTextAfterLiveMarkdownRange(
+  view: EditorView,
+  specs: LiveMarkdownSpec[],
+  markTypes: MarkType[]
+) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock) return false;
+
+  const cursor = $from.parentOffset;
+  const range = getLiveMarkdownRanges($from.parent.textContent, specs).find(
+    (candidate) => candidate.to + 1 === cursor
+  );
+  if (!range) return false;
+
+  const from = $from.start() + range.to;
+  const storedMarks = view.state.storedMarks?.filter((mark) => !markTypes.includes(mark.type)) ?? [];
+  const transaction = view.state.tr.delete(from, from + 1);
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, from))
+      .setStoredMarks(storedMarks)
+      .scrollIntoView()
+  );
+  return true;
+}
+
 function getMarkerFromFoldedMarks(marks: readonly Mark[], spec: LiveMarkdownSpec) {
   const strongMark = spec.marks.find((mark) => mark.kind === "strong");
   const emphasisMark = spec.marks.find((mark) => mark.kind === "emphasis");
@@ -648,6 +678,14 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       },
       handleKeyDown: (view, event) => {
         const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
+
+        if (event.key === "Backspace" && !hasModifier) {
+          const handled = deleteTextAfterLiveMarkdownRange(view, specs, managedMarkTypes);
+          if (handled) {
+            event.preventDefault();
+            return true;
+          }
+        }
 
         if ((event.key === "ArrowLeft" || event.key === "ArrowRight") && !hasModifier) {
           const handled = moveCursorOverLiveMarkdownDelimiter(

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -387,8 +387,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       ]
     },
     {
-      markers: ["***", "___"],
-      pattern: /(?:\*\*\*|___)[^\n]*?(?:\*\*\*|___)/g,
+      markers: ["***"],
+      pattern: /\*\*\*[^\n]*?\*\*\*/g,
       marks: [
         {
           kind: "strong",
@@ -407,8 +407,41 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       ]
     },
     {
-      markers: ["**", "__"],
-      pattern: /(?:\*\*|__)[^\n]*?(?:\*\*|__)/g,
+      markers: ["___"],
+      pattern: /(?<![\p{L}\p{N}_])___(?!_)[^\n]*?(?<!_)___(?!_)(?![\p{L}\p{N}_])/gu,
+      marks: [
+        {
+          kind: "strong",
+          markType: strongSchema.type(ctx),
+          getAttr: (marker) => ({
+            marker: marker[0]
+          })
+        },
+        {
+          kind: "emphasis",
+          markType: emphasisSchema.type(ctx),
+          getAttr: (marker) => ({
+            marker: marker[0]
+          })
+        }
+      ]
+    },
+    {
+      markers: ["**"],
+      pattern: /\*\*[^\n]*?\*\*/g,
+      marks: [
+        {
+          kind: "strong",
+          markType: strongSchema.type(ctx),
+          getAttr: (marker) => ({
+            marker: marker[0]
+          })
+        }
+      ]
+    },
+    {
+      markers: ["__"],
+      pattern: /(?<![\p{L}\p{N}_])__(?!_)[^\n]*?(?<!_)__(?!_)(?![\p{L}\p{N}_])/gu,
       marks: [
         {
           kind: "strong",
@@ -454,7 +487,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
     },
     {
       markers: ["_"],
-      pattern: /(?<!_)_(?!_)[^_\n]*?(?<!_)_(?!_)/g,
+      pattern: /(?<![\p{L}\p{N}_])_(?!_)[^\n]*?(?<!_)_(?!_)(?![\p{L}\p{N}_])/gu,
       marks: [
         {
           kind: "emphasis",

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -110,6 +110,75 @@ function getMarkByType(marks: readonly Mark[], markType: MarkType) {
   return marks.find((mark) => mark.type === markType);
 }
 
+function getManagedMarkTypes(specs: LiveMarkdownSpec[]) {
+  const markTypes: MarkType[] = [];
+
+  for (const spec of specs) {
+    for (const mark of spec.marks) {
+      if (!markTypes.includes(mark.markType)) {
+        markTypes.push(mark.markType);
+      }
+    }
+  }
+
+  return markTypes;
+}
+
+function hasManagedMark(marks: readonly Mark[] | null | undefined, markTypes: MarkType[]) {
+  return Boolean(marks?.some((mark) => markTypes.includes(mark.type)));
+}
+
+function selectionContainsManagedMark(state: EditorState, markTypes: MarkType[]) {
+  const { selection } = state;
+  if (selection.empty) return false;
+
+  let found = false;
+  state.doc.nodesBetween(selection.from, selection.to, (node) => {
+    if (found) return false;
+    if (!node.isText) return true;
+
+    found = hasManagedMark(node.marks, markTypes);
+    return !found;
+  });
+
+  return found;
+}
+
+function emptyTextblockSelection(state: EditorState) {
+  const { selection } = state;
+
+  return (
+    selection instanceof TextSelection &&
+    selection.empty &&
+    selection.$from.parent.isTextblock &&
+    selection.$from.parent.content.size === 0
+  );
+}
+
+function shouldClearManagedStoredMarks(
+  transactions: readonly { docChanged: boolean }[],
+  oldState: EditorState,
+  newState: EditorState,
+  markTypes: MarkType[]
+) {
+  if (!hasManagedMark(newState.storedMarks, markTypes)) return false;
+  if (!transactions.some((transaction) => transaction.docChanged)) return false;
+
+  if (selectionContainsManagedMark(oldState, markTypes)) return true;
+
+  return oldState.doc.content.size > newState.doc.content.size && emptyTextblockSelection(newState);
+}
+
+function clearManagedStoredMarks(state: EditorState, markTypes: MarkType[]) {
+  const storedMarks = state.storedMarks;
+  if (!storedMarks) return null;
+
+  const nextMarks = storedMarks.filter((mark) => !markTypes.includes(mark.type));
+  if (nextMarks.length === storedMarks.length) return null;
+
+  return state.tr.setStoredMarks(nextMarks);
+}
+
 function getMarkerFromFoldedMarks(marks: readonly Mark[], spec: LiveMarkdownSpec) {
   const strongMark = spec.marks.find((mark) => mark.kind === "strong");
   const emphasisMark = spec.marks.find((mark) => mark.kind === "emphasis");
@@ -499,9 +568,15 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       ]
     }
   ];
+  const managedMarkTypes = getManagedMarkTypes(specs);
 
   return new Plugin({
     key: liveMarkdownKey,
+    appendTransaction: (transactions, oldState, newState) => {
+      if (!shouldClearManagedStoredMarks(transactions, oldState, newState, managedMarkTypes)) return null;
+
+      return clearManagedStoredMarks(newState, managedMarkTypes);
+    },
     state: {
       init: (): LiveMarkdownPluginState => ({
         suppressActiveAt: null,


### PR DESCRIPTION
## Summary
- Keep live Markdown underscore emphasis/strong matching from triggering inside identifier-style words.
- Clear stale inline formatting state after deleting finalized Markdown marks so the next typed text is plain.
- Type plain text outside folded Markdown delimiters on both opening and closing edges, matching the visual cursor position.
- Handle Backspace/Delete at folded delimiter edges by deleting real text instead of leaking virtual markers into text.
- Preserve explicit underscore formatting such as `_2_`, `__2__`, and `___2___`.
- Add regression coverage for intraword underscores, deletion/retyping across emphasis, strong, strong+emphasis, strikethrough, and inline code, editing inside remaining formatted text, typing before/after folded delimiters, and Backspace/Delete at folded delimiter edges.

## Why
Issue #146 reported that `user_info_data` rendered `info` as italic in the WYSIWYG editor because the live Markdown scanner treated intraword underscores as emphasis markers. Follow-up testing also showed that after deleting a finalized inline mark, ProseMirror could keep the old stored mark and apply it to newly typed text. Additional edge cases occurred when the cursor visually sat beside folded delimiters such as `**`; typing or deleting could still act on the inline mark boundary and leak/extend formatting.

## Validation
- `pnpm --filter @markra/app test` passed: 41 files / 814 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

Closes #146