### PR TITLE
fix(titlebar): align web with Windows layout

### DIFF
--- a/apps/web/src/runtime/index.test.ts
+++ b/apps/web/src/runtime/index.test.ts
@@ -28,7 +28,7 @@ describe("web runtime", () => {
     expect(runtime.features.pandoc).toBe(false);
     expect(runtime.features.s3ImageUpload).toBe(false);
     expect(runtime.features.updater).toBe(false);
-    expect(runtime.platform.resolveDesktopPlatform()).toBe("linux");
+    expect(runtime.platform.resolveDesktopPlatform()).toBe("windows");
     await expect(runtime.updater.checkAppUpdate()).resolves.toBeNull();
   });
 });

--- a/apps/web/src/runtime/index.ts
+++ b/apps/web/src/runtime/index.ts
@@ -36,7 +36,7 @@ export function createWebRuntime(options: WebRuntimeOptions = {}): AppRuntime {
     files: createWebFileRuntime(settings, options),
     menu: createWebMenuRuntime(defaultRuntime.menu, options),
     platform: {
-      resolveDesktopPlatform: () => "linux"
+      resolveDesktopPlatform: () => "windows"
     },
     settings,
     webResource: createWebResourceRuntime(options),

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1550,7 +1550,7 @@ describe("Markra workspace", () => {
     expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith(mockFolderPath);
   });
 
-  it("opens a markdown folder from the Windows titlebar open button", async () => {
+  it("opens a markdown folder from the Windows file tree header", async () => {
     mockedResolveDesktopPlatform.mockReturnValue("windows");
     mockedOpenNativeMarkdownFolder.mockResolvedValue({
       path: mockFolderPath,
@@ -1563,8 +1563,8 @@ describe("Markra workspace", () => {
 
     renderApp();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Open Folder..." }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle file list" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open Folder" }));
 
     expect(await screen.findByRole("complementary", { name: "Markdown file tree" })).toBeInTheDocument();
     expect(screen.getAllByText("vault").length).toBeGreaterThan(0);
@@ -1582,7 +1582,7 @@ describe("Markra workspace", () => {
     });
   });
 
-  it("starts the titlebar folder picker in the same click turn when the document is clean", async () => {
+  it("starts the Windows file tree folder picker in the same click turn when the document is clean", async () => {
     mockedResolveDesktopPlatform.mockReturnValue("windows");
     let resolveFolder: ((folder: { name: string; path: string }) => unknown) | null = null;
     mockedOpenNativeMarkdownFolder.mockReturnValue(new Promise((resolve) => {
@@ -1591,8 +1591,8 @@ describe("Markra workspace", () => {
 
     renderApp();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Open Folder..." }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle file list" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open Folder" }));
 
     expect(mockedOpenNativeMarkdownFolder).toHaveBeenCalledTimes(1);
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -340,6 +340,7 @@ describe("Markra workspace", () => {
   });
 
   it("places browser titlebar tabs over the editor area when runtime disables native window chrome", async () => {
+    mockedResolveDesktopPlatform.mockReturnValue("windows");
     configureAppRuntime({
       ...createDefaultAppRuntime(),
       features: {
@@ -349,6 +350,9 @@ describe("Markra workspace", () => {
         pandoc: true,
         s3ImageUpload: true,
         updater: true
+      },
+      platform: {
+        resolveDesktopPlatform: () => "windows"
       }
     });
     mockedGetStoredWorkspaceState.mockResolvedValue({
@@ -374,9 +378,11 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("complementary", { name: "Markdown file tree" })).toHaveAttribute("aria-hidden", "false");
     expect(screen.getByRole("tab", { name: /browser\.md/ })).toBeInTheDocument();
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "auto minmax(0, 1fr) auto",
+      gridTemplateColumns: "minmax(0,1fr) 164px",
       left: "289px"
     });
+    expect(container.querySelector(".windows-titlebar-actions")).toBeInTheDocument();
+    expect(container.querySelector(".titlebar-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".document-tabs-drag-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".native-title-slot")?.getAttribute("style") ?? "").not.toContain("margin-left");
   });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2748,6 +2748,7 @@ function WorkspaceApp() {
                   ? handleOpenTreeFileToSide
                   : undefined
               }
+              onOpenFolder={handleOpenMarkdownFolder}
               onOpenRecentFolder={handleOpenRecentMarkdownFolder}
               onOpenSettings={handleOpenSettings}
               onRemoveRecentFolder={removeRecentFolder}

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -276,6 +276,35 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(openFolder).not.toHaveBeenCalled();
   });
 
+  it("places the Windows open folder action in the sidebar header before search", () => {
+    const openFolder = vi.fn();
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        platform="windows"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onOpenFolder={openFolder}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+    const headerActions = container.querySelector(".markdown-file-tree-header-actions") as HTMLElement;
+
+    expect(
+      within(headerActions).getAllByRole("button").map((button) => button.getAttribute("aria-label"))
+    ).toEqual(["Open Folder", "Search Markdown files"]);
+    expect(screen.getByRole("button", { name: "Open Folder" })).toContainElement(
+      container.querySelector(".lucide-folder-open")
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Folder" }));
+
+    expect(openFolder).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps create actions unavailable until a folder root is open", () => {
     const createFile = vi.fn();
     const { container } = render(

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -36,6 +36,7 @@ import {
   ChevronRight,
   FileText,
   Folder,
+  FolderOpen,
   ImageIcon,
   LayoutTemplate,
   ListChevronsDownUp,
@@ -84,6 +85,7 @@ type MarkdownFileTreeDrawerProps = {
   onDeleteFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   onOpenFile: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   onOpenFileToSide?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
+  onOpenFolder?: () => unknown | Promise<unknown>;
   onOpenRecentFolder?: (folder: RecentMarkdownFolder) => unknown | Promise<unknown>;
   onOpenSettings?: () => unknown | Promise<unknown>;
   onRemoveRecentFolder?: (folder: RecentMarkdownFolder) => unknown | Promise<unknown>;
@@ -512,6 +514,7 @@ export function MarkdownFileTreeDrawer({
   onDeleteFile,
   onOpenFile,
   onOpenFileToSide,
+  onOpenFolder,
   onOpenRecentFolder,
   onOpenSettings = () => {},
   onRemoveRecentFolder,
@@ -573,6 +576,7 @@ export function MarkdownFileTreeDrawer({
   const resolvedMaxWidth = Math.max(resolvedMinWidth, maxWidth);
   const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
   const showWindowsSidebarToggle = platform === "windows" && onToggleMarkdownFiles;
+  const showWindowsOpenFolderAction = platform === "windows" && onOpenFolder;
   const WindowsSidebarToggleIcon = open ? PanelLeft : PanelRight;
   const drawerTopPaddingClassName = platform === "windows" ? "pt-0" : "pt-10";
   const fileCreationAvailable = folderOpen && Boolean(onCreateFile);
@@ -1457,7 +1461,16 @@ export function MarkdownFileTreeDrawer({
           <h2 className="m-0 truncate text-[14px] font-[560] tracking-normal text-(--text-heading)">
             {label("app.files")}
           </h2>
-          <div className="flex items-center gap-0.5">
+          <div className="markdown-file-tree-header-actions flex items-center gap-0.5">
+            {showWindowsOpenFolderAction ? (
+              <IconButton
+                className="rounded-md"
+                label={label("app.openFolder")}
+                onClick={onOpenFolder}
+              >
+                <FolderOpen aria-hidden="true" size={15} />
+              </IconButton>
+            ) : null}
             <IconButton
               className="rounded-md"
               label={label("app.searchMarkdownFiles")}

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -312,7 +312,7 @@ describe("NativeTitleBar", () => {
     );
 
     expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
-    expect(screen.getByRole("button", { name: "Open Markdown or Folder" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toBeInTheDocument();
   });
 
@@ -714,7 +714,7 @@ describe("NativeTitleBar", () => {
     expect(screen.queryByRole("heading", { name: "Draft.md" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Toggle file list" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "New file" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open Markdown or Folder" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Markdown" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Switch to dark theme" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toBeInTheDocument();
@@ -723,7 +723,7 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
   });
 
-  it("offers separate Markdown file and folder actions from the Windows open button", () => {
+  it("omits the Markdown or folder picker from the Windows titlebar", () => {
     const openMarkdown = vi.fn();
     const openMarkdownFolder = vi.fn();
     render(
@@ -743,15 +743,10 @@ describe("NativeTitleBar", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
-
-    expect(screen.getByRole("menu", { name: "Open Markdown or Folder" })).toHaveClass("right-0");
-    expect(screen.getByRole("menuitem", { name: "Open Markdown File" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Open Folder..." }));
-
-    expect(openMarkdownFolder).toHaveBeenCalledTimes(1);
-    expect(openMarkdown).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
     expect(screen.queryByRole("menu", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
+    expect(openMarkdown).not.toHaveBeenCalled();
+    expect(openMarkdownFolder).not.toHaveBeenCalled();
   });
 
   it("keeps the unified Markdown or folder picker on macOS", () => {

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -133,6 +133,38 @@ describe("NativeTitleBar", () => {
     expect(titleSlot?.getAttribute("style") ?? "").not.toContain("transform");
   });
 
+  it("uses the Windows titlebar layout for web chrome when the runtime resolves Windows", () => {
+    const { container } = render(
+      <NativeTitleBar
+        aiAgentOpen={false}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen
+        markdownFilesWidth={288}
+        nativeWindowChrome={false}
+        platform="windows"
+        theme="light"
+        titleContent={(
+          <div role="tablist" aria-label="Open documents">
+            <button type="button" role="tab" aria-selected="true">Draft.md</button>
+          </div>
+        )}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".native-titlebar")).toHaveStyle({
+      gridTemplateColumns: "minmax(0,1fr) 164px",
+      left: "289px"
+    });
+    expect(container.querySelector(".windows-titlebar-actions")).toBeInTheDocument();
+    expect(container.querySelector(".titlebar-spacer")).not.toBeInTheDocument();
+  });
+
   it("keeps macOS titlebar tabs clear of transformed actions before the AI panel", () => {
     const { container } = render(
       <NativeTitleBar
@@ -228,6 +260,35 @@ describe("NativeTitleBar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     expect(toggleSourceMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("reserves AI panel width for Windows titlebar tabs when file actions shift left", () => {
+    const { container } = render(
+      <NativeTitleBar
+        aiAgentOpen
+        aiAgentWidth={384}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen={false}
+        platform="windows"
+        theme="light"
+        titleContent={(
+          <div role="tablist" aria-label="Open documents">
+            <button type="button" role="tab" aria-selected="true">Draft.md</button>
+          </div>
+        )}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".native-titlebar")).toHaveStyle({
+      gridTemplateColumns: "minmax(0,1fr) 548px"
+    });
+    expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
   });
 
   it("keeps compact Windows file actions clear of the Markra AI panel", () => {

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -495,7 +495,6 @@ export function NativeTitleBar({
             className={`windows-titlebar-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 ${windowsTitlebarActionsTransitionClassName} hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none`}
             style={windowsTitlebarActionsStyle}
           >
-            {renderFixedOpenAction("")}
             {renderDocumentActions("document-actions relative flex h-10 items-center justify-end gap-0.5")}
           </div>
         </header>
@@ -511,7 +510,6 @@ export function NativeTitleBar({
           className={`windows-titlebar-actions flex h-10 items-center justify-end gap-0.5 text-(--text-secondary) opacity-40 ${windowsTitlebarActionsTransitionClassName} hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none`}
           style={windowsTitlebarActionsStyle}
         >
-          {renderFixedOpenAction("")}
           {renderDocumentActions("document-actions relative flex h-10 items-center justify-end gap-0.5")}
         </div>
       </header>

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -476,11 +476,12 @@ export function NativeTitleBar({
     />
   ) : null;
 
-  if (nativeWindowChrome && platform === "windows") {
+  if (platform === "windows") {
     if (titleContent) {
+      const windowsTitlebarActionSlotWidth = titlebarSideSlotWidth + (aiAgentOpen ? aiAgentWidth : 0);
       const windowsTitlebarStyle: CSSProperties = {
         ...(markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
-        gridTemplateColumns: `minmax(0,1fr) ${titlebarSideSlotWidth}px`
+        gridTemplateColumns: `minmax(0,1fr) ${windowsTitlebarActionSlotWidth}px`
       };
 
       return (


### PR DESCRIPTION
## Summary
- Align the web runtime with the Windows platform layout so web and Windows share the same titlebar chrome branch.
- Let Windows titlebar layout apply even when native window chrome is disabled.
- Reserve AI panel width for shifted Windows titlebar actions to avoid tab/action overlap.
- Move the Windows open-folder action from the titlebar into the file tree header, before search.

## Why
- Issue #168 asks for the left/right sidebar titlebar button treatment to be consistent.
- The web runtime previously resolved as Linux, so it used a separate browser-style titlebar path instead of the Windows path.
- The folder picker now lives with the file sidebar controls on Windows, matching the requested placement.

## Validation
- `pnpm --filter @markra/web test` passed, 33 tests.
- `pnpm --filter @markra/app test` passed, 871 tests. JSDOM printed expected `scrollBy` not implemented warnings, but the command exited successfully.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/web build` passed.
- `git diff --check` passed.

Refs #168

