### PR TITLE
fix(editor): improve inserted table display

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3807,8 +3807,9 @@ describe("Markra workspace", () => {
 
     await waitFor(() => {
       const currentSourceEditor = screen.getByRole("textbox", { name: "Markdown source" }) as HTMLTextAreaElement;
-      expect(currentSourceEditor.value).toContain("Column 1");
-      expect(currentSourceEditor.value).toContain("Column 2");
+      expect(currentSourceEditor.value).toMatch(/\|\s+\|\s+\|\n\|\s+-+\s+\|\s+-+\s+\|\n\|\s+\|\s+\|/u);
+      expect(currentSourceEditor.value).not.toContain("Column 1");
+      expect(currentSourceEditor.value).not.toContain("Column 2");
     });
   });
 
@@ -4663,8 +4664,12 @@ describe("Markra workspace", () => {
     });
 
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
-    expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 1");
-    expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 2");
+    const headerCells = Array.from(container.querySelectorAll(".ProseMirror table tr:first-child th")).map(
+      (cell) => cell.textContent
+    );
+    expect(headerCells).toEqual(["", ""]);
+    expect(container.querySelector(".ProseMirror table")).not.toHaveTextContent("Column 1");
+    expect(container.querySelector(".ProseMirror table")).not.toHaveTextContent("Column 2");
   });
 
   it("does not expose native editor AI context actions without selected text", async () => {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6598,7 +6598,12 @@ describe("MarkdownPaper editing", () => {
     fireEvent.mouseDown(tableOption);
 
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
-    expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Column 1");
+    const headerCells = Array.from(container.querySelectorAll(".ProseMirror table tr:first-child th")).map(
+      (cell) => cell.textContent
+    );
+    expect(headerCells).toEqual(["", ""]);
+    expect(container.querySelector(".ProseMirror table")).not.toHaveTextContent("Column 1");
+    expect(container.querySelector(".ProseMirror table")).not.toHaveTextContent("Column 2");
     expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/ta");
     await settleMarkdownListener();
   });

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -35,7 +35,7 @@ const outlineScrollTopMargin = 24;
 const outlineScrollTopOffset = fixedTitlebarHeight + outlineScrollTopMargin;
 const aiCommandSelectionBottomMargin = 24;
 const defaultMarkdownTable = [
-  "| Column 1 | Column 2 |",
+  "|  |  |",
   "| --- | --- |",
   "|  |  |"
 ].join("\n");

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1726,6 +1726,16 @@
     background: var(--editor-bg-secondary);
   }
 
+  .markdown-paper tbody tr:first-child:has(th) ~ tr:nth-child(even) td {
+    @apply bg-(--bg-primary);
+    background: var(--editor-paper-bg);
+  }
+
+  .markdown-paper tbody tr:first-child:has(th) ~ tr:nth-child(odd) td {
+    @apply bg-(--bg-secondary);
+    background: var(--editor-bg-secondary);
+  }
+
   .markdown-paper th p,
   .markdown-paper td p {
     @apply m-0;

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -36,7 +36,11 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper table");
     expect(styles).toContain(".markdown-paper th");
     expect(styles).toContain(".markdown-paper td");
-    expect(styles).toContain(".markdown-paper tbody tr:nth-child(even)");
+    expect(styles).toContain("background: var(--editor-bg-secondary)");
+    expect(styles).toContain("color: var(--editor-text-heading)");
+    expect(styles).toContain(".markdown-paper tbody tr:nth-child(even) td");
+    expect(styles).toContain(".markdown-paper tbody tr:first-child:has(th) ~ tr:nth-child(even) td");
+    expect(styles).toContain(".markdown-paper tbody tr:first-child:has(th) ~ tr:nth-child(odd) td");
   });
 
   it("uses app-themed custom scrollbars across scroll containers", () => {

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -216,8 +216,8 @@ function createDefaultTableNode(view: EditorView, commands: {
   tableRow: NodeType;
 }) {
   const headerRow = commands.tableHeaderRow.create(null, [
-    createTableCell(view, commands.tableHeader, commands.paragraph, "Column 1"),
-    createTableCell(view, commands.tableHeader, commands.paragraph, "Column 2")
+    createTableCell(view, commands.tableHeader, commands.paragraph),
+    createTableCell(view, commands.tableHeader, commands.paragraph)
   ]);
   const bodyRow = commands.tableRow.create(null, [
     createTableCell(view, commands.tableCell, commands.paragraph),


### PR DESCRIPTION

## Summary
- Insert new tables with blank header cells instead of Column 1 / Column 2 placeholders.
- Preserve theme-specific table header colors while offsetting tbody zebra striping when the header row is rendered inside tbody.
- Update slash command, native menu, split editor, and stylesheet coverage for the new behavior.

## Why
- Fixes the table display issue where the first body row could share the header background, while keeping zebra striping active for table content.

## Validation
- `pnpm --filter @markra/app test -- src/styles.test.ts src/components/MarkdownPaper.test.tsx src/App.test.tsx -t "includes readable Markdown table styles|inserts a table from the slash command menu|inserts a markdown table from the native editor menu handler|keeps source and visual editors synchronized in split mode"` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed

## Related Issues
- Closes #161
