### PR TITLE
[codex] feat editor footnote wysiwyg support

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -678,6 +678,449 @@ describe("MarkdownPaper editing", () => {
     expect(editorSurface).toHaveAttribute("writingsuggestions", "false");
   });
 
+  it("shows the matching footnote content while hovering a footnote reference", async () => {
+    const source = ["A sentence with a footnote[^preview].", "", "[^preview]: Synthetic footnote preview text."].join(
+      "\n"
+    );
+    const { container } = await renderEditor(source);
+    const reference = container.querySelector<HTMLElement>(
+      '.ProseMirror sup[data-type="footnote_reference"][data-label="preview"]'
+    );
+
+    expect(reference).toBeInTheDocument();
+
+    fireEvent.mouseEnter(reference!);
+
+    const preview = await screen.findByRole("tooltip");
+    expect(preview).toHaveTextContent("Synthetic footnote preview text.");
+
+    fireEvent.mouseLeave(reference!);
+
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+
+  it("keeps nested footnote definitions out of the parent reference preview", async () => {
+    const source = ["Only the first footnote is referenced[^1].", "", "[^1]: First preview text."].join("\n");
+    const { container, view } = await renderEditor(source);
+    const reference = container.querySelector<HTMLElement>(
+      '.ProseMirror sup[data-type="footnote_reference"][data-label="1"]'
+    );
+    const firstDefinition = view.state.doc.lastChild;
+    const paragraph = view.state.schema.nodes.paragraph;
+    const footnoteDefinition = view.state.schema.nodes.footnote_definition;
+
+    expect(reference).toBeInTheDocument();
+    expect(firstDefinition?.type.name).toBe("footnote_definition");
+    expect(paragraph).toBeDefined();
+    expect(footnoteDefinition).toBeDefined();
+
+    const nestedDefinition = footnoteDefinition!.create(
+      { label: "2" },
+      paragraph!.create(null, view.state.schema.text("Second preview text."))
+    );
+    view.dispatch(
+      view.state.tr.insert(view.state.doc.content.size - 2, nestedDefinition)
+    );
+
+    fireEvent.mouseEnter(reference!);
+
+    const preview = await screen.findByRole("tooltip");
+    expect(preview).toHaveTextContent("First preview text.");
+    expect(preview).not.toHaveTextContent("Second preview text.");
+  });
+
+  it("positions short footnote previews from their rendered width", async () => {
+    const source = ["A sentence with a footnote[^preview].", "", "[^preview]: Short preview."].join("\n");
+    const { container } = await renderEditor(source);
+    const reference = container.querySelector<HTMLElement>(
+      '.ProseMirror sup[data-type="footnote_reference"][data-label="preview"]'
+    );
+
+    expect(reference).toBeInTheDocument();
+
+    reference!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 116,
+          height: 16,
+          left: 240,
+          right: 252,
+          top: 100,
+          width: 12,
+          x: 240,
+          y: 100,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.classList.contains("markra-footnote-preview")) {
+          return {
+            bottom: 44,
+            height: 44,
+            left: 0,
+            right: 148,
+            top: 0,
+            width: 148,
+            x: 0,
+            y: 0,
+            toJSON: () => ({})
+          } as DOMRect;
+        }
+
+        return {
+          bottom: 0,
+          height: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({})
+        } as DOMRect;
+      });
+
+    try {
+      fireEvent.mouseEnter(reference!);
+
+      const preview = await screen.findByRole("tooltip");
+      expect(preview.style.left).toBe("172px");
+      expect(preview.style.top).toBe("124px");
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it("keeps typed footnote references as markdown instead of escaped text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    typeText(view, "A typed footnote[^1]");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+    const lastMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(lastMarkdown).toContain("[^1]");
+    expect(lastMarkdown).not.toContain("\\[^1]");
+  });
+
+  it("keeps an existing footnote reference when another reference is typed after it", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "Synthetic references[^1][^2]");
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror sup[data-type="footnote_reference"]')).toHaveLength(2)
+    );
+    expect(
+      container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="2"]')
+    ).toBeInTheDocument();
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("Synthetic references[^1][^2]");
+    expect(markdown).not.toContain("\\[^");
+  });
+
+  it("keeps an existing footnote reference when raw reference markdown is inserted after it", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "Synthetic references[^1]");
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+
+    insertTextDirectly(view, "[^2]");
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror sup[data-type="footnote_reference"]')).toHaveLength(2)
+    );
+    expect(
+      container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="2"]')
+    ).toBeInTheDocument();
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("Synthetic references[^1][^2]");
+    expect(markdown).not.toContain("\\[^");
+  });
+
+  it("keeps typed footnote definitions as markdown instead of escaped text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    typeText(view, "[^1]: Synthetic typed definition.");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+    const lastMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(lastMarkdown).toContain("[^1]: Synthetic typed definition.");
+    expect(lastMarkdown).not.toContain("\\[^1]");
+  });
+
+  it("keeps full footnote definition input as markdown instead of escaped text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    expect(insertTextThroughInputHandler(view, "[^1]: asdfds")).toBe(true);
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+    const lastMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(lastMarkdown).toContain("[^1]: asdfds");
+    expect(lastMarkdown).not.toContain("\\[^1]");
+  });
+
+  it("turns a typed footnote definition marker into a definition when the colon is typed", async () => {
+    const { container, view } = await renderEditor("");
+
+    typeText(view, "[^2]:");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="2"]')
+      ).toBeInTheDocument()
+    );
+    expect(
+      container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="2"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it("serializes adjacent footnote definitions without continuation indentation", async () => {
+    const source = ["[^1]: First synthetic footnote.", "", "[^2]: Second synthetic footnote."].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("\n    [^2]:");
+  });
+
+  it("keeps text typed after an empty footnote definition marker unindented", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "[^1]: First synthetic footnote.");
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "[^2]:");
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="2"]')
+      ).toBeInTheDocument()
+    );
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "Second synthetic footnote.");
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("\n    [^2]:");
+    expect(markdown).not.toContain("\n    Second synthetic footnote.");
+  });
+
+  it("exits a footnote definition when pressing Enter after definition text", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "[^1]: First synthetic footnote.");
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "Second synthetic paragraph.");
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\nSecond synthetic paragraph.");
+    expect(markdown).not.toContain("\n    Second synthetic paragraph.");
+  });
+
+  it("normalizes pasted adjacent footnote definitions without continuation indentation", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    insertTextDirectly(view, "[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror dl[data-type="footnote_definition"]')).toHaveLength(2)
+    );
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("\n    [^2]:");
+  });
+
+  it("keeps pasted multiline footnote definitions without dropping continuation text", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    insertTextDirectly(
+      view,
+      ["[^1]: First synthetic footnote.", "    Continued synthetic line.", "", "[^2]: Second synthetic footnote."].join(
+        "\n"
+      )
+    );
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror dl[data-type="footnote_definition"]')).toHaveLength(2)
+    );
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("First synthetic footnote.");
+    expect(markdown).toContain("Continued synthetic line.");
+    expect(markdown).toContain("[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("\n    [^2]:");
+  });
+
+  it("normalizes pasted footnote definitions separated by a single newline", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    insertTextDirectly(view, "[^1]: First synthetic footnote.\n[^2]: Second synthetic footnote.");
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror dl[data-type="footnote_definition"]')).toHaveLength(2)
+    );
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("[^1]: First synthetic footnote.\n    [^2]: Second synthetic footnote.");
+  });
+
+  it("serializes consecutively typed footnote definitions without continuation indentation", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "[^1]: First synthetic footnote.");
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+
+    expect(pressEnter(view)).toBe(true);
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "[^2]: Second synthetic footnote.");
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror dl[data-type="footnote_definition"]')).toHaveLength(2)
+    );
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("\n    [^2]:");
+  });
+
+  it("lifts a typed footnote definition after one Enter out of the previous definition", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "[^1]: First synthetic footnote.");
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "[^2]: Second synthetic footnote.");
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ProseMirror dl[data-type="footnote_definition"]')).toHaveLength(2)
+    );
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("[^1]: First synthetic footnote.\n\n[^2]: Second synthetic footnote.");
+    expect(markdown).not.toContain("\n    [^2]:");
+  });
+
+  it("normalizes pasted footnote markdown as footnotes instead of escaped text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    insertTextDirectly(view, "这是引用：[^1]\n\n[^1]: 这是脚注");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror dl[data-type="footnote_definition"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+    const lastMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(lastMarkdown).toContain("这是引用：[^1]");
+    expect(lastMarkdown).toContain("[^1]: 这是脚注");
+    expect(lastMarkdown).not.toContain("\\[^1]");
+  });
+
+  it("normalizes a sentence-ending footnote reference as markdown instead of escaped text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    insertTextDirectly(view, "这是引用[^1]\n\n[^1]: 这是脚注");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+    const lastMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(lastMarkdown).toContain("这是引用[^1]");
+    expect(lastMarkdown).not.toContain("这是引用\\[^1]");
+  });
+
+  it("normalizes a standalone sentence-ending footnote reference as markdown instead of escaped text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    insertTextDirectly(view, "这是引用[^1]");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.ProseMirror sup[data-type="footnote_reference"][data-label="1"]')
+      ).toBeInTheDocument()
+    );
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+    const lastMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(lastMarkdown).toContain("这是引用[^1]");
+    expect(lastMarkdown).not.toContain("这是引用\\[^1]");
+  });
+
   it("blocks document-changing editor transactions while read-only", async () => {
     const onMarkdownChange = vi.fn();
     const { editor, view } = await renderEditor("Locked content", {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -1121,6 +1121,60 @@ describe("MarkdownPaper editing", () => {
     expect(lastMarkdown).not.toContain("这是引用\\[^1]");
   });
 
+  it("keeps typed footnote syntax inside inline code instead of converting it to a reference", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "Synthetic code `[^1]`");
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror code")).toHaveTextContent("[^1]"));
+    expect(container.querySelector('.ProseMirror sup[data-type="footnote_reference"]')).not.toBeInTheDocument();
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("`[^1]`");
+  });
+
+  it("keeps pasted footnote syntax between inline code markers unescaped", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "``");
+    moveCursor(view, 2);
+    insertTextDirectly(view, "[^2]");
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror code")).toHaveTextContent("[^2]"));
+    expect(container.querySelector('.ProseMirror sup[data-type="footnote_reference"]')).not.toBeInTheDocument();
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("`[^2]`");
+    expect(markdown).not.toContain("`\\[^2]`");
+  });
+
+  it("serializes pasted footnote syntax between live inline code markers unescaped", async () => {
+    const { editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "``");
+    moveCursor(view, 2);
+    view.pasteText("[^2]", new Event("paste") as ClipboardEvent);
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("`[^2]`");
+    expect(markdown).not.toContain("\\`\\[^2]\\`");
+  });
+
+  it("keeps pasted footnote syntax inside fenced code instead of converting it to a reference", async () => {
+    const { container, view } = await renderEditor("");
+
+    insertTextDirectly(view, ["```", "[^1]", "```"].join("\n"));
+
+    await waitFor(() =>
+      expect(container.querySelector('.ProseMirror sup[data-type="footnote_reference"]')).not.toBeInTheDocument()
+    );
+  });
+
   it("blocks document-changing editor transactions while read-only", async () => {
     const onMarkdownChange = vi.fn();
     const { editor, view } = await renderEditor("Locked content", {
@@ -5191,6 +5245,29 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("places the folded closing delimiter after the cursor at the end of formatted text", async () => {
+    const { container, view } = await renderEditor("`sample`");
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+
+    expect(container.querySelector(".ProseMirror code")).toHaveTextContent("sample");
+    const codeEnd = findTextPosition(view, "sample", "sample".length);
+    const closingDelimiterDecorations: Array<{ from: number; to: number }> = [];
+    view.someProp("decorations", (decorations) => {
+      const value = typeof decorations === "function" ? decorations(view.state) : decorations;
+      value?.forEachSet((set) => {
+        closingDelimiterDecorations.push(
+          ...set.find(codeEnd, codeEnd, (spec: { side?: number }) => spec.side === 1)
+        );
+      });
+      return undefined;
+    });
+    expect(
+      closingDelimiterDecorations.some((decoration) => decoration.from === codeEnd && decoration.to === codeEnd)
+    ).toBe(true);
+    await settleMarkdownListener();
+  });
+
   it("hides folded markdown delimiters after the cursor moves to other text", async () => {
     const { container, view } = await renderEditor();
 
@@ -5499,6 +5576,95 @@ describe("MarkdownPaper editing", () => {
 
     expect(inlineCode.container.querySelector(".ProseMirror code")).toHaveTextContent("23");
     expect(inlineCode.container.querySelector(".ProseMirror")?.textContent).toBe("23");
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed at the end of finalized inline code inside the code mark", async () => {
+    const { container, editor, view } = await renderEditor("`sample`");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " text");
+
+    expect(container.querySelector(".ProseMirror code")).toHaveTextContent("sample text");
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("`sample text`");
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed after confirming live inline code inside the code mark", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "``");
+    moveCursor(view, 2);
+    typeText(view, "sample");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, " text");
+
+    expect(container.querySelector(".ProseMirror code")).toHaveTextContent("sample text");
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("`sample text`");
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed after moving past the folded closing delimiter outside the code mark", async () => {
+    const { container, editor, view } = await renderEditor("`sample`");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    expect(pressArrowRight(view)).toBe(true);
+    const codeEnd = findTextPosition(view, "sample", "sample".length);
+    const exitedClosingDelimiterDecorations: Array<{ from: number; to: number }> = [];
+    view.someProp("decorations", (decorations) => {
+      const value = typeof decorations === "function" ? decorations(view.state) : decorations;
+      value?.forEachSet((set) => {
+        exitedClosingDelimiterDecorations.push(
+          ...set.find(codeEnd, codeEnd, (spec: { side?: number }) => spec.side === -1)
+        );
+      });
+      return undefined;
+    });
+    expect(
+      exitedClosingDelimiterDecorations.some((decoration) => decoration.from === codeEnd && decoration.to === codeEnd)
+    ).toBe(true);
+    expect(container.querySelector(".ProseMirror code")?.textContent).toBe("sample");
+    expect(pressArrowRight(view)).toBe(true);
+    const stableExitedClosingDelimiterDecorations: Array<{ from: number; to: number }> = [];
+    view.someProp("decorations", (decorations) => {
+      const value = typeof decorations === "function" ? decorations(view.state) : decorations;
+      value?.forEachSet((set) => {
+        stableExitedClosingDelimiterDecorations.push(
+          ...set.find(codeEnd, codeEnd, (spec: { side?: number }) => spec.side === -1)
+        );
+      });
+      return undefined;
+    });
+    expect(
+      stableExitedClosingDelimiterDecorations.some(
+        (decoration) => decoration.from === codeEnd && decoration.to === codeEnd
+      )
+    ).toBe(true);
+    expect(container.querySelector(".ProseMirror code")?.textContent).toBe("sample");
+    typeText(view, " text");
+
+    expect(container.querySelector(".ProseMirror code")).toHaveTextContent("sample");
+    expect(container.querySelector(".ProseMirror code")).not.toHaveTextContent("sample text");
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("`sample` text");
+    expect(markdown).not.toContain("`sample text`");
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed at the start of finalized inline code inside the code mark", async () => {
+    const { container, editor, view } = await renderEditor("`sample`");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "sample"));
+    typeText(view, "pre");
+
+    expect(container.querySelector(".ProseMirror code")).toHaveTextContent("presample");
+    expect(serializeMarkdown(view.state.doc)).toContain("`presample`");
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -17,6 +17,9 @@ import {
   markraCodeBlockPlugin,
   markraFrontmatterRemarkPlugin,
   markraFrontmatterSchema,
+  markraFootnoteDefinitionInputPlugin,
+  markraFootnotePreviewPlugin,
+  markraFootnoteReferenceInputRule,
   markraHeadingLevelPlugin,
   markraHeadingTogglePlugin,
   markraListTogglePlugin,
@@ -270,6 +273,8 @@ function MilkdownEditorSurface({
         .use(markraCommonmark)
         .use(markraFrontmatterSchema)
         .use(markraGfm)
+        .use(markraFootnoteReferenceInputRule)
+        .use(markraFootnoteDefinitionInputPlugin())
         .use(markraTaskListSchema)
         .use(markraTaskListPlugin)
         .use(markraCalloutSerializerPlugin);
@@ -288,6 +293,7 @@ function MilkdownEditorSurface({
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)
         .use(markraSearchPlugin())
+        .use(markraFootnotePreviewPlugin())
         .use(markraBlockDragPlugin(blockDragLabels))
         .use(markraHeadingTogglePlugin(headingToggleLabels))
         .use(markraListTogglePlugin(listToggleLabels))

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1942,6 +1942,32 @@
     display: none !important;
   }
 
+  .markdown-paper sup[data-type="footnote_reference"] {
+    color: var(--editor-link-color);
+    cursor: help;
+    font-weight: 650;
+    text-decoration: none;
+  }
+
+  .markdown-paper .markra-footnote-preview {
+    position: fixed;
+    z-index: 80;
+    max-width: min(20rem, calc(100vw - 1.5rem));
+    border: 1px solid var(--editor-border);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--editor-paper-bg) 96%, transparent);
+    padding: 0.625rem 0.75rem;
+    color: var(--editor-text-primary);
+    font-family: var(--editor-font-family);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+    pointer-events: none;
+    white-space: pre-wrap;
+    box-shadow: 0 16px 40px rgba(15, 23, 42, 0.14);
+  }
+
   .markdown-paper .markra-live-link-icon {
     @apply inline-block text-(--editor-link-color);
     margin-left: 0.18em;

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2334,6 +2334,15 @@
     font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
   }
 
+  .markdown-paper code .markra-live-mark-inlineCode {
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    color: inherit;
+    font-size: inherit;
+  }
+
   .markdown-paper .markra-ai-preview-delete {
     @apply rounded-[3px] text-(--text-secondary) line-through decoration-red-500/50 decoration-1;
     background: color-mix(in srgb, oklch(63.7% 0.237 25.331) 7%, transparent);

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -324,9 +324,14 @@ describe("editor stylesheet", () => {
     const preCodeStart = styles.indexOf(".markdown-paper pre code {");
     const preCodeEnd = styles.indexOf(".markdown-paper .markra-code-block");
     const preCodeStyles = styles.slice(preCodeStart, preCodeEnd);
+    const activeInlineCodeStart = styles.indexOf(".markdown-paper code .markra-live-mark-inlineCode {");
+    const activeInlineCodeEnd = styles.indexOf(".markdown-paper .markra-ai-preview-delete");
+    const activeInlineCodeStyles = styles.slice(activeInlineCodeStart, activeInlineCodeEnd);
 
     expect(inlineCodeStyles).toContain("color: oklch");
     expect(inlineCodeStyles).toContain("box-shadow");
+    expect(activeInlineCodeStyles).toContain("background: transparent");
+    expect(activeInlineCodeStyles).toContain("box-shadow: none");
     expect(preCodeStyles).toContain("color: inherit");
     expect(preCodeStyles).toContain("box-shadow: none");
     expect(styles).toContain(".markdown-paper .hljs-meta");

--- a/packages/editor/src/footnote.ts
+++ b/packages/editor/src/footnote.ts
@@ -1,0 +1,752 @@
+import {
+  Fragment,
+  type Mark,
+  type Node as ProseNode,
+  type NodeType,
+  type ResolvedPos
+} from "@milkdown/kit/prose/model";
+import { inlineCodeSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import { footnoteDefinitionSchema, footnoteReferenceSchema } from "@milkdown/kit/preset/gfm";
+import { InputRule } from "@milkdown/kit/prose/inputrules";
+import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $inputRule, $prose } from "@milkdown/kit/utils";
+
+const footnoteReferenceSelector = 'sup[data-type="footnote_reference"][data-label]';
+const footnoteReferenceInputPattern = /\[\^([^\]\s]+)\]$/u;
+const footnoteDefinitionInputPattern = /^\[\^([^\]\s]+)\]:[ \t]*(.*)$/u;
+const footnoteDefinitionBlockPattern = /^[ \t]{0,3}\[\^([^\]\s]+)\]:[ \t]*(.*)$/u;
+const footnoteReferenceMarkdownPattern = /\[\^([^\]\s]+)\]/gu;
+const footnoteDefinitionContinuationPattern = /^(?: {4}|\t)(.*)$/u;
+const fencedCodeDelimiterPattern = /^[ \t]{0,3}(`{3,}|~{3,})/u;
+const footnotePreviewGap = 8;
+const footnotePreviewPadding = 12;
+const footnotePreviewWidth = 320;
+
+let footnotePreviewIdSeed = 0;
+
+type MarkdownCodeRange = {
+  closed: boolean;
+  from: number;
+  to: number;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function isEscaped(text: string, index: number) {
+  let slashCount = 0;
+
+  for (let position = index - 1; position >= 0 && text[position] === "\\"; position -= 1) {
+    slashCount += 1;
+  }
+
+  return slashCount % 2 === 1;
+}
+
+function readBacktickRunLength(text: string, start: number) {
+  if (text[start] !== "`" || isEscaped(text, start)) return 0;
+
+  let length = 1;
+  while (text[start + length] === "`") length += 1;
+  return length;
+}
+
+function findClosingBacktickRun(text: string, start: number, markerLength: number) {
+  for (let position = start; position < text.length; position += 1) {
+    if (readBacktickRunLength(text, position) !== markerLength) continue;
+    return position;
+  }
+
+  return null;
+}
+
+function inlineCodeRanges(text: string): MarkdownCodeRange[] {
+  const ranges: MarkdownCodeRange[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const markerLength = readBacktickRunLength(text, cursor);
+    if (markerLength === 0) {
+      cursor += 1;
+      continue;
+    }
+
+    const closingStart = findClosingBacktickRun(text, cursor + markerLength, markerLength);
+    if (closingStart === null) {
+      ranges.push({ closed: false, from: cursor, to: text.length });
+      break;
+    }
+
+    const closingEnd = closingStart + markerLength;
+    ranges.push({ closed: true, from: cursor, to: closingEnd });
+    cursor = closingEnd;
+  }
+
+  return ranges;
+}
+
+function readLineBounds(text: string, start: number) {
+  const lineEnd = text.indexOf("\n", start);
+  const to = lineEnd === -1 ? text.length : lineEnd;
+  return {
+    next: lineEnd === -1 ? text.length : lineEnd + 1,
+    text: text.slice(start, to),
+    to
+  };
+}
+
+function fencedCodeRanges(text: string): MarkdownCodeRange[] {
+  const ranges: MarkdownCodeRange[] = [];
+  let fence: { marker: string; markerLength: number; from: number } | null = null;
+  let lineStart = 0;
+
+  while (lineStart < text.length) {
+    const line = readLineBounds(text, lineStart);
+    const match = fencedCodeDelimiterPattern.exec(line.text);
+    const marker = match?.[1] ?? "";
+
+    if (marker) {
+      const markerCharacter = marker[0] ?? "";
+      if (!fence) {
+        fence = { from: lineStart, marker: markerCharacter, markerLength: marker.length };
+      } else if (markerCharacter === fence.marker && marker.length >= fence.markerLength) {
+        ranges.push({ closed: true, from: fence.from, to: line.to });
+        fence = null;
+      }
+    }
+
+    if (line.next === lineStart) break;
+    lineStart = line.next;
+  }
+
+  if (fence) ranges.push({ closed: false, from: fence.from, to: text.length });
+
+  return ranges;
+}
+
+function markdownCodeRanges(text: string) {
+  return [...fencedCodeRanges(text), ...inlineCodeRanges(text)];
+}
+
+function positionIsInMarkdownCodeRange(position: number, range: MarkdownCodeRange) {
+  return position > range.from && (position < range.to || (!range.closed && position <= range.to));
+}
+
+function positionIsInMarkdownCode(position: number, ranges: MarkdownCodeRange[]) {
+  return ranges.some((range) => positionIsInMarkdownCodeRange(position, range));
+}
+
+function hasUnescapedFootnoteSyntaxOutsideCode(text: string) {
+  const codeRanges = markdownCodeRanges(text);
+
+  footnoteReferenceMarkdownPattern.lastIndex = 0;
+  for (const match of text.matchAll(footnoteReferenceMarkdownPattern)) {
+    const from = match.index;
+    if (isEscaped(text, from) || positionIsInMarkdownCode(from, codeRanges)) continue;
+    return true;
+  }
+
+  return false;
+}
+
+function elementFromEventTarget(target: EventTarget | null) {
+  return target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+}
+
+function findFootnoteReference(target: EventTarget | null) {
+  return elementFromEventTarget(target)?.closest<HTMLElement>(footnoteReferenceSelector) ?? null;
+}
+
+function findAncestorDepth($from: ResolvedPos, type: NodeType) {
+  for (let depth = $from.depth - 1; depth > 0; depth -= 1) {
+    if ($from.node(depth).type === type) return depth;
+  }
+
+  return null;
+}
+
+function readFootnoteLabel(reference: HTMLElement) {
+  const label = reference.dataset.label?.trim();
+  return label ? label : null;
+}
+
+function footnoteDefinitionPreviewText(definition: ProseNode) {
+  const blocks: string[] = [];
+
+  definition.descendants((node) => {
+    if (node.type.name === "footnote_definition") return false;
+    if (!node.isTextblock) return true;
+
+    const text = node.textBetween(0, node.content.size, "\n").trim();
+    if (text) blocks.push(text);
+    return false;
+  });
+
+  const text = blocks.join("\n").trim();
+  return text ? text : null;
+}
+
+function findFootnoteDefinitionText(doc: ProseNode, label: string) {
+  let content: string | null = null;
+
+  doc.descendants((node) => {
+    if (content !== null) return false;
+    if (node.type.name !== "footnote_definition") return true;
+    if (String(node.attrs.label ?? "") !== label) return false;
+
+    content = footnoteDefinitionPreviewText(node);
+    return false;
+  });
+
+  return content;
+}
+
+function findPreviewRoot(view: EditorView) {
+  const markdownPaper = view.dom.closest(".markdown-paper");
+  if (markdownPaper instanceof HTMLElement) return markdownPaper;
+
+  return view.dom.parentElement ?? view.dom.ownerDocument.body;
+}
+
+class MarkraFootnotePreviewView {
+  private readonly id = `markra-footnote-preview-${footnotePreviewIdSeed += 1}`;
+  private readonly root: HTMLElement;
+  private preview: HTMLElement | null = null;
+  private reference: HTMLElement | null = null;
+  private view: EditorView;
+
+  constructor(view: EditorView) {
+    this.view = view;
+    this.root = findPreviewRoot(view);
+    view.dom.addEventListener("mouseover", this.handleMouseOver);
+    view.dom.addEventListener("mouseout", this.handleMouseOut);
+  }
+
+  update(view: EditorView) {
+    this.view = view;
+    if (!this.reference) return;
+
+    if (!this.reference.isConnected) {
+      this.hide();
+      return;
+    }
+
+    this.show(this.reference);
+  }
+
+  destroy() {
+    this.view.dom.removeEventListener("mouseover", this.handleMouseOver);
+    this.view.dom.removeEventListener("mouseout", this.handleMouseOut);
+    this.hide();
+  }
+
+  private readonly handleMouseOver = (event: MouseEvent) => {
+    const reference = findFootnoteReference(event.target);
+    if (!reference || reference === this.reference) return;
+
+    this.show(reference);
+  };
+
+  private readonly handleMouseOut = (event: MouseEvent) => {
+    const reference = findFootnoteReference(event.target);
+    if (!reference || reference !== this.reference) return;
+    if (event.relatedTarget instanceof Node && reference.contains(event.relatedTarget)) return;
+
+    this.hide();
+  };
+
+  private show(reference: HTMLElement) {
+    const label = readFootnoteLabel(reference);
+    if (!label) {
+      this.hide();
+      return;
+    }
+
+    const content = findFootnoteDefinitionText(this.view.state.doc, label);
+    if (!content) {
+      this.hide();
+      return;
+    }
+
+    const preview = this.ensurePreview();
+    preview.dataset.label = label;
+    preview.textContent = content;
+    this.reference?.removeAttribute("aria-describedby");
+    this.reference = reference;
+    this.reference.setAttribute("aria-describedby", this.id);
+    this.positionPreview(reference, preview);
+  }
+
+  private hide() {
+    this.reference?.removeAttribute("aria-describedby");
+    this.reference = null;
+    this.preview?.remove();
+    this.preview = null;
+  }
+
+  private ensurePreview() {
+    if (this.preview) return this.preview;
+
+    const preview = this.view.dom.ownerDocument.createElement("div");
+    preview.id = this.id;
+    preview.className = "markra-footnote-preview";
+    preview.contentEditable = "false";
+    preview.role = "tooltip";
+    this.root.append(preview);
+    this.preview = preview;
+    return preview;
+  }
+
+  private positionPreview(reference: HTMLElement, preview: HTMLElement) {
+    const ownerWindow = reference.ownerDocument.defaultView;
+    const viewportWidth = ownerWindow?.innerWidth ?? 1024;
+    const viewportHeight = ownerWindow?.innerHeight ?? 768;
+    const maxWidth = Math.min(footnotePreviewWidth, Math.max(180, viewportWidth - footnotePreviewPadding * 2));
+    const referenceRect = reference.getBoundingClientRect();
+
+    preview.style.maxWidth = `${maxWidth}px`;
+    const previewRect = preview.getBoundingClientRect();
+    const previewWidth = previewRect.width > 0 ? Math.min(previewRect.width, maxWidth) : maxWidth;
+
+    const left = clamp(
+      referenceRect.left + referenceRect.width / 2 - previewWidth / 2,
+      footnotePreviewPadding,
+      Math.max(footnotePreviewPadding, viewportWidth - previewWidth - footnotePreviewPadding)
+    );
+    const previewHeight = previewRect.height;
+    const fitsBelow =
+      referenceRect.bottom + footnotePreviewGap + previewHeight + footnotePreviewPadding <= viewportHeight;
+    const top = fitsBelow
+      ? referenceRect.bottom + footnotePreviewGap
+      : Math.max(footnotePreviewPadding, referenceRect.top - previewHeight - footnotePreviewGap);
+
+    preview.style.left = `${Math.round(left)}px`;
+    preview.style.top = `${Math.round(top)}px`;
+  }
+}
+
+export function markraFootnotePreviewPlugin() {
+  return $prose(() => new Plugin({
+    view: (view) => new MarkraFootnotePreviewView(view)
+  }));
+}
+
+export const markraFootnoteReferenceInputRule = $inputRule((ctx) => {
+  const inlineCode = inlineCodeSchema.type(ctx);
+  const footnoteReference = footnoteReferenceSchema.type(ctx);
+
+  return new InputRule(footnoteReferenceInputPattern, (state, match, start, end) => {
+    const label = match[1]?.trim();
+    if (!label) return null;
+
+    const $start = state.doc.resolve(start);
+    if ($start.parent.type.spec.code) return null;
+    if ($start.marks().some((mark) => mark.type === inlineCode)) return null;
+
+    const textBeforeMatch = $start.parent.textBetween(0, $start.parentOffset, "", "");
+    if (isEscaped(textBeforeMatch, textBeforeMatch.length) || positionIsInMarkdownCode(
+      textBeforeMatch.length,
+      inlineCodeRanges(textBeforeMatch)
+    )) {
+      return null;
+    }
+
+    const reference = footnoteReference.create({ label });
+    const transaction = state.tr.replaceWith(start, end, reference);
+    return transaction.setSelection(TextSelection.create(transaction.doc, start + reference.nodeSize));
+  });
+});
+
+export function markraFootnoteDefinitionInputPlugin() {
+  return $prose((ctx) => {
+    const footnoteDefinition = footnoteDefinitionSchema.type(ctx);
+    const footnoteReference = footnoteReferenceSchema.type(ctx);
+    const inlineCode = inlineCodeSchema.type(ctx);
+    const paragraph = paragraphSchema.type(ctx);
+
+    const createDefinition = (state: EditorView["state"], label: string, text: string) => {
+      const definitionParagraph = text ? paragraph.create(null, state.schema.text(text)) : paragraph.create();
+      return footnoteDefinition.create({ label }, definitionParagraph);
+    };
+
+    const marksIncludeInlineCode = (marks: readonly Mark[]) => marks.some((mark) => mark.type === inlineCode);
+
+    const createInlineContentWithReferences = (state: EditorView["state"], text: string, marks: readonly Mark[] = []) => {
+      const content: ProseNode[] = [];
+      let cursor = 0;
+      const codeRanges = markdownCodeRanges(text);
+
+      if (marksIncludeInlineCode(marks)) return text ? [state.schema.text(text, marks)] : [];
+
+      footnoteReferenceMarkdownPattern.lastIndex = 0;
+      for (const match of text.matchAll(footnoteReferenceMarkdownPattern)) {
+        const from = match.index;
+        const label = match[1]?.trim();
+        if (isEscaped(text, from) || positionIsInMarkdownCode(from, codeRanges)) continue;
+        if (!label) continue;
+
+        if (from > cursor) content.push(state.schema.text(text.slice(cursor, from), marks));
+        content.push(footnoteReference.create({ label }));
+        cursor = from + match[0].length;
+      }
+
+      if (cursor < text.length) content.push(state.schema.text(text.slice(cursor), marks));
+      return content;
+    };
+
+    const createParagraphWithReferences = (state: EditorView["state"], text: string) => {
+      const content = createInlineContentWithReferences(state, text);
+      return paragraph.create(null, content.length > 0 ? Fragment.fromArray(content) : undefined);
+    };
+
+    const paragraphNeedsInlinePreservation = (node: ProseNode) => {
+      let needsPreservation = false;
+
+      node.forEach((child) => {
+        if (!child.isText || marksIncludeInlineCode(child.marks)) needsPreservation = true;
+      });
+
+      return needsPreservation;
+    };
+
+    const paragraphHasConvertibleFootnoteSyntax = (node: ProseNode) => {
+      let hasConvertibleFootnoteSyntax = false;
+
+      node.forEach((child) => {
+        if (hasConvertibleFootnoteSyntax) return;
+        if (!child.isText || !child.text || marksIncludeInlineCode(child.marks)) return;
+
+        if (hasUnescapedFootnoteSyntaxOutsideCode(child.text)) hasConvertibleFootnoteSyntax = true;
+      });
+
+      return hasConvertibleFootnoteSyntax;
+    };
+
+    const createParagraphPreservingInlineNodes = (state: EditorView["state"], node: ProseNode) => {
+      const content: ProseNode[] = [];
+
+      node.forEach((child) => {
+        if (child.isText && child.text) {
+          content.push(...createInlineContentWithReferences(state, child.text, child.marks));
+          return;
+        }
+
+        content.push(child);
+      });
+
+      return paragraph.create(node.attrs, content.length > 0 ? Fragment.fromArray(content) : undefined);
+    };
+
+    const stripFootnoteContinuationIndent = (line: string) => {
+      const continuationMatch = footnoteDefinitionContinuationPattern.exec(line);
+      return continuationMatch ? continuationMatch[1] ?? "" : line;
+    };
+
+    const lineIsBlank = (line: string) => /^[ \t]*$/u.test(line);
+
+    const readFootnoteDefinitionLine = (line: string) => {
+      const definitionMatch = footnoteDefinitionBlockPattern.exec(line);
+      const label = definitionMatch?.[1]?.trim();
+      if (!definitionMatch || !label) return null;
+
+      return {
+        label,
+        text: definitionMatch[2] ?? ""
+      };
+    };
+
+    const nextNonBlankLineIndex = (lines: string[], start: number) => {
+      let index = start;
+      while (index < lines.length && lineIsBlank(lines[index] ?? "")) index += 1;
+      return index;
+    };
+
+    const createFootnoteMarkdownNodes = (state: EditorView["state"], text: string) => {
+      const lines = text.replace(/\r\n?/gu, "\n").split("\n");
+      const nodes: ProseNode[] = [];
+      let index = 0;
+
+      while (index < lines.length) {
+        if (lineIsBlank(lines[index] ?? "")) {
+          index += 1;
+          continue;
+        }
+
+        const definition = readFootnoteDefinitionLine(lines[index] ?? "");
+        if (definition) {
+          const textLines = [definition.text];
+          index += 1;
+
+          while (index < lines.length) {
+            const line = lines[index] ?? "";
+            if (readFootnoteDefinitionLine(line)) break;
+
+            if (lineIsBlank(line)) {
+              const nextIndex = nextNonBlankLineIndex(lines, index + 1);
+              const nextLine = lines[nextIndex] ?? "";
+              if (!footnoteDefinitionContinuationPattern.test(nextLine)) break;
+
+              textLines.push("");
+              index = nextIndex;
+              continue;
+            }
+
+            const continuationMatch = footnoteDefinitionContinuationPattern.exec(line);
+            if (!continuationMatch) break;
+
+            textLines.push(stripFootnoteContinuationIndent(line));
+            index += 1;
+          }
+
+          nodes.push(createDefinition(state, definition.label, textLines.join("\n").trimEnd()));
+          continue;
+        }
+
+        const paragraphLines: string[] = [];
+        while (index < lines.length) {
+          const line = lines[index] ?? "";
+          if (lineIsBlank(line) || readFootnoteDefinitionLine(line)) break;
+
+          paragraphLines.push(line);
+          index += 1;
+        }
+
+        const paragraphText = paragraphLines.join("\n").trim();
+        if (paragraphText) nodes.push(createParagraphWithReferences(state, paragraphText));
+      }
+
+      return nodes;
+    };
+
+    type NormalizedFootnoteParagraph = {
+      from: number;
+      to: number;
+      parsed: Fragment;
+    };
+
+    const findNormalizableParagraph = (state: EditorView["state"]): NormalizedFootnoteParagraph | null => {
+      let normalized: NormalizedFootnoteParagraph | null = null;
+
+      state.doc.descendants((node, position) => {
+        if (normalized) return false;
+        if (node.type !== paragraph) return true;
+
+        if (!paragraphHasConvertibleFootnoteSyntax(node)) return false;
+
+        const nodes = paragraphNeedsInlinePreservation(node)
+          ? [createParagraphPreservingInlineNodes(state, node)]
+          : createFootnoteMarkdownNodes(state, node.textContent);
+        if (nodes.length === 0) return false;
+
+        normalized = {
+          from: position,
+          parsed: Fragment.fromArray(nodes),
+          to: position + node.nodeSize
+        };
+        return false;
+      });
+
+      return normalized;
+    };
+
+    const replaceCurrentParagraphWithDefinition = (view: EditorView, label: string, text: string) => {
+      const { state } = view;
+      const { $from } = state.selection;
+      const definition = createDefinition(state, label, text);
+      const paragraphFrom = $from.before();
+      const paragraphTo = $from.after();
+      const ancestorDefinitionDepth = findAncestorDepth($from, footnoteDefinition);
+
+      if (ancestorDefinitionDepth !== null) {
+        const ancestorDefinition = $from.node(ancestorDefinitionDepth);
+        if (ancestorDefinition.childCount <= 1) return false;
+
+        const ancestorParent = $from.node(ancestorDefinitionDepth - 1);
+        const ancestorIndex = $from.index(ancestorDefinitionDepth - 1);
+        if (!ancestorParent.canReplaceWith(ancestorIndex + 1, ancestorIndex + 1, footnoteDefinition)) return false;
+
+        const ancestorTo = $from.after(ancestorDefinitionDepth);
+        const transaction = state.tr.delete(paragraphFrom, paragraphTo);
+        const insertPosition = transaction.mapping.map(ancestorTo);
+        view.dispatch(
+          transaction
+            .insert(insertPosition, definition)
+            .setSelection(TextSelection.create(transaction.doc, insertPosition + 2 + text.length))
+            .scrollIntoView()
+        );
+        return true;
+      }
+
+      const parent = $from.node($from.depth - 1);
+      const index = $from.index($from.depth - 1);
+      if (!parent.canReplaceWith(index, index + 1, footnoteDefinition)) return false;
+
+      const transaction = state.tr.replaceWith(paragraphFrom, paragraphTo, definition);
+      view.dispatch(
+        transaction
+          .setSelection(TextSelection.create(transaction.doc, paragraphFrom + 2 + text.length))
+          .scrollIntoView()
+      );
+      return true;
+    };
+
+    const exitFootnoteDefinition = (view: EditorView, ancestorDefinitionDepth: number) => {
+      const { state } = view;
+      const { $from } = state.selection;
+      const ancestorDefinition = $from.node(ancestorDefinitionDepth);
+      const currentChildIndex = $from.index(ancestorDefinitionDepth);
+      if (currentChildIndex !== ancestorDefinition.childCount - 1) return false;
+
+      const ancestorParent = $from.node(ancestorDefinitionDepth - 1);
+      const ancestorIndex = $from.index(ancestorDefinitionDepth - 1);
+      if (!ancestorParent.canReplaceWith(ancestorIndex + 1, ancestorIndex + 1, paragraph)) return false;
+
+      const insertPosition = $from.after(ancestorDefinitionDepth);
+      const transaction = state.tr.insert(insertPosition, paragraph.create());
+      view.dispatch(
+        transaction
+          .setSelection(TextSelection.create(transaction.doc, insertPosition + 1))
+          .scrollIntoView()
+      );
+      return true;
+    };
+
+    const previousSiblingIsFootnoteDefinition = ($from: ResolvedPos) => {
+      if ($from.depth === 0) return false;
+
+      const parentNode = $from.node($from.depth - 1);
+      const index = $from.index($from.depth - 1);
+      if (index === 0) return false;
+
+      return parentNode.child(index - 1).type === footnoteDefinition;
+    };
+
+    return new Plugin({
+      appendTransaction(transactions, _oldState, newState) {
+        if (!transactions.some((transaction) => transaction.docChanged)) return null;
+
+        const normalized = findNormalizableParagraph(newState);
+        if (!normalized) return null;
+
+        const transaction = newState.tr;
+        const $from = transaction.doc.resolve(normalized.from);
+        const parent = $from.node($from.depth);
+        const index = $from.index($from.depth);
+        if (!parent.canReplace(index, index + 1, normalized.parsed)) return null;
+
+        return transaction.replaceWith(normalized.from, normalized.to, normalized.parsed);
+      },
+      props: {
+        handleKeyDown(view, event) {
+          if (event.key !== "Enter" || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return false;
+
+          const { state } = view;
+          const { selection } = state;
+          if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+          const { $from } = selection;
+          if (!$from.parent.isTextblock || $from.parent.type !== paragraph) return false;
+          if ($from.parent.content.size === 0 && previousSiblingIsFootnoteDefinition($from)) {
+            event.preventDefault();
+            return true;
+          }
+
+          const ancestorDefinitionDepth = findAncestorDepth($from, footnoteDefinition);
+          if (ancestorDefinitionDepth === null) return false;
+
+          if ($from.parent.content.size !== 0) {
+            if ($from.parentOffset !== $from.parent.content.size) return false;
+
+            event.preventDefault();
+            return exitFootnoteDefinition(view, ancestorDefinitionDepth);
+          }
+
+          event.preventDefault();
+          return true;
+        },
+        handlePaste(view, event, slice) {
+          const pastedText = slice.content.textBetween(0, slice.content.size, "\n");
+          if (!pastedText || pastedText.includes("\n")) return false;
+          if (!hasUnescapedFootnoteSyntaxOutsideCode(pastedText)) return false;
+
+          const { state } = view;
+          const { selection } = state;
+          if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+          const { $from } = selection;
+          if (!$from.parent.isTextblock || $from.parent.type !== paragraph) return false;
+
+          const pastedFrom = $from.parentOffset;
+          const pastedTo = pastedFrom + pastedText.length;
+          const nextText = [
+            $from.parent.textContent.slice(0, pastedFrom),
+            pastedText,
+            $from.parent.textContent.slice(pastedFrom)
+          ].join("");
+          const inlineCodeRange = inlineCodeRanges(nextText).find((range) => {
+            if (!range.closed) return false;
+
+            const markerLength = readBacktickRunLength(nextText, range.from);
+            return pastedFrom >= range.from + markerLength && pastedTo <= range.to - markerLength;
+          });
+          if (!inlineCodeRange) return false;
+
+          const markerLength = readBacktickRunLength(nextText, inlineCodeRange.from);
+          const content = nextText.slice(inlineCodeRange.from + markerLength, inlineCodeRange.to - markerLength);
+          if (!content) return false;
+
+          const start = $from.start() + inlineCodeRange.from;
+          const end = $from.start() + inlineCodeRange.to - pastedText.length;
+          const markedText = state.schema.text(content, [inlineCode.create()]);
+          const transaction = state.tr.replaceWith(start, end, markedText);
+          event.preventDefault();
+          view.dispatch(
+            transaction
+              .setSelection(TextSelection.create(transaction.doc, start + content.length))
+              .scrollIntoView()
+          );
+          return true;
+        },
+        handleTextInput(view, from, to, text) {
+          if (from !== to || text.length === 0) return false;
+
+          const { state } = view;
+          const { $from } = state.selection;
+          if (!$from.parent.isTextblock || $from.parent.type !== paragraph) return false;
+          if ($from.parentOffset !== $from.parent.content.size) return false;
+
+          if (
+            $from.parent.content.size === 0 &&
+            findAncestorDepth($from, footnoteDefinition) !== null &&
+            /^[ \t]+$/u.test(text)
+          ) {
+            return true;
+          }
+
+          const fullDefinitionMatch = footnoteDefinitionInputPattern.exec(text);
+          if (fullDefinitionMatch && $from.parent.content.size === 0) {
+            const label = fullDefinitionMatch[1]?.trim();
+            if (!label) return false;
+
+            return replaceCurrentParagraphWithDefinition(view, label, fullDefinitionMatch[2] ?? "");
+          }
+
+          const reference = $from.parent.firstChild;
+          if (reference?.type !== footnoteReference) return false;
+
+          const rest = $from.parent.textBetween(reference.nodeSize, $from.parent.content.size, "", "");
+          const label = String(reference.attrs.label ?? "").trim();
+          if (!label) return false;
+
+          if (rest === "" && text === ":") return replaceCurrentParagraphWithDefinition(view, label, "");
+          if (rest !== ":") return false;
+
+          const definitionText = text.trimStart();
+          return replaceCurrentParagraphWithDefinition(view, label, definitionText);
+        }
+      }
+    });
+  });
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -3,6 +3,7 @@ export * from "./block-drag.ts";
 export * from "./callout.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
+export * from "./footnote.ts";
 export * from "./frontmatter.ts";
 export * from "./heading-level.ts";
 export * from "./heading-toggle.ts";

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -52,9 +52,14 @@ type SuppressedLiveMarkdownRange = ActiveLiveMarkdownRange & {
   cursor: number;
 };
 
+type ExitedFoldedMarkdownRange = FoldedMarkdownRange & {
+  cursor: number;
+};
+
 type LiveMarkdownPluginState = {
   suppressActiveAt: number | null;
   activeFoldedRange: FoldedMarkdownRange | null;
+  exitedFoldedRange: ExitedFoldedMarkdownRange | null;
   suppressedLiveRange: SuppressedLiveMarkdownRange | null;
 };
 
@@ -179,6 +184,61 @@ function clearManagedStoredMarks(state: EditorState, markTypes: MarkType[]) {
   return state.tr.setStoredMarks(nextMarks);
 }
 
+function insertTextAfterExitedFoldedMarkdown(
+  view: EditorView,
+  text: string,
+  markTypes: MarkType[]
+) {
+  if (text.length === 0) return false;
+
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
+  if (selection.from !== pluginState?.exitedFoldedRange?.cursor) return false;
+
+  const marks = selection.$from.marks().filter((mark) => !markTypes.includes(mark.type));
+  const insertedText = view.state.schema.text(text, marks);
+  const transaction = view.state.tr.replaceSelectionWith(insertedText, false).setStoredMarks(marks);
+
+  view.dispatch(transaction.scrollIntoView());
+  return true;
+}
+
+function moveCursorPastFoldedMarkdownDelimiter(
+  view: EditorView,
+  specs: LiveMarkdownSpec[],
+  direction: "left" | "right"
+) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
+
+  if (direction === "right") {
+    const foldedRange =
+      pluginState?.activeFoldedRange ?? getFoldedMarkdownRangeAtCursor(view.state.doc, selection.from, specs);
+    if (!foldedRange || selection.from !== foldedRange.to) return false;
+
+    view.dispatch(
+      view.state.tr
+        .setMeta(liveMarkdownKey, { exitedFoldedRange: { ...foldedRange, cursor: selection.from } })
+        .scrollIntoView()
+    );
+    return true;
+  }
+
+  const exitedRange = pluginState?.exitedFoldedRange ?? null;
+  if (!exitedRange || selection.from !== exitedRange.cursor) return false;
+
+  view.dispatch(
+    view.state.tr
+      .setMeta(liveMarkdownKey, { activeFoldedRange: exitedRange, exitedFoldedRange: null })
+      .scrollIntoView()
+  );
+  return true;
+}
+
 function deleteTextAfterLiveMarkdownRange(
   view: EditorView,
   specs: LiveMarkdownSpec[],
@@ -276,7 +336,8 @@ function buildLiveMarkdownDecorations(
   doc: ProseNode,
   specs: LiveMarkdownSpec[],
   activeLiveRange: ActiveLiveMarkdownRange | null,
-  activeFoldedRange: FoldedMarkdownRange | null
+  activeFoldedRange: FoldedMarkdownRange | null,
+  exitedFoldedRange: ExitedFoldedMarkdownRange | null
 ) {
   const decorations: Decoration[] = [];
 
@@ -316,13 +377,18 @@ function buildLiveMarkdownDecorations(
     }
   });
 
-  if (activeFoldedRange) {
+  const foldedRange = activeFoldedRange ?? exitedFoldedRange;
+
+  if (foldedRange) {
     // Finalized marks use virtual markers so the user can re-enter an editable Markdown-like state.
     decorations.push(
-      Decoration.widget(activeFoldedRange.from, () => createDelimiterWidget(activeFoldedRange.marker), { side: -1 }),
-      Decoration.widget(activeFoldedRange.to, () => createDelimiterWidget(activeFoldedRange.marker), { side: -1 }),
-      Decoration.inline(activeFoldedRange.from, activeFoldedRange.to, {
-        class: ["markra-live-mark", ...activeFoldedRange.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ")
+      Decoration.widget(foldedRange.from, () => createDelimiterWidget(foldedRange.marker), { side: -1 }),
+      Decoration.widget(foldedRange.to, () => createDelimiterWidget(foldedRange.marker), {
+        side: exitedFoldedRange ? -1 : 1,
+        marks: exitedFoldedRange ? [] : undefined
+      }),
+      Decoration.inline(foldedRange.from, foldedRange.to, {
+        class: ["markra-live-mark", ...foldedRange.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ")
       })
     );
   }
@@ -611,15 +677,26 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       init: (): LiveMarkdownPluginState => ({
         suppressActiveAt: null,
         activeFoldedRange: null,
+        exitedFoldedRange: null,
         suppressedLiveRange: null
       }),
       apply: (tr, value, _oldState, newState): LiveMarkdownPluginState => {
         const meta = tr.getMeta(liveMarkdownKey) as Partial<LiveMarkdownPluginState> | undefined;
+        if (meta && "exitedFoldedRange" in meta) {
+          return {
+            suppressActiveAt: null,
+            activeFoldedRange: meta.activeFoldedRange ?? null,
+            exitedFoldedRange: meta.exitedFoldedRange ?? null,
+            suppressedLiveRange: null
+          };
+        }
+
         if (meta?.suppressedLiveRange) {
           // Preserve the folded view after an arrow-key collapse until the cursor leaves that edge.
           return {
             suppressActiveAt: null,
             activeFoldedRange: null,
+            exitedFoldedRange: null,
             suppressedLiveRange: meta.suppressedLiveRange
           };
         }
@@ -628,20 +705,24 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           return {
             suppressActiveAt: meta.suppressActiveAt,
             activeFoldedRange: null,
+            exitedFoldedRange: null,
             suppressedLiveRange: null
           };
         }
 
         if (tr.selectionSet) {
           const selection = newState.selection instanceof TextSelection ? newState.selection : null;
+          const exitedFoldedRange =
+            selection?.from === value.exitedFoldedRange?.cursor ? value.exitedFoldedRange : null;
           const activeFoldedRange =
-            selection?.empty && selection.from !== value.suppressActiveAt
+            selection?.empty && selection.from !== value.suppressActiveAt && !exitedFoldedRange
               ? getFoldedMarkdownRangeAtCursor(newState.doc, selection.from, specs)
               : null;
 
           return {
             suppressActiveAt: selection?.from === value.suppressActiveAt ? value.suppressActiveAt : null,
             activeFoldedRange,
+            exitedFoldedRange,
             suppressedLiveRange:
               selection?.from === value.suppressedLiveRange?.cursor ? value.suppressedLiveRange : null
           };
@@ -651,6 +732,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           return {
             suppressActiveAt: null,
             activeFoldedRange: null,
+            exitedFoldedRange: null,
             suppressedLiveRange: null
           };
         }
@@ -673,9 +755,11 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           state.doc,
           specs,
           activeLiveRange,
-          pluginState?.activeFoldedRange ?? null
+          pluginState?.activeFoldedRange ?? null,
+          pluginState?.exitedFoldedRange ?? null
         );
       },
+      handleTextInput: (view, _from, _to, text) => insertTextAfterExitedFoldedMarkdown(view, text, managedMarkTypes),
       handleKeyDown: (view, event) => {
         const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
 
@@ -688,13 +772,16 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
         }
 
         if ((event.key === "ArrowLeft" || event.key === "ArrowRight") && !hasModifier) {
-          const handled = moveCursorOverLiveMarkdownDelimiter(
+          const handledLiveRange = moveCursorOverLiveMarkdownDelimiter(
             view,
             specs,
             event.key === "ArrowLeft" ? "left" : "right"
           );
+          const handledFoldedRange =
+            handledLiveRange ||
+            moveCursorPastFoldedMarkdownDelimiter(view, specs, event.key === "ArrowLeft" ? "left" : "right");
 
-          if (handled) {
+          if (handledFoldedRange) {
             event.preventDefault();
             return true;
           }


### PR DESCRIPTION
## Summary
- Add Markra footnote editor plugins for WYSIWYG references, definitions, and hover previews.
- Normalize pasted and typed footnote markdown without adding escape characters or nested definition indentation.
- Preserve references around inline atoms and exit footnote definitions cleanly when pressing Enter after definition text.
- Keep inline-code and fenced-code content from being converted into footnote references, and keep pasted footnote-looking text inside live inline-code markers serialized as inline code.
- Prevent active inline-code editing from drawing a second nested background inside existing code marks.
- Keep text typed at the end of a finalized inline-code mark inside the code mark, while ArrowRight past the folded closing delimiter moves subsequent input outside.
- Place folded inline-code delimiters on the correct side of the cursor so the caret can visibly move inside and outside code.

## Commit Structure
- `feat(editor): add footnote wysiwyg support`
- `fix(editor): handle inline code cursor boundaries`

## Why
- WYSIWYG input could serialize footnotes as escaped markdown, nest adjacent definitions, or show unrelated definition content in previews.
- Follow-up edge cases covered multiline definitions, single-newline adjacent definitions, code spans/blocks, source indentation after leaving a footnote, paste inside live inline code markers, inline-code active styling, inline-code edge typing, and cursor placement at folded inline-code boundaries.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 257 tests
- `pnpm --dir packages/app exec vitest run src/styles.test.ts` passed: 28 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed
- `rg -n "\\bvoid\\b" packages/editor/src/input-rules.ts packages/app/src/components/MarkdownPaper.test.tsx` returned no matches
- Commit reword only: `git diff --stat HEAD 77d0896f` returned no content changes

Closes #153