### PR TITLE
fix(app): protect unsaved markdown on close

### DIFF
--- a/apps/desktop/src-tauri/src/app_exit.rs
+++ b/apps/desktop/src-tauri/src/app_exit.rs
@@ -1,0 +1,44 @@
+use tauri::{Emitter, Manager, Runtime};
+
+const APP_EXIT_REQUESTED_EVENT: &str = "markra://app-exit-requested";
+
+fn should_intercept_app_exit(code: Option<i32>, open_window_count: usize) -> bool {
+    code.is_none() && open_window_count > 0
+}
+
+pub(crate) fn handle_app_exit_requested<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    code: Option<i32>,
+    api: tauri::ExitRequestApi,
+) {
+    let windows = app.webview_windows();
+    if !should_intercept_app_exit(code, windows.len()) {
+        return;
+    }
+
+    api.prevent_exit();
+    let target_window = windows
+        .values()
+        .find(|window| window.is_focused().unwrap_or(false))
+        .or_else(|| windows.values().next());
+
+    if let Some(window) = target_window {
+        let _ = window.emit(APP_EXIT_REQUESTED_EVENT, ());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intercepts_user_exit_when_windows_are_open() {
+        assert!(should_intercept_app_exit(None, 1));
+    }
+
+    #[test]
+    fn allows_programmatic_or_windowless_exit() {
+        assert!(!should_intercept_app_exit(Some(0), 1));
+        assert!(!should_intercept_app_exit(None, 0));
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod ai_http;
+mod app_exit;
 mod external_urls;
 mod image_upload;
 mod language;
@@ -12,6 +13,7 @@ mod window_state;
 mod windows;
 
 use ai_http::{request_ai_provider_json, request_native_chat, request_native_chat_stream};
+use app_exit::handle_app_exit_requested;
 use external_urls::open_external_url;
 use image_upload::{upload_picgo_image, upload_s3_image, upload_webdav_image};
 use markdown_files::{
@@ -145,11 +147,15 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building Markra")
-        .run(|app, event| {
+        .run(|app, event| match event {
+            tauri::RunEvent::ExitRequested { code, api, .. } => {
+                handle_app_exit_requested(app, code, api);
+            }
             #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
-            if let tauri::RunEvent::Opened { urls } = event {
+            tauri::RunEvent::Opened { urls } => {
                 queue_opened_markdown_paths(app, opened_markdown_paths_from_urls(&urls));
             }
+            _ => {}
         });
 }
 

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -112,6 +112,7 @@ export const desktopRuntime = {
     closeWindow: windowRuntime.closeNativeWindow,
     listEditorWindowRestoreStates: windowRuntime.listNativeEditorWindowRestoreStates,
     listenSettingsWindowTarget: windowRuntime.listenNativeSettingsWindowTarget,
+    listenWindowCloseRequested: windowRuntime.listenNativeWindowCloseRequested,
     minimizeWindow: windowRuntime.minimizeNativeWindow,
     openExternalUrl: windowRuntime.openNativeExternalUrl,
     openSettingsWindow: windowRuntime.openSettingsWindow,

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -110,7 +110,9 @@ export const desktopRuntime = {
   },
   window: {
     closeWindow: windowRuntime.closeNativeWindow,
+    exitApp: windowRuntime.exitNativeApp,
     listEditorWindowRestoreStates: windowRuntime.listNativeEditorWindowRestoreStates,
+    listenAppExitRequested: windowRuntime.listenNativeAppExitRequested,
     listenSettingsWindowTarget: windowRuntime.listenNativeSettingsWindowTarget,
     listenWindowCloseRequested: windowRuntime.listenNativeWindowCloseRequested,
     minimizeWindow: windowRuntime.minimizeNativeWindow,

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -1,8 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { exit } from "@tauri-apps/plugin-process";
 import {
   closeNativeWindow,
+  exitNativeApp,
+  listenNativeAppExitRequested,
   listenNativeWindowCloseRequested,
   listenNativeSettingsWindowTarget,
   listNativeEditorWindowRestoreStates,
@@ -24,9 +27,14 @@ vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: vi.fn()
 }));
 
+vi.mock("@tauri-apps/plugin-process", () => ({
+  exit: vi.fn()
+}));
+
 const mockedGetCurrentWindow = vi.mocked(getCurrentWindow);
 const mockedInvoke = vi.mocked(invoke);
 const mockedListen = vi.mocked(listen);
+const mockedExit = vi.mocked(exit);
 
 describe("native window actions", () => {
   beforeEach(() => {
@@ -37,6 +45,7 @@ describe("native window actions", () => {
     mockedGetCurrentWindow.mockReset();
     mockedInvoke.mockReset();
     mockedListen.mockReset();
+    mockedExit.mockReset();
   });
 
   afterEach(() => {
@@ -71,6 +80,28 @@ describe("native window actions", () => {
     const closeRequestEvent = onCloseRequested.mock.calls[0]?.[0] as { preventDefault: () => unknown } | undefined;
     closeRequestEvent?.preventDefault();
     expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("listens for native app exit requests", async () => {
+    const cleanup = vi.fn();
+    mockedListen.mockImplementation((_event, callback) => Promise.resolve(cleanup));
+    const onExitRequested = vi.fn();
+
+    await expect(listenNativeAppExitRequested(onExitRequested)).resolves.toBe(cleanup);
+    const onEvent = mockedListen.mock.calls[0]?.[1] as (() => unknown) | undefined;
+    if (!onEvent) throw new Error("app exit request listener was not registered");
+    onEvent();
+
+    expect(mockedListen).toHaveBeenCalledWith("markra://app-exit-requested", expect.any(Function));
+    expect(onExitRequested).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirms and exits the native app", async () => {
+    mockedExit.mockResolvedValue(undefined);
+
+    await exitNativeApp();
+
+    expect(mockedExit).toHaveBeenCalledWith(0);
   });
 
   it("minimizes the current Tauri window", async () => {

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   closeNativeWindow,
+  listenNativeWindowCloseRequested,
   listenNativeSettingsWindowTarget,
   listNativeEditorWindowRestoreStates,
   minimizeNativeWindow,
@@ -49,6 +50,27 @@ describe("native window actions", () => {
     await closeNativeWindow();
 
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("listens for native window close requests", async () => {
+    const cleanup = vi.fn();
+    const onCloseRequested = vi.fn();
+    const onCloseRequestedNative = vi.fn().mockResolvedValue(cleanup);
+    mockedGetCurrentWindow.mockReturnValue({
+      onCloseRequested: onCloseRequestedNative
+    } as unknown as ReturnType<typeof getCurrentWindow>);
+
+    await expect(listenNativeWindowCloseRequested(onCloseRequested)).resolves.toBe(cleanup);
+    const nativeHandler = onCloseRequestedNative.mock.calls[0]?.[0] as ((event: { preventDefault: () => unknown }) => unknown) | undefined;
+    if (!nativeHandler) throw new Error("close request listener was not registered");
+    const preventDefault = vi.fn();
+    await nativeHandler({ preventDefault });
+
+    expect(onCloseRequestedNative).toHaveBeenCalledWith(expect.any(Function));
+    expect(onCloseRequested).toHaveBeenCalledWith({ preventDefault: expect.any(Function) });
+    const closeRequestEvent = onCloseRequested.mock.calls[0]?.[0] as { preventDefault: () => unknown } | undefined;
+    closeRequestEvent?.preventDefault();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
   });
 
   it("minimizes the current Tauri window", async () => {

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { exit } from "@tauri-apps/plugin-process";
 
 export type NativeSettingsWindowTarget = "exportPandocPath";
 
@@ -22,6 +23,7 @@ type NativeSettingsWindowTargetPayload = {
 };
 
 const nativeSettingsWindowTargetEvent = "markra://settings-window-target";
+const nativeAppExitRequestedEvent = "markra://app-exit-requested";
 
 function isNativeSettingsWindowTarget(value: unknown): value is NativeSettingsWindowTarget {
   return value === "exportPandocPath";
@@ -44,6 +46,15 @@ export async function listenNativeSettingsWindowTarget(onTarget: (target: Native
       onTarget(event.payload.target);
     }
   });
+}
+
+export async function listenNativeAppExitRequested(onExitRequested: () => unknown | Promise<unknown>) {
+  if (!("__TAURI_INTERNALS__" in window)) {
+    return () => {};
+  }
+
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen(nativeAppExitRequestedEvent, () => onExitRequested());
 }
 
 export function openNativeExternalUrl(url: string) {
@@ -120,6 +131,15 @@ export async function listNativeEditorWindowRestoreStates() {
   }
 
   return normalizeNativeEditorWindowRestoreStates(await invoke("list_editor_window_restore_states"));
+}
+
+export async function exitNativeApp() {
+  if (!("__TAURI_INTERNALS__" in window)) {
+    window.close();
+    return;
+  }
+
+  await exit(0);
 }
 
 export async function listenNativeWindowCloseRequested(

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -13,6 +13,10 @@ export type SetNativeEditorWindowRestoreStateInput = {
   openFilePaths: string[];
 };
 
+export type NativeWindowCloseRequestEvent = {
+  preventDefault: () => unknown;
+};
+
 type NativeSettingsWindowTargetPayload = {
   target?: unknown;
 };
@@ -116,6 +120,19 @@ export async function listNativeEditorWindowRestoreStates() {
   }
 
   return normalizeNativeEditorWindowRestoreStates(await invoke("list_editor_window_restore_states"));
+}
+
+export async function listenNativeWindowCloseRequested(
+  onCloseRequested: (event: NativeWindowCloseRequestEvent) => unknown | Promise<unknown>
+) {
+  const currentWindow = await getCurrentNativeWindow();
+  if (!currentWindow) return () => {};
+
+  return currentWindow.onCloseRequested(async (event) => {
+    await onCloseRequested({
+      preventDefault: () => event.preventDefault()
+    });
+  });
 }
 
 export async function closeNativeWindow() {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1940,10 +1940,12 @@ describe("Markra workspace", () => {
     expect(screen.queryByText("Native file")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "mock-files" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Markdown" })).toBeDisabled();
-    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith(expect.objectContaining({
+      activeDraftId: null,
+      draftTabs: [],
       filePath: null,
       openFilePaths: []
-    });
+    }));
   });
 
   it("previews an image asset from the current folder tree and returns to markdown files", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -5,6 +5,8 @@ import {
   openNativeMarkdownPath,
   readNativeMarkdownFile,
   saveNativeMarkdownFile,
+  exitNativeApp,
+  listenNativeAppExitRequested,
   listenNativeWindowCloseRequested,
   setNativeEditorWindowRestoreState,
   watchNativeMarkdownFile
@@ -28,6 +30,8 @@ vi.mock("../lib/tauri", () => ({
   openNativeMarkdownPath: vi.fn(),
   readNativeMarkdownFile: vi.fn(),
   saveNativeMarkdownFile: vi.fn(),
+  exitNativeApp: vi.fn(),
+  listenNativeAppExitRequested: vi.fn(),
   listenNativeWindowCloseRequested: vi.fn(),
   setNativeEditorWindowRestoreState: vi.fn(),
   setNativeWindowTitle: vi.fn(),
@@ -42,6 +46,8 @@ const mockedOpenNativeMarkdownFileInNewWindow = vi.mocked(openNativeMarkdownFile
 const mockedOpenNativeMarkdownPath = vi.mocked(openNativeMarkdownPath);
 const mockedReadNativeMarkdownFile = vi.mocked(readNativeMarkdownFile);
 const mockedSaveNativeMarkdownFile = vi.mocked(saveNativeMarkdownFile);
+const mockedExitNativeApp = vi.mocked(exitNativeApp);
+const mockedListenNativeAppExitRequested = vi.mocked(listenNativeAppExitRequested);
 const mockedListenNativeWindowCloseRequested = vi.mocked(listenNativeWindowCloseRequested);
 const mockedSetNativeEditorWindowRestoreState = vi.mocked(setNativeEditorWindowRestoreState);
 const mockedWatchNativeMarkdownFile = vi.mocked(watchNativeMarkdownFile);
@@ -56,6 +62,8 @@ describe("useMarkdownDocument", () => {
     mockedOpenNativeMarkdownFileInNewWindow.mockReset();
     mockedReadNativeMarkdownFile.mockReset();
     mockedSaveNativeMarkdownFile.mockReset();
+    mockedExitNativeApp.mockReset();
+    mockedListenNativeAppExitRequested.mockReset();
     mockedListenNativeWindowCloseRequested.mockReset();
     mockedSetNativeEditorWindowRestoreState.mockReset();
     mockedWatchNativeMarkdownFile.mockReset();
@@ -77,6 +85,8 @@ describe("useMarkdownDocument", () => {
       name: "saved.md",
       path: "/mock-files/saved.md"
     });
+    mockedExitNativeApp.mockResolvedValue(undefined);
+    mockedListenNativeAppExitRequested.mockResolvedValue(() => {});
     mockedListenNativeWindowCloseRequested.mockResolvedValue(() => {});
     mockedSetNativeEditorWindowRestoreState.mockResolvedValue(undefined);
   });
@@ -616,6 +626,118 @@ describe("useMarkdownDocument", () => {
 
     expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("prompts before web unload when the editor has unsaved markdown", () => {
+    const editorMarkdown = "# Scratch\n\nUnsaved web draft.";
+    renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    const event = new Event("beforeunload", { cancelable: true }) as BeforeUnloadEvent;
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("keeps the app open when native app exit discard is cancelled", async () => {
+    let appExitHandler: (() => unknown | Promise<unknown>) | null = null;
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeAppExitRequested.mockImplementation(async (handler) => {
+      appExitHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeAppExitRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nDraft");
+    });
+
+    await act(async () => {
+      if (!appExitHandler) throw new Error("native app exit handler was not registered");
+      await appExitHandler();
+    });
+
+    expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
+    expect(mockedExitNativeApp).not.toHaveBeenCalled();
+  });
+
+  it("exits the app when native app exit discard is confirmed", async () => {
+    let appExitHandler: (() => unknown | Promise<unknown>) | null = null;
+    const confirmDiscardUnsavedChanges = vi.fn(() => true);
+    mockedListenNativeAppExitRequested.mockImplementation(async (handler) => {
+      appExitHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeAppExitRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nDraft");
+    });
+
+    await act(async () => {
+      if (!appExitHandler) throw new Error("native app exit handler was not registered");
+      await appExitHandler();
+    });
+
+    expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
+    expect(mockedExitNativeApp).toHaveBeenCalledTimes(1);
   });
 
   it("closes a clean tab without prompting when the editor still exposes stale markdown", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -5,6 +5,7 @@ import {
   openNativeMarkdownPath,
   readNativeMarkdownFile,
   saveNativeMarkdownFile,
+  listenNativeWindowCloseRequested,
   setNativeEditorWindowRestoreState,
   watchNativeMarkdownFile
 } from "../lib/tauri";
@@ -27,15 +28,21 @@ vi.mock("../lib/tauri", () => ({
   openNativeMarkdownPath: vi.fn(),
   readNativeMarkdownFile: vi.fn(),
   saveNativeMarkdownFile: vi.fn(),
+  listenNativeWindowCloseRequested: vi.fn(),
   setNativeEditorWindowRestoreState: vi.fn(),
   setNativeWindowTitle: vi.fn(),
   watchNativeMarkdownFile: vi.fn()
 }));
 
+type MockWindowCloseRequestEvent = {
+  preventDefault: () => unknown;
+};
+
 const mockedOpenNativeMarkdownFileInNewWindow = vi.mocked(openNativeMarkdownFileInNewWindow);
 const mockedOpenNativeMarkdownPath = vi.mocked(openNativeMarkdownPath);
 const mockedReadNativeMarkdownFile = vi.mocked(readNativeMarkdownFile);
 const mockedSaveNativeMarkdownFile = vi.mocked(saveNativeMarkdownFile);
+const mockedListenNativeWindowCloseRequested = vi.mocked(listenNativeWindowCloseRequested);
 const mockedSetNativeEditorWindowRestoreState = vi.mocked(setNativeEditorWindowRestoreState);
 const mockedWatchNativeMarkdownFile = vi.mocked(watchNativeMarkdownFile);
 const mockedConsumeWelcomeDocumentState = vi.mocked(consumeWelcomeDocumentState);
@@ -49,6 +56,7 @@ describe("useMarkdownDocument", () => {
     mockedOpenNativeMarkdownFileInNewWindow.mockReset();
     mockedReadNativeMarkdownFile.mockReset();
     mockedSaveNativeMarkdownFile.mockReset();
+    mockedListenNativeWindowCloseRequested.mockReset();
     mockedSetNativeEditorWindowRestoreState.mockReset();
     mockedWatchNativeMarkdownFile.mockReset();
     mockedConsumeWelcomeDocumentState.mockReset();
@@ -69,6 +77,7 @@ describe("useMarkdownDocument", () => {
       name: "saved.md",
       path: "/mock-files/saved.md"
     });
+    mockedListenNativeWindowCloseRequested.mockResolvedValue(() => {});
     mockedSetNativeEditorWindowRestoreState.mockResolvedValue(undefined);
   });
 
@@ -513,6 +522,100 @@ describe("useMarkdownDocument", () => {
 
     expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
     expect(result.current.tabs.some((tab) => tab.id === guideTab!.id)).toBe(true);
+  });
+
+  it("prevents native window close when dirty document discard is cancelled", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nDraft");
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows native window close when dirty document discard is confirmed", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    const confirmDiscardUnsavedChanges = vi.fn(() => true);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nDraft");
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 
   it("closes a clean tab without prompting when the editor still exposes stale markdown", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -639,6 +639,7 @@ describe("useMarkdownDocument", () => {
         restoreWorkspaceOnStartup: false
       })
     );
+    mockedSaveStoredWorkspaceState.mockClear();
 
     const event = new Event("beforeunload", { cancelable: true }) as BeforeUnloadEvent;
     act(() => {
@@ -646,6 +647,17 @@ describe("useMarkdownDocument", () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      activeDraftId: "untitled:0",
+      draftTabs: [
+        {
+          content: editorMarkdown,
+          id: "untitled:0",
+          name: "Untitled.md",
+          path: null
+        }
+      ]
+    });
   });
 
   it("keeps the app open when native app exit discard is cancelled", async () => {
@@ -1121,6 +1133,149 @@ describe("useMarkdownDocument", () => {
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(notesPath);
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("restores dirty draft tabs from the last workspace", async () => {
+    const guidePath = "/mock-files/vault/guide.md";
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      activeDraftId: "untitled:1",
+      aiAgentSessionId: "session-drafts",
+      draftTabs: [
+        {
+          content: "# Guide\n\nRecovered file edits.",
+          id: `file:${guidePath}`,
+          name: "guide.md",
+          path: guidePath
+        },
+        {
+          content: "# Scratch\n\nRecovered untitled edits.",
+          id: "untitled:1",
+          name: "Scratch.md",
+          path: null
+        }
+      ],
+      filePath: guidePath,
+      fileTreeOpen: false,
+      folderName: null,
+      folderPath: null,
+      openFilePaths: [guidePath]
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nSaved content.",
+      name: "guide.md",
+      path: guidePath
+    });
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.document.name).toBe("Scratch.md"));
+
+    expect(result.current.document).toMatchObject({
+      content: "# Scratch\n\nRecovered untitled edits.",
+      dirty: true,
+      name: "Scratch.md",
+      path: null
+    });
+    expect(result.current.tabs).toEqual([
+      expect.objectContaining({
+        content: "# Guide\n\nRecovered file edits.",
+        dirty: true,
+        id: `file:${guidePath}`,
+        name: "guide.md",
+        path: guidePath
+      }),
+      expect.objectContaining({
+        content: "# Scratch\n\nRecovered untitled edits.",
+        dirty: true,
+        id: "untitled:1",
+        name: "Scratch.md",
+        path: null
+      })
+    ]);
+    expect(result.current.activeTabId).toBe("untitled:1");
+    expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("persists dirty untitled drafts as markdown changes", async () => {
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    act(() => {
+      result.current.handleMarkdownChange("# Scratch\n\nUnsaved local draft.");
+    });
+
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      activeDraftId: "untitled:0",
+      draftTabs: [
+        {
+          content: "# Scratch\n\nUnsaved local draft.",
+          id: "untitled:0",
+          name: "Untitled.md",
+          path: null
+        }
+      ]
+    });
+  });
+
+  it("clears a saved file draft after saving the document", async () => {
+    const guidePath = "/mock-files/vault/guide.md";
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nSaved content.",
+      name: "guide.md",
+      path: guidePath
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValue({
+      name: "guide.md",
+      path: guidePath
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: guidePath,
+        relativePath: "guide.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nUnsaved edits.");
+    });
+
+    mockedSaveStoredWorkspaceState.mockClear();
+
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith(expect.objectContaining({
+      activeDraftId: null,
+      draftTabs: []
+    }));
   });
 
   it("restores additional editor windows from the saved update-restart snapshot", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -5,6 +5,7 @@ import {
   createAiAgentSessionId,
   getStoredWorkspaceState,
   saveStoredWorkspaceState,
+  type StoredWorkspaceDraftTab,
   type StoredWorkspaceWindow
 } from "../lib/settings/app-settings";
 import { getMarkdownOutline, getWordCount } from "@markra/markdown";
@@ -85,6 +86,17 @@ function documentFromTab(tab: MarkdownDocumentTab): DocumentState {
   };
 }
 
+function documentFromDraftTab(draft: StoredWorkspaceDraftTab, revision: number): DocumentState {
+  return {
+    path: draft.path,
+    name: draft.name,
+    content: draft.content,
+    dirty: true,
+    open: true,
+    revision
+  };
+}
+
 function fileTabId(path: string) {
   return `file:${path}`;
 }
@@ -129,6 +141,33 @@ function activeFilePathFromTabs(tabs: readonly MarkdownDocumentTab[], activeTabI
 
 function isPristineUntitledDocument(document: DocumentState) {
   return document.open && document.path === null && document.content === "" && !document.dirty && document.revision === 0;
+}
+
+function draftTabFromDocumentTab(tab: MarkdownDocumentTab): StoredWorkspaceDraftTab | null {
+  if (!tab.open || !tab.dirty) return null;
+  if (tab.path === null && tab.content.trim().length === 0) return null;
+
+  return {
+    content: tab.content,
+    id: tab.id,
+    name: tab.name || (tab.path ? pathNameFromPath(tab.path) : "Untitled.md"),
+    path: tab.path
+  };
+}
+
+function draftWorkspacePatchFromTabs(tabs: readonly MarkdownDocumentTab[], activeTabId: string | null) {
+  const draftTabs = tabs.flatMap((tab) => {
+    const draft = draftTabFromDocumentTab(tab);
+    return draft ? [draft] : [];
+  });
+  const activeDraftId = activeTabId && draftTabs.some((draft) => draft.id === activeTabId)
+    ? activeTabId
+    : null;
+
+  return {
+    activeDraftId,
+    draftTabs
+  };
 }
 
 function normalizeComparableMarkdownHeadings(content: string) {
@@ -358,7 +397,12 @@ export function useMarkdownDocument({
         ? { ...current, content, dirty: false }
         : { ...current, content, dirty: true };
 
+    const currentActiveTabId = activeTabIdRef.current;
+    const nextTabs = currentActiveTabId
+      ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
+      : tabsRef.current;
     setActiveDocument(nextDocument);
+    persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, currentActiveTabId));
     return nextDocument;
   }, [currentMarkdown, isActiveEditorMarkdownEquivalent, setActiveDocument]);
 
@@ -411,7 +455,12 @@ export function useMarkdownDocument({
         ? { ...current, content, dirty: false }
         : { ...current, content, dirty: true };
 
+    const currentActiveTabId = activeTabIdRef.current;
+    const nextTabs = currentActiveTabId
+      ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
+      : tabsRef.current;
     setActiveDocument(nextDocument);
+    persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, currentActiveTabId));
   }, [editorReady, isActiveEditorMarkdownEquivalent, setActiveDocument]);
 
   const handleMarkdownTabChange = useCallback((tabId: string, content: string) => {
@@ -432,6 +481,7 @@ export function useMarkdownDocument({
       });
 
       tabsRef.current = nextTabs;
+      persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current));
       return nextTabs;
     });
   }, [handleMarkdownChange]);
@@ -453,13 +503,19 @@ export function useMarkdownDocument({
       setActiveTabState(nextTabs, tab.id);
       registerWindowRestoreState(activeFilePathFromTabs(nextTabs, tab.id), openFilePathsFromTabs(nextTabs));
       persistWorkspaceState({
+        ...draftWorkspacePatchFromTabs(nextTabs, tab.id),
         filePath: null,
         openFilePaths: openFilePathsFromTabs(nextTabs)
       });
     } else {
       setActiveDocument(nextDocument);
       registerWindowRestoreState(null, []);
-      persistWorkspaceState({ filePath: null, openFilePaths: [] });
+      const nextTabs = [createDocumentTab(nextDocument, activeTabIdRef.current ?? "untitled:0")];
+      persistWorkspaceState({
+        ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
+        filePath: null,
+        openFilePaths: []
+      });
     }
     return true;
   }, [createUntitledTabId, documentTabsEnabled, registerWindowRestoreState, setActiveDocument, setActiveTabState, syncActiveDocumentFromEditor]);
@@ -497,7 +553,14 @@ export function useMarkdownDocument({
     setDocument(nextDocument);
     documentRef.current = nextDocument;
     registerWindowRestoreState(null, []);
-    if (options.persistWorkspace !== false) persistWorkspaceState({ filePath: null, openFilePaths: [] });
+    if (options.persistWorkspace !== false) {
+      persistWorkspaceState({
+        activeDraftId: null,
+        draftTabs: [],
+        filePath: null,
+        openFilePaths: []
+      });
+    }
   }, [registerWindowRestoreState]);
 
   const applyNativeMarkdownFile = useCallback(
@@ -546,7 +609,11 @@ export function useMarkdownDocument({
 
       if (updateTreeRoot) onTreeRootFromFilePath(file.path);
       registerWindowRestoreState(file.path, nextOpenFilePaths);
+      const nextDraftTabs = documentTabsEnabled
+        ? tabsRef.current
+        : [createDocumentTab(nextDocument, activeTabIdRef.current ?? fileTabId(file.path))];
       persistWorkspaceState({
+        ...draftWorkspacePatchFromTabs(nextDraftTabs, activeTabIdRef.current),
         aiAgentSessionId: sessionId,
         filePath: file.path,
         openFilePaths: nextOpenFilePaths,
@@ -613,6 +680,7 @@ export function useMarkdownDocument({
       if (updateTreeRoot && activeFile) onTreeRootFromFilePath(activeFile.path);
       registerWindowRestoreState(activeFile?.path ?? null, files.map((file) => file.path));
       persistWorkspaceState({
+        ...draftWorkspacePatchFromTabs(tabsRef.current, activeTabIdRef.current),
         aiAgentSessionId: sessionId,
         filePath: activeFile?.path ?? null,
         openFilePaths: files.map((file) => file.path),
@@ -622,6 +690,43 @@ export function useMarkdownDocument({
     },
     [documentTabsEnabled, onTreeRootFromFilePath, registerWindowRestoreState, resolveWorkspaceSessionId, setActiveDocument, setActiveTabState]
   );
+
+  const restoreWorkspaceDraftTabs = useCallback((
+    draftTabs: readonly StoredWorkspaceDraftTab[] | undefined,
+    activeDraftId: string | null | undefined,
+    preferredSessionId?: string | null
+  ) => {
+    if (!draftTabs?.length) return false;
+
+    const draftDocumentTabs = draftTabs.map((draft, index) =>
+      createDocumentTab(documentFromDraftTab(draft, documentRef.current.revision + index + 1), draft.id)
+    );
+    const currentTabs = tabsRef.current.filter((tab) =>
+      !isPristineUntitledDocument(documentFromTab(tab)) &&
+      !draftDocumentTabs.some((draftTab) => draftTab.id === tab.id || (draftTab.path !== null && draftTab.path === tab.path))
+    );
+    const nextTabs = [...currentTabs, ...draftDocumentTabs];
+    const nextActiveTabId =
+      activeDraftId && nextTabs.some((tab) => tab.id === activeDraftId)
+        ? activeDraftId
+        : activeTabIdRef.current && nextTabs.some((tab) => tab.id === activeTabIdRef.current)
+          ? activeTabIdRef.current
+          : draftDocumentTabs.at(-1)?.id ?? nextTabs.at(-1)?.id ?? null;
+    const nextActiveFilePath = activeFilePathFromTabs(nextTabs, nextActiveTabId);
+    const sessionId = resolveWorkspaceSessionId(preferredSessionId ?? workspaceSessionIdRef.current);
+
+    setActiveTabState(nextTabs, nextActiveTabId);
+    registerWindowRestoreState(nextActiveFilePath, openFilePathsFromTabs(nextTabs));
+    persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(nextTabs, nextActiveTabId),
+      aiAgentSessionId: sessionId,
+      filePath: nextActiveFilePath,
+      openFilePaths: openFilePathsFromTabs(nextTabs)
+    });
+
+    if (nextActiveFilePath) onTreeRootFromFilePath(nextActiveFilePath);
+    return true;
+  }, [onTreeRootFromFilePath, registerWindowRestoreState, resolveWorkspaceSessionId, setActiveTabState]);
 
   const openMarkdownFile = useCallback(async (options: OpenMarkdownFileOptions = {}) => {
     const target = await openNativeMarkdownPath(
@@ -689,6 +794,7 @@ export function useMarkdownDocument({
         setTabs(nextTabs);
         registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
         persistWorkspaceState({
+          ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
           filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
           openFilePaths: openFilePathsFromTabs(nextTabs)
         });
@@ -727,6 +833,7 @@ export function useMarkdownDocument({
     setTabs(nextTabs);
     registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
     persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
       filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
@@ -766,6 +873,7 @@ export function useMarkdownDocument({
     setTabs(nextTabs);
     registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
     persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
       filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
@@ -806,6 +914,7 @@ export function useMarkdownDocument({
     }
 
     persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
       filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
@@ -836,14 +945,16 @@ export function useMarkdownDocument({
       };
 
       setActiveDocument(nextDocument);
+      const nextTabs = documentTabsEnabled
+        ? tabsRef.current.map((tab) => tab.id === activeTabIdRef.current ? createDocumentTab(nextDocument, tab.id) : tab)
+        : [createDocumentTab(nextDocument, activeTabIdRef.current ?? fileTabId(savedFile.path))];
       const nextOpenFilePaths = documentTabsEnabled
-        ? openFilePathsFromTabs(tabsRef.current.map((tab) =>
-          tab.id === activeTabIdRef.current ? createDocumentTab(nextDocument, tab.id) : tab
-        ))
+        ? openFilePathsFromTabs(nextTabs)
         : [savedFile.path];
       if (saveAs || current.path === null) onTreeRootFromFilePath(savedFile.path);
       registerWindowRestoreState(savedFile.path, nextOpenFilePaths);
       persistWorkspaceState({
+        ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
         filePath: savedFile.path,
         openFilePaths: nextOpenFilePaths,
         ...(saveAs || current.path === null ? { folderName: null, folderPath: null } : {})
@@ -891,6 +1002,7 @@ export function useMarkdownDocument({
       if (saveAs || tab.path === null) onTreeRootFromFilePath(savedFile.path);
       registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
       persistWorkspaceState({
+        ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
         filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
         openFilePaths: openFilePathsFromTabs(nextTabs),
         ...(saveAs || tab.path === null ? { folderName: null, folderPath: null } : {})
@@ -912,6 +1024,7 @@ export function useMarkdownDocument({
     setActiveTabState(tabsRef.current, tab.id);
     registerWindowRestoreState(tab.path, openFilePathsFromTabs(tabsRef.current));
     persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(tabsRef.current, tab.id),
       filePath: tab.path,
       openFilePaths: openFilePathsFromTabs(tabsRef.current)
     });
@@ -939,6 +1052,7 @@ export function useMarkdownDocument({
     setActiveTabState(nextTabs, nextActiveTab?.id ?? null);
     registerWindowRestoreState(nextActiveTab?.path ?? null, openFilePathsFromTabs(nextTabs));
     persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(nextTabs, nextActiveTab?.id ?? null),
       filePath: nextActiveTab?.path ?? null,
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
@@ -1206,6 +1320,16 @@ export function useMarkdownDocument({
             if (restoredFiles) restoredWorkspace = true;
           }
 
+          if (workspace.draftTabs?.length) {
+            const restoredDrafts = restoreWorkspaceDraftTabs(
+              workspace.draftTabs,
+              workspace.activeDraftId,
+              sessionId
+            );
+            if (!active) return;
+            if (restoredDrafts) restoredWorkspace = true;
+          }
+
           for (const path of additionalRestoreWindowFilePaths) {
             await openNativeMarkdownFileInNewWindow(path);
             if (!active) return;
@@ -1252,6 +1376,7 @@ export function useMarkdownDocument({
     onTreeRootFromFolderPath,
     preferencesReady,
     restoreNativeMarkdownFiles,
+    restoreWorkspaceDraftTabs,
     resolveWorkspaceSessionId,
     restoreWorkspaceOnStartup,
     setActiveDocument

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -16,6 +16,7 @@ import {
   resolveNativeMarkdownPath,
   saveNativeMarkdownFile,
   setNativeEditorWindowRestoreState,
+  listenNativeWindowCloseRequested,
   listenNativeOpenedMarkdownPaths,
   takeNativeOpenedMarkdownPaths,
   watchNativeMarkdownFile,
@@ -1007,6 +1008,29 @@ export function useMarkdownDocument({
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, [hasDiscardableTabChanges]);
+
+  useEffect(() => {
+    let active = true;
+    let cleanup: (() => unknown) | null = null;
+
+    listenNativeWindowCloseRequested(async (event) => {
+      syncActiveDocumentFromEditor();
+      const canDiscard = await confirmCanDiscardCurrentDocument();
+      if (!canDiscard) event.preventDefault();
+    }).then((nextCleanup) => {
+      if (active) {
+        cleanup = nextCleanup;
+        return;
+      }
+
+      nextCleanup();
+    }).catch(() => {});
+
+    return () => {
+      active = false;
+      cleanup?.();
+    };
+  }, [confirmCanDiscardCurrentDocument, syncActiveDocumentFromEditor]);
 
   useEffect(() => {
     const path = initialMarkdownFilePath();

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/settings/app-settings";
 import { getMarkdownOutline, getWordCount } from "@markra/markdown";
 import {
+  exitNativeApp,
   openNativeMarkdownFolderInNewWindow,
   openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
@@ -16,6 +17,7 @@ import {
   resolveNativeMarkdownPath,
   saveNativeMarkdownFile,
   setNativeEditorWindowRestoreState,
+  listenNativeAppExitRequested,
   listenNativeWindowCloseRequested,
   listenNativeOpenedMarkdownPaths,
   takeNativeOpenedMarkdownPaths,
@@ -996,6 +998,7 @@ export function useMarkdownDocument({
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      syncActiveDocumentFromEditor();
       const hasUnsavedChanges = tabsRef.current.some((tab) => hasDiscardableTabChanges(tab));
       if (!hasUnsavedChanges) return;
 
@@ -1007,7 +1010,7 @@ export function useMarkdownDocument({
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [hasDiscardableTabChanges]);
+  }, [hasDiscardableTabChanges, syncActiveDocumentFromEditor]);
 
   useEffect(() => {
     let active = true;
@@ -1017,6 +1020,29 @@ export function useMarkdownDocument({
       syncActiveDocumentFromEditor();
       const canDiscard = await confirmCanDiscardCurrentDocument();
       if (!canDiscard) event.preventDefault();
+    }).then((nextCleanup) => {
+      if (active) {
+        cleanup = nextCleanup;
+        return;
+      }
+
+      nextCleanup();
+    }).catch(() => {});
+
+    return () => {
+      active = false;
+      cleanup?.();
+    };
+  }, [confirmCanDiscardCurrentDocument, syncActiveDocumentFromEditor]);
+
+  useEffect(() => {
+    let active = true;
+    let cleanup: (() => unknown) | null = null;
+
+    listenNativeAppExitRequested(async () => {
+      syncActiveDocumentFromEditor();
+      const canDiscard = await confirmCanDiscardCurrentDocument();
+      if (canDiscard) await exitNativeApp();
     }).then((nextCleanup) => {
       if (active) {
         cleanup = nextCleanup;

--- a/packages/app/src/lib/settings/app-settings.test.ts
+++ b/packages/app/src/lib/settings/app-settings.test.ts
@@ -1040,6 +1040,33 @@ describe("app settings", () => {
           openFilePaths: ["/mock-files/vault/archive.md"]
         }
       ],
+      activeDraftId: "untitled:1",
+      draftTabs: [
+        {
+          content: "# Local draft\n\nStill unsaved.",
+          id: "untitled:1",
+          name: " Draft.md ",
+          path: null
+        },
+        {
+          content: "",
+          id: "file:/mock-files/vault/README.md",
+          name: "README.md",
+          path: " /mock-files/vault/README.md "
+        },
+        {
+          content: "# Duplicate",
+          id: "untitled:1",
+          name: "Duplicate.md",
+          path: null
+        },
+        {
+          content: "   ",
+          id: "untitled:blank",
+          name: "Blank.md",
+          path: null
+        }
+      ],
       sideBySideGroup: {
         primaryFilePath: "/mock-files/vault/README.md",
         sideFilePath: "/mock-files/vault/notes.md"
@@ -1064,6 +1091,21 @@ describe("app settings", () => {
             "/mock-files/vault/notes.md",
             "/mock-files/vault/README.md"
           ]
+        }
+      ],
+      activeDraftId: "untitled:1",
+      draftTabs: [
+        {
+          content: "# Local draft\n\nStill unsaved.",
+          id: "untitled:1",
+          name: "Draft.md",
+          path: null
+        },
+        {
+          content: "",
+          id: "file:/mock-files/vault/README.md",
+          name: "README.md",
+          path: "/mock-files/vault/README.md"
         }
       ],
       sideBySideGroup: {
@@ -1151,6 +1193,42 @@ describe("app settings", () => {
         "/mock-files/vault/README.md",
         "/mock-files/vault/notes.md"
       ],
+      openWindows: []
+    });
+    expect(store.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears saved workspace draft tabs", async () => {
+    store.get.mockResolvedValue({
+      activeDraftId: "untitled:1",
+      aiAgentSessionId: "session-a",
+      draftTabs: [
+        {
+          content: "# Draft",
+          id: "untitled:1",
+          name: "Draft.md",
+          path: null
+        }
+      ],
+      filePath: null,
+      fileTreeOpen: false,
+      folderName: null,
+      folderPath: null,
+      openFilePaths: []
+    });
+
+    await saveStoredWorkspaceState({
+      activeDraftId: null,
+      draftTabs: []
+    });
+
+    expect(store.set).toHaveBeenCalledWith("workspace", {
+      aiAgentSessionId: "session-a",
+      filePath: null,
+      fileTreeOpen: false,
+      folderName: null,
+      folderPath: null,
+      openFilePaths: [],
       openWindows: []
     });
     expect(store.save).toHaveBeenCalledTimes(1);

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -151,7 +151,9 @@ export type ExportSettings = {
   pdfWidthMm: number;
 };
 export type StoredWorkspaceState = {
+  activeDraftId?: string | null;
   aiAgentSessionId: string | null;
+  draftTabs?: StoredWorkspaceDraftTab[];
   filePath: string | null;
   fileTreeOpen: boolean;
   folderName: string | null;
@@ -159,6 +161,12 @@ export type StoredWorkspaceState = {
   openFilePaths: string[];
   openWindows?: StoredWorkspaceWindow[];
   sideBySideGroup?: StoredWorkspaceSideBySideGroup | null;
+};
+export type StoredWorkspaceDraftTab = {
+  content: string;
+  id: string;
+  name: string;
+  path: string | null;
 };
 export type StoredWorkspaceWindow = {
   filePath: string | null;
@@ -1205,6 +1213,11 @@ export function normalizeWorkspaceState(value: unknown): StoredWorkspaceState {
   const workspace = value as Partial<StoredWorkspaceState>;
   const openFilePaths = normalizeWorkspaceOpenFilePaths(workspace.openFilePaths);
   const openFilePathSet = new Set(openFilePaths);
+  const draftTabs = normalizeWorkspaceDraftTabs(workspace.draftTabs);
+  const activeDraftId = normalizeNullableString(workspace.activeDraftId);
+  const persistedActiveDraftId = activeDraftId && draftTabs.some((draft) => draft.id === activeDraftId)
+    ? activeDraftId
+    : null;
   const sideBySideGroup = normalizeWorkspaceSideBySideGroup(workspace.sideBySideGroup);
   const persistedSideBySideGroup =
     sideBySideGroup &&
@@ -1214,6 +1227,7 @@ export function normalizeWorkspaceState(value: unknown): StoredWorkspaceState {
       : null;
 
   return {
+    ...(draftTabs.length > 0 ? { activeDraftId: persistedActiveDraftId, draftTabs } : {}),
     aiAgentSessionId: normalizeNullableString(workspace.aiAgentSessionId),
     filePath: normalizeNullableString(workspace.filePath),
     fileTreeOpen: typeof workspace.fileTreeOpen === "boolean" ? workspace.fileTreeOpen : false,
@@ -1223,6 +1237,41 @@ export function normalizeWorkspaceState(value: unknown): StoredWorkspaceState {
     openWindows: normalizeWorkspaceWindows(workspace.openWindows),
     ...(persistedSideBySideGroup ? { sideBySideGroup: persistedSideBySideGroup } : {})
   };
+}
+
+function normalizeWorkspaceDraftTabs(value: unknown): StoredWorkspaceDraftTab[] {
+  if (!Array.isArray(value)) return [];
+
+  const seenIds = new Set<string>();
+  const draftTabs: StoredWorkspaceDraftTab[] = [];
+  const normalizeDraftString = (item: unknown) => {
+    if (typeof item !== "string") return null;
+
+    const trimmed = item.trim();
+    return trimmed ? trimmed : null;
+  };
+
+  value.forEach((item) => {
+    if (typeof item !== "object" || item === null) return;
+
+    const candidate = item as Partial<StoredWorkspaceDraftTab>;
+    const id = normalizeDraftString(candidate.id);
+    if (!id || seenIds.has(id) || typeof candidate.content !== "string") return;
+
+    const path = normalizeDraftString(candidate.path);
+    if (!path && candidate.content.trim().length === 0) return;
+
+    const name = normalizeDraftString(candidate.name) ?? (path ? pathNameFromPath(path) : "Untitled.md");
+    seenIds.add(id);
+    draftTabs.push({
+      content: candidate.content,
+      id,
+      name,
+      path
+    });
+  });
+
+  return draftTabs;
 }
 
 function normalizeWorkspaceOpenFilePaths(value: unknown) {

--- a/packages/app/src/lib/tauri/window.ts
+++ b/packages/app/src/lib/tauri/window.ts
@@ -17,12 +17,20 @@ export type NativeWindowCloseRequestEvent = {
   preventDefault: () => unknown;
 };
 
+export function exitNativeApp() {
+  return getAppRuntime().window.exitApp();
+}
+
 export function openSettingsWindow(target?: NativeSettingsWindowTarget) {
   return getAppRuntime().window.openSettingsWindow(target);
 }
 
 export function listenNativeSettingsWindowTarget(onTarget: (target: NativeSettingsWindowTarget) => unknown) {
   return getAppRuntime().window.listenSettingsWindowTarget(onTarget);
+}
+
+export function listenNativeAppExitRequested(onExitRequested: () => unknown | Promise<unknown>) {
+  return getAppRuntime().window.listenAppExitRequested(onExitRequested);
 }
 
 export function listenNativeWindowCloseRequested(

--- a/packages/app/src/lib/tauri/window.ts
+++ b/packages/app/src/lib/tauri/window.ts
@@ -13,12 +13,22 @@ export type SetNativeEditorWindowRestoreStateInput = {
   openFilePaths: string[];
 };
 
+export type NativeWindowCloseRequestEvent = {
+  preventDefault: () => unknown;
+};
+
 export function openSettingsWindow(target?: NativeSettingsWindowTarget) {
   return getAppRuntime().window.openSettingsWindow(target);
 }
 
 export function listenNativeSettingsWindowTarget(onTarget: (target: NativeSettingsWindowTarget) => unknown) {
   return getAppRuntime().window.listenSettingsWindowTarget(onTarget);
+}
+
+export function listenNativeWindowCloseRequested(
+  onCloseRequested: (event: NativeWindowCloseRequestEvent) => unknown | Promise<unknown>
+) {
+  return getAppRuntime().window.listenWindowCloseRequested(onCloseRequested);
 }
 
 export function openNativeExternalUrl(url: string) {

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -45,6 +45,7 @@ import type {
 import type {
   NativeEditorWindowRestoreState,
   NativeSettingsWindowTarget,
+  NativeWindowCloseRequestEvent,
   SetNativeEditorWindowRestoreStateInput
 } from "../lib/tauri/window";
 import type { NativePandocSetupAction } from "../lib/tauri/dialog";
@@ -229,6 +230,9 @@ export type AppWindowRuntime = {
   closeWindow: () => Promise<unknown>;
   listEditorWindowRestoreStates: () => Promise<NativeEditorWindowRestoreState[]>;
   listenSettingsWindowTarget: (onTarget: (target: NativeSettingsWindowTarget) => unknown) => Promise<RuntimeCleanup>;
+  listenWindowCloseRequested: (
+    onCloseRequested: (event: NativeWindowCloseRequestEvent) => unknown | Promise<unknown>
+  ) => Promise<RuntimeCleanup>;
   minimizeWindow: () => Promise<unknown>;
   openExternalUrl: (url: string) => Promise<unknown>;
   openSettingsWindow: (target?: NativeSettingsWindowTarget) => Promise<unknown>;
@@ -369,6 +373,7 @@ export function createDefaultAppRuntime(): AppRuntime {
       closeWindow: async () => undefined,
       listEditorWindowRestoreStates: async () => [],
       listenSettingsWindowTarget: async () => () => undefined,
+      listenWindowCloseRequested: async () => () => undefined,
       minimizeWindow: async () => undefined,
       openExternalUrl: async (url) => {
         if (typeof window !== "undefined") {

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -228,7 +228,9 @@ export type AppFeatureRuntime = {
 
 export type AppWindowRuntime = {
   closeWindow: () => Promise<unknown>;
+  exitApp: () => Promise<unknown>;
   listEditorWindowRestoreStates: () => Promise<NativeEditorWindowRestoreState[]>;
+  listenAppExitRequested: (onExitRequested: () => unknown | Promise<unknown>) => Promise<RuntimeCleanup>;
   listenSettingsWindowTarget: (onTarget: (target: NativeSettingsWindowTarget) => unknown) => Promise<RuntimeCleanup>;
   listenWindowCloseRequested: (
     onCloseRequested: (event: NativeWindowCloseRequestEvent) => unknown | Promise<unknown>
@@ -371,7 +373,9 @@ export function createDefaultAppRuntime(): AppRuntime {
     },
     window: {
       closeWindow: async () => undefined,
+      exitApp: async () => undefined,
       listEditorWindowRestoreStates: async () => [],
+      listenAppExitRequested: async () => () => undefined,
       listenSettingsWindowTarget: async () => () => undefined,
       listenWindowCloseRequested: async () => () => undefined,
       minimizeWindow: async () => undefined,

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -10,10 +10,13 @@ import {
   detectNativePandocPath,
   downloadNativeWebImage,
   closeNativeWindow,
+  exitNativeApp,
   openNativeMarkdownFolder,
   openNativeMarkdownFolderInNewWindow,
   openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
+  listenNativeAppExitRequested,
+  listenNativeWindowCloseRequested,
   listenNativeOpenedMarkdownPaths,
   readNativeMarkdownImageFile,
   readNativeMarkdownFile,
@@ -145,6 +148,9 @@ vi.mock("../lib/tauri", () => ({
   installNativeEditorContextMenu: vi.fn(),
   openNativeExternalUrl: vi.fn(),
   closeNativeWindow: vi.fn(),
+  exitNativeApp: vi.fn(),
+  listenNativeAppExitRequested: vi.fn(),
+  listenNativeWindowCloseRequested: vi.fn(),
   openSettingsWindow: vi.fn(),
   setNativeWindowTitle: vi.fn()
 }));
@@ -521,6 +527,9 @@ export const mockedInstallNativeEditorContextMenu = vi.mocked(installNativeEdito
 export const mockedOpenSettingsWindow = vi.mocked(openSettingsWindow);
 export const mockedOpenNativeExternalUrl = vi.mocked(openNativeExternalUrl);
 export const mockedCloseNativeWindow = vi.mocked(closeNativeWindow);
+export const mockedExitNativeApp = vi.mocked(exitNativeApp);
+export const mockedListenNativeAppExitRequested = vi.mocked(listenNativeAppExitRequested);
+export const mockedListenNativeWindowCloseRequested = vi.mocked(listenNativeWindowCloseRequested);
 export const mockedCheckNativeAppUpdate = vi.mocked(checkNativeAppUpdate);
 export const mockedResolveDesktopPlatform = vi.mocked(resolveDesktopPlatform);
 export const mockedConsumeWelcomeDocumentState = vi.mocked(consumeWelcomeDocumentState);
@@ -680,6 +689,9 @@ export function installAppTestHarness() {
     mockedInstallNativeEditorContextMenu.mockReset();
     mockedOpenNativeExternalUrl.mockReset();
     mockedCloseNativeWindow.mockReset();
+    mockedExitNativeApp.mockReset();
+    mockedListenNativeAppExitRequested.mockReset();
+    mockedListenNativeWindowCloseRequested.mockReset();
     mockedCheckNativeAppUpdate.mockReset();
     mockedResolveDesktopPlatform.mockReset();
     mockedOpenSettingsWindow.mockReset();
@@ -740,6 +752,9 @@ export function installAppTestHarness() {
     mockedInstallNativeEditorContextMenu.mockResolvedValue(() => {});
     mockedOpenNativeExternalUrl.mockResolvedValue(undefined);
     mockedCloseNativeWindow.mockResolvedValue(undefined);
+    mockedExitNativeApp.mockResolvedValue(undefined);
+    mockedListenNativeAppExitRequested.mockResolvedValue(() => {});
+    mockedListenNativeWindowCloseRequested.mockResolvedValue(() => {});
     mockedDownloadNativeWebImage.mockResolvedValue(new File([new Uint8Array([1, 2, 3])], "web-image.png", {
       type: "image/png"
     }));


### PR DESCRIPTION
## Summary
- Add close/exit guards for Tauri window close, Tauri app exit, and browser tab refresh/close.
- Persist dirty untitled and modified-file tabs as workspace drafts, then restore them on startup.
- Clear recovered drafts when tabs are saved or closed, and keep app/window restore state in sync.

## Why
- Unsaved markdown could be lost when closing the desktop app, quitting from the app menu/Cmd+Q, or closing/refreshing the web page.
- Prompting protects intentional closes, while draft recovery protects restarts or exits where the prompt path cannot complete.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx -t "web unload|native app exit|native window close|draft"` passed
- `pnpm --filter @markra/app test` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` passed

## Risk
- Browser close prompts use the browser-provided generic beforeunload dialog; custom prompt text is not supported by modern browsers.
- Drafts intentionally restore as dirty content so users can review and save or close them.

## Related Issues
- Closes #178
