### PR TITLE
fix(app): improve overflowing document tab scrolling

### DIFF
--- a/packages/app/src/components/MarkdownTabsBar.test.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.test.tsx
@@ -14,6 +14,13 @@ describe("MarkdownTabsBar", () => {
     return mock;
   }
 
+  const overflowItems = Array.from({ length: 8 }, (_, index) => ({
+    dirty: false,
+    id: `tab-${index + 1}`,
+    name: `Synthetic ${index + 1}.md`,
+    path: `/synthetic/doc-${index + 1}.md`
+  }));
+
   it("marks only titlebar tab empty space as a window drag region", () => {
     const { container } = render(
       <MarkdownTabsBar
@@ -37,6 +44,87 @@ describe("MarkdownTabsBar", () => {
     expect(container.querySelector(".document-tabs-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
     expect(screen.getByRole("tab", { name: /Alpha\.md/ }).closest("[data-tauri-drag-region]")).toBeNull();
     expect(container.querySelector(".document-tabs-drag-spacer")).toHaveAttribute("data-tauri-drag-region");
+  });
+
+  it("keeps the new tab action outside the horizontally scrolling tablist", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-1"
+        items={overflowItems}
+        placement="titlebar"
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const tablist = screen.getByRole("tablist", { name: "Open documents" });
+    const newTabButton = screen.getByRole("button", { name: "New tab" });
+
+    expect(tablist).not.toContainElement(newTabButton);
+    expect(newTabButton.closest(".document-tabs-controls")).toBeInTheDocument();
+  });
+
+  it("scrolls overflowing tabs horizontally with a vertical mouse wheel", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-1"
+        items={overflowItems}
+        placement="titlebar"
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const tablist = screen.getByRole("tablist", { name: "Open documents" });
+    Object.defineProperty(tablist, "clientWidth", { configurable: true, value: 220 });
+    Object.defineProperty(tablist, "scrollWidth", { configurable: true, value: 960 });
+    tablist.scrollLeft = 0;
+
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 84
+    });
+
+    tablist.dispatchEvent(wheelEvent);
+
+    expect(tablist.scrollLeft).toBe(84);
+  });
+
+  it("keeps the active tab visible when selection changes", () => {
+    const { rerender } = render(
+      <MarkdownTabsBar
+        activeTabId="tab-1"
+        items={overflowItems}
+        placement="titlebar"
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const scrollIntoView = vi.fn();
+    for (const element of document.querySelectorAll<HTMLElement>("[data-document-tab-id='tab-8']")) {
+      element.scrollIntoView = scrollIntoView;
+    }
+
+    rerender(
+      <MarkdownTabsBar
+        activeTabId="tab-8"
+        items={overflowItems}
+        placement="titlebar"
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      inline: "nearest"
+    });
   });
 
   it("omits titlebar empty drag space when native drag regions are unavailable", () => {

--- a/packages/app/src/components/MarkdownTabsBar.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.tsx
@@ -4,7 +4,8 @@ import {
   useState,
   type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent
 } from "react";
 import { Columns2, FileText, ImageIcon, Pencil, Plus, X } from "lucide-react";
 import { Button, IconButton, PopoverSurface } from "@markra/ui";
@@ -82,6 +83,7 @@ export function MarkdownTabsBar({
   const pointerDragCleanupRef = useRef<(() => unknown) | null>(null);
   const pointerEditorDropTargetRef = useRef<HTMLElement | null>(null);
   const suppressClickTabIdRef = useRef<string | null>(null);
+  const tabListRef = useRef<HTMLDivElement | null>(null);
 
   const setPageDocumentTabDragging = () => {
     document.documentElement.setAttribute("data-document-tab-dragging", "true");
@@ -124,9 +126,23 @@ export function MarkdownTabsBar({
 
   const tabItemGroups = items.map((item) => Array.isArray(item) ? item : [item]);
   const documentItems = tabItemGroups.flatMap((item) => item);
+  const documentTabIdsKey = documentItems.map((tab) => tab.id).join("\n");
   const sideGroupedTabIds = new Set(
     items.flatMap((item) => Array.isArray(item) ? item.slice(1).map((tab) => tab.id) : [])
   );
+
+  useEffect(() => {
+    if (!activeTabId) return;
+
+    const activeTabElement = Array.from(
+      tabListRef.current?.querySelectorAll<HTMLElement>("[data-document-tab-id]") ?? []
+    ).find((element) => element.dataset.documentTabId === activeTabId);
+
+    activeTabElement?.scrollIntoView?.({
+      block: "nearest",
+      inline: "nearest"
+    });
+  }, [activeTabId, documentTabIdsKey]);
 
   if (documentItems.length === 0) return null;
 
@@ -349,6 +365,19 @@ export function MarkdownTabsBar({
   const handlePreventNativeTabDrag = (event: ReactDragEvent) => {
     event.preventDefault();
   };
+  const handleTabsWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+    const tabList = event.currentTarget;
+    if (Math.abs(event.deltaX) >= Math.abs(event.deltaY) || event.deltaY === 0) return;
+
+    const maxScrollLeft = tabList.scrollWidth - tabList.clientWidth;
+    if (maxScrollLeft <= 0) return;
+
+    const nextScrollLeft = Math.max(0, Math.min(maxScrollLeft, tabList.scrollLeft + event.deltaY));
+    if (nextScrollLeft === tabList.scrollLeft) return;
+
+    tabList.scrollLeft = nextScrollLeft;
+    event.preventDefault();
+  };
   const handleSelectTabClick = (tab: MarkdownTabsBarDocumentItem, selectTabId: string) => {
     if (suppressClickTabIdRef.current === tab.id) {
       suppressClickTabIdRef.current = null;
@@ -494,21 +523,31 @@ export function MarkdownTabsBar({
       aria-label={label("app.documentTabs")}
     >
       <div
-        className={`flex h-full min-w-0 gap-1 overflow-x-auto text-[12px] leading-5 font-[560] text-(--text-secondary) ${
+        className={`document-tabs-row flex h-full min-w-0 gap-1 text-[12px] leading-5 font-[560] text-(--text-secondary) ${
           titlebarPlacement ? "items-center px-1.5" : "items-end px-3"
         }`}
-        role="tablist"
-        aria-label={label("app.documentTabs")}
       >
-        {items.map((item, index) => Array.isArray(item) ? renderDocumentTabGroup(item, index) : renderDocumentTab(item))}
-        <IconButton
-          className={`${titlebarPlacement ? "" : "mb-1"} rounded-md opacity-70 hover:opacity-100 focus-visible:opacity-100`}
-          label={label("app.newDocumentTab")}
-          size="icon-xs"
-          onClick={onNewTab}
+        <div
+          ref={tabListRef}
+          className={`document-tabs-scroll flex h-full min-w-0 flex-[0_1_auto] gap-1 overflow-x-auto ${
+            titlebarPlacement ? "items-center" : "items-end"
+          }`}
+          role="tablist"
+          aria-label={label("app.documentTabs")}
+          onWheel={handleTabsWheel}
         >
-          <Plus aria-hidden="true" size={13} />
-        </IconButton>
+          {items.map((item, index) => Array.isArray(item) ? renderDocumentTabGroup(item, index) : renderDocumentTab(item))}
+        </div>
+        <div className="document-tabs-controls flex h-full shrink-0 items-center">
+          <IconButton
+            className={`${titlebarPlacement ? "" : "mb-1"} rounded-md opacity-70 hover:opacity-100 focus-visible:opacity-100`}
+            label={label("app.newDocumentTab")}
+            size="icon-xs"
+            onClick={onNewTab}
+          >
+            <Plus aria-hidden="true" size={13} />
+          </IconButton>
+        </div>
         {titlebarPlacement && nativeDragRegionEnabled ? (
           <span
             aria-hidden="true"

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -587,6 +587,32 @@
 }
 
 @layer components {
+  .document-tabs-scroll {
+    scrollbar-color: color-mix(in srgb, var(--text-secondary) 38%, transparent) transparent;
+    scrollbar-width: thin;
+  }
+
+  .document-tabs-scroll::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+
+  .document-tabs-scroll::-webkit-scrollbar-thumb {
+    min-width: 48px;
+    min-height: 0;
+    border: 0;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--text-secondary) 38%, transparent);
+  }
+
+  .document-tabs-scroll::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in srgb, var(--text-secondary) 54%, transparent);
+  }
+
+  .document-tabs-scroll::-webkit-scrollbar-thumb:active {
+    background-color: color-mix(in srgb, var(--accent) 42%, transparent);
+  }
+
   .markra-slash-menu {
     @apply fixed z-[60] w-60 rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 text-(--text-primary);
     box-shadow: var(--ai-command-popover-shadow);


### PR DESCRIPTION
## Summary
- Keep the new-tab action outside the horizontally scrolling document tab list.
- Let vertical mouse wheel input scroll overflowing document tabs horizontally.
- Scroll the active document tab into view after selection changes.
- Use a thinner, lower-emphasis scrollbar for overflowing document tabs.

## Why
The previous titlebar tab layout could hide overflowed tabs behind fixed titlebar actions and ordinary mouse users had no obvious way to reach later tabs. The default horizontal scrollbar also appeared too visually heavy inside the compact titlebar.

## Validation
- `pnpm --filter @markra/app test -- MarkdownTabsBar.test.tsx` passed: 42 test files, 874 tests.
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification.
- Local browser QA on `http://127.0.0.1:1421/`: 12 tabs overflowed, the New tab action stayed outside the tablist, vertical wheel input moved the tablist horizontally, and the active tab scrollbar rendered as a thinner 4px track.

Closes #168