### PR TITLE
feat(menu): add self-drawn context menus

### DIFF
--- a/apps/desktop/src/runtime/tauri/menu.test.ts
+++ b/apps/desktop/src/runtime/tauri/menu.test.ts
@@ -73,6 +73,28 @@ function findMenuItemById(items: TestMenuItem[], id: string): TestActionMenuItem
   return null;
 }
 
+function domMenu() {
+  return document.querySelector("[data-markra-context-menu]");
+}
+
+function domMenuItemById(id: string) {
+  const item = document.querySelector<HTMLButtonElement>(`[data-menu-item-id="${id}"]`);
+  if (!item) throw new Error(`Expected DOM menu item ${id}.`);
+
+  return item;
+}
+
+function queryDomMenuItemById(id: string) {
+  return document.querySelector<HTMLButtonElement>(`[data-menu-item-id="${id}"]`);
+}
+
+function domSubmenuById(id: string) {
+  const submenu = document.querySelector(`[data-menu-submenu-id="${id}"]`);
+  if (!submenu) throw new Error(`Expected DOM submenu ${id}.`);
+
+  return submenu;
+}
+
 async function flushNativeMenuPopup() {
   await Promise.resolve();
   await Promise.resolve();
@@ -177,7 +199,7 @@ describe("native menu", () => {
     expect(handlers.saveDocument).toHaveBeenCalledTimes(1);
   });
 
-  it("shows a native context menu only inside the markdown paper", async () => {
+  it("shows a self-drawn context menu only inside the markdown paper", async () => {
     const target = document.createElement("main");
     const paper = document.createElement("article");
     const outside = document.createElement("button");
@@ -196,31 +218,72 @@ describe("native menu", () => {
 
     outside.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
 
+    expect(domMenu()).toBeNull();
+    expect(mockedMenuNew).not.toHaveBeenCalled();
     expect(popup).not.toHaveBeenCalled();
 
-    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    await flushNativeMenuPopup();
+    paper.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 16,
+      clientY: 24
+    }));
 
-    expect(mockedMenuNew).toHaveBeenCalledTimes(1);
-    expect(popup).toHaveBeenCalledTimes(1);
+    expect(mockedMenuNew).not.toHaveBeenCalled();
+    expect(popup).not.toHaveBeenCalled();
+    expect(domMenu()).not.toBeNull();
 
-    const table = menuItemById(latestMenuItems(), "markra:context:table");
-    expect(table).toMatchObject({
-      accelerator: "CmdOrCtrl+Alt+T",
-      text: "Table"
-    });
+    const table = domMenuItemById("markra:context:table");
+    expect(table.textContent).toContain("Table");
+    expect(table.textContent).toContain("Cmd/Ctrl+Alt+T");
 
-    table.action?.("markra:context:table");
+    table.click();
 
     expect(insertTable).toHaveBeenCalledTimes(1);
 
     cleanup();
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
 
-    expect(popup).toHaveBeenCalledTimes(1);
+    expect(domMenu()).toBeNull();
+    expect(popup).not.toHaveBeenCalled();
   });
 
-  it("shows customized markdown shortcuts in the native context menu", async () => {
+  it("shows a self-drawn editor context menu inside the markdown paper", async () => {
+    const bold = vi.fn();
+    document.body.innerHTML = "<main><article class=\"markdown-paper\"><p>Example note</p></article></main>";
+    const paragraph = document.querySelector("p");
+    if (!paragraph) throw new Error("Expected paragraph to be rendered.");
+
+    const cleanup = await installNativeEditorContextMenu(document, {
+      formatBold: bold
+    });
+
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 32,
+      clientY: 48
+    });
+    paragraph.dispatchEvent(event);
+
+    const menu = document.querySelector<HTMLElement>("[data-markra-context-menu]");
+    const boldItem = document.querySelector<HTMLButtonElement>("[data-menu-item-id='markra:context:bold']");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mockedMenuNew).not.toHaveBeenCalled();
+    expect(menu).not.toBeNull();
+    expect(menu?.style.left).toBe("32px");
+    expect(menu?.style.top).toBe("48px");
+
+    boldItem?.click();
+
+    expect(bold).toHaveBeenCalledTimes(1);
+    expect(document.querySelector("[data-markra-context-menu]")).toBeNull();
+
+    cleanup();
+  });
+
+  it("shows customized markdown shortcuts in the self-drawn context menu", async () => {
     const target = document.createElement("main");
     const paper = document.createElement("article");
     paper.className = "markdown-paper";
@@ -235,12 +298,10 @@ describe("native menu", () => {
     });
 
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    await flushNativeMenuPopup();
 
-    expect(menuItemById(latestMenuItems(), "markra:context:bold")).toMatchObject({
-      accelerator: "CmdOrCtrl+Alt+B",
-      text: "Bold"
-    });
+    const bold = domMenuItemById("markra:context:bold");
+    expect(bold.textContent).toContain("Bold");
+    expect(bold.textContent).toContain("Cmd/Ctrl+Alt+B");
   });
 
   it("shows customized insert shortcuts in native menus", async () => {
@@ -271,20 +332,12 @@ describe("native menu", () => {
     });
 
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    await flushNativeMenuPopup();
-
-    expect(menuItemById(latestMenuItems(), "markra:context:link")).toMatchObject({
-      accelerator: "CmdOrCtrl+Alt+K",
-      text: "Link"
-    });
-    expect(menuItemById(latestMenuItems(), "markra:context:image")).toMatchObject({
-      accelerator: "CmdOrCtrl+Alt+I",
-      text: "Image"
-    });
-    expect(menuItemById(latestMenuItems(), "markra:context:table")).toMatchObject({
-      accelerator: "CmdOrCtrl+Shift+T",
-      text: "Table"
-    });
+    expect(domMenuItemById("markra:context:link").textContent).toContain("Link");
+    expect(domMenuItemById("markra:context:link").textContent).toContain("Cmd/Ctrl+Alt+K");
+    expect(domMenuItemById("markra:context:image").textContent).toContain("Image");
+    expect(domMenuItemById("markra:context:image").textContent).toContain("Cmd/Ctrl+Alt+I");
+    expect(domMenuItemById("markra:context:table").textContent).toContain("Table");
+    expect(domMenuItemById("markra:context:table").textContent).toContain("Cmd/Ctrl+Shift+T");
   });
 
   it("passes customized app shortcuts to the native application menu", async () => {
@@ -308,7 +361,7 @@ describe("native menu", () => {
     });
   });
 
-  it("groups richer editor formatting actions in the native context menu", async () => {
+  it("groups richer editor formatting actions in the self-drawn context menu", async () => {
     const target = document.createElement("main");
     const paper = document.createElement("article");
     const handlers: NativeMenuHandlers = {
@@ -333,35 +386,42 @@ describe("native menu", () => {
 
     await installNativeEditorContextMenu(target, handlers);
 
-    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    await flushNativeMenuPopup();
+    const openMenu = () => {
+      paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    };
 
-    const items = latestMenuItems();
+    openMenu();
 
-    expect(menuItemById(items, "markra:context:format")).toMatchObject({ text: "Format" });
-    expect(menuItemById(items, "markra:context:strikethrough")).toMatchObject({ text: "Strikethrough" });
-    expect(menuItemById(items, "markra:context:inline-code")).toMatchObject({ text: "Inline Code" });
-    expect(menuItemById(items, "markra:context:heading-2")).toMatchObject({ text: "Heading 2" });
-    expect(menuItemById(items, "markra:context:ordered-list")).toMatchObject({ text: "Ordered List" });
-    expect(menuItemById(items, "markra:context:quote")).toMatchObject({ text: "Quote" });
-    expect(menuItemById(items, "markra:context:code-block")).toMatchObject({ text: "Code Block" });
-    expect(menuItemById(items, "markra:context:image")).toMatchObject({ text: "Image" });
-    const exportMenu = menuItemById(items, "markra:context:export");
-    expect(exportMenu).toMatchObject({ text: "Export" });
-    expect(menuItemById(menuItemChildren(exportMenu), "markra:context:export-pdf")).toMatchObject({ text: "Export PDF" });
-    expect(menuItemById(menuItemChildren(exportMenu), "markra:context:export-html")).toMatchObject({ text: "Export HTML" });
-    expect(menuItemById(menuItemChildren(exportMenu), "markra:context:export-docx")).toMatchObject({ text: "Export DOCX" });
-    expect(menuItemById(menuItemChildren(exportMenu), "markra:context:export-epub")).toMatchObject({ text: "Export EPUB" });
-    expect(menuItemById(menuItemChildren(exportMenu), "markra:context:export-latex")).toMatchObject({ text: "Export LaTeX" });
+    expect(domMenuItemById("markra:context:format").textContent).toContain("Format");
+    expect(domMenuItemById("markra:context:strikethrough").textContent).toContain("Strikethrough");
+    expect(domMenuItemById("markra:context:inline-code").textContent).toContain("Inline Code");
+    expect(domMenuItemById("markra:context:heading-2").textContent).toContain("Heading 2");
+    expect(domMenuItemById("markra:context:ordered-list").textContent).toContain("Ordered List");
+    expect(domMenuItemById("markra:context:quote").textContent).toContain("Quote");
+    expect(domMenuItemById("markra:context:code-block").textContent).toContain("Code Block");
+    expect(domMenuItemById("markra:context:image").textContent).toContain("Image");
+    expect(domMenuItemById("markra:context:export").textContent).toContain("Export");
+    expect(domSubmenuById("markra:context:export").textContent).toContain("Export PDF");
+    expect(domSubmenuById("markra:context:export").textContent).toContain("Export HTML");
+    expect(domSubmenuById("markra:context:export").textContent).toContain("Export DOCX");
+    expect(domSubmenuById("markra:context:export").textContent).toContain("Export EPUB");
+    expect(domSubmenuById("markra:context:export").textContent).toContain("Export LaTeX");
 
-    menuItemById(items, "markra:context:strikethrough").action?.("markra:context:strikethrough");
-    menuItemById(items, "markra:context:code-block").action?.("markra:context:code-block");
-    menuItemById(items, "markra:context:image").action?.("markra:context:image");
-    menuItemById(items, "markra:context:export-pdf").action?.("markra:context:export-pdf");
-    menuItemById(items, "markra:context:export-html").action?.("markra:context:export-html");
-    menuItemById(items, "markra:context:export-docx").action?.("markra:context:export-docx");
-    menuItemById(items, "markra:context:export-epub").action?.("markra:context:export-epub");
-    menuItemById(items, "markra:context:export-latex").action?.("markra:context:export-latex");
+    domMenuItemById("markra:context:strikethrough").click();
+    openMenu();
+    domMenuItemById("markra:context:code-block").click();
+    openMenu();
+    domMenuItemById("markra:context:image").click();
+    openMenu();
+    domMenuItemById("markra:context:export-pdf").click();
+    openMenu();
+    domMenuItemById("markra:context:export-html").click();
+    openMenu();
+    domMenuItemById("markra:context:export-docx").click();
+    openMenu();
+    domMenuItemById("markra:context:export-epub").click();
+    openMenu();
+    domMenuItemById("markra:context:export-latex").click();
 
     expect(handlers.formatStrikethrough).toHaveBeenCalledTimes(1);
     expect(handlers.formatCodeBlock).toHaveBeenCalledTimes(1);
@@ -390,20 +450,15 @@ describe("native menu", () => {
     });
 
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    await flushNativeMenuPopup();
 
-    expect(findMenuItemById(latestMenuItems(), "markra:context:ai")).toBeNull();
+    expect(queryDomMenuItemById("markra:context:ai")).toBeNull();
 
-    mockedMenuNew.mockClear();
     aiCommandsAvailable = true;
 
     paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-    await flushNativeMenuPopup();
 
-    const items = latestMenuItems();
-    const aiMenu = menuItemById(items, "markra:context:ai");
-    expect(aiMenu).toMatchObject({ text: "AI toolkit" });
-    expect(aiMenu).not.toHaveProperty("icon");
+    const aiMenu = domMenuItemById("markra:context:ai");
+    expect(aiMenu.textContent).toContain("AI toolkit");
     const aiActionItems = [
       ["markra:context:ai-polish", "Polish"],
       ["markra:context:ai-rewrite", "Rewrite"],
@@ -413,20 +468,19 @@ describe("native menu", () => {
     ] as const;
 
     for (const [id, text] of aiActionItems) {
-      const item = menuItemById(items, id);
-
-      expect(item).toMatchObject({ text });
-      expect(item).not.toHaveProperty("icon");
+      expect(domMenuItemById(id).textContent).toContain(text);
     }
 
-    menuItemById(items, "markra:context:ai-polish").action?.("markra:context:ai-polish");
-    menuItemById(items, "markra:context:ai-translate").action?.("markra:context:ai-translate");
+    domMenuItemById("markra:context:ai-polish").click();
+    aiCommandsAvailable = true;
+    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    domMenuItemById("markra:context:ai-translate").click();
 
     expect(aiPolish).toHaveBeenCalledTimes(1);
     expect(aiTranslate).toHaveBeenCalledTimes(1);
   });
 
-  it("shows native markdown file tree actions for a file target", async () => {
+  it("shows self-drawn markdown file tree actions for a file target", async () => {
     const createFile = vi.fn();
     const createFolder = vi.fn();
     const createDailyNote = vi.fn();
@@ -440,44 +494,44 @@ describe("native menu", () => {
       relativePath: "README.md"
     };
 
-    await showNativeMarkdownFileTreeContextMenu({
-      createFile,
-      createFileFromTemplates: [
-        { create: createDailyNote, id: "daily-note", name: "Daily note" }
-      ],
-      createFolder,
-      deleteFile,
-      openFileToSide,
-      renameFile,
-      saveFileAsTemplate
-    }, "en", file);
+    const showMenu = async () => {
+      await showNativeMarkdownFileTreeContextMenu({
+        createFile,
+        createFileFromTemplates: [
+          { create: createDailyNote, id: "daily-note", name: "Daily note" }
+        ],
+        createFolder,
+        deleteFile,
+        openFileToSide,
+        renameFile,
+        saveFileAsTemplate
+      }, "en", file);
+    };
 
-    const items = latestMenuItems();
-    const newFile = menuItemById(items, "markra:file-tree:new");
-    const templateMenu = menuItemById(items, "markra:file-tree:new-from-template");
-    const dailyNote = menuItemById(menuItemChildren(templateMenu), "markra:file-tree:new-from-template:daily-note");
-    const newFolder = menuItemById(items, "markra:file-tree:new-folder");
-    const openToSide = menuItemById(items, "markra:file-tree:open-to-side");
-    const saveAsTemplate = menuItemById(items, "markra:file-tree:save-as-template");
-    const rename = menuItemById(items, "markra:file-tree:rename");
-    const deleteItem = menuItemById(items, "markra:file-tree:delete");
+    await showMenu();
 
-    expect(newFile).toMatchObject({ text: "New file" });
-    expect(templateMenu).toMatchObject({ text: "New from template" });
-    expect(dailyNote).toMatchObject({ text: "Daily note" });
-    expect(newFolder).toMatchObject({ text: "New Folder" });
-    expect(openToSide).toMatchObject({ text: "Open to side" });
-    expect(saveAsTemplate).toMatchObject({ text: "Save as template" });
-    expect(rename).toMatchObject({ text: "Rename file" });
-    expect(deleteItem).toMatchObject({ text: "Delete file" });
+    expect(domMenuItemById("markra:file-tree:new").textContent).toContain("New file");
+    expect(domMenuItemById("markra:file-tree:new-from-template").textContent).toContain("New from template");
+    expect(domMenuItemById("markra:file-tree:new-from-template:daily-note").textContent).toContain("Daily note");
+    expect(domMenuItemById("markra:file-tree:new-folder").textContent).toContain("New Folder");
+    expect(domMenuItemById("markra:file-tree:open-to-side").textContent).toContain("Open to side");
+    expect(domMenuItemById("markra:file-tree:save-as-template").textContent).toContain("Save as template");
+    expect(domMenuItemById("markra:file-tree:rename").textContent).toContain("Rename file");
+    expect(domMenuItemById("markra:file-tree:delete").textContent).toContain("Delete file");
 
-    newFile.action?.("markra:file-tree:new");
-    dailyNote.action?.("markra:file-tree:new-from-template:daily-note");
-    newFolder.action?.("markra:file-tree:new-folder");
-    openToSide.action?.("markra:file-tree:open-to-side");
-    saveAsTemplate.action?.("markra:file-tree:save-as-template");
-    rename.action?.("markra:file-tree:rename");
-    deleteItem.action?.("markra:file-tree:delete");
+    domMenuItemById("markra:file-tree:new").click();
+    await showMenu();
+    domMenuItemById("markra:file-tree:new-from-template:daily-note").click();
+    await showMenu();
+    domMenuItemById("markra:file-tree:new-folder").click();
+    await showMenu();
+    domMenuItemById("markra:file-tree:open-to-side").click();
+    await showMenu();
+    domMenuItemById("markra:file-tree:save-as-template").click();
+    await showMenu();
+    domMenuItemById("markra:file-tree:rename").click();
+    await showMenu();
+    domMenuItemById("markra:file-tree:delete").click();
 
     expect(createFile).toHaveBeenCalledTimes(1);
     expect(createDailyNote).toHaveBeenCalledTimes(1);
@@ -486,10 +540,11 @@ describe("native menu", () => {
     expect(saveFileAsTemplate).toHaveBeenCalledWith(file);
     expect(renameFile).toHaveBeenCalledWith(file);
     expect(deleteFile).toHaveBeenCalledWith(file);
-    expect(popup).toHaveBeenCalledTimes(1);
+    expect(mockedMenuNew).not.toHaveBeenCalled();
+    expect(popup).not.toHaveBeenCalled();
   });
 
-  it("hides the native markdown file tree side-open action without a handler", async () => {
+  it("hides the markdown file tree side-open action without a handler", async () => {
     const file = {
       name: "README.md",
       path: "/vault/README.md",
@@ -503,10 +558,10 @@ describe("native menu", () => {
       renameFile: vi.fn()
     }, "en", file);
 
-    expect(findMenuItemById(latestMenuItems(), "markra:file-tree:open-to-side")).toBeNull();
+    expect(queryDomMenuItemById("markra:file-tree:open-to-side")).toBeNull();
   });
 
-  it("disables the native markdown file tree side-open action when unavailable for the target", async () => {
+  it("disables the markdown file tree side-open action when unavailable for the target", async () => {
     const openFileToSide = vi.fn();
     const file = {
       name: "README.md",
@@ -523,16 +578,17 @@ describe("native menu", () => {
       renameFile: vi.fn()
     }, "en", file);
 
-    const openToSide = menuItemById(latestMenuItems(), "markra:file-tree:open-to-side");
+    const openToSide = domMenuItemById("markra:file-tree:open-to-side");
 
-    expect(openToSide).toMatchObject({ text: "Open to side", enabled: false });
+    expect(openToSide.textContent).toContain("Open to side");
+    expect(openToSide).toBeDisabled();
 
-    openToSide.action?.("markra:file-tree:open-to-side");
+    openToSide.click();
 
     expect(openFileToSide).not.toHaveBeenCalled();
   });
 
-  it("shows a native markdown file tree delete action for a folder target", async () => {
+  it("shows a markdown file tree delete action for a folder target", async () => {
     const createFile = vi.fn();
     const createFolder = vi.fn();
     const renameFile = vi.fn();
@@ -551,17 +607,16 @@ describe("native menu", () => {
       renameFile
     }, "en", folder);
 
-    const items = latestMenuItems();
-    const deleteItem = menuItemById(items, "markra:file-tree:delete");
+    const deleteItem = domMenuItemById("markra:file-tree:delete");
 
-    expect(deleteItem).toMatchObject({ text: "Delete folder" });
-    expect(findMenuItemById(items, "markra:file-tree:rename")).toBeNull();
+    expect(deleteItem.textContent).toContain("Delete folder");
+    expect(queryDomMenuItemById("markra:file-tree:rename")).toBeNull();
 
-    deleteItem.action?.("markra:file-tree:delete");
+    deleteItem.click();
 
     expect(deleteFile).toHaveBeenCalledWith(folder);
     expect(renameFile).not.toHaveBeenCalled();
-    expect(popup).toHaveBeenCalledTimes(1);
+    expect(popup).not.toHaveBeenCalled();
   });
 
   it("only shows create actions for the markdown file tree root target", async () => {
@@ -572,11 +627,8 @@ describe("native menu", () => {
       renameFile: vi.fn()
     }, "en");
 
-    const items = latestMenuItems();
-
-    expect(items).toEqual([
-      expect.objectContaining({ id: "markra:file-tree:new", text: "New file" }),
-      expect.objectContaining({ id: "markra:file-tree:new-folder", text: "New Folder" })
-    ]);
+    expect(domMenuItemById("markra:file-tree:new").textContent).toContain("New file");
+    expect(domMenuItemById("markra:file-tree:new-folder").textContent).toContain("New Folder");
+    expect(queryDomMenuItemById("markra:file-tree:delete")).toBeNull();
   });
 });

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -1,19 +1,18 @@
 import { listen } from "@tauri-apps/api/event";
-import {
-  Menu,
-  type MenuItemOptions,
-  type PredefinedMenuItemOptions,
-  type SubmenuOptions
-} from "@tauri-apps/api/menu";
 import { invoke } from "@tauri-apps/api/core";
-import { t, type AppLanguage, type I18nKey } from "@markra/shared";
 import {
-  defaultMarkdownShortcuts,
-  markdownShortcutToNativeAccelerator,
-  normalizeMarkdownShortcuts,
-  type MarkdownShortcutAction,
-  type MarkdownShortcutMap
-} from "@markra/editor";
+  createEditorContextMenuEntries,
+  createEditorContextMenuEntriesFromOptions,
+  createMarkdownFileTreeContextMenuEntries,
+  contextMenuPositionFromEvent,
+  currentContextMenuPosition,
+  nativeAcceleratorsForMarkdownShortcuts,
+  showContextMenu,
+  type ContextMenuEntry,
+  type ContextMenuIdPrefixes
+} from "@markra/app/runtime";
+import type { MarkdownShortcutMap } from "@markra/editor";
+import type { AppLanguage } from "@markra/shared";
 import type { NativeMarkdownFolderFile } from "./file";
 
 export type NativeMenuHandlers = Partial<Record<NativeMenuCommand, () => unknown | Promise<unknown>>>;
@@ -80,94 +79,10 @@ type NativeMenuCommandPayload = {
   command: NativeMenuCommand;
 };
 
-type NativeApplicationMenuAccelerators = Partial<Record<NativeMenuCommand, string>>;
-
-const nativeMarkdownShortcutCommands: Partial<Record<MarkdownShortcutAction, NativeMenuCommand>> = {
-  bold: "formatBold",
-  bulletList: "formatBulletList",
-  codeBlock: "formatCodeBlock",
-  heading1: "formatHeading1",
-  heading2: "formatHeading2",
-  heading3: "formatHeading3",
-  image: "insertImage",
-  inlineCode: "formatInlineCode",
-  italic: "formatItalic",
-  link: "insertLink",
-  orderedList: "formatOrderedList",
-  paragraph: "formatParagraph",
-  quote: "formatQuote",
-  strikethrough: "formatStrikethrough",
-  table: "insertTable",
-  toggleAiAgent: "toggleAiAgent",
-  toggleAiCommand: "toggleAiCommand",
-  toggleMarkdownFiles: "toggleMarkdownFiles",
-  toggleReadOnlyMode: "toggleReadOnlyMode",
-  toggleSourceMode: "toggleSourceMode"
-};
-
-function shortcutAccelerator(shortcuts: MarkdownShortcutMap | undefined, action: MarkdownShortcutAction): string | undefined {
-  const shortcut = normalizeMarkdownShortcuts(shortcuts ?? defaultMarkdownShortcuts)[action];
-
-  return markdownShortcutToNativeAccelerator(shortcut) ?? markdownShortcutToNativeAccelerator(defaultMarkdownShortcuts[action]) ?? undefined;
-}
-
-function nativeAcceleratorsForMarkdownShortcuts(shortcuts: MarkdownShortcutMap | undefined) {
-  const accelerators: NativeApplicationMenuAccelerators = {};
-
-  if (!shortcuts) return accelerators;
-
-  for (const [action, command] of Object.entries(nativeMarkdownShortcutCommands) as Array<[MarkdownShortcutAction, NativeMenuCommand]>) {
-    const accelerator = shortcutAccelerator(shortcuts, action);
-    if (accelerator && accelerator !== shortcutAccelerator(defaultMarkdownShortcuts, action)) {
-      accelerators[command] = accelerator;
-    }
-  }
-
-  return accelerators;
-}
-
 function runNativeMenuAction(handler: (() => unknown | Promise<unknown>) | undefined) {
   if (!handler) return;
 
   Promise.resolve(handler()).catch(() => {});
-}
-
-function customItem(
-  id: string,
-  text: string,
-  accelerator: string | undefined,
-  handler: (() => unknown | Promise<unknown>) | undefined,
-  enabled = true
-): MenuItemOptions {
-  return {
-    id,
-    text,
-    accelerator,
-    enabled,
-    action: enabled ? () => runNativeMenuAction(handler) : undefined
-  };
-}
-
-function separator(): PredefinedMenuItemOptions {
-  return {
-    item: "Separator"
-  };
-}
-
-function predefined(item: PredefinedMenuItemOptions["item"], text?: string): PredefinedMenuItemOptions {
-  return text ? { item, text } : { item };
-}
-
-function submenu(id: string, text: string, items: SubmenuOptions["items"]): SubmenuOptions {
-  return {
-    id,
-    items,
-    text
-  };
-}
-
-function menuLabel(language: AppLanguage, key: I18nKey) {
-  return t(language, key);
 }
 
 export async function listenNativeApplicationMenuCommands(handlers: NativeMenuHandlers) {
@@ -199,89 +114,8 @@ export function createNativeEditorContextMenuItems(
   handlers: NativeMenuHandlers,
   language: AppLanguage = "en",
   options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap } = {}
-) {
-  const label = (key: I18nKey) => menuLabel(language, key);
-  const formatItems = [
-    customItem("markra:context:bold", label("menu.bold"), shortcutAccelerator(options.markdownShortcuts, "bold"), handlers.formatBold),
-    customItem("markra:context:italic", label("menu.italic"), shortcutAccelerator(options.markdownShortcuts, "italic"), handlers.formatItalic),
-    customItem(
-      "markra:context:strikethrough",
-      label("menu.strikethrough"),
-      shortcutAccelerator(options.markdownShortcuts, "strikethrough"),
-      handlers.formatStrikethrough
-    ),
-    customItem(
-      "markra:context:inline-code",
-      label("menu.inlineCode"),
-      shortcutAccelerator(options.markdownShortcuts, "inlineCode"),
-      handlers.formatInlineCode
-    ),
-    separator(),
-    customItem("markra:context:paragraph", label("menu.paragraph"), shortcutAccelerator(options.markdownShortcuts, "paragraph"), handlers.formatParagraph),
-    customItem("markra:context:heading-1", label("menu.heading1"), shortcutAccelerator(options.markdownShortcuts, "heading1"), handlers.formatHeading1),
-    customItem("markra:context:heading-2", label("menu.heading2"), shortcutAccelerator(options.markdownShortcuts, "heading2"), handlers.formatHeading2),
-    customItem("markra:context:heading-3", label("menu.heading3"), shortcutAccelerator(options.markdownShortcuts, "heading3"), handlers.formatHeading3),
-    separator(),
-    customItem(
-      "markra:context:bullet-list",
-      label("menu.bulletList"),
-      shortcutAccelerator(options.markdownShortcuts, "bulletList"),
-      handlers.formatBulletList
-    ),
-    customItem(
-      "markra:context:ordered-list",
-      label("menu.orderedList"),
-      shortcutAccelerator(options.markdownShortcuts, "orderedList"),
-      handlers.formatOrderedList
-    ),
-    customItem("markra:context:quote", label("menu.quote"), shortcutAccelerator(options.markdownShortcuts, "quote"), handlers.formatQuote),
-    customItem(
-      "markra:context:code-block",
-      label("menu.codeBlock"),
-      shortcutAccelerator(options.markdownShortcuts, "codeBlock"),
-      handlers.formatCodeBlock
-    )
-  ];
-  const items: Array<MenuItemOptions | PredefinedMenuItemOptions | SubmenuOptions> = [
-    predefined("Cut", label("menu.cut")),
-    predefined("Copy", label("menu.copy")),
-    predefined("Paste", label("menu.paste")),
-    predefined("SelectAll", label("menu.selectAll")),
-    separator(),
-    submenu("markra:context:format", label("menu.format"), formatItems),
-    separator(),
-    customItem("markra:context:link", label("menu.link"), shortcutAccelerator(options.markdownShortcuts, "link"), handlers.insertLink),
-    customItem("markra:context:image", label("menu.image"), shortcutAccelerator(options.markdownShortcuts, "image"), handlers.insertImage),
-    customItem("markra:context:table", label("menu.table"), shortcutAccelerator(options.markdownShortcuts, "table"), handlers.insertTable),
-    separator(),
-    submenu("markra:context:export", label("menu.export"), [
-      customItem("markra:context:export-pdf", label("menu.exportPdf"), "CmdOrCtrl+P", handlers.exportPdf),
-      customItem("markra:context:export-html", label("menu.exportHtml"), "CmdOrCtrl+Shift+E", handlers.exportHtml),
-      customItem("markra:context:export-docx", label("menu.exportDocx"), undefined, handlers.exportDocx),
-      customItem("markra:context:export-epub", label("menu.exportEpub"), undefined, handlers.exportEpub),
-      customItem("markra:context:export-latex", label("menu.exportLatex"), undefined, handlers.exportLatex)
-    ])
-  ];
-
-  if (options.aiCommandsAvailable) {
-    items.push(
-      separator(),
-      submenu("markra:context:ai", label("app.aiToolkit"), [
-        customItem("markra:context:ai-polish", label("app.aiPolish"), undefined, handlers.aiPolish),
-        customItem("markra:context:ai-rewrite", label("app.aiRewrite"), undefined, handlers.aiRewrite),
-        customItem(
-          "markra:context:ai-continue-writing",
-          label("app.aiContinueWriting"),
-          undefined,
-          handlers.aiContinueWriting
-        ),
-        customItem("markra:context:ai-summarize", label("app.aiSummarize"), undefined, handlers.aiSummarize),
-        customItem("markra:context:ai-translate", label("app.aiTranslate"), undefined, handlers.aiTranslate)
-      ])
-    );
-  }
-
-  return items;
+): ContextMenuEntry[] {
+  return createEditorContextMenuEntries(handlers, language, options, desktopContextMenuIdPrefixes);
 }
 
 export async function installNativeEditorContextMenu(
@@ -290,108 +124,41 @@ export async function installNativeEditorContextMenu(
   language: AppLanguage = "en",
   options: NativeEditorContextMenuOptions = {}
 ) {
+  let closeCurrentMenu: (() => unknown) | null = null;
   const handleContextMenu = (event: Event) => {
+    const documentTarget = resolveContextMenuDocument(event);
+    const mouseEvent = event instanceof MouseEvent ? event : null;
     const element = event.target instanceof Element ? event.target : null;
-    if (!element?.closest(".markdown-paper")) return;
+    if (!documentTarget || !mouseEvent || !element?.closest(".markdown-paper")) return;
 
     event.preventDefault();
-    showNativeEditorContextMenu(handlers, language, {
-      aiCommandsAvailable: readAiCommandsAvailable(options),
-      markdownShortcuts: options.markdownShortcuts
-    }).catch(() => {});
+    event.stopPropagation();
+    closeCurrentMenu?.();
+    closeCurrentMenu = showContextMenu(documentTarget, {
+      entries: createEditorContextMenuEntriesFromOptions(
+        handlers,
+        language,
+        options,
+        desktopContextMenuIdPrefixes
+      ),
+      position: contextMenuPositionFromEvent(mouseEvent)
+    });
   };
 
   target.addEventListener("contextmenu", handleContextMenu);
 
   return () => {
     target.removeEventListener("contextmenu", handleContextMenu);
+    closeCurrentMenu?.();
   };
-}
-
-async function showNativeEditorContextMenu(
-  handlers: NativeMenuHandlers,
-  language: AppLanguage,
-  options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap }
-) {
-  const menu = await Menu.new({
-    items: createNativeEditorContextMenuItems(handlers, language, options)
-  });
-
-  await menu.popup();
-}
-
-function readAiCommandsAvailable(options: NativeEditorContextMenuOptions) {
-  try {
-    return Boolean(options.getAiCommandsAvailable?.());
-  } catch {
-    return false;
-  }
 }
 
 export function createNativeMarkdownFileTreeContextMenuItems(
   handlers: NativeMarkdownFileTreeContextMenuHandlers,
   language: AppLanguage = "en",
   file?: NativeMarkdownFolderFile
-) {
-  const label = (key: I18nKey) => menuLabel(language, key);
-  const fileIsFolder = file?.kind === "folder";
-  const fileIsAsset = file?.kind === "asset";
-  const templateItems = handlers.createFileFromTemplates?.map((template) =>
-    customItem(
-      `markra:file-tree:new-from-template:${template.id}`,
-      template.name,
-      undefined,
-      template.create
-    )
-  ) ?? [];
-  const items: Array<MenuItemOptions | PredefinedMenuItemOptions | SubmenuOptions> = [
-    customItem("markra:file-tree:new", label("app.newMarkdownFile"), undefined, handlers.createFile),
-    ...(templateItems.length > 0
-      ? [submenu("markra:file-tree:new-from-template", label("app.newMarkdownFileFromTemplate"), templateItems)]
-      : []),
-    customItem("markra:file-tree:new-folder", label("app.newMarkdownFolder"), undefined, handlers.createFolder)
-  ];
-
-  if (!file) return items;
-
-  if (fileIsFolder) {
-    items.push(
-      separator(),
-      customItem("markra:file-tree:delete", label("app.deleteMarkdownFolder"), undefined, () => handlers.deleteFile?.(file))
-    );
-
-    return items;
-  }
-
-  items.push(separator());
-  if (!fileIsAsset && handlers.openFileToSide) {
-    const canOpenFileToSide = handlers.canOpenFileToSide?.(file) ?? true;
-    items.push(
-      customItem(
-        "markra:file-tree:open-to-side",
-        label("app.openDocumentToSide"),
-        undefined,
-        canOpenFileToSide ? () => handlers.openFileToSide?.(file) : undefined,
-        canOpenFileToSide
-      )
-    );
-  }
-  if (!fileIsAsset && handlers.saveFileAsTemplate) {
-    items.push(
-      customItem(
-        "markra:file-tree:save-as-template",
-        label("app.saveMarkdownFileAsTemplate"),
-        undefined,
-        () => handlers.saveFileAsTemplate?.(file)
-      )
-    );
-  }
-  items.push(
-    customItem("markra:file-tree:rename", label("app.renameMarkdownFile"), undefined, () => handlers.renameFile?.(file)),
-    customItem("markra:file-tree:delete", label("app.deleteMarkdownFile"), undefined, () => handlers.deleteFile?.(file))
-  );
-
-  return items;
+): ContextMenuEntry[] {
+  return createMarkdownFileTreeContextMenuEntries(handlers, language, file, desktopContextMenuIdPrefixes);
 }
 
 export async function showNativeMarkdownFileTreeContextMenu(
@@ -399,9 +166,23 @@ export async function showNativeMarkdownFileTreeContextMenu(
   language: AppLanguage = "en",
   file?: NativeMarkdownFolderFile
 ) {
-  const menu = await Menu.new({
-    items: createNativeMarkdownFileTreeContextMenuItems(handlers, language, file)
-  });
+  const documentTarget = typeof document === "undefined" ? null : document;
+  if (!documentTarget) return;
 
-  await menu.popup();
+  showContextMenu(documentTarget, {
+    entries: createNativeMarkdownFileTreeContextMenuItems(handlers, language, file),
+    position: currentContextMenuPosition(documentTarget)
+  });
+}
+
+const desktopContextMenuIdPrefixes: ContextMenuIdPrefixes = {
+  editor: "markra:context",
+  fileTree: "markra:file-tree"
+};
+
+function resolveContextMenuDocument(event: Event) {
+  if (event.target instanceof Node) return event.target.ownerDocument;
+  if (typeof document !== "undefined") return document;
+
+  return null;
 }

--- a/apps/web/src/runtime/web/menu.ts
+++ b/apps/web/src/runtime/web/menu.ts
@@ -1,578 +1,29 @@
-import {
-  defaultMarkdownShortcuts,
-  markdownShortcutToNativeAccelerator,
-  normalizeMarkdownShortcuts,
-  type MarkdownShortcutAction,
-  type MarkdownShortcutMap
-} from "@markra/editor";
-import { t, type AppLanguage, type I18nKey } from "@markra/shared";
 import type {
   AppMenuRuntime,
   NativeEditorContextMenuOptions,
   NativeMarkdownFolderFile,
   NativeMarkdownFileTreeContextMenuHandlers,
-  NativeMenuHandlers,
   RuntimeCleanup
 } from "@markra/app/runtime";
+import {
+  createEditorContextMenuEntries,
+  createEditorContextMenuEntriesFromOptions,
+  createMarkdownFileTreeContextMenuEntries,
+  contextMenuPositionFromEvent,
+  currentContextMenuPosition,
+  showContextMenu,
+  type ContextMenuIdPrefixes
+} from "@markra/app/runtime";
+import type { AppLanguage } from "@markra/shared";
 import type { WebRuntimeOptions } from "./types";
 
-type WebContextMenuEntry = WebContextMenuItem | WebContextMenuSeparator | WebContextMenuSubmenu;
-
-type WebContextMenuItem = {
-  action?: () => unknown | Promise<unknown>;
-  accelerator?: string;
-  enabled: boolean;
-  id: string;
-  kind: "item";
-  label: string;
+const webContextMenuIdPrefixes: ContextMenuIdPrefixes = {
+  editor: "markra:web-context",
+  fileTree: "markra:web-file-tree"
 };
-
-type WebContextMenuSeparator = {
-  kind: "separator";
-};
-
-type WebContextMenuSubmenu = {
-  enabled: boolean;
-  entries: WebContextMenuEntry[];
-  id: string;
-  kind: "submenu";
-  label: string;
-};
-
-type BrowserEditCommand = "copy" | "cut" | "paste" | "selectAll";
-
-const webContextMenuAttribute = "data-markra-web-context-menu";
-const webContextMenuStyleId = "markra-web-context-menu-style";
 
 function resolveDocument(options: WebRuntimeOptions): Document | null {
   return options.document ?? (typeof document === "undefined" ? null : document);
-}
-
-function menuLabel(language: AppLanguage, key: I18nKey) {
-  return t(language, key);
-}
-
-function shortcutAccelerator(shortcuts: MarkdownShortcutMap | undefined, action: MarkdownShortcutAction): string | undefined {
-  const shortcut = normalizeMarkdownShortcuts(shortcuts ?? defaultMarkdownShortcuts)[action];
-
-  return markdownShortcutToNativeAccelerator(shortcut) ?? markdownShortcutToNativeAccelerator(defaultMarkdownShortcuts[action]) ?? undefined;
-}
-
-function runMenuAction(action: (() => unknown | Promise<unknown>) | undefined) {
-  if (!action) return;
-
-  Promise.resolve(action()).catch(() => {});
-}
-
-function runBrowserEditCommand(command: BrowserEditCommand) {
-  const documentTarget = typeof document === "undefined" ? null : document;
-  const execCommand = documentTarget
-    ? (documentTarget as unknown as Record<string, unknown>)["execCommand"]
-    : null;
-  if (typeof execCommand === "function") {
-    execCommand.call(documentTarget, command);
-  }
-}
-
-function item(
-  id: string,
-  label: string,
-  accelerator: string | undefined,
-  action: (() => unknown | Promise<unknown>) | undefined,
-  enabled = Boolean(action)
-): WebContextMenuItem {
-  return {
-    action,
-    accelerator,
-    enabled,
-    id,
-    kind: "item",
-    label
-  };
-}
-
-function browserItem(id: string, label: string, accelerator: string, command: BrowserEditCommand) {
-  return item(id, label, accelerator, () => runBrowserEditCommand(command), true);
-}
-
-function separator(): WebContextMenuSeparator {
-  return { kind: "separator" };
-}
-
-function submenu(id: string, label: string, entries: WebContextMenuEntry[]): WebContextMenuSubmenu {
-  const visibleEntries = collapseSeparators(entries);
-
-  return {
-    enabled: visibleEntries.some((entry) => {
-      if (entry.kind === "item") return entry.enabled;
-      if (entry.kind === "submenu") return entry.enabled;
-
-      return false;
-    }),
-    entries: visibleEntries,
-    id,
-    kind: "submenu",
-    label
-  };
-}
-
-function createWebEditorContextMenuItems(
-  handlers: NativeMenuHandlers,
-  language: AppLanguage = "en",
-  options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap } = {}
-): WebContextMenuEntry[] {
-  const label = (key: I18nKey) => menuLabel(language, key);
-  const formatItems: WebContextMenuEntry[] = [
-    item("markra:web-context:bold", label("menu.bold"), shortcutAccelerator(options.markdownShortcuts, "bold"), handlers.formatBold),
-    item("markra:web-context:italic", label("menu.italic"), shortcutAccelerator(options.markdownShortcuts, "italic"), handlers.formatItalic),
-    item(
-      "markra:web-context:strikethrough",
-      label("menu.strikethrough"),
-      shortcutAccelerator(options.markdownShortcuts, "strikethrough"),
-      handlers.formatStrikethrough
-    ),
-    item(
-      "markra:web-context:inline-code",
-      label("menu.inlineCode"),
-      shortcutAccelerator(options.markdownShortcuts, "inlineCode"),
-      handlers.formatInlineCode
-    ),
-    separator(),
-    item("markra:web-context:paragraph", label("menu.paragraph"), shortcutAccelerator(options.markdownShortcuts, "paragraph"), handlers.formatParagraph),
-    item("markra:web-context:heading-1", label("menu.heading1"), shortcutAccelerator(options.markdownShortcuts, "heading1"), handlers.formatHeading1),
-    item("markra:web-context:heading-2", label("menu.heading2"), shortcutAccelerator(options.markdownShortcuts, "heading2"), handlers.formatHeading2),
-    item("markra:web-context:heading-3", label("menu.heading3"), shortcutAccelerator(options.markdownShortcuts, "heading3"), handlers.formatHeading3),
-    separator(),
-    item("markra:web-context:bullet-list", label("menu.bulletList"), shortcutAccelerator(options.markdownShortcuts, "bulletList"), handlers.formatBulletList),
-    item("markra:web-context:ordered-list", label("menu.orderedList"), shortcutAccelerator(options.markdownShortcuts, "orderedList"), handlers.formatOrderedList),
-    item("markra:web-context:quote", label("menu.quote"), shortcutAccelerator(options.markdownShortcuts, "quote"), handlers.formatQuote),
-    item("markra:web-context:code-block", label("menu.codeBlock"), shortcutAccelerator(options.markdownShortcuts, "codeBlock"), handlers.formatCodeBlock)
-  ];
-  const exportMenu = submenu("markra:web-context:export", label("menu.export"), [
-    item("markra:web-context:export-pdf", label("menu.exportPdf"), "CmdOrCtrl+P", handlers.exportPdf),
-    item("markra:web-context:export-html", label("menu.exportHtml"), "CmdOrCtrl+Shift+E", handlers.exportHtml),
-    item("markra:web-context:export-docx", label("menu.exportDocx"), undefined, handlers.exportDocx),
-    item("markra:web-context:export-epub", label("menu.exportEpub"), undefined, handlers.exportEpub),
-    item("markra:web-context:export-latex", label("menu.exportLatex"), undefined, handlers.exportLatex)
-  ]);
-  const entries: WebContextMenuEntry[] = [
-    browserItem("markra:web-context:cut", label("menu.cut"), "CmdOrCtrl+X", "cut"),
-    browserItem("markra:web-context:copy", label("menu.copy"), "CmdOrCtrl+C", "copy"),
-    browserItem("markra:web-context:paste", label("menu.paste"), "CmdOrCtrl+V", "paste"),
-    browserItem("markra:web-context:select-all", label("menu.selectAll"), "CmdOrCtrl+A", "selectAll"),
-    separator(),
-    submenu("markra:web-context:format", label("menu.format"), formatItems),
-    separator(),
-    item("markra:web-context:link", label("menu.link"), shortcutAccelerator(options.markdownShortcuts, "link"), handlers.insertLink),
-    item("markra:web-context:image", label("menu.image"), shortcutAccelerator(options.markdownShortcuts, "image"), handlers.insertImage),
-    item("markra:web-context:table", label("menu.table"), shortcutAccelerator(options.markdownShortcuts, "table"), handlers.insertTable)
-  ];
-
-  if (exportMenu.enabled) {
-    entries.push(separator(), exportMenu);
-  }
-
-  if (options.aiCommandsAvailable) {
-    entries.push(
-      separator(),
-      submenu("markra:web-context:ai", label("app.aiToolkit"), [
-        item("markra:web-context:ai-polish", label("app.aiPolish"), undefined, handlers.aiPolish),
-        item("markra:web-context:ai-rewrite", label("app.aiRewrite"), undefined, handlers.aiRewrite),
-        item("markra:web-context:ai-continue-writing", label("app.aiContinueWriting"), undefined, handlers.aiContinueWriting),
-        item("markra:web-context:ai-summarize", label("app.aiSummarize"), undefined, handlers.aiSummarize),
-        item("markra:web-context:ai-translate", label("app.aiTranslate"), undefined, handlers.aiTranslate)
-      ])
-    );
-  }
-
-  return collapseSeparators(entries);
-}
-
-function createWebMarkdownFileTreeContextMenuItems(
-  handlers: NativeMarkdownFileTreeContextMenuHandlers,
-  language: AppLanguage = "en",
-  file?: NativeMarkdownFolderFile
-): WebContextMenuEntry[] {
-  const label = (key: I18nKey) => menuLabel(language, key);
-  const fileIsFolder = file?.kind === "folder";
-  const fileIsAsset = file?.kind === "asset";
-  const templateItems = handlers.createFileFromTemplates?.map((template) =>
-    item(`markra:web-file-tree:new-from-template:${template.id}`, template.name, undefined, template.create)
-  ) ?? [];
-  const entries: WebContextMenuEntry[] = [
-    item("markra:web-file-tree:new", label("app.newMarkdownFile"), undefined, handlers.createFile),
-    ...(templateItems.length > 0
-      ? [submenu("markra:web-file-tree:new-from-template", label("app.newMarkdownFileFromTemplate"), templateItems)]
-      : []),
-    item("markra:web-file-tree:new-folder", label("app.newMarkdownFolder"), undefined, handlers.createFolder)
-  ];
-
-  if (!file) return collapseSeparators(entries);
-
-  if (fileIsFolder) {
-    entries.push(
-      separator(),
-      item("markra:web-file-tree:delete", label("app.deleteMarkdownFolder"), undefined, () => handlers.deleteFile?.(file), Boolean(handlers.deleteFile))
-    );
-
-    return collapseSeparators(entries);
-  }
-
-  entries.push(separator());
-  if (!fileIsAsset && handlers.openFileToSide) {
-    const canOpenFileToSide = handlers.canOpenFileToSide?.(file) ?? true;
-    entries.push(
-      item(
-        "markra:web-file-tree:open-to-side",
-        label("app.openDocumentToSide"),
-        undefined,
-        canOpenFileToSide ? () => handlers.openFileToSide?.(file) : undefined,
-        canOpenFileToSide
-      )
-    );
-  }
-  if (!fileIsAsset && handlers.saveFileAsTemplate) {
-    entries.push(
-      item(
-        "markra:web-file-tree:save-as-template",
-        label("app.saveMarkdownFileAsTemplate"),
-        undefined,
-        () => handlers.saveFileAsTemplate?.(file)
-      )
-    );
-  }
-  entries.push(
-    item("markra:web-file-tree:rename", label("app.renameMarkdownFile"), undefined, () => handlers.renameFile?.(file), Boolean(handlers.renameFile)),
-    item("markra:web-file-tree:delete", label("app.deleteMarkdownFile"), undefined, () => handlers.deleteFile?.(file), Boolean(handlers.deleteFile))
-  );
-
-  return collapseSeparators(entries);
-}
-
-function collapseSeparators(entries: WebContextMenuEntry[]) {
-  const collapsed: WebContextMenuEntry[] = [];
-
-  entries.forEach((entry) => {
-    if (entry.kind === "separator" && (collapsed.length === 0 || collapsed.at(-1)?.kind === "separator")) return;
-    if (entry.kind === "submenu") {
-      const submenuEntry = submenu(entry.id, entry.label, entry.entries);
-      if (submenuEntry.entries.length === 0) return;
-
-      collapsed.push(submenuEntry);
-      return;
-    }
-    collapsed.push(entry);
-  });
-
-  if (collapsed.at(-1)?.kind === "separator") {
-    collapsed.pop();
-  }
-
-  return collapsed;
-}
-
-function readAiCommandsAvailable(options: NativeEditorContextMenuOptions) {
-  try {
-    return Boolean(options.getAiCommandsAvailable?.());
-  } catch {
-    return false;
-  }
-}
-
-function ensureContextMenuStyle(documentTarget: Document) {
-  if (documentTarget.getElementById(webContextMenuStyleId)) return;
-
-  const style = documentTarget.createElement("style");
-  style.id = webContextMenuStyleId;
-  style.textContent = `
-    .markra-web-context-menu,
-    .markra-web-context-menu-submenu {
-      position: fixed;
-      z-index: 2147483647;
-      min-width: 216px;
-      max-width: min(280px, calc(100vw - 16px));
-      padding: 5px;
-      border: 1px solid var(--border-default, rgb(238 238 238));
-      border-radius: 8px;
-      background: var(--bg-primary, rgb(250 250 250));
-      color: var(--text-primary, rgb(51 51 51));
-      box-shadow: 0 14px 36px color-mix(in srgb, var(--shadow-color, rgb(31 35 44)) 16%, transparent);
-      font: 520 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-      outline: none;
-      user-select: none;
-    }
-
-    .markra-web-context-menu-submenu-shell {
-      position: relative;
-    }
-
-    .markra-web-context-menu-submenu {
-      position: absolute;
-      top: -5px;
-      left: calc(100% - 4px);
-      display: none;
-      max-width: min(280px, calc(100vw - 16px));
-    }
-
-    .markra-web-context-menu-submenu-shell[data-submenu-align="left"] > .markra-web-context-menu-submenu {
-      right: calc(100% - 4px);
-      left: auto;
-    }
-
-    .markra-web-context-menu-submenu-shell:hover > .markra-web-context-menu-submenu,
-    .markra-web-context-menu-submenu-shell:focus-within > .markra-web-context-menu-submenu {
-      display: block;
-    }
-
-    .markra-web-context-menu-item {
-      display: flex;
-      width: 100%;
-      height: 28px;
-      align-items: center;
-      justify-content: space-between;
-      gap: 18px;
-      border: 0;
-      border-radius: 6px;
-      background: transparent;
-      padding: 0 8px;
-      color: var(--text-primary, rgb(51 51 51));
-      font: inherit;
-      text-align: left;
-    }
-
-    .markra-web-context-menu-item:not(:disabled) {
-      cursor: pointer;
-    }
-
-    .markra-web-context-menu-item:not(:disabled):hover,
-    .markra-web-context-menu-item:not(:disabled):focus-visible {
-      background: var(--bg-hover, rgb(245 245 245));
-      color: var(--text-heading, rgb(51 51 51));
-      outline: none;
-    }
-
-    .markra-web-context-menu-item:disabled {
-      opacity: 0.42;
-    }
-
-    .markra-web-context-menu-label {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .markra-web-context-menu-accelerator {
-      flex: none;
-      color: var(--text-tertiary, rgb(153 153 153));
-      font-size: 12px;
-      font-weight: 520;
-    }
-
-    .markra-web-context-menu-arrow {
-      flex: none;
-      color: var(--text-tertiary, rgb(153 153 153));
-      font-size: 13px;
-      font-weight: 620;
-    }
-
-    .markra-web-context-menu-separator {
-      height: 1px;
-      margin: 5px 4px;
-      background: var(--border-default, rgb(238 238 238));
-    }
-  `;
-  documentTarget.head.append(style);
-}
-
-function formatAccelerator(accelerator: string | undefined) {
-  return accelerator?.replace(/CmdOrCtrl/gu, "Cmd/Ctrl");
-}
-
-function positionContextMenu(menu: HTMLElement, event: MouseEvent) {
-  const margin = 8;
-  const width = menu.offsetWidth || 216;
-  const height = menu.offsetHeight || 320;
-  const viewportWidth = menu.ownerDocument.defaultView?.innerWidth ?? 1024;
-  const viewportHeight = menu.ownerDocument.defaultView?.innerHeight ?? 768;
-  const left = Math.max(margin, Math.min(event.clientX, viewportWidth - width - margin));
-  const top = Math.max(margin, Math.min(event.clientY, viewportHeight - height - margin));
-
-  menu.style.left = `${left}px`;
-  menu.style.top = `${top}px`;
-}
-
-function alignContextSubmenus(menu: HTMLElement) {
-  const viewportWidth = menu.ownerDocument.defaultView?.innerWidth ?? 1024;
-  const rootRect = menu.getBoundingClientRect();
-  const submenuWidth = 216;
-
-  menu.querySelectorAll<HTMLElement>(".markra-web-context-menu-submenu-shell").forEach((shell) => {
-    if (rootRect.right + submenuWidth > viewportWidth - 8) {
-      shell.dataset.submenuAlign = "left";
-      return;
-    }
-
-    delete shell.dataset.submenuAlign;
-  });
-}
-
-function currentContextMenuMouseEvent(documentTarget: Document) {
-  const currentEvent = (documentTarget.defaultView as (Window & { event?: Event }) | null)?.event;
-  if (currentEvent instanceof MouseEvent) return currentEvent;
-
-  return new MouseEvent("contextmenu", {
-    bubbles: true,
-    cancelable: true,
-    clientX: 8,
-    clientY: 8
-  });
-}
-
-function createContextMenuItem(documentTarget: Document, entry: WebContextMenuItem, closeMenu: () => unknown) {
-  const button = documentTarget.createElement("button");
-  button.className = "markra-web-context-menu-item";
-  button.type = "button";
-  button.role = "menuitem";
-  button.disabled = !entry.enabled;
-  button.dataset.menuItemId = entry.id;
-
-  const label = documentTarget.createElement("span");
-  label.className = "markra-web-context-menu-label";
-  label.textContent = entry.label;
-  button.append(label);
-
-  const accelerator = formatAccelerator(entry.accelerator);
-  if (accelerator) {
-    const shortcut = documentTarget.createElement("span");
-    shortcut.className = "markra-web-context-menu-accelerator";
-    shortcut.textContent = accelerator;
-    button.append(shortcut);
-  }
-
-  button.addEventListener("pointerdown", (event) => {
-    event.preventDefault();
-  });
-  button.addEventListener("click", () => {
-    if (!entry.enabled) return;
-    runMenuAction(entry.action);
-    closeMenu();
-  });
-
-  return button;
-}
-
-function appendContextMenuEntries(
-  documentTarget: Document,
-  container: HTMLElement,
-  entries: WebContextMenuEntry[],
-  closeMenu: () => unknown
-) {
-  entries.forEach((entry) => {
-    if (entry.kind === "separator") {
-      const separatorElement = documentTarget.createElement("div");
-      separatorElement.className = "markra-web-context-menu-separator";
-      separatorElement.role = "separator";
-      container.append(separatorElement);
-      return;
-    }
-
-    if (entry.kind === "submenu") {
-      container.append(createContextSubmenu(documentTarget, entry, closeMenu));
-      return;
-    }
-
-    container.append(createContextMenuItem(documentTarget, entry, closeMenu));
-  });
-}
-
-function createContextSubmenu(documentTarget: Document, entry: WebContextMenuSubmenu, closeMenu: () => unknown) {
-  const shell = documentTarget.createElement("div");
-  shell.className = "markra-web-context-menu-submenu-shell";
-
-  const button = documentTarget.createElement("button");
-  button.className = "markra-web-context-menu-item";
-  button.type = "button";
-  button.role = "menuitem";
-  button.disabled = !entry.enabled;
-  button.dataset.menuItemId = entry.id;
-  button.setAttribute("aria-haspopup", "menu");
-
-  const label = documentTarget.createElement("span");
-  label.className = "markra-web-context-menu-label";
-  label.textContent = entry.label;
-  button.append(label);
-
-  const arrow = documentTarget.createElement("span");
-  arrow.className = "markra-web-context-menu-arrow";
-  arrow.setAttribute("aria-hidden", "true");
-  arrow.textContent = ">";
-  button.append(arrow);
-
-  const submenuElement = documentTarget.createElement("div");
-  submenuElement.className = "markra-web-context-menu-submenu";
-  submenuElement.dataset.menuSubmenuId = entry.id;
-  submenuElement.role = "menu";
-  appendContextMenuEntries(documentTarget, submenuElement, entry.entries, closeMenu);
-
-  button.addEventListener("pointerdown", (event) => {
-    event.preventDefault();
-  });
-  button.addEventListener("click", (event) => {
-    event.preventDefault();
-    button.focus({ preventScroll: true });
-  });
-
-  shell.append(button, submenuElement);
-
-  return shell;
-}
-
-function showWebContextMenu(documentTarget: Document, event: MouseEvent, entries: WebContextMenuEntry[]) {
-  ensureContextMenuStyle(documentTarget);
-  documentTarget.querySelector(`[${webContextMenuAttribute}]`)?.remove();
-
-  const menu = documentTarget.createElement("div");
-  menu.className = "markra-web-context-menu";
-  menu.setAttribute(webContextMenuAttribute, "true");
-  menu.role = "menu";
-  menu.tabIndex = -1;
-
-  let closed = false;
-  const closeMenu = () => {
-    if (closed) return;
-
-    closed = true;
-    documentTarget.removeEventListener("pointerdown", handleDocumentPointerDown, true);
-    documentTarget.removeEventListener("keydown", handleDocumentKeyDown, true);
-    documentTarget.defaultView?.removeEventListener("resize", closeMenu);
-    documentTarget.defaultView?.removeEventListener("scroll", closeMenu, true);
-    menu.remove();
-  };
-  const handleDocumentPointerDown = (pointerEvent: PointerEvent) => {
-    const target = pointerEvent.target instanceof Node ? pointerEvent.target : null;
-    if (target && menu.contains(target)) return;
-
-    closeMenu();
-  };
-  const handleDocumentKeyDown = (keyboardEvent: KeyboardEvent) => {
-    if (keyboardEvent.key === "Escape") {
-      keyboardEvent.preventDefault();
-      closeMenu();
-    }
-  };
-
-  appendContextMenuEntries(documentTarget, menu, entries, closeMenu);
-
-  documentTarget.body.append(menu);
-  positionContextMenu(menu, event);
-  alignContextSubmenus(menu);
-  menu.focus({ preventScroll: true });
-  documentTarget.addEventListener("pointerdown", handleDocumentPointerDown, true);
-  documentTarget.addEventListener("keydown", handleDocumentKeyDown, true);
-  documentTarget.defaultView?.addEventListener("resize", closeMenu);
-  documentTarget.defaultView?.addEventListener("scroll", closeMenu, true);
-
-  return closeMenu;
 }
 
 export function createWebMenuRuntime(
@@ -582,11 +33,11 @@ export function createWebMenuRuntime(
   return {
     ...defaultMenuRuntime,
     createEditorContextMenuItems: (handlers, language, menuOptions) =>
-      createWebEditorContextMenuItems(handlers, language, menuOptions),
+      createEditorContextMenuEntries(handlers, language, menuOptions, webContextMenuIdPrefixes),
     createMarkdownFileTreeContextMenuItems: (handlers, language, file) =>
-      createWebMarkdownFileTreeContextMenuItems(handlers, language, file),
+      createMarkdownFileTreeContextMenuEntries(handlers, language, file, webContextMenuIdPrefixes),
     installEditorContextMenu: async (target, handlers, language = "en", menuOptions = {}) => {
-      let closeCurrentMenu: (() => unknown) | null = null;
+      let closeCurrentMenu: RuntimeCleanup | null = null;
       const handleContextMenu = (event: Event) => {
         const documentTarget = resolveDocument(options);
         const mouseEvent = event instanceof MouseEvent ? event : null;
@@ -596,14 +47,15 @@ export function createWebMenuRuntime(
         event.preventDefault();
         event.stopPropagation();
         closeCurrentMenu?.();
-        closeCurrentMenu = showWebContextMenu(
-          documentTarget,
-          mouseEvent,
-          createWebEditorContextMenuItems(handlers, language, {
-            aiCommandsAvailable: readAiCommandsAvailable(menuOptions),
-            markdownShortcuts: menuOptions.markdownShortcuts
-          })
-        );
+        closeCurrentMenu = showContextMenu(documentTarget, {
+          entries: createEditorContextMenuEntriesFromOptions(
+            handlers,
+            language,
+            menuOptions,
+            webContextMenuIdPrefixes
+          ),
+          position: contextMenuPositionFromEvent(mouseEvent)
+        });
       };
 
       target.addEventListener("contextmenu", handleContextMenu);
@@ -621,11 +73,15 @@ export function createWebMenuRuntime(
       const documentTarget = resolveDocument(options);
       if (!documentTarget) return;
 
-      showWebContextMenu(
-        documentTarget,
-        currentContextMenuMouseEvent(documentTarget),
-        createWebMarkdownFileTreeContextMenuItems(handlers, language, file)
-      );
+      showContextMenu(documentTarget, {
+        entries: createMarkdownFileTreeContextMenuEntries(
+          handlers,
+          language,
+          file,
+          webContextMenuIdPrefixes
+        ),
+        position: currentContextMenuPosition(documentTarget)
+      });
     }
   };
 }

--- a/packages/app/src/components/ContextMenu.test.tsx
+++ b/packages/app/src/components/ContextMenu.test.tsx
@@ -1,0 +1,99 @@
+import { showContextMenu } from "./ContextMenu";
+
+function getMenu() {
+  return document.querySelector("[data-markra-context-menu]");
+}
+
+function getMenuItemById(id: string) {
+  const item = document.querySelector<HTMLButtonElement>(`[data-menu-item-id="${id}"]`);
+  if (!item) throw new Error(`Menu item not found: ${id}`);
+
+  return item;
+}
+
+describe("ContextMenu", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders a themed self-drawn menu at the requested point and closes after selecting an item", () => {
+    const select = vi.fn();
+
+    showContextMenu(document, {
+      entries: [
+        {
+          id: "markra:test:open",
+          kind: "item",
+          label: "Open",
+          onSelect: select
+        }
+      ],
+      position: {
+        x: 32,
+        y: 48
+      }
+    });
+
+    const menu = getMenu();
+    expect(menu).not.toBeNull();
+    expect(menu).toHaveAttribute("role", "menu");
+    expect(menu).toHaveClass("bg-(--bg-primary)");
+    expect((menu as HTMLElement).style.left).toBe("32px");
+    expect((menu as HTMLElement).style.top).toBe("48px");
+
+    getMenuItemById("markra:test:open").click();
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(getMenu()).toBeNull();
+  });
+
+  it("renders disabled items and submenus with native-like menu roles", () => {
+    const disabledSelect = vi.fn();
+    const childSelect = vi.fn();
+
+    showContextMenu(document, {
+      entries: [
+        {
+          disabled: true,
+          id: "markra:test:disabled",
+          kind: "item",
+          label: "Disabled",
+          onSelect: disabledSelect
+        },
+        {
+          entries: [
+            {
+              id: "markra:test:child",
+              kind: "item",
+              label: "Child",
+              onSelect: childSelect
+            }
+          ],
+          id: "markra:test:submenu",
+          kind: "submenu",
+          label: "More"
+        }
+      ],
+      position: {
+        x: 8,
+        y: 8
+      }
+    });
+
+    const disabledItem = getMenuItemById("markra:test:disabled");
+    const submenuButton = getMenuItemById("markra:test:submenu");
+
+    disabledItem.click();
+
+    expect(disabledItem).toBeDisabled();
+    expect(disabledSelect).not.toHaveBeenCalled();
+    expect(submenuButton).toHaveAttribute("aria-haspopup", "menu");
+    expect(document.querySelector("[data-menu-submenu-id='markra:test:submenu']")).toHaveAttribute("role", "menu");
+
+    getMenuItemById("markra:test:child").click();
+
+    expect(childSelect).toHaveBeenCalledTimes(1);
+    expect(getMenu()).toBeNull();
+  });
+});

--- a/packages/app/src/components/ContextMenu.test.tsx
+++ b/packages/app/src/components/ContextMenu.test.tsx
@@ -89,6 +89,8 @@ describe("ContextMenu", () => {
     expect(disabledItem).toBeDisabled();
     expect(disabledSelect).not.toHaveBeenCalled();
     expect(submenuButton).toHaveAttribute("aria-haspopup", "menu");
+    expect(submenuButton.querySelector("svg")).not.toBeNull();
+    expect(submenuButton).not.toHaveTextContent(">");
     expect(document.querySelector("[data-menu-submenu-id='markra:test:submenu']")).toHaveAttribute("role", "menu");
 
     getMenuItemById("markra:test:child").click();

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -1,0 +1,378 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode
+} from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+export type ContextMenuEntry = ContextMenuItem | ContextMenuSeparator | ContextMenuSubmenu;
+
+export type ContextMenuItem = {
+  accelerator?: string;
+  disabled?: boolean;
+  icon?: ReactNode;
+  id: string;
+  kind: "item";
+  label: string;
+  onSelect?: () => unknown | Promise<unknown>;
+};
+
+export type ContextMenuSeparator = {
+  kind: "separator";
+};
+
+export type ContextMenuSubmenu = {
+  disabled?: boolean;
+  entries: ContextMenuEntry[];
+  id: string;
+  kind: "submenu";
+  label: string;
+};
+
+export type ContextMenuPosition = {
+  x: number;
+  y: number;
+};
+
+export type ContextMenuProps = {
+  ariaLabel?: string;
+  entries: ContextMenuEntry[];
+  onClose: () => unknown;
+  position: ContextMenuPosition;
+};
+
+export type ShowContextMenuOptions = {
+  ariaLabel?: string;
+  entries: ContextMenuEntry[];
+  position: ContextMenuPosition;
+};
+
+const contextMenuRootAttribute = "data-markra-context-menu-root";
+const contextMenuAttribute = "data-markra-context-menu";
+const legacyWebContextMenuAttribute = "data-markra-web-context-menu";
+const defaultContextMenuWidth = 216;
+const defaultContextMenuHeight = 320;
+const contextMenuViewportMargin = 8;
+const contextSubmenuWidth = 216;
+
+let activeContextMenuCleanup: (() => unknown) | null = null;
+
+export function contextMenuItem(
+  id: string,
+  label: string,
+  accelerator: string | undefined,
+  onSelect: (() => unknown | Promise<unknown>) | undefined,
+  disabled = !onSelect
+): ContextMenuItem {
+  return {
+    accelerator,
+    disabled,
+    id,
+    kind: "item",
+    label,
+    onSelect
+  };
+}
+
+export function contextMenuSeparator(): ContextMenuSeparator {
+  return {
+    kind: "separator"
+  };
+}
+
+export function contextMenuSubmenu(id: string, label: string, entries: ContextMenuEntry[]): ContextMenuSubmenu {
+  const collapsedEntries = collapseContextMenuEntries(entries);
+
+  return {
+    disabled: !collapsedEntries.some((entry) => {
+      if (entry.kind === "item") return !entry.disabled;
+      if (entry.kind === "submenu") return !entry.disabled;
+
+      return false;
+    }),
+    entries: collapsedEntries,
+    id,
+    kind: "submenu",
+    label
+  };
+}
+
+export function collapseContextMenuEntries(entries: ContextMenuEntry[]) {
+  const collapsed: ContextMenuEntry[] = [];
+
+  entries.forEach((entry) => {
+    if (entry.kind === "separator" && (collapsed.length === 0 || collapsed.at(-1)?.kind === "separator")) return;
+    if (entry.kind === "submenu") {
+      const submenu = contextMenuSubmenu(entry.id, entry.label, entry.entries);
+      if (submenu.entries.length === 0) return;
+
+      collapsed.push(submenu);
+      return;
+    }
+
+    collapsed.push(entry);
+  });
+
+  if (collapsed.at(-1)?.kind === "separator") {
+    collapsed.pop();
+  }
+
+  return collapsed;
+}
+
+export function contextMenuPositionFromEvent(event: MouseEvent): ContextMenuPosition {
+  return {
+    x: event.clientX,
+    y: event.clientY
+  };
+}
+
+export function currentContextMenuPosition(documentTarget: Document): ContextMenuPosition {
+  const currentEvent = (documentTarget.defaultView as (Window & { event?: Event }) | null)?.event;
+  if (currentEvent instanceof MouseEvent) return contextMenuPositionFromEvent(currentEvent);
+
+  return {
+    x: contextMenuViewportMargin,
+    y: contextMenuViewportMargin
+  };
+}
+
+export function showContextMenu(documentTarget: Document, options: ShowContextMenuOptions) {
+  closeActiveContextMenu();
+
+  const container = documentTarget.createElement("div");
+  container.setAttribute(contextMenuRootAttribute, "true");
+  documentTarget.body.append(container);
+
+  const root = createRoot(container);
+  let closed = false;
+  const closeMenu = () => {
+    if (closed) return;
+
+    closed = true;
+    if (activeContextMenuCleanup === closeMenu) activeContextMenuCleanup = null;
+    root.unmount();
+    container.remove();
+  };
+
+  activeContextMenuCleanup = closeMenu;
+  flushSync(() => {
+    root.render(
+      <ContextMenu
+        ariaLabel={options.ariaLabel}
+        entries={options.entries}
+        position={options.position}
+        onClose={closeMenu}
+      />
+    );
+  });
+
+  return closeMenu;
+}
+
+export function closeActiveContextMenu() {
+  activeContextMenuCleanup?.();
+  activeContextMenuCleanup = null;
+}
+
+export function ContextMenu({ ariaLabel, entries, onClose, position }: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>({
+    left: position.x,
+    top: position.y
+  });
+  const [submenuAlignLeft, setSubmenuAlignLeft] = useState(false);
+  const collapsedEntries = collapseContextMenuEntries(entries);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const documentTarget = menu.ownerDocument;
+    const windowTarget = documentTarget.defaultView;
+    const viewportWidth = windowTarget?.innerWidth ?? 1024;
+    const viewportHeight = windowTarget?.innerHeight ?? 768;
+    const width = menu.offsetWidth || defaultContextMenuWidth;
+    const height = menu.offsetHeight || defaultContextMenuHeight;
+    const left = Math.max(contextMenuViewportMargin, Math.min(position.x, viewportWidth - width - contextMenuViewportMargin));
+    const top = Math.max(contextMenuViewportMargin, Math.min(position.y, viewportHeight - height - contextMenuViewportMargin));
+
+    setMenuStyle({
+      left,
+      top
+    });
+    setSubmenuAlignLeft(left + width + contextSubmenuWidth > viewportWidth - contextMenuViewportMargin);
+  }, [position.x, position.y]);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const documentTarget = menu.ownerDocument;
+    const windowTarget = documentTarget.defaultView;
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target instanceof Node ? event.target : null;
+      if (target && menu.contains(target)) return;
+
+      onClose();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+
+      event.preventDefault();
+      onClose();
+    };
+
+    documentTarget.addEventListener("pointerdown", handlePointerDown, true);
+    documentTarget.addEventListener("keydown", handleKeyDown, true);
+    windowTarget?.addEventListener("resize", onClose);
+    windowTarget?.addEventListener("scroll", onClose, true);
+
+    return () => {
+      documentTarget.removeEventListener("pointerdown", handlePointerDown, true);
+      documentTarget.removeEventListener("keydown", handleKeyDown, true);
+      windowTarget?.removeEventListener("resize", onClose);
+      windowTarget?.removeEventListener("scroll", onClose, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-[2147483647] min-w-[216px] max-w-[min(280px,calc(100vw-16px))] rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 font-[520] text-(--text-primary) shadow-[0_14px_36px_color-mix(in_srgb,var(--text-heading)_16%,transparent)] outline-none select-none"
+      role="menu"
+      tabIndex={-1}
+      aria-label={ariaLabel}
+      style={menuStyle}
+      {...{
+        [contextMenuAttribute]: "true",
+        [legacyWebContextMenuAttribute]: "true"
+      }}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      <ContextMenuEntries entries={collapsedEntries} submenuAlignLeft={submenuAlignLeft} onClose={onClose} />
+    </div>
+  );
+}
+
+type ContextMenuEntriesProps = {
+  entries: ContextMenuEntry[];
+  onClose: () => unknown;
+  submenuAlignLeft: boolean;
+};
+
+function ContextMenuEntries({ entries, onClose, submenuAlignLeft }: ContextMenuEntriesProps) {
+  return entries.map((entry, index) => {
+    if (entry.kind === "separator") {
+      return (
+        <div
+          className="my-1 h-px bg-(--border-default)"
+          key={`separator-${index}`}
+          role="separator"
+        />
+      );
+    }
+
+    if (entry.kind === "submenu") {
+      return (
+        <ContextSubmenu
+          entry={entry}
+          key={entry.id}
+          submenuAlignLeft={submenuAlignLeft}
+          onClose={onClose}
+        />
+      );
+    }
+
+    return (
+      <ContextMenuButton
+        entry={entry}
+        key={entry.id}
+        onClose={onClose}
+      />
+    );
+  });
+}
+
+type ContextMenuButtonProps = {
+  entry: ContextMenuItem;
+  onClose: () => unknown;
+};
+
+function ContextMenuButton({ entry, onClose }: ContextMenuButtonProps) {
+  const disabled = Boolean(entry.disabled);
+
+  return (
+    <button
+      className="flex h-7 w-full items-center justify-between gap-4 rounded-md border-0 bg-transparent px-2 text-left font-inherit text-(--text-primary) outline-none transition-[background-color,color,opacity] duration-150 ease-out enabled:cursor-pointer enabled:hover:bg-(--bg-hover) enabled:hover:text-(--text-heading) enabled:focus-visible:bg-(--bg-hover) enabled:focus-visible:text-(--text-heading) disabled:opacity-45"
+      data-menu-item-id={entry.id}
+      disabled={disabled}
+      role="menuitem"
+      type="button"
+      onPointerDown={(event) => event.preventDefault()}
+      onClick={() => {
+        if (disabled) return;
+
+        Promise.resolve(entry.onSelect?.()).catch(() => {});
+        onClose();
+      }}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        {entry.icon ? <span className="shrink-0 text-(--text-secondary)">{entry.icon}</span> : null}
+        <span className="min-w-0 truncate">{entry.label}</span>
+      </span>
+      {entry.accelerator ? (
+        <span className="shrink-0 text-[12px] font-[520] text-(--text-secondary)">
+          {formatAccelerator(entry.accelerator)}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+type ContextSubmenuProps = {
+  entry: ContextMenuSubmenu;
+  onClose: () => unknown;
+  submenuAlignLeft: boolean;
+};
+
+function ContextSubmenu({ entry, onClose, submenuAlignLeft }: ContextSubmenuProps) {
+  const disabled = Boolean(entry.disabled);
+
+  return (
+    <div className="group/context-menu-submenu relative">
+      <button
+        className="flex h-7 w-full items-center justify-between gap-4 rounded-md border-0 bg-transparent px-2 text-left font-inherit text-(--text-primary) outline-none transition-[background-color,color,opacity] duration-150 ease-out enabled:cursor-pointer enabled:hover:bg-(--bg-hover) enabled:hover:text-(--text-heading) enabled:focus-visible:bg-(--bg-hover) enabled:focus-visible:text-(--text-heading) disabled:opacity-45"
+        aria-haspopup="menu"
+        data-menu-item-id={entry.id}
+        disabled={disabled}
+        role="menuitem"
+        type="button"
+        onPointerDown={(event) => event.preventDefault()}
+        onClick={(event) => {
+          event.preventDefault();
+          event.currentTarget.focus({ preventScroll: true });
+        }}
+      >
+        <span className="min-w-0 truncate">{entry.label}</span>
+        <span className="shrink-0 text-[13px] font-[620] text-(--text-secondary)" aria-hidden="true">&gt;</span>
+      </button>
+      <div
+        className={`absolute top-[-4px] hidden min-w-[216px] max-w-[min(280px,calc(100vw-16px))] rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 font-[520] text-(--text-primary) shadow-[0_14px_36px_color-mix(in_srgb,var(--text-heading)_16%,transparent)] outline-none group-hover/context-menu-submenu:block group-focus-within/context-menu-submenu:block ${
+          submenuAlignLeft ? "right-[calc(100%-4px)]" : "left-[calc(100%-4px)]"
+        }`}
+        data-menu-submenu-id={entry.id}
+        role="menu"
+      >
+        <ContextMenuEntries entries={entry.entries} submenuAlignLeft={submenuAlignLeft} onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+function formatAccelerator(accelerator: string) {
+  return accelerator.replace(/CmdOrCtrl/gu, "Cmd/Ctrl");
+}

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -5,6 +5,7 @@ import {
   type CSSProperties,
   type ReactNode
 } from "react";
+import { ChevronRight } from "lucide-react";
 import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
 
@@ -358,7 +359,12 @@ function ContextSubmenu({ entry, onClose, submenuAlignLeft }: ContextSubmenuProp
         }}
       >
         <span className="min-w-0 truncate">{entry.label}</span>
-        <span className="shrink-0 text-[13px] font-[620] text-(--text-secondary)" aria-hidden="true">&gt;</span>
+        <ChevronRight
+          aria-hidden="true"
+          className="shrink-0 text-(--text-secondary)"
+          size={14}
+          strokeWidth={2.25}
+        />
       </button>
       <div
         className={`absolute top-[-4px] hidden min-w-[216px] max-w-[min(280px,calc(100vw-16px))] rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 font-[520] text-(--text-primary) shadow-[0_14px_36px_color-mix(in_srgb,var(--text-heading)_16%,transparent)] outline-none group-hover/context-menu-submenu:block group-focus-within/context-menu-submenu:block ${

--- a/packages/app/src/components/MarkdownTabsBar.test.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.test.tsx
@@ -524,6 +524,29 @@ describe("MarkdownTabsBar", () => {
     expect(onCloseTab).toHaveBeenCalledWith("tab-c");
   });
 
+  it("renders tab actions with the shared context menu component", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /Alpha\.md/ }));
+
+    expect(document.querySelector("[data-markra-context-menu]")).not.toBeNull();
+  });
+
   it("opens a markdown tab to the side from the tab actions menu", () => {
     const onOpenTabToSide = vi.fn();
 

--- a/packages/app/src/components/MarkdownTabsBar.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.tsx
@@ -8,9 +8,10 @@ import {
   type WheelEvent as ReactWheelEvent
 } from "react";
 import { Columns2, FileText, ImageIcon, Pencil, Plus, X } from "lucide-react";
-import { Button, IconButton, PopoverSurface } from "@markra/ui";
+import { IconButton } from "@markra/ui";
 import { t, type AppLanguage } from "@markra/shared";
 import type { MarkdownDocumentTab } from "../hooks/useMarkdownDocument";
+import { ContextMenu, type ContextMenuEntry } from "./ContextMenu";
 
 export type MarkdownTabsBarDocumentItem = Pick<MarkdownDocumentTab, "dirty" | "id" | "name"> & {
   displayKind?: "image" | "markdown";
@@ -74,7 +75,6 @@ export function MarkdownTabsBar({
   const [renameFileName, setRenameFileName] = useState("");
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameCancelledRef = useRef(false);
-  const contextMenuRef = useRef<HTMLDivElement | null>(null);
   const [contextMenu, setContextMenu] = useState<TabContextMenuState | null>(null);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
   const [dragOverTabId, setDragOverTabId] = useState<string | null>(null);
@@ -98,25 +98,6 @@ export function MarkdownTabsBar({
     renameInputRef.current.focus();
     renameInputRef.current.select();
   }, [renamingTabId]);
-
-  useEffect(() => {
-    if (!contextMenu) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!contextMenuRef.current?.contains(event.target as Node)) setContextMenu(null);
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setContextMenu(null);
-    };
-
-    window.addEventListener("pointerdown", handlePointerDown);
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("pointerdown", handlePointerDown);
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [contextMenu]);
 
   useEffect(() => () => {
     pointerDragCleanupRef.current?.();
@@ -362,6 +343,65 @@ export function MarkdownTabsBar({
     setContextMenu(null);
     action();
   };
+  const contextMenuEntries: ContextMenuEntry[] = contextMenuTab ? [
+    ...(onRenameTab && contextMenuTab.path
+      ? [
+          {
+            icon: <Pencil aria-hidden="true" size={14} />,
+            id: "markra:tab:rename",
+            kind: "item" as const,
+            label: label("app.renameMarkdownFile"),
+            onSelect: () => runTabContextMenuAction(() => startRenamingTab(contextMenuTab))
+          }
+        ]
+      : []),
+    ...(onOpenTabToSide && contextMenuTab.path && contextMenuTab.displayKind !== "image"
+      ? [
+          {
+            disabled: !contextMenuTabCanOpenToSide,
+            icon: <Columns2 aria-hidden="true" size={14} />,
+            id: "markra:tab:open-to-side",
+            kind: "item" as const,
+            label: label("app.openDocumentToSide"),
+            onSelect: () => runTabContextMenuAction(() => onOpenTabToSide(contextMenuTab.id))
+          }
+        ]
+      : []),
+    ...(onCancelSideBySide && contextMenuTabIsSideBySide
+      ? [
+          {
+            icon: <Columns2 aria-hidden="true" size={14} />,
+            id: "markra:tab:cancel-side-by-side",
+            kind: "item" as const,
+            label: label("app.cancelSideBySideDocuments"),
+            onSelect: () => runTabContextMenuAction(() => onCancelSideBySide(contextMenuTab.id))
+          }
+        ]
+      : []),
+    {
+      icon: <X aria-hidden="true" size={14} />,
+      id: "markra:tab:close",
+      kind: "item",
+      label: label("app.closeDocumentTab"),
+      onSelect: () => runTabContextMenuAction(() => closeTabs([contextMenuTab.id]))
+    },
+    {
+      disabled: contextMenuOtherTabIds.length === 0,
+      icon: <X aria-hidden="true" size={14} />,
+      id: "markra:tab:close-other",
+      kind: "item",
+      label: label("app.closeOtherDocumentTabs"),
+      onSelect: () => runTabContextMenuAction(() => closeTabs(contextMenuOtherTabIds))
+    },
+    {
+      disabled: contextMenuRightTabIds.length === 0,
+      icon: <X aria-hidden="true" size={14} />,
+      id: "markra:tab:close-right",
+      kind: "item",
+      label: label("app.closeDocumentTabsToRight"),
+      onSelect: () => runTabContextMenuAction(() => closeTabs(contextMenuRightTabIds))
+    }
+  ] : [];
   const handlePreventNativeTabDrag = (event: ReactDragEvent) => {
     event.preventDefault();
   };
@@ -574,92 +614,15 @@ export function MarkdownTabsBar({
         </div>
       ) : null}
       {contextMenu && contextMenuTab ? (
-        <div
-          ref={contextMenuRef}
-          className="fixed z-50"
-          style={{
-            left: contextMenu.x,
-            top: contextMenu.y
+        <ContextMenu
+          ariaLabel={contextMenuTab.name || "Untitled.md"}
+          entries={contextMenuEntries}
+          position={{
+            x: contextMenu.x,
+            y: contextMenu.y
           }}
-        >
-          <PopoverSurface
-            className="grid w-52 gap-1 rounded-lg p-1 text-[12px] leading-5 font-[560]"
-            open
-            role="menu"
-            aria-label={contextMenuTab.name || "Untitled.md"}
-            onContextMenu={(event) => event.preventDefault()}
-          >
-            {onRenameTab && contextMenuTab.path ? (
-              <Button
-                className="w-full justify-start rounded-md text-left"
-                size="sm"
-                variant="ghost"
-                role="menuitem"
-                onClick={() => runTabContextMenuAction(() => startRenamingTab(contextMenuTab))}
-              >
-                <Pencil aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-                <span className="truncate">{label("app.renameMarkdownFile")}</span>
-              </Button>
-            ) : null}
-            {onOpenTabToSide && contextMenuTab.path && contextMenuTab.displayKind !== "image" ? (
-              <Button
-                className="w-full justify-start rounded-md text-left"
-                disabled={!contextMenuTabCanOpenToSide}
-                size="sm"
-                variant="ghost"
-                role="menuitem"
-                onClick={() => runTabContextMenuAction(() => onOpenTabToSide(contextMenuTab.id))}
-              >
-                <Columns2 aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-                <span className="truncate">{label("app.openDocumentToSide")}</span>
-              </Button>
-            ) : null}
-            {onCancelSideBySide && contextMenuTabIsSideBySide ? (
-              <Button
-                className="w-full justify-start rounded-md text-left"
-                size="sm"
-                variant="ghost"
-                role="menuitem"
-                onClick={() => runTabContextMenuAction(() => onCancelSideBySide(contextMenuTab.id))}
-              >
-                <Columns2 aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-                <span className="truncate">{label("app.cancelSideBySideDocuments")}</span>
-              </Button>
-            ) : null}
-            <Button
-              className="w-full justify-start rounded-md text-left"
-              size="sm"
-              variant="ghost"
-              role="menuitem"
-              onClick={() => runTabContextMenuAction(() => closeTabs([contextMenuTab.id]))}
-            >
-              <X aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-              <span className="truncate">{label("app.closeDocumentTab")}</span>
-            </Button>
-            <Button
-              className="w-full justify-start rounded-md text-left"
-              disabled={contextMenuOtherTabIds.length === 0}
-              size="sm"
-              variant="ghost"
-              role="menuitem"
-              onClick={() => runTabContextMenuAction(() => closeTabs(contextMenuOtherTabIds))}
-            >
-              <X aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-              <span className="truncate">{label("app.closeOtherDocumentTabs")}</span>
-            </Button>
-            <Button
-              className="w-full justify-start rounded-md text-left"
-              disabled={contextMenuRightTabIds.length === 0}
-              size="sm"
-              variant="ghost"
-              role="menuitem"
-              onClick={() => runTabContextMenuAction(() => closeTabs(contextMenuRightTabIds))}
-            >
-              <X aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-              <span className="truncate">{label("app.closeDocumentTabsToRight")}</span>
-            </Button>
-          </PopoverSurface>
-        </div>
+          onClose={() => setContextMenu(null)}
+        />
       ) : null}
     </section>
   );

--- a/packages/app/src/runtime/context-menu-items.ts
+++ b/packages/app/src/runtime/context-menu-items.ts
@@ -1,0 +1,266 @@
+import {
+  defaultMarkdownShortcuts,
+  markdownShortcutToNativeAccelerator,
+  normalizeMarkdownShortcuts,
+  type MarkdownShortcutAction,
+  type MarkdownShortcutMap
+} from "@markra/editor";
+import { t, type AppLanguage, type I18nKey } from "@markra/shared";
+import {
+  collapseContextMenuEntries,
+  contextMenuItem,
+  contextMenuSeparator,
+  contextMenuSubmenu,
+  type ContextMenuEntry
+} from "../components/ContextMenu";
+import type {
+  NativeEditorContextMenuOptions,
+  NativeMarkdownFileTreeContextMenuHandlers,
+  NativeMenuCommand,
+  NativeMenuHandlers
+} from "../lib/tauri/menu";
+import type { NativeMarkdownFolderFile } from "../lib/tauri/file";
+
+type BrowserEditCommand = "copy" | "cut" | "paste" | "selectAll";
+
+export type ContextMenuIdPrefixes = {
+  editor: string;
+  fileTree: string;
+};
+
+const defaultContextMenuIdPrefixes: ContextMenuIdPrefixes = {
+  editor: "markra:context",
+  fileTree: "markra:file-tree"
+};
+
+const nativeMarkdownShortcutCommands: Partial<Record<MarkdownShortcutAction, NativeMenuCommand>> = {
+  bold: "formatBold",
+  bulletList: "formatBulletList",
+  codeBlock: "formatCodeBlock",
+  heading1: "formatHeading1",
+  heading2: "formatHeading2",
+  heading3: "formatHeading3",
+  image: "insertImage",
+  inlineCode: "formatInlineCode",
+  italic: "formatItalic",
+  link: "insertLink",
+  orderedList: "formatOrderedList",
+  paragraph: "formatParagraph",
+  quote: "formatQuote",
+  strikethrough: "formatStrikethrough",
+  table: "insertTable",
+  toggleAiAgent: "toggleAiAgent",
+  toggleAiCommand: "toggleAiCommand",
+  toggleMarkdownFiles: "toggleMarkdownFiles",
+  toggleReadOnlyMode: "toggleReadOnlyMode",
+  toggleSourceMode: "toggleSourceMode"
+};
+
+function menuLabel(language: AppLanguage, key: I18nKey) {
+  return t(language, key);
+}
+
+function shortcutAccelerator(shortcuts: MarkdownShortcutMap | undefined, action: MarkdownShortcutAction): string | undefined {
+  const shortcut = normalizeMarkdownShortcuts(shortcuts ?? defaultMarkdownShortcuts)[action];
+
+  return markdownShortcutToNativeAccelerator(shortcut) ?? markdownShortcutToNativeAccelerator(defaultMarkdownShortcuts[action]) ?? undefined;
+}
+
+export function nativeAcceleratorsForMarkdownShortcuts(shortcuts: MarkdownShortcutMap | undefined) {
+  const accelerators: Partial<Record<NativeMenuCommand, string>> = {};
+
+  if (!shortcuts) return accelerators;
+
+  for (const [action, command] of Object.entries(nativeMarkdownShortcutCommands) as Array<[MarkdownShortcutAction, NativeMenuCommand]>) {
+    const accelerator = shortcutAccelerator(shortcuts, action);
+    if (accelerator && accelerator !== shortcutAccelerator(defaultMarkdownShortcuts, action)) {
+      accelerators[command] = accelerator;
+    }
+  }
+
+  return accelerators;
+}
+
+function runBrowserEditCommand(command: BrowserEditCommand) {
+  const documentTarget = typeof document === "undefined" ? null : document;
+  const execCommand = documentTarget
+    ? (documentTarget as unknown as Record<string, unknown>)["execCommand"]
+    : null;
+  if (typeof execCommand === "function") {
+    execCommand.call(documentTarget, command);
+  }
+}
+
+function browserItem(id: string, label: string, accelerator: string, command: BrowserEditCommand) {
+  return contextMenuItem(id, label, accelerator, () => runBrowserEditCommand(command), false);
+}
+
+function readAiCommandsAvailable(options: NativeEditorContextMenuOptions) {
+  try {
+    return Boolean(options.getAiCommandsAvailable?.());
+  } catch {
+    return false;
+  }
+}
+
+export function createEditorContextMenuEntries(
+  handlers: NativeMenuHandlers,
+  language: AppLanguage = "en",
+  options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap } = {},
+  idPrefixes: Partial<ContextMenuIdPrefixes> = {}
+): ContextMenuEntry[] {
+  const prefixes = {
+    ...defaultContextMenuIdPrefixes,
+    ...idPrefixes
+  };
+  const editorId = (suffix: string) => `${prefixes.editor}:${suffix}`;
+  const label = (key: I18nKey) => menuLabel(language, key);
+  const formatItems: ContextMenuEntry[] = [
+    contextMenuItem(editorId("bold"), label("menu.bold"), shortcutAccelerator(options.markdownShortcuts, "bold"), handlers.formatBold),
+    contextMenuItem(editorId("italic"), label("menu.italic"), shortcutAccelerator(options.markdownShortcuts, "italic"), handlers.formatItalic),
+    contextMenuItem(
+      editorId("strikethrough"),
+      label("menu.strikethrough"),
+      shortcutAccelerator(options.markdownShortcuts, "strikethrough"),
+      handlers.formatStrikethrough
+    ),
+    contextMenuItem(
+      editorId("inline-code"),
+      label("menu.inlineCode"),
+      shortcutAccelerator(options.markdownShortcuts, "inlineCode"),
+      handlers.formatInlineCode
+    ),
+    contextMenuSeparator(),
+    contextMenuItem(editorId("paragraph"), label("menu.paragraph"), shortcutAccelerator(options.markdownShortcuts, "paragraph"), handlers.formatParagraph),
+    contextMenuItem(editorId("heading-1"), label("menu.heading1"), shortcutAccelerator(options.markdownShortcuts, "heading1"), handlers.formatHeading1),
+    contextMenuItem(editorId("heading-2"), label("menu.heading2"), shortcutAccelerator(options.markdownShortcuts, "heading2"), handlers.formatHeading2),
+    contextMenuItem(editorId("heading-3"), label("menu.heading3"), shortcutAccelerator(options.markdownShortcuts, "heading3"), handlers.formatHeading3),
+    contextMenuSeparator(),
+    contextMenuItem(editorId("bullet-list"), label("menu.bulletList"), shortcutAccelerator(options.markdownShortcuts, "bulletList"), handlers.formatBulletList),
+    contextMenuItem(editorId("ordered-list"), label("menu.orderedList"), shortcutAccelerator(options.markdownShortcuts, "orderedList"), handlers.formatOrderedList),
+    contextMenuItem(editorId("quote"), label("menu.quote"), shortcutAccelerator(options.markdownShortcuts, "quote"), handlers.formatQuote),
+    contextMenuItem(editorId("code-block"), label("menu.codeBlock"), shortcutAccelerator(options.markdownShortcuts, "codeBlock"), handlers.formatCodeBlock)
+  ];
+  const exportMenu = contextMenuSubmenu(editorId("export"), label("menu.export"), [
+    contextMenuItem(editorId("export-pdf"), label("menu.exportPdf"), "CmdOrCtrl+P", handlers.exportPdf),
+    contextMenuItem(editorId("export-html"), label("menu.exportHtml"), "CmdOrCtrl+Shift+E", handlers.exportHtml),
+    contextMenuItem(editorId("export-docx"), label("menu.exportDocx"), undefined, handlers.exportDocx),
+    contextMenuItem(editorId("export-epub"), label("menu.exportEpub"), undefined, handlers.exportEpub),
+    contextMenuItem(editorId("export-latex"), label("menu.exportLatex"), undefined, handlers.exportLatex)
+  ]);
+  const entries: ContextMenuEntry[] = [
+    browserItem(editorId("cut"), label("menu.cut"), "CmdOrCtrl+X", "cut"),
+    browserItem(editorId("copy"), label("menu.copy"), "CmdOrCtrl+C", "copy"),
+    browserItem(editorId("paste"), label("menu.paste"), "CmdOrCtrl+V", "paste"),
+    browserItem(editorId("select-all"), label("menu.selectAll"), "CmdOrCtrl+A", "selectAll"),
+    contextMenuSeparator(),
+    contextMenuSubmenu(editorId("format"), label("menu.format"), formatItems),
+    contextMenuSeparator(),
+    contextMenuItem(editorId("link"), label("menu.link"), shortcutAccelerator(options.markdownShortcuts, "link"), handlers.insertLink),
+    contextMenuItem(editorId("image"), label("menu.image"), shortcutAccelerator(options.markdownShortcuts, "image"), handlers.insertImage),
+    contextMenuItem(editorId("table"), label("menu.table"), shortcutAccelerator(options.markdownShortcuts, "table"), handlers.insertTable)
+  ];
+
+  if (!exportMenu.disabled) {
+    entries.push(contextMenuSeparator(), exportMenu);
+  }
+
+  if (options.aiCommandsAvailable) {
+    entries.push(
+      contextMenuSeparator(),
+      contextMenuSubmenu(editorId("ai"), label("app.aiToolkit"), [
+        contextMenuItem(editorId("ai-polish"), label("app.aiPolish"), undefined, handlers.aiPolish),
+        contextMenuItem(editorId("ai-rewrite"), label("app.aiRewrite"), undefined, handlers.aiRewrite),
+        contextMenuItem(editorId("ai-continue-writing"), label("app.aiContinueWriting"), undefined, handlers.aiContinueWriting),
+        contextMenuItem(editorId("ai-summarize"), label("app.aiSummarize"), undefined, handlers.aiSummarize),
+        contextMenuItem(editorId("ai-translate"), label("app.aiTranslate"), undefined, handlers.aiTranslate)
+      ])
+    );
+  }
+
+  return collapseContextMenuEntries(entries);
+}
+
+export function createEditorContextMenuEntriesFromOptions(
+  handlers: NativeMenuHandlers,
+  language: AppLanguage,
+  options: NativeEditorContextMenuOptions,
+  idPrefixes?: Partial<ContextMenuIdPrefixes>
+) {
+  return createEditorContextMenuEntries(
+    handlers,
+    language,
+    {
+      aiCommandsAvailable: readAiCommandsAvailable(options),
+      markdownShortcuts: options.markdownShortcuts
+    },
+    idPrefixes
+  );
+}
+
+export function createMarkdownFileTreeContextMenuEntries(
+  handlers: NativeMarkdownFileTreeContextMenuHandlers,
+  language: AppLanguage = "en",
+  file?: NativeMarkdownFolderFile,
+  idPrefixes: Partial<ContextMenuIdPrefixes> = {}
+): ContextMenuEntry[] {
+  const prefixes = {
+    ...defaultContextMenuIdPrefixes,
+    ...idPrefixes
+  };
+  const fileTreeId = (suffix: string) => `${prefixes.fileTree}:${suffix}`;
+  const label = (key: I18nKey) => menuLabel(language, key);
+  const fileIsFolder = file?.kind === "folder";
+  const fileIsAsset = file?.kind === "asset";
+  const templateItems = handlers.createFileFromTemplates?.map((template) =>
+    contextMenuItem(fileTreeId(`new-from-template:${template.id}`), template.name, undefined, template.create)
+  ) ?? [];
+  const entries: ContextMenuEntry[] = [
+    contextMenuItem(fileTreeId("new"), label("app.newMarkdownFile"), undefined, handlers.createFile),
+    ...(templateItems.length > 0
+      ? [contextMenuSubmenu(fileTreeId("new-from-template"), label("app.newMarkdownFileFromTemplate"), templateItems)]
+      : []),
+    contextMenuItem(fileTreeId("new-folder"), label("app.newMarkdownFolder"), undefined, handlers.createFolder)
+  ];
+
+  if (!file) return collapseContextMenuEntries(entries);
+
+  if (fileIsFolder) {
+    entries.push(
+      contextMenuSeparator(),
+      contextMenuItem(fileTreeId("delete"), label("app.deleteMarkdownFolder"), undefined, () => handlers.deleteFile?.(file), !handlers.deleteFile)
+    );
+
+    return collapseContextMenuEntries(entries);
+  }
+
+  entries.push(contextMenuSeparator());
+  if (!fileIsAsset && handlers.openFileToSide) {
+    const canOpenFileToSide = handlers.canOpenFileToSide?.(file) ?? true;
+    entries.push(
+      contextMenuItem(
+        fileTreeId("open-to-side"),
+        label("app.openDocumentToSide"),
+        undefined,
+        canOpenFileToSide ? () => handlers.openFileToSide?.(file) : undefined,
+        !canOpenFileToSide
+      )
+    );
+  }
+  if (!fileIsAsset && handlers.saveFileAsTemplate) {
+    entries.push(
+      contextMenuItem(
+        fileTreeId("save-as-template"),
+        label("app.saveMarkdownFileAsTemplate"),
+        undefined,
+        () => handlers.saveFileAsTemplate?.(file)
+      )
+    );
+  }
+  entries.push(
+    contextMenuItem(fileTreeId("rename"), label("app.renameMarkdownFile"), undefined, () => handlers.renameFile?.(file), !handlers.renameFile),
+    contextMenuItem(fileTreeId("delete"), label("app.deleteMarkdownFile"), undefined, () => handlers.deleteFile?.(file), !handlers.deleteFile)
+  );
+
+  return collapseContextMenuEntries(entries);
+}

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -1,6 +1,7 @@
 import type { AppLanguage } from "@markra/shared";
 import type { MarkdownShortcutMap } from "@markra/editor";
 import type { DesktopPlatform } from "../lib/platform";
+import type { ContextMenuEntry } from "../components/ContextMenu";
 import type {
   NativeAiChatRequest,
   NativeAiHttpRequest,
@@ -175,12 +176,12 @@ export type AppMenuRuntime = {
     handlers: NativeMenuHandlers,
     language?: AppLanguage,
     options?: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap }
-  ) => unknown[];
+  ) => ContextMenuEntry[];
   createMarkdownFileTreeContextMenuItems: (
     handlers: NativeMarkdownFileTreeContextMenuHandlers,
     language?: AppLanguage,
     file?: NativeMarkdownFolderFile
-  ) => unknown[];
+  ) => ContextMenuEntry[];
   installApplicationMenu: (
     handlers: NativeMenuHandlers,
     language?: AppLanguage,
@@ -449,6 +450,28 @@ export type {
   UploadNativeS3ImageInput,
   UploadNativeWebDavImageInput
 } from "../lib/tauri/file";
+export type {
+  ContextMenuEntry,
+  ContextMenuPosition,
+  ContextMenuProps,
+  ShowContextMenuOptions
+} from "../components/ContextMenu";
+export {
+  closeActiveContextMenu,
+  contextMenuItem,
+  contextMenuPositionFromEvent,
+  contextMenuSeparator,
+  contextMenuSubmenu,
+  currentContextMenuPosition,
+  showContextMenu
+} from "../components/ContextMenu";
+export {
+  createEditorContextMenuEntries,
+  createEditorContextMenuEntriesFromOptions,
+  createMarkdownFileTreeContextMenuEntries,
+  nativeAcceleratorsForMarkdownShortcuts,
+  type ContextMenuIdPrefixes
+} from "./context-menu-items";
 export type {
   NativeEditorContextMenuOptions,
   NativeMarkdownFileTreeContextMenuHandlers,


### PR DESCRIPTION
## Summary
- add a shared self-drawn ContextMenu component for themed app context menus
- share editor and file tree context menu item generation across desktop and web runtimes
- switch desktop editor/file-tree context menus and tab context menus to the shared UI while keeping the application menu native

## Why
- native desktop context popups do not follow Markra themes such as sepia or custom themes
- sharing the menu renderer keeps web, desktop, and tab menus consistent

## Validation
- `pnpm --filter @markra/app test -- src/components/ContextMenu.test.tsx src/components/MarkdownTabsBar.test.tsx --runInBand` passed
- `pnpm --filter @markra/desktop test -- src/runtime/tauri/menu.test.ts --runInBand` passed
- `pnpm --filter @markra/web test -- src/runtime/web/menu.test.ts --runInBand` passed
- `pnpm --filter @markra/app build && pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/web build && pnpm --filter @markra/web typecheck:test` passed
- `pnpm --filter @markra/desktop build && pnpm --filter @markra/desktop typecheck:test` passed

## Risk
- context menu behavior now depends on the React-rendered menu for editor, file tree, and tab menus; native application menus are unchanged

Closes #158