### PR TITLE
fix(app): improve web file creation and tab scrolling

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1402,6 +1402,41 @@ describe("Markra workspace", () => {
     expect(screen.queryByRole("button", { name: "docs/guide.md" })).not.toBeInTheDocument();
   });
 
+  it("keeps the web file tree usable for new unsaved files before a folder is opened", async () => {
+    configureAppRuntime({
+      ...createDefaultAppRuntime(),
+      features: {
+        ai: true,
+        export: true,
+        nativeWindowChrome: false,
+        pandoc: true,
+        s3ImageUpload: true,
+        updater: true
+      }
+    });
+
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle file list" }));
+
+    expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
+    fireEvent.contextMenu(screen.getByText("No Markdown files"));
+    const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls.at(-1)?.[0];
+    act(() => {
+      contextHandlers?.createFile?.();
+    });
+
+    const fileNameInput = screen.getByRole("textbox", { name: "New file name" });
+    fireEvent.change(fileNameInput, { target: { value: "Scratch.md" } });
+    fireEvent.keyDown(fileNameInput, { key: "Enter" });
+
+    expect(mockedCreateNativeMarkdownTreeFile).not.toHaveBeenCalled();
+    expect(screen.getByRole("tab", { name: /Scratch\.md/ })).toBeInTheDocument();
+    expect(screen.getByLabelText("Unsaved changes")).toBeInTheDocument();
+  });
+
   it("resizes the left markdown file tree from its right edge", async () => {
     mockOpenMarkdownFile({
       content: "# Native file\n\nOpened from disk.",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -162,6 +162,12 @@ function createImageDocumentTab(file: NativeMarkdownFolderFile): ImageDocumentTa
   };
 }
 
+function unsavedMarkdownFileNameFromTreeInput(fileName: string) {
+  const trimmedName = fileName.trim();
+  if (!trimmedName) return "Untitled.md";
+  return /\.(?:md|markdown)$/iu.test(trimmedName) ? trimmedName : `${trimmedName}.md`;
+}
+
 function documentTabAsFolderFile(tab: MarkdownTabsBarDocumentItem): NativeMarkdownFolderFile | null {
   if (!tab.path) return null;
 
@@ -1519,6 +1525,16 @@ function WorkspaceApp() {
     contents?: string
   ) => {
     try {
+      if (!fileTree.sourcePath) {
+        captureActiveDocumentViewState();
+        setActiveImageFile(null);
+        await createBlankDocument({
+          content: contents ?? "",
+          name: unsavedMarkdownFileNameFromTreeInput(fileName)
+        });
+        return;
+      }
+
       const file = await createMarkdownTreeFile(fileName, parentPath, contents);
       if (file) {
         captureActiveDocumentViewState();
@@ -1528,7 +1544,7 @@ function WorkspaceApp() {
     } catch {
       // Native file errors are surfaced by the platform operation when possible.
     }
-  }, [captureActiveDocumentViewState, createMarkdownTreeFile, openTreeMarkdownFile]);
+  }, [captureActiveDocumentViewState, createBlankDocument, createMarkdownTreeFile, fileTree.sourcePath, openTreeMarkdownFile]);
   const handleQuickCreateMarkdownTreeFile = useCallback(() => {
     captureActiveDocumentViewState();
     setActiveImageFile(null);

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -305,8 +305,9 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(openFolder).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps create actions unavailable until a folder root is open", () => {
+  it("keeps folder creation unavailable until a folder root is open", () => {
     const createFile = vi.fn();
+    const createFolder = vi.fn();
     const { container } = render(
       <MarkdownFileTreeDrawer
         currentPath={null}
@@ -316,17 +317,23 @@ describe("MarkdownFileTreeDrawer", () => {
         outlineItems={[]}
         rootName="No folder"
         onCreateFile={createFile}
+        onCreateFolder={createFolder}
         onOpenFile={() => {}}
         onSelectOutlineItem={() => {}}
       />
     );
 
-    expect(screen.queryByRole("button", { name: "New file" })).not.toBeInTheDocument();
-    expect(screen.queryByText("No folder")).not.toBeInTheDocument();
-    expect(container.querySelector(".file-tree-scroll")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+    expect(screen.getByText("No folder")).toBeInTheDocument();
+    expect(container.querySelector(".file-tree-scroll")).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+
+    expect(screen.getByRole("menuitem", { name: "New file" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "New Folder" })).not.toBeInTheDocument();
     expect(mockedShowNativeMarkdownFileTreeContextMenu).not.toHaveBeenCalled();
     expect(createFile).not.toHaveBeenCalled();
+    expect(createFolder).not.toHaveBeenCalled();
   });
 
   it("places open Windows sidebar controls inside a separated drawer footer", () => {
@@ -637,6 +644,46 @@ describe("MarkdownFileTreeDrawer", () => {
     fireEvent.keyDown(renameInput, { key: "Enter" });
 
     expect(renameFile).toHaveBeenCalledWith(markdownFiles[0], "Renamed.md");
+  });
+
+  it("keeps the empty file tree available for root file creation without an open folder", () => {
+    const createFile = vi.fn();
+    const createFolder = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath={null}
+        files={[]}
+        folderOpen={false}
+        open
+        outlineItems={[]}
+        rootName="No folder"
+        onCreateFile={createFile}
+        onCreateFolder={createFolder}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
+    expect(screen.getByText("No Markdown files")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+
+    fireEvent.contextMenu(screen.getByText("No Markdown files"));
+    const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls[0]?.[0];
+
+    expect(contextHandlers?.createFile).toEqual(expect.any(Function));
+    expect(contextHandlers?.createFolder).toBeUndefined();
+
+    act(() => {
+      contextHandlers?.createFile?.();
+    });
+    const newFileInput = screen.getByRole("textbox", { name: "New file name" });
+    fireEvent.change(newFileInput, { target: { value: "Scratch" } });
+    fireEvent.keyDown(newFileInput, { key: "Enter" });
+
+    expect(createFile).toHaveBeenCalledWith("Scratch");
+    expect(createFolder).not.toHaveBeenCalled();
   });
 
   it("starts a markdown file from a lightweight template", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -579,7 +579,7 @@ export function MarkdownFileTreeDrawer({
   const showWindowsOpenFolderAction = platform === "windows" && onOpenFolder;
   const WindowsSidebarToggleIcon = open ? PanelLeft : PanelRight;
   const drawerTopPaddingClassName = platform === "windows" ? "pt-0" : "pt-10";
-  const fileCreationAvailable = folderOpen && Boolean(onCreateFile);
+  const fileCreationAvailable = Boolean(onCreateFile);
   const folderCreationAvailable = folderOpen && Boolean(onCreateFolder);
   const folderActionsAvailable = fileCreationAvailable || folderCreationAvailable;
   const folderExpansionAvailable = folderPaths.length > 0;
@@ -608,7 +608,7 @@ export function MarkdownFileTreeDrawer({
   }, [currentPath, normalizeTreeCreateParentPath, rootPath]);
   const recentFolderChoices = recentFolders.slice(0, 5);
   const recentFolderAreaVisible = recentFolderChoices.length > 0 && Boolean(onOpenRecentFolder);
-  const filePanelVisible = folderOpen;
+  const filePanelVisible = folderOpen || (open && fileCreationAvailable);
   const filePanelStyle = outlineOpen ? { flex: `0 1 ${100 - outlineHeightPercent}%` } : undefined;
   const outlinePanelStyle = outlineOpen ? { flex: `0 1 ${outlineHeightPercent}%` } : undefined;
   useEffect(() => {
@@ -1673,9 +1673,11 @@ export function MarkdownFileTreeDrawer({
                     {tree.length > 0 || creatingFile || creatingFolder ? (
                       renderNodes(tree)
                     ) : (
-                      <p className="m-0 px-4 py-3 text-[12px] text-(--text-secondary)">
-                        {label("app.noMarkdownFiles")}
-                      </p>
+                      <div className="min-h-full" role="tree" aria-label={label("app.markdownFiles")}>
+                        <p className="m-0 px-4 py-3 text-[12px] text-(--text-secondary)">
+                          {label("app.noMarkdownFiles")}
+                        </p>
+                      </div>
                     )}
                   </div>
                 )}

--- a/packages/app/src/components/MarkdownTabsBar.test.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.test.tsx
@@ -14,6 +14,107 @@ describe("MarkdownTabsBar", () => {
     return mock;
   }
 
+  function renderOverflowingTabsBar() {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          },
+          {
+            dirty: false,
+            id: "tab-c",
+            name: "Gamma.md",
+            path: "/synthetic/gamma.md"
+          },
+          {
+            dirty: false,
+            id: "tab-d",
+            name: "Delta.md",
+            path: "/synthetic/delta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const tabList = screen.getByRole("tablist", { name: "Open documents" }) as HTMLElement;
+    let scrollLeft = 0;
+
+    Object.defineProperty(tabList, "clientWidth", {
+      configurable: true,
+      value: 240
+    });
+    Object.defineProperty(tabList, "scrollWidth", {
+      configurable: true,
+      value: 720
+    });
+    Object.defineProperty(tabList, "scrollLeft", {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (value) => {
+        scrollLeft = value;
+      }
+    });
+
+    return tabList;
+  }
+
+  it("scrolls overflowing document tabs horizontally from a vertical mouse wheel", () => {
+    const tabList = renderOverflowingTabsBar();
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 160
+    });
+    const preventDefault = vi.spyOn(wheelEvent, "preventDefault");
+
+    fireEvent(tabList, wheelEvent);
+
+    expect(tabList.scrollLeft).toBe(160);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trap tab wheel events at scroll edges or during horizontal wheel input", () => {
+    const tabList = renderOverflowingTabsBar();
+    const edgeWheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -80
+    });
+    const preventEdgeDefault = vi.spyOn(edgeWheelEvent, "preventDefault");
+
+    fireEvent(tabList, edgeWheelEvent);
+
+    expect(tabList.scrollLeft).toBe(0);
+    expect(preventEdgeDefault).not.toHaveBeenCalled();
+
+    const horizontalWheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaX: 120,
+      deltaY: 10
+    });
+    const preventHorizontalDefault = vi.spyOn(horizontalWheelEvent, "preventDefault");
+
+    fireEvent(tabList, horizontalWheelEvent);
+
+    expect(tabList.scrollLeft).toBe(0);
+    expect(preventHorizontalDefault).not.toHaveBeenCalled();
+  });
+
   it("marks only titlebar tab empty space as a window drag region", () => {
     const { container } = render(
       <MarkdownTabsBar

--- a/packages/app/src/components/MarkdownTabsBar.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.tsx
@@ -4,7 +4,8 @@ import {
   useState,
   type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent
+  type PointerEvent as ReactPointerEvent,
+  type WheelEvent as ReactWheelEvent
 } from "react";
 import { Columns2, FileText, ImageIcon, Pencil, Plus, X } from "lucide-react";
 import { Button, IconButton, PopoverSurface } from "@markra/ui";
@@ -349,6 +350,20 @@ export function MarkdownTabsBar({
   const handlePreventNativeTabDrag = (event: ReactDragEvent) => {
     event.preventDefault();
   };
+  const handleTabsWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
+    const tabList = event.currentTarget;
+    const maxScrollLeft = tabList.scrollWidth - tabList.clientWidth;
+
+    if (maxScrollLeft <= 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) return;
+
+    const wheelUnitMultiplier = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? tabList.clientWidth : 1;
+    const nextScrollLeft = Math.max(0, Math.min(maxScrollLeft, tabList.scrollLeft + event.deltaY * wheelUnitMultiplier));
+
+    if (nextScrollLeft === tabList.scrollLeft) return;
+
+    tabList.scrollLeft = nextScrollLeft;
+    event.preventDefault();
+  };
   const handleSelectTabClick = (tab: MarkdownTabsBarDocumentItem, selectTabId: string) => {
     if (suppressClickTabIdRef.current === tab.id) {
       suppressClickTabIdRef.current = null;
@@ -499,6 +514,7 @@ export function MarkdownTabsBar({
         }`}
         role="tablist"
         aria-label={label("app.documentTabs")}
+        onWheel={handleTabsWheel}
       >
         {items.map((item, index) => Array.isArray(item) ? renderDocumentTabGroup(item, index) : renderDocumentTab(item))}
         <IconButton

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -54,6 +54,16 @@ export type MarkdownDocumentTab = DocumentState & {
   id: string;
 };
 
+type CreateBlankDocumentOptions = {
+  content?: string;
+  name?: string;
+};
+
+function blankDocumentName(name: string | null | undefined) {
+  const trimmedName = name?.trim();
+  return trimmedName ? trimmedName : "Untitled.md";
+}
+
 function createDocumentTab(document: DocumentState, id: string): MarkdownDocumentTab {
   return {
     ...document,
@@ -423,11 +433,11 @@ export function useMarkdownDocument({
     });
   }, [handleMarkdownChange]);
 
-  const resetToBlankDocument = useCallback(() => {
+  const resetToBlankDocument = useCallback((options: CreateBlankDocumentOptions = {}) => {
     const nextDocument = {
       path: null,
-      name: "Untitled.md",
-      content: "",
+      name: blankDocumentName(options.name),
+      content: options.content ?? "",
       dirty: true,
       open: true,
       revision: documentRef.current.revision + 1
@@ -451,20 +461,20 @@ export function useMarkdownDocument({
     return true;
   }, [createUntitledTabId, documentTabsEnabled, registerWindowRestoreState, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]);
 
-  const createBlankDocument = useCallback(() => {
-    if (documentTabsEnabled) return Promise.resolve(resetToBlankDocument());
+  const createBlankDocument = useCallback((options: CreateBlankDocumentOptions = {}) => {
+    if (documentTabsEnabled) return Promise.resolve(resetToBlankDocument(options));
 
     const canDiscard = confirmCanDiscardCurrentDocument();
     if (typeof canDiscard === "boolean") {
       if (!canDiscard) return Promise.resolve(false);
 
-      return Promise.resolve(resetToBlankDocument());
+      return Promise.resolve(resetToBlankDocument(options));
     }
 
     return canDiscard.then((confirmed) => {
       if (!confirmed) return false;
 
-      return resetToBlankDocument();
+      return resetToBlankDocument(options);
     });
   }, [confirmCanDiscardCurrentDocument, documentTabsEnabled, resetToBlankDocument]);
 


### PR DESCRIPTION
## Summary
- Keep the web file tree visible when no folder is open so users can right-click or use New to create an unsaved Markdown file.
- Create untitled document tabs from that empty web file tree without calling native folder APIs.
- Allow vertical mouse wheel input to scroll overflowing document tabs horizontally while preserving edge/page scroll and horizontal wheel behavior.

## Validation
- `pnpm --filter @markra/app test -- MarkdownFileTreeDrawer.test.tsx` passed.
- `pnpm --filter @markra/app test -- App.test.tsx` passed.
- `pnpm --filter @markra/app test -- MarkdownTabsBar.test.tsx` passed.
- `pnpm --filter @markra/web build` passed.
- Chrome + Playwright smoke test verified web empty-tree file creation and vertical wheel tab scrolling.

Closes #168