### PR TITLE
fix(app): preserve template blanks and root creates

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -718,6 +718,42 @@ describe("MarkdownFileTreeDrawer", () => {
     }
   });
 
+  it("starts root create actions at the tree root when the current file is in the root folder", () => {
+    const createFile = vi.fn();
+    const createFolder = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onCreateFile={createFile}
+        onCreateFolder={createFolder}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+    const newFileInput = screen.getByRole("textbox", { name: "New file name" });
+    fireEvent.change(newFileInput, { target: { value: "Root note" } });
+    fireEvent.keyDown(newFileInput, { key: "Enter" });
+
+    expect(createFile).toHaveBeenCalledWith("Root note");
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New Folder" }));
+    const newFolderInput = screen.getByRole("textbox", { name: "New folder name" });
+    fireEvent.change(newFolderInput, { target: { value: "Inbox" } });
+    fireEvent.keyDown(newFolderInput, { key: "Enter" });
+
+    expect(createFolder).toHaveBeenCalledWith("Inbox");
+  });
+
   it("starts a markdown file from a custom template", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-21T09:30:00"));

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -580,6 +581,15 @@ export function MarkdownFileTreeDrawer({
   const folderExpansionAvailable = folderPaths.length > 0;
   const allFoldersExpanded = folderExpansionAvailable && folderPaths.every((folderPath) => expandedFolders.has(folderPath));
   const dragMoveAvailable = folderOpen && Boolean(onMoveFile);
+  const normalizeTreeCreateParentPath = useCallback((path: string | null | undefined) => {
+    const normalizedParentPath = normalizeCreateParentPath(path);
+    if (!normalizedParentPath) return null;
+
+    const normalizedRootPath = rootPath ? normalizeMovedPath(rootPath) : null;
+    if (normalizedRootPath && normalizeMovedPath(normalizedParentPath) === normalizedRootPath) return null;
+
+    return normalizedParentPath;
+  }, [rootPath]);
   const activeCreateParentPath = useMemo(() => {
     const normalizedRootPath = rootPath ? normalizeMovedPath(rootPath) : null;
     const currentParentPath = currentPath ? parentPathFromPath(currentPath) : null;
@@ -587,11 +597,11 @@ export function MarkdownFileTreeDrawer({
 
     const normalizedParentPath = normalizeMovedPath(currentParentPath);
     if (normalizedParentPath === normalizedRootPath || normalizedParentPath.startsWith(`${normalizedRootPath}/`)) {
-      return currentParentPath;
+      return normalizeTreeCreateParentPath(currentParentPath);
     }
 
     return null;
-  }, [currentPath, rootPath]);
+  }, [currentPath, normalizeTreeCreateParentPath, rootPath]);
   const recentFolderChoices = recentFolders.slice(0, 5);
   const recentFolderAreaVisible = recentFolderChoices.length > 0 && Boolean(onOpenRecentFolder);
   const filePanelVisible = folderOpen;
@@ -644,7 +654,7 @@ export function MarkdownFileTreeDrawer({
     setNewFolderName("");
     setRenamingPath(null);
     setRenameFileName("");
-    setCreatingParentPath(normalizeCreateParentPath(parentPath));
+    setCreatingParentPath(normalizeTreeCreateParentPath(parentPath));
     setCreatingTemplate(template);
     setCreatingTemplateStartedAt(template ? startedAt : null);
     setCreatingFile(true);
@@ -661,7 +671,7 @@ export function MarkdownFileTreeDrawer({
     setCreatingTemplateStartedAt(null);
     setRenamingPath(null);
     setRenameFileName("");
-    setCreatingParentPath(normalizeCreateParentPath(parentPath));
+    setCreatingParentPath(normalizeTreeCreateParentPath(parentPath));
     setCreatingFolder(true);
     setNewFolderName("");
     setCreateMenuOpen(false);

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -3246,6 +3246,16 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
+  it("loads template blank paragraphs from markdown blank lines", async () => {
+    const { editor, view } = await renderEditor("# Template\n\n\n\n## Next");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+    expect(serializeMarkdown(view.state.doc)).toBe("# Template\n\n\n\n## Next\n");
+  });
+
   it("saves blank list items without br tags", async () => {
     const onMarkdownChange = vi.fn();
     const { container, view } = await renderEditor("- First\n- Second", { onMarkdownChange });

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -25,9 +25,15 @@ import { readAiSelectionContextFromView } from "../hooks/useEditorController";
 
 type MarkdownTreeNode = {
   children?: MarkdownTreeNode[];
+  position?: {
+    end?: { line?: number };
+    start?: { line?: number };
+  };
   type?: string;
   value?: unknown;
 };
+
+const blankParagraphContainerTypes = new Set(["blockquote", "listItem", "root"]);
 
 const markraBlockImageSchema = imageSchema.extendSchema((previous) => (ctx) => ({
   ...previous(ctx),
@@ -47,6 +53,49 @@ const markraBlockImageSchema = imageSchema.extendSchema((previous) => (ctx) => (
     }
   }
 }));
+
+function lineNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function blankParagraphCountBetween(previous: MarkdownTreeNode, next: MarkdownTreeNode) {
+  const previousEndLine = lineNumber(previous.position?.end?.line);
+  const nextStartLine = lineNumber(next.position?.start?.line);
+  if (previousEndLine === null || nextStartLine === null) return 0;
+
+  // One blank line is the ordinary Markdown block separator; extra pairs represent empty paragraphs.
+  const blankLines = nextStartLine - previousEndLine - 1;
+  return Math.max(0, Math.floor((blankLines - 1) / 2));
+}
+
+function blankParagraphNode(): MarkdownTreeNode {
+  return {
+    children: [],
+    type: "paragraph"
+  };
+}
+
+function preserveBlankParagraphs(node: MarkdownTreeNode) {
+  if (!Array.isArray(node.children)) return;
+
+  node.children.forEach(preserveBlankParagraphs);
+  if (!blankParagraphContainerTypes.has(node.type ?? "")) return;
+
+  const children: MarkdownTreeNode[] = [];
+  node.children.forEach((child, index) => {
+    const previous = node.children?.[index - 1];
+
+    if (previous) {
+      const count = blankParagraphCountBetween(previous, child);
+      for (let blankIndex = 0; blankIndex < count; blankIndex += 1) {
+        children.push(blankParagraphNode());
+      }
+    }
+
+    children.push(child);
+  });
+  node.children = children;
+}
 
 function trimParagraphEdgeWhitespace(children: MarkdownTreeNode[]) {
   const trimmed = [...children];
@@ -136,11 +185,16 @@ function liftImageParagraphs(node: MarkdownTreeNode) {
   node.children = children;
 }
 
+const markraBlankParagraphRemarkPlugin = $remark("markraBlankParagraphRemark", () => () => (tree: MarkdownTreeNode) => {
+  preserveBlankParagraphs(tree);
+});
+
 const markraBlockImageRemarkPlugin = $remark("markraBlockImageRemark", () => () => (tree: MarkdownTreeNode) => {
   liftImageParagraphs(tree);
 });
 
 export const markraCommonmark = [
+  markraBlankParagraphRemarkPlugin,
   markraBlockImageRemarkPlugin,
   commonmarkSchema,
   markraBlockImageSchema,


### PR DESCRIPTION
## Summary
- Preserve empty paragraphs when loading Markdown templates with intentional blank lines.
- Keep file/folder creation working when the selected file lives at the tree root.
- Add regression coverage for template blank lines and root-level create actions.

## Why
- Milkdown parsing collapsed extra Markdown blank lines, so templates lost preset spacing.
- Root-level file selection produced the root folder path as a create parent, but the tree renders root create rows with a null parent path.

## Validation
- `pnpm --filter @markra/app test` passed: 42 files, 867 tests.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low. Changes are scoped to Markdown parse normalization and file tree create parent normalization.

Closes #159