### PR TITLE
feat(editor): add heading level toolbar controls

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -79,6 +79,7 @@ import { saveEditorImage } from "./lib/image-upload";
 import { replaceMovedPath } from "./lib/path-move";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
 import type {
+  SelectionHeadingLevel,
   SelectionFormattingAction,
   SelectionFormattingShortcutAction
 } from "./lib/selection-formatting";
@@ -305,6 +306,7 @@ function WorkspaceApp() {
   const [aiCommandOverlayInset, setAiCommandOverlayInset] = useState(0);
   const [aiSelectionToolbarAnchor, setAiSelectionToolbarAnchor] = useState<SelectionAnchor | null>(null);
   const [aiSelectionToolbarActiveActions, setAiSelectionToolbarActiveActions] = useState<SelectionFormattingAction[]>([]);
+  const [aiSelectionToolbarHeadingLevel, setAiSelectionToolbarHeadingLevel] = useState<SelectionHeadingLevel | null>(null);
   const [aiSelectionToolbarCopySucceeded, setAiSelectionToolbarCopySucceeded] = useState(false);
   const [aiContextMenuActionPending, setAiContextMenuActionPending] = useState(false);
   const [editorMode, setEditorMode] = useState<EditorMode>("visual");
@@ -407,8 +409,15 @@ function WorkspaceApp() {
   const replaceEditorSearchMatch = editor.replaceSearchMatch;
   const revealEditorSearchMatch = editor.revealSearchMatch;
   const runEditorShortcut = editor.runEditorShortcut;
-  const getEditorSelectionFormattingActions = editor.getSelectionFormattingActions;
+  const getEditorSelectionFormattingState = editor.getSelectionFormattingState;
+  const setEditorSelectionHeadingLevel = editor.setSelectionHeadingLevel;
   const showEditorSearchMatches = editor.showSearchMatches;
+  const syncAiSelectionToolbarFormattingState = useCallback(() => {
+    const formattingState = getEditorSelectionFormattingState();
+
+    setAiSelectionToolbarActiveActions(formattingState.actions);
+    setAiSelectionToolbarHeadingLevel(formattingState.headingLevel);
+  }, [getEditorSelectionFormattingState]);
   const readCurrentMarkdownForDocument = useCallback((fallbackContent: string) => {
     if (sourceSurfaceActive) return fallbackContent;
 
@@ -931,6 +940,7 @@ function WorkspaceApp() {
     updateActiveAiSelection(selection);
     clearAiSelectionToolbarCopySuccess();
     setAiSelectionToolbarActiveActions([]);
+    setAiSelectionToolbarHeadingLevel(null);
 
     if (!aiFeatureEnabled) {
       setAiSelectionToolbarAnchor(null);
@@ -978,7 +988,7 @@ function WorkspaceApp() {
     }
 
     if (showSelectionToolbar) {
-      setAiSelectionToolbarActiveActions(getEditorSelectionFormattingActions());
+      syncAiSelectionToolbarFormattingState();
       setAiSelectionToolbarAnchor(selectionAnchorFromDomSelection(window.getSelection()));
     } else {
       aiCommand.openAiCommand(selection);
@@ -996,7 +1006,7 @@ function WorkspaceApp() {
     editorPreferences.preferences.closeAiCommandOnAgentPanelOpen,
     editorPreferences.preferences.showAiQuickInputOnSelection,
     editorPreferences.preferences.showAiSelectionToolbarOnSelection,
-    getEditorSelectionFormattingActions,
+    syncAiSelectionToolbarFormattingState,
     clearAiSelectionToolbarCopySuccess,
     readOnlyMode,
     updateActiveAiSelection
@@ -1935,12 +1945,24 @@ function WorkspaceApp() {
       altKey: Boolean(shortcut.altKey),
       shiftKey: Boolean(shortcut.shiftKey)
     });
-    setAiSelectionToolbarActiveActions(getEditorSelectionFormattingActions());
+    syncAiSelectionToolbarFormattingState();
   }, [
     editorPreferences.preferences.markdownShortcuts,
-    getEditorSelectionFormattingActions,
     handleRunEditorShortcut,
-    readOnlyMode
+    readOnlyMode,
+    syncAiSelectionToolbarFormattingState
+  ]);
+  const handleAiSelectionToolbarHeadingLevelAction = useCallback((level: SelectionHeadingLevel) => {
+    if (readOnlyMode) return;
+    if (!setEditorSelectionHeadingLevel(level)) return;
+
+    syncVisualMarkdownAfterEditorCommand();
+    syncAiSelectionToolbarFormattingState();
+  }, [
+    readOnlyMode,
+    setEditorSelectionHeadingLevel,
+    syncAiSelectionToolbarFormattingState,
+    syncVisualMarkdownAfterEditorCommand
   ]);
   const handleAiSelectionToolbarInsertLink = useCallback(() => {
     if (readOnlyMode) return;
@@ -3026,6 +3048,7 @@ function WorkspaceApp() {
         {aiFeatureEnabled ? (
           <AiSelectionToolbar
             activeFormattingActions={aiSelectionToolbarActiveActions}
+            activeHeadingLevel={aiSelectionToolbarHeadingLevel}
             anchor={aiSelectionToolbarAnchor}
             busy={aiCommand.submitting || aiContextMenuActionPending}
             copySucceeded={aiSelectionToolbarCopySucceeded}
@@ -3037,6 +3060,7 @@ function WorkspaceApp() {
             onOpenCommand={handleAiSelectionToolbarOpenCommand}
             onRunFormattingAction={handleAiSelectionToolbarFormattingAction}
             onRunAction={handleAiSelectionToolbarAction}
+            onSetHeadingLevel={handleAiSelectionToolbarHeadingLevelAction}
           />
         ) : null}
 

--- a/packages/app/src/components/AiSelectionToolbar.test.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.test.tsx
@@ -60,7 +60,6 @@ describe("AiSelectionToolbar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Italic" }));
     fireEvent.click(screen.getByRole("button", { name: "Strikethrough" }));
     fireEvent.click(screen.getByRole("button", { name: "Inline Code" }));
-    fireEvent.click(screen.getByRole("button", { name: "Heading 1" }));
     fireEvent.click(screen.getByRole("button", { name: "Quote" }));
     fireEvent.click(screen.getByRole("button", { name: "Bullet List" }));
     fireEvent.click(screen.getByRole("button", { name: "Ordered List" }));
@@ -72,7 +71,6 @@ describe("AiSelectionToolbar", () => {
       "italic",
       "strikethrough",
       "inlineCode",
-      "heading1",
       "quote",
       "bulletList",
       "orderedList"
@@ -84,7 +82,8 @@ describe("AiSelectionToolbar", () => {
   it("marks active formatting tools as pressed", () => {
     render(
       <AiSelectionToolbar
-        activeFormattingActions={["bold", "heading1", "link"]}
+        activeFormattingActions={["bold", "link"]}
+        activeHeadingLevel={1}
         anchor={anchor}
         language="en"
         open
@@ -97,9 +96,103 @@ describe("AiSelectionToolbar", () => {
     );
 
     expect(screen.getByRole("button", { name: "Bold" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: "Heading 1" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Heading Level H1" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("combobox", { name: "Heading Level" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Link" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "Italic" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("routes heading level choices from the toolbar", () => {
+    const onSetHeadingLevel = vi.fn();
+
+    render(
+      <AiSelectionToolbar
+        activeHeadingLevel={2}
+        anchor={anchor}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={vi.fn()}
+        onRunAction={vi.fn()}
+        onSetHeadingLevel={onSetHeadingLevel}
+      />
+    );
+
+    const headingButton = screen.getByRole("button", { name: "Heading Level H2" });
+    expect(headingButton).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(headingButton);
+
+    expect(headingButton).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menu", { name: "Heading Level" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitemradio", { name: "H1" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitemradio", { name: "H6" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "H3" }));
+
+    expect(onSetHeadingLevel).toHaveBeenCalledWith(3);
+  });
+
+  it("renders the heading level menu outside the scrollable toolbar shell", () => {
+    render(
+      <AiSelectionToolbar
+        activeHeadingLevel={2}
+        anchor={anchor}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={vi.fn()}
+        onRunAction={vi.fn()}
+        onSetHeadingLevel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Heading Level H2" }));
+
+    const headingMenu = screen.getByRole("menu", { name: "Heading Level" });
+
+    expect(headingMenu.closest(".overflow-x-auto")).toBeNull();
+    expect(headingMenu).toHaveClass("fixed");
+  });
+
+  it("keeps the heading level menu available outside headings", () => {
+    const { rerender } = render(
+      <AiSelectionToolbar
+        activeHeadingLevel={null}
+        anchor={anchor}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={vi.fn()}
+        onRunAction={vi.fn()}
+        onSetHeadingLevel={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Heading Level" })).toBeEnabled();
+
+    rerender(
+      <AiSelectionToolbar
+        activeHeadingLevel={1}
+        anchor={anchor}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={vi.fn()}
+        onRunAction={vi.fn()}
+        onSetHeadingLevel={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Heading Level H1" })).toBeEnabled();
   });
 
   it("shows the copy button success state in place", () => {

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -1,11 +1,18 @@
-import { type CSSProperties } from "react";
+import { Fragment, useEffect, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import {
   Bold,
   Check,
   Code2,
   Copy,
   FileText,
+  Heading,
   Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
   Italic,
   Languages,
   Link,
@@ -30,6 +37,8 @@ import {
 } from "../lib/ai-actions";
 import type { SelectionAnchor } from "../lib/selection-anchor";
 import {
+  selectionHeadingLevels,
+  type SelectionHeadingLevel,
   type SelectionFormattingAction,
   type SelectionFormattingShortcutAction
 } from "../lib/selection-formatting";
@@ -45,6 +54,12 @@ type BasicSelectionAction = {
   labelKey: I18nKey;
 };
 
+type HeadingLevelOption = {
+  icon: LucideIcon;
+  label: string;
+  level: SelectionHeadingLevel;
+};
+
 type AiSelectionToolbarProps = {
   anchor: SelectionAnchor | null;
   busy?: boolean;
@@ -52,11 +67,13 @@ type AiSelectionToolbarProps = {
   language?: AppLanguage;
   open: boolean;
   activeFormattingActions?: readonly SelectionFormattingAction[];
+  activeHeadingLevel?: SelectionHeadingLevel | null;
   quickActionPrompts?: AiQuickActionPrompts;
   onCopySelection: () => unknown;
   onInsertLink: () => unknown;
   onOpenCommand: () => unknown;
   onRunFormattingAction: (action: SelectionFormattingShortcutAction) => unknown;
+  onSetHeadingLevel?: (level: SelectionHeadingLevel) => unknown;
   onRunAction: (intent: AiQuickActionId, prompt: string) => unknown;
 };
 
@@ -107,11 +124,6 @@ const basicSelectionActions: BasicSelectionAction[] = [
     labelKey: "menu.inlineCode"
   },
   {
-    action: "heading1",
-    icon: Heading1,
-    labelKey: "menu.heading1"
-  },
-  {
     action: "quote",
     icon: Quote,
     labelKey: "menu.quote"
@@ -128,6 +140,21 @@ const basicSelectionActions: BasicSelectionAction[] = [
   }
 ];
 
+const headingLevelIcons: Record<SelectionHeadingLevel, LucideIcon> = {
+  1: Heading1,
+  2: Heading2,
+  3: Heading3,
+  4: Heading4,
+  5: Heading5,
+  6: Heading6
+};
+
+const headingLevelOptions: HeadingLevelOption[] = selectionHeadingLevels.map((level) => ({
+  icon: headingLevelIcons[level],
+  label: `H${level}`,
+  level
+}));
+
 export function AiSelectionToolbar({
   anchor,
   busy = false,
@@ -135,23 +162,143 @@ export function AiSelectionToolbar({
   language = "en",
   open,
   activeFormattingActions = [],
+  activeHeadingLevel = null,
   quickActionPrompts = defaultAiQuickActionPrompts,
   onCopySelection,
   onInsertLink,
   onOpenCommand,
   onRunFormattingAction,
+  onSetHeadingLevel = () => {},
   onRunAction
 }: AiSelectionToolbarProps) {
+  const [headingLevelMenuOpen, setHeadingLevelMenuOpen] = useState(false);
+  const [headingLevelMenuStyle, setHeadingLevelMenuStyle] = useState<CSSProperties | null>(null);
+  const headingLevelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const headingLevelMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const positionHeadingLevelMenu = (button: HTMLButtonElement) => {
+    const buttonRect = button.getBoundingClientRect();
+    const menuWidthPx = 112;
+    const viewportPaddingPx = 8;
+    const maxLeft = Math.max(viewportPaddingPx, window.innerWidth - menuWidthPx - viewportPaddingPx);
+    const left = Math.min(Math.max(buttonRect.left, viewportPaddingPx), maxLeft);
+
+    setHeadingLevelMenuStyle({
+      left: `${Math.round(left)}px`,
+      top: `${Math.round(buttonRect.bottom + 4)}px`
+    });
+  };
+
+  useEffect(() => {
+    if (!open) {
+      setHeadingLevelMenuOpen(false);
+      setHeadingLevelMenuStyle(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setHeadingLevelMenuOpen(false);
+    setHeadingLevelMenuStyle(null);
+  }, [anchor?.bottom, anchor?.left, anchor?.right, anchor?.top]);
+
+  useEffect(() => {
+    if (!headingLevelMenuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+
+      if (headingLevelButtonRef.current?.contains(target) || headingLevelMenuRef.current?.contains(target)) {
+        return;
+      }
+
+      setHeadingLevelMenuOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setHeadingLevelMenuOpen(false);
+      }
+    };
+
+    const handleLayoutChange = () => {
+      const button = headingLevelButtonRef.current;
+      if (button) {
+        positionHeadingLevelMenu(button);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", handleLayoutChange);
+    window.addEventListener("scroll", handleLayoutChange, true);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", handleLayoutChange);
+      window.removeEventListener("scroll", handleLayoutChange, true);
+    };
+  }, [headingLevelMenuOpen]);
+
   if (!open || !anchor) return null;
 
   const label = (key: I18nKey) => t(language, key);
   const activeFormattingActionSet = new Set(activeFormattingActions);
+  const activeHeadingLevelOption =
+    activeHeadingLevel === null
+      ? null
+      : headingLevelOptions.find((option) => option.level === activeHeadingLevel) ?? null;
+  const ActiveHeadingLevelIcon = activeHeadingLevelOption?.icon ?? Heading;
+  const headingLevelLabel = activeHeadingLevelOption
+    ? `${label("menu.headingLevel")} ${activeHeadingLevelOption.label}`
+    : label("menu.headingLevel");
   const copyLabel = label(copySucceeded ? "app.aiCopied" : "app.aiCopy");
   const translationTargetLanguage = aiTranslationLanguageName(language);
   const style: CSSProperties = {
     left: `${Math.round((anchor.left + anchor.right) / 2)}px`,
     top: `${Math.max(12, Math.round(anchor.top - toolbarOffsetPx))}px`
   };
+  const headingLevelMenu =
+    headingLevelMenuOpen && headingLevelMenuStyle && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            className="pointer-events-auto fixed z-[60] grid grid-cols-3 gap-1 rounded-md border border-(--border-default) bg-(--bg-primary) p-1 shadow-(--ai-command-popover-shadow)"
+            ref={headingLevelMenuRef}
+            style={headingLevelMenuStyle}
+            role="menu"
+            aria-label={label("menu.headingLevel")}
+          >
+            {headingLevelOptions.map((option) => {
+              const HeadingLevelIcon = option.icon;
+              const selected = option.level === activeHeadingLevel;
+
+              return (
+                <button
+                  className={`inline-flex size-8 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) ${
+                    selected
+                      ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                      : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+                  }`}
+                  key={option.level}
+                  type="button"
+                  role="menuitemradio"
+                  aria-label={option.label}
+                  aria-checked={selected}
+                  title={option.label}
+                  onClick={() => {
+                    setHeadingLevelMenuOpen(false);
+                    onSetHeadingLevel(option.level);
+                  }}
+                >
+                  <HeadingLevelIcon aria-hidden="true" size={15} />
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )
+      : null;
 
   return (
     <section
@@ -202,22 +349,49 @@ export function AiSelectionToolbar({
           const active = activeFormattingActionSet.has(action.action);
 
           return (
-            <button
-              className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
-                active
-                  ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
-                  : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
-              }`}
-              key={action.action}
-              type="button"
-              disabled={busy}
-              title={actionLabel}
-              onClick={() => onRunFormattingAction(action.action)}
-              aria-label={actionLabel}
-              aria-pressed={active}
-            >
-              <Icon aria-hidden="true" size={14} />
-            </button>
+            <Fragment key={action.action}>
+              <button
+                className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
+                  active
+                    ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                    : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+                }`}
+                type="button"
+                disabled={busy}
+                title={actionLabel}
+                onClick={() => onRunFormattingAction(action.action)}
+                aria-label={actionLabel}
+                aria-pressed={active}
+              >
+                <Icon aria-hidden="true" size={14} />
+              </button>
+              {action.action === "inlineCode" ? (
+                <div className="relative inline-flex shrink-0">
+                  <button
+                    className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
+                      activeHeadingLevelOption
+                        ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                        : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+                    }`}
+                    ref={headingLevelButtonRef}
+                    type="button"
+                    disabled={busy}
+                    title={headingLevelLabel}
+                    onClick={(event) => {
+                      if (!headingLevelMenuOpen) {
+                        positionHeadingLevelMenu(event.currentTarget);
+                      }
+                      setHeadingLevelMenuOpen(!headingLevelMenuOpen);
+                    }}
+                    aria-label={headingLevelLabel}
+                    aria-haspopup="menu"
+                    aria-expanded={headingLevelMenuOpen}
+                  >
+                    <ActiveHeadingLevelIcon aria-hidden="true" size={15} />
+                  </button>
+                </div>
+              ) : null}
+            </Fragment>
           );
         })}
         <button
@@ -251,6 +425,7 @@ export function AiSelectionToolbar({
           {copySucceeded ? <Check aria-hidden="true" size={14} /> : <Copy aria-hidden="true" size={14} />}
         </button>
       </div>
+      {headingLevelMenu}
     </section>
   );
 }

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -22,7 +22,13 @@ import {
 } from "@markra/editor";
 import type { MarkdownOutlineItem } from "@markra/markdown";
 import type { SearchRange } from "@markra/shared";
-import { readSelectionFormattingActionsFromView } from "../lib/selection-formatting";
+import {
+  readSelectionFormattingActionsFromView,
+  readSelectionFormattingStateFromView,
+  setSelectionHeadingLevelInView,
+  type SelectionHeadingLevel,
+  type SelectionFormattingState
+} from "../lib/selection-formatting";
 
 const fixedTitlebarHeight = 40;
 const outlineScrollTopMargin = 24;
@@ -355,6 +361,36 @@ export function useEditorController() {
       return readSelectionFormattingActionsFromView(view);
     } catch {
       return [];
+    }
+  }, []);
+
+  const getSelectionFormattingState = useCallback((): SelectionFormattingState => {
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) {
+        return {
+          actions: [],
+          headingLevel: null
+        };
+      }
+
+      return readSelectionFormattingStateFromView(view);
+    } catch {
+      return {
+        actions: [],
+        headingLevel: null
+      };
+    }
+  }, []);
+
+  const setSelectionHeadingLevel = useCallback((level: SelectionHeadingLevel) => {
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return false;
+
+      return setSelectionHeadingLevelInView(view, level);
+    } catch {
+      return false;
     }
   }, []);
 
@@ -759,6 +795,7 @@ export function useEditorController() {
     isCurrentMarkdownEquivalent,
     getSelection,
     getSelectionFormattingActions,
+    getSelectionFormattingState,
     getSectionAnchors,
     getTableAnchors,
     handleEditorReady,
@@ -773,6 +810,7 @@ export function useEditorController() {
     revealSearchMatch,
     runEditorShortcut,
     scrollAiSelectionAboveCommand,
+    setSelectionHeadingLevel,
     scrollToAiPreview,
     selectOutlineItem,
     showSearchMatches

--- a/packages/app/src/lib/selection-formatting.test.tsx
+++ b/packages/app/src/lib/selection-formatting.test.tsx
@@ -14,7 +14,12 @@ import { editorViewCtx } from "@milkdown/kit/core";
 import { TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { MarkdownPaper } from "../components/MarkdownPaper";
-import { readSelectionFormattingActionsFromView, type SelectionFormattingAction } from "./selection-formatting";
+import {
+  readSelectionFormattingActionsFromView,
+  readSelectionFormattingStateFromView,
+  setSelectionHeadingLevelInView,
+  type SelectionFormattingAction
+} from "./selection-formatting";
 
 async function renderEditor(initialContent: string) {
   let editor: Editor | null = null;
@@ -61,6 +66,22 @@ function selectText(view: EditorView, text: string) {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, from + text.length)));
 }
 
+function findBlockEndPosition(view: EditorView, typeName: string, text: string) {
+  let position: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (position !== null) return false;
+    if (node.type.name !== typeName || !node.textContent.includes(text)) return true;
+
+    position = nodePosition + node.nodeSize;
+    return false;
+  });
+
+  if (position === null) throw new Error(`Could not find ${typeName} block in editor: ${text}`);
+
+  return position;
+}
+
 describe("selection formatting", () => {
   it.each([
     ["bold", "bold text", "bold"],
@@ -88,5 +109,47 @@ describe("selection formatting", () => {
     selectText(view, selectedText);
 
     expect(readSelectionFormattingActionsFromView(view)).toContain(action satisfies SelectionFormattingAction);
+  });
+
+  it("reports the current heading level at the selection", async () => {
+    const { view } = await renderEditor("## Heading text");
+
+    selectText(view, "Heading text");
+
+    expect(readSelectionFormattingStateFromView(view)).toMatchObject({
+      headingLevel: 2
+    });
+  });
+
+  it("reports the current heading level when the selection ends at the heading boundary", async () => {
+    const { view } = await renderEditor("### Heading text\n\nParagraph text");
+    const from = findTextPosition(view, "Heading text");
+    const to = findBlockEndPosition(view, "heading", "Heading text");
+
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+
+    expect(readSelectionFormattingStateFromView(view)).toMatchObject({
+      headingLevel: 3
+    });
+  });
+
+  it("sets the selected heading level", async () => {
+    const { view } = await renderEditor("## Heading text");
+
+    selectText(view, "Heading text");
+
+    expect(setSelectionHeadingLevelInView(view, 3)).toBe(true);
+    expect(readSelectionFormattingStateFromView(view).headingLevel).toBe(3);
+  });
+
+  it("turns the selected paragraph into the chosen heading level", async () => {
+    const { view } = await renderEditor("Paragraph text");
+
+    selectText(view, "Paragraph text");
+
+    expect(readSelectionFormattingStateFromView(view).headingLevel).toBeNull();
+
+    expect(setSelectionHeadingLevelInView(view, 4)).toBe(true);
+    expect(readSelectionFormattingStateFromView(view).headingLevel).toBe(4);
   });
 });

--- a/packages/app/src/lib/selection-formatting.ts
+++ b/packages/app/src/lib/selection-formatting.ts
@@ -1,5 +1,6 @@
 import type { ResolvedPos } from "@milkdown/kit/prose/model";
-import type { EditorState } from "@milkdown/kit/prose/state";
+import { setBlockType } from "@milkdown/kit/prose/commands";
+import { TextSelection, type EditorState } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 
 export const selectionFormattingShortcutActions = [
@@ -13,8 +14,16 @@ export const selectionFormattingShortcutActions = [
   "orderedList"
 ] as const;
 
+export const selectionHeadingLevels = [1, 2, 3, 4, 5, 6] as const;
+
 export type SelectionFormattingShortcutAction = typeof selectionFormattingShortcutActions[number];
 export type SelectionFormattingAction = SelectionFormattingShortcutAction | "link";
+export type SelectionHeadingLevel = typeof selectionHeadingLevels[number];
+
+export type SelectionFormattingState = {
+  actions: SelectionFormattingAction[];
+  headingLevel: SelectionHeadingLevel | null;
+};
 
 const markActionTypeNames = {
   bold: "strong",
@@ -62,6 +71,61 @@ function selectionHasMark(state: EditorState, markName: string) {
   return state.doc.rangeHasMark(state.selection.from, state.selection.to, markType);
 }
 
+function normalizeHeadingLevel(value: unknown) {
+  if (typeof value !== "number") return null;
+  if (!selectionHeadingLevels.includes(value as SelectionHeadingLevel)) return null;
+
+  return value as SelectionHeadingLevel;
+}
+
+type ActiveHeading = {
+  from: number;
+  level: SelectionHeadingLevel;
+};
+
+function findHeadingAtPosition(position: ResolvedPos): ActiveHeading | null {
+  for (let depth = position.depth; depth > 0; depth -= 1) {
+    const node = position.node(depth);
+    if (node.type.name !== "heading") continue;
+
+    const level = normalizeHeadingLevel(node.attrs.level);
+    if (level === null) return null;
+
+    return {
+      from: position.before(depth),
+      level
+    };
+  }
+
+  return null;
+}
+
+function resolveBoundedPosition(state: EditorState, position: number) {
+  return state.doc.resolve(Math.max(0, Math.min(position, state.doc.content.size)));
+}
+
+function findHeadingNearPosition(state: EditorState, position: number, fallbackOffset: -1 | 0 | 1) {
+  const directHeading = findHeadingAtPosition(resolveBoundedPosition(state, position));
+  if (directHeading || fallbackOffset === 0) return directHeading;
+
+  const fallbackPosition = position + fallbackOffset;
+  if (fallbackPosition < 0 || fallbackPosition > state.doc.content.size) return null;
+
+  return findHeadingAtPosition(resolveBoundedPosition(state, fallbackPosition));
+}
+
+function findActiveHeading(state: EditorState): ActiveHeading | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection)) return null;
+  if (selection.empty) return findHeadingNearPosition(state, selection.head, 0);
+
+  const startHeading = findHeadingNearPosition(state, selection.from, 1);
+  const endHeading = findHeadingNearPosition(state, selection.to, -1);
+  if (!startHeading || !endHeading || startHeading.from !== endHeading.from) return null;
+
+  return startHeading;
+}
+
 export function readSelectionFormattingActionsFromView(view: EditorView): SelectionFormattingAction[] {
   const { state } = view;
   const activeActions: SelectionFormattingAction[] = [];
@@ -76,4 +140,21 @@ export function readSelectionFormattingActionsFromView(view: EditorView): Select
   if (selectionHasAncestor(state, "ordered_list")) activeActions.push("orderedList");
 
   return activeActions;
+}
+
+export function readSelectionFormattingStateFromView(view: EditorView): SelectionFormattingState {
+  return {
+    actions: readSelectionFormattingActionsFromView(view),
+    headingLevel: findActiveHeading(view.state)?.level ?? null
+  };
+}
+
+export function setSelectionHeadingLevelInView(view: EditorView, level: SelectionHeadingLevel) {
+  const heading = view.state.schema.nodes.heading;
+  if (!heading) return false;
+
+  const changed = setBlockType(heading, { level })(view.state, view.dispatch, view);
+  if (changed) view.focus();
+
+  return changed;
 }

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Durchgestrichen",
   "menu.inlineCode": "Inline-Code",
   "menu.paragraph": "Absatz",
+  "menu.headingLevel": "Überschriftenebene",
   "menu.heading1": "Überschrift 1",
   "menu.heading2": "Überschrift 2",
   "menu.heading3": "Überschrift 3",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -556,6 +556,7 @@ const messages: BaseLocaleMessages = {
   "menu.strikethrough": "Strikethrough",
   "menu.inlineCode": "Inline Code",
   "menu.paragraph": "Paragraph",
+  "menu.headingLevel": "Heading Level",
   "menu.heading1": "Heading 1",
   "menu.heading2": "Heading 2",
   "menu.heading3": "Heading 3",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Tachado",
   "menu.inlineCode": "Código en línea",
   "menu.paragraph": "Párrafo",
+  "menu.headingLevel": "Nivel de encabezado",
   "menu.heading1": "Encabezado 1",
   "menu.heading2": "Encabezado 2",
   "menu.heading3": "Encabezado 3",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Barré",
   "menu.inlineCode": "Code en ligne",
   "menu.paragraph": "Paragraphe",
+  "menu.headingLevel": "Niveau de titre",
   "menu.heading1": "Titre 1",
   "menu.heading2": "Titre 2",
   "menu.heading3": "Titre 3",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Barrato",
   "menu.inlineCode": "Codice inline",
   "menu.paragraph": "Paragrafo",
+  "menu.headingLevel": "Livello titolo",
   "menu.heading1": "Titolo 1",
   "menu.heading2": "Titolo 2",
   "menu.heading3": "Titolo 3",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "取り消し線",
   "menu.inlineCode": "インラインコード",
   "menu.paragraph": "段落",
+  "menu.headingLevel": "見出しレベル",
   "menu.heading1": "見出し 1",
   "menu.heading2": "見出し 2",
   "menu.heading3": "見出し 3",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "취소선",
   "menu.inlineCode": "인라인 코드",
   "menu.paragraph": "단락",
+  "menu.headingLevel": "제목 수준",
   "menu.heading1": "제목 1",
   "menu.heading2": "제목 2",
   "menu.heading3": "제목 3",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Tachado",
   "menu.inlineCode": "Código embutido",
   "menu.paragraph": "Parágrafo",
+  "menu.headingLevel": "Nível do título",
   "menu.heading1": "Título 1",
   "menu.heading2": "Título 2",
   "menu.heading3": "Título 3",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Зачёркнутый",
   "menu.inlineCode": "Встроенный код",
   "menu.paragraph": "Абзац",
+  "menu.headingLevel": "Уровень заголовка",
   "menu.heading1": "Заголовок 1",
   "menu.heading2": "Заголовок 2",
   "menu.heading3": "Заголовок 3",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -567,6 +567,7 @@ export type I18nKey =
   | "menu.strikethrough"
   | "menu.inlineCode"
   | "menu.paragraph"
+  | "menu.headingLevel"
   | "menu.heading1"
   | "menu.heading2"
   | "menu.heading3"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "删除线",
   "menu.inlineCode": "行内代码",
   "menu.paragraph": "段落",
+  "menu.headingLevel": "标题级别",
   "menu.heading1": "标题 1",
   "menu.heading2": "标题 2",
   "menu.heading3": "标题 3",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -556,6 +556,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "刪除線",
   "menu.inlineCode": "行內程式碼",
   "menu.paragraph": "段落",
+  "menu.headingLevel": "標題層級",
   "menu.heading1": "標題 1",
   "menu.heading2": "標題 2",
   "menu.heading3": "標題 3",


### PR DESCRIPTION
## Summary
- Replace the floating toolbar heading promote/demote buttons with a compact heading-level menu.
- Show the heading trigger and H1-H6 choices as icon-only heading level buttons, with the trigger tracking the active selected heading level.
- Render the heading menu as a fixed floating layer outside the toolbar scroll container so it is not clipped when opened.
- Track the active heading level from editor selections, including selections that end at a heading block boundary.

## Validation
- `pnpm --filter @markra/app test -- src/components/AiSelectionToolbar.test.tsx` passed (42 files, 865 tests)
- `pnpm --filter @markra/app test -- src/lib/selection-formatting.test.tsx` passed (42 files, 865 tests)
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/shared typecheck:test` passed
- `pnpm --filter @markra/shared test -- src/i18n/index.test.ts` passed (4 files, 19 tests)
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/shared build` passed
- `pnpm --filter @markra/desktop build` passed
- `git diff --check` passed

## Related Issues
Refs #155
