### PR TITLE
fix(editor): render task lists as interactive checkboxes

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -667,6 +667,17 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".markdown-paper")).toHaveAttribute("data-editor-theme", "light");
   });
 
+  it("disables browser writing suggestions on the visual editor surface", async () => {
+    const { container } = await renderEditor();
+    const editorSurface = container.querySelector(".ProseMirror");
+
+    expect(editorSurface).toHaveAttribute("autocomplete", "off");
+    expect(editorSurface).toHaveAttribute("autocorrect", "off");
+    expect(editorSurface).toHaveAttribute("autocapitalize", "off");
+    expect(editorSurface).toHaveAttribute("spellcheck", "false");
+    expect(editorSurface).toHaveAttribute("writingsuggestions", "false");
+  });
+
   it("blocks document-changing editor transactions while read-only", async () => {
     const onMarkdownChange = vi.fn();
     const { editor, view } = await renderEditor("Locked content", {
@@ -746,6 +757,38 @@ describe("MarkdownPaper editing", () => {
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain(source);
+  });
+
+  it("renders GFM task list items as clickable checkboxes", async () => {
+    const source = ["- [x] Finish mock draft", "- [ ] Review mock copy"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    const checkboxes = Array.from(container.querySelectorAll<HTMLInputElement>('.ProseMirror input[type="checkbox"]'));
+
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(serializeMarkdown(view.state.doc)).toBe("* [x] Finish mock draft\n* [ ] Review mock copy\n");
+
+    fireEvent.click(checkboxes[1]);
+
+    expect(checkboxes[1]).toBeChecked();
+    expect(serializeMarkdown(view.state.doc)).toBe("* [x] Finish mock draft\n* [x] Review mock copy\n");
+  });
+
+  it("turns typed GFM task list syntax into a checkbox", async () => {
+    const { container, editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "- [ ] a");
+
+    const checkbox = container.querySelector<HTMLInputElement>('.ProseMirror input[type="checkbox"]');
+
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+    expect(container.querySelector(".ProseMirror li")).toHaveTextContent("a");
+    expect(serializeMarkdown(view.state.doc)).toContain("* [ ] a");
   });
 
   it.each([

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -31,6 +31,8 @@ import {
   markraSearchPlugin,
   markraSlashCommands,
   markraTableControlsPlugin,
+  markraTaskListPlugin,
+  markraTaskListSchema,
   normalizeMarkdownShortcuts,
   serializeLinkImageLiveMarkdown,
   type MarkdownShortcutMap,
@@ -236,7 +238,11 @@ function MilkdownEditorSurface({
               ...options.attributes,
               "aria-label": markdownDocumentLabel,
               "aria-readonly": readOnlyRef.current ? "true" : "false",
-              spellcheck: "true"
+              autocomplete: "off",
+              autocapitalize: "off",
+              autocorrect: "off",
+              spellcheck: "false",
+              writingsuggestions: "false"
             },
             editable: () => !readOnlyRef.current
           }));
@@ -264,6 +270,8 @@ function MilkdownEditorSurface({
         .use(markraCommonmark)
         .use(markraFrontmatterSchema)
         .use(markraGfm)
+        .use(markraTaskListSchema)
+        .use(markraTaskListPlugin)
         .use(markraCalloutSerializerPlugin);
 
       if (githubAlertsEnabled) {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -665,6 +665,30 @@
     @apply wrap-break-word whitespace-pre-wrap;
   }
 
+  .markdown-paper .ProseMirror li[data-item-type="task"] {
+    @apply relative flex list-none items-start gap-2;
+  }
+
+  .markdown-paper .markra-task-list-checkbox {
+    @apply mt-1 h-4 w-4 shrink-0 cursor-pointer rounded-sm border border-(--border-strong) accent-(--accent);
+  }
+
+  .markdown-paper .markra-task-list-checkbox:disabled {
+    @apply cursor-not-allowed opacity-55;
+  }
+
+  .markdown-paper .markra-task-list-content {
+    @apply min-w-0 flex-1;
+  }
+
+  .markdown-paper .markra-task-list-content > p:first-child {
+    @apply mt-0;
+  }
+
+  .markdown-paper .markra-task-list-content > p:last-child {
+    @apply mb-0;
+  }
+
   .markdown-paper .ProseMirror-focused {
     @apply outline-none;
   }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -17,3 +17,4 @@ export * from "./search.ts";
 export * from "./shortcuts.ts";
 export * from "./slash-commands.ts";
 export * from "./table-controls.ts";
+export * from "./task-list.ts";

--- a/packages/editor/src/task-list.ts
+++ b/packages/editor/src/task-list.ts
@@ -1,0 +1,184 @@
+import { bulletListSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import { Plugin } from "@milkdown/kit/prose/state";
+import type { EditorView, NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+function isSingleParagraphTaskList(node: ProseNode) {
+  let hasTaskItem = false;
+  let allItemsAreSingleParagraphTasks = true;
+
+  node.forEach((child) => {
+    if (
+      child.type.name !== "list_item" ||
+      child.attrs.checked === null ||
+      child.childCount !== 1 ||
+      child.firstChild?.type.name !== "paragraph"
+    ) {
+      allItemsAreSingleParagraphTasks = false;
+      return;
+    }
+
+    hasTaskItem = true;
+  });
+
+  return hasTaskItem && allItemsAreSingleParagraphTasks;
+}
+
+export const markraTaskListSchema = bulletListSchema.extendSchema((previous) => (ctx) => {
+  const baseSchema = previous(ctx);
+
+  return {
+    ...baseSchema,
+    toMarkdown: {
+      ...baseSchema.toMarkdown,
+      runner: (state, node) => {
+        if (!isSingleParagraphTaskList(node)) {
+          baseSchema.toMarkdown.runner(state, node);
+          return;
+        }
+
+        state
+          .openNode("list", undefined, {
+            ordered: false,
+            spread: false
+          })
+          .next(node.content)
+          .closeNode();
+      }
+    }
+  };
+});
+
+class TaskListItemView implements NodeView {
+  contentDOM: HTMLElement;
+  dom: HTMLElement;
+
+  private checkbox: HTMLInputElement | null = null;
+  private node: ProseNode;
+  private readonly onCheckboxClick: (event: MouseEvent) => unknown;
+
+  constructor(
+    node: ProseNode,
+    private readonly view: EditorView,
+    private readonly getPos: () => number | undefined
+  ) {
+    this.node = node;
+    this.dom = document.createElement("li");
+    this.contentDOM = this.dom;
+    this.onCheckboxClick = (event) => this.handleCheckboxClick(event);
+    this.render();
+  }
+
+  update(node: ProseNode) {
+    if (node.type !== this.node.type) return false;
+
+    const wasTask = this.node.attrs.checked !== null;
+    const isTask = node.attrs.checked !== null;
+    this.node = node;
+
+    if (wasTask !== isTask) {
+      return false;
+    }
+
+    this.syncDomAttributes();
+    this.syncCheckbox();
+    return true;
+  }
+
+  destroy() {
+    this.checkbox?.removeEventListener("click", this.onCheckboxClick);
+  }
+
+  ignoreMutation(record: ViewMutationRecord) {
+    return Boolean(this.checkbox && record.target === this.checkbox);
+  }
+
+  stopEvent(event: Event) {
+    return Boolean(this.checkbox && event.target === this.checkbox);
+  }
+
+  private render() {
+    this.checkbox?.removeEventListener("click", this.onCheckboxClick);
+    this.checkbox = null;
+    this.dom.replaceChildren();
+    this.syncDomAttributes();
+
+    if (this.node.attrs.checked === null) {
+      this.contentDOM = this.dom;
+      return;
+    }
+
+    const checkbox = document.createElement("input");
+    checkbox.className = "markra-task-list-checkbox";
+    checkbox.type = "checkbox";
+    checkbox.contentEditable = "false";
+    checkbox.addEventListener("click", this.onCheckboxClick);
+
+    const content = document.createElement("div");
+    content.className = "markra-task-list-content";
+
+    this.checkbox = checkbox;
+    this.contentDOM = content;
+    this.dom.append(checkbox, content);
+    this.syncCheckbox();
+  }
+
+  private syncDomAttributes() {
+    if (this.node.attrs.checked === null) {
+      delete this.dom.dataset.itemType;
+      delete this.dom.dataset.checked;
+    } else {
+      this.dom.dataset.itemType = "task";
+      this.dom.dataset.checked = String(this.node.attrs.checked);
+    }
+
+    this.setOptionalDataAttribute("label", this.node.attrs.label);
+    this.setOptionalDataAttribute("listType", this.node.attrs.listType);
+    this.setOptionalDataAttribute("spread", this.node.attrs.spread);
+  }
+
+  private syncCheckbox() {
+    if (!this.checkbox) return;
+
+    this.checkbox.checked = Boolean(this.node.attrs.checked);
+    this.checkbox.disabled = !this.view.editable;
+    this.checkbox.setAttribute("aria-label", this.checkbox.checked ? "Mark task incomplete" : "Mark task complete");
+  }
+
+  private setOptionalDataAttribute(name: string, value: unknown) {
+    if (typeof value === "string") {
+      this.dom.dataset[name] = value;
+      return;
+    }
+
+    delete this.dom.dataset[name];
+  }
+
+  private handleCheckboxClick(event: MouseEvent) {
+    if (!this.view.editable) return;
+
+    const position = this.getPos();
+    if (typeof position !== "number") return;
+
+    const checked = event.currentTarget instanceof HTMLInputElement
+      ? event.currentTarget.checked
+      : !Boolean(this.node.attrs.checked);
+    const transaction = this.view.state.tr.setNodeMarkup(position, undefined, {
+      ...this.node.attrs,
+      checked
+    });
+
+    this.view.dispatch(transaction);
+  }
+}
+
+export const markraTaskListPlugin = $prose(() => {
+  return new Plugin({
+    props: {
+      nodeViews: {
+        list_item: (node, view, getPos) => new TaskListItemView(node, view, getPos)
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Render GFM task list items as interactive checkboxes in WYSIWYG mode.
- Keep checkbox clicks in sync with Markdown state and visual state.
- Disable browser writing suggestions on the visual editor surface and keep single-paragraph task lists serialized without blank lines.

## Why
Task list markdown such as `- [ ] item` was displayed as a plain list, typed task syntax did not reliably become a checkbox, checkbox clicks only updated source state after mode switching, and browser suggestions could appear under the editor cursor.

## Validation
- `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx -t "task list|browser writing suggestions"` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/desktop build` passed

## Related Issues
- Closes #149
