### PR TITLE
fix(app): keep Windows titlebar actions clear of AI panel

### DIFF
--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -198,7 +198,8 @@ describe("NativeTitleBar", () => {
     const toggleSourceMode = vi.fn();
     const { container } = render(
       <NativeTitleBar
-        aiAgentOpen={false}
+        aiAgentOpen
+        aiAgentWidth={384}
         dirty={false}
         documentName="Draft.md"
         markdownFilesOpen={false}
@@ -222,10 +223,36 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".native-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".document-actions")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".native-title-slot")).not.toHaveAttribute("data-tauri-drag-region");
+    expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     expect(toggleSourceMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps compact Windows file actions clear of the Markra AI panel", () => {
+    const { container } = render(
+      <NativeTitleBar
+        aiAgentOpen
+        aiAgentWidth={384}
+        dirty
+        documentName="Draft.md"
+        markdownFilesOpen={false}
+        quickCreateMarkdownFileVisible
+        theme="light"
+        platform="windows"
+        onCreateMarkdownFile={() => {}}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
+    expect(screen.getByRole("button", { name: "Open Markdown or Folder" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toBeInTheDocument();
   });
 
   it("toggles the right-side Markra AI panel from the file action area", () => {
@@ -632,6 +659,7 @@ describe("NativeTitleBar", () => {
     expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toBeInTheDocument();
     expect(container.querySelector(".document-actions")).toHaveClass("relative");
     expect(container.querySelector(".document-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
+    expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
   });
 
   it("offers separate Markdown file and folder actions from the Windows open button", () => {

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -449,6 +449,12 @@ export function NativeTitleBar({
       background: `linear-gradient(to right, var(--bg-secondary) 0 ${markdownFilesWidth}px, var(--bg-primary) ${markdownFilesWidth}px 100%)`
     }
     : undefined;
+  const windowsTitlebarActionsStyle: CSSProperties | undefined = aiAgentOpen
+    ? { transform: `translateX(-${aiAgentWidth}px)` }
+    : undefined;
+  const windowsTitlebarActionsTransitionClassName = aiAgentResizing
+    ? "transition-none"
+    : "transition-[opacity,background-color,color,transform] duration-150 ease-out";
   const titlebarGridStyle: CSSProperties = {
     ...(titlebarSurfaceStyle ?? {}),
     ...(!nativeWindowChrome && markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
@@ -484,7 +490,10 @@ export function NativeTitleBar({
           aria-label={label("app.windowDragRegion")}
         >
           {renderTitleContent("native-title-slot min-w-0 h-10 pr-3 pl-4")}
-          <div className="relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 transition-[opacity,background-color,color] duration-150 ease-out hover:opacity-100 focus-within:opacity-100">
+          <div
+            className={`windows-titlebar-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 ${windowsTitlebarActionsTransitionClassName} hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none`}
+            style={windowsTitlebarActionsStyle}
+          >
             {renderFixedOpenAction("")}
             {renderDocumentActions("document-actions relative flex h-10 items-center justify-end gap-0.5")}
           </div>
@@ -497,7 +506,10 @@ export function NativeTitleBar({
         className="native-titlebar fixed top-0 right-3.5 z-10 flex h-10 w-auto select-none items-center justify-end [-webkit-user-select:none]"
         aria-label={label("app.windowDragRegion")}
       >
-        <div className="flex h-10 items-center justify-end gap-0.5 text-(--text-secondary) opacity-40 transition-[opacity,background-color,color] duration-150 ease-out hover:opacity-100 focus-within:opacity-100">
+        <div
+          className={`windows-titlebar-actions flex h-10 items-center justify-end gap-0.5 text-(--text-secondary) opacity-40 ${windowsTitlebarActionsTransitionClassName} hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none`}
+          style={windowsTitlebarActionsStyle}
+        >
           {renderFixedOpenAction("")}
           {renderDocumentActions("document-actions relative flex h-10 items-center justify-end gap-0.5")}
         </div>


### PR DESCRIPTION
## Summary
- Move the Windows titlebar action group left by the open AI panel width so source and split controls stay clickable.
- Cover both compact Windows titlebar and tabbed Windows titlebar variants with regression tests.

## Why
- On Windows, the AI panel overlays the right edge of the app while the platform-specific titlebar action area stayed fixed, hiding source and split controls behind the panel.

## Validation
- `pnpm --filter @markra/app test src/components/NativeTitleBar.test.tsx`
- `pnpm --filter @markra/app build`

## Risk
- Low: scoped to Windows titlebar positioning and existing action handlers are unchanged.

## Related Issues
- Refs #160