### PR TITLE
fix(editor): exit blockquotes on Enter

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5159,6 +5159,53 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps Enter inside quote formatting before the quote end", async () => {
+    const { container, editor, view } = await renderEditor(["> First", ">", "> Second"].join("\n"));
+    moveCursor(view, findTextPosition(view, "First", "First".length));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "Middle");
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(container.querySelector(".ProseMirror blockquote")).toHaveTextContent("FirstMiddleSecond");
+    expect(serializeMarkdown(view.state.doc)).toContain("> First\n>\n> Middle");
+    expect(serializeMarkdown(view.state.doc)).toContain("> Second");
+    await settleMarkdownListener();
+  });
+
+  it("exits quote formatting before following prose when pressing Enter at the quote end", async () => {
+    const { editor, view } = await renderEditor(["> Quote", "", "After"].join("\n"));
+    moveCursor(view, findTextPosition(view, "Quote", "Quote".length));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "Next");
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    expect(serializeMarkdown(view.state.doc)).toBe("> Quote\n\nNext\n\nAfter\n");
+    await settleMarkdownListener();
+  });
+
+  it("finalizes live markdown inside quote formatting before exiting on the next Enter", async () => {
+    const { container, editor, view } = await renderEditor("> ");
+    moveCursor(view, findFirstTextBlockCursor(view));
+    typeText(view, "**Quote**");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expectLiveMark(container, "strong", "Quote");
+    expect(pressEnter(view)).toBe(true);
+    expect(container.querySelector(".ProseMirror blockquote strong")).toHaveTextContent("Quote");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "Next");
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    expect(serializeMarkdown(view.state.doc)).toBe("> **Quote**\n\nNext\n");
+    await settleMarkdownListener();
+  });
+
   it("keeps the cursor inside quote formatting when pressing Shift+Enter", async () => {
     const { container, view } = await renderEditor("> Quote");
     moveCursor(view, findTextPosition(view, "Quote", "Quote".length));

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5130,15 +5130,46 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("keeps empty quote formatting when pressing Enter", async () => {
-    const { container, view } = await renderEditor("> ");
+  it("exits empty quote formatting when pressing Enter", async () => {
+    const { container, editor, view } = await renderEditor("> ");
     moveCursor(view, findFirstTextBlockCursor(view));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
 
     expect(container.querySelector(".ProseMirror blockquote")).toBeInTheDocument();
     expect(pressEnter(view)).toBe(true);
 
-    expect(container.querySelector(".ProseMirror blockquote")).toBeInTheDocument();
-    expect(container.querySelector(".ProseMirror")?.textContent).toBe("");
+    expect(container.querySelector(".ProseMirror blockquote")).not.toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    typeText(view, "Next");
+    expect(serializeMarkdown(view.state.doc)).toBe("Next\n");
+    await settleMarkdownListener();
+  });
+
+  it("exits quote formatting when pressing Enter at the quote end", async () => {
+    const { container, editor, view } = await renderEditor("> Quote");
+    moveCursor(view, findTextPosition(view, "Quote", "Quote".length));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(container.querySelector(".ProseMirror blockquote")).toHaveTextContent("Quote");
+    expect(pressEnter(view)).toBe(true);
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    typeText(view, "Next");
+    expect(serializeMarkdown(view.state.doc)).toBe("> Quote\n\nNext\n");
+    await settleMarkdownListener();
+  });
+
+  it("keeps the cursor inside quote formatting when pressing Shift+Enter", async () => {
+    const { container, view } = await renderEditor("> Quote");
+    moveCursor(view, findTextPosition(view, "Quote", "Quote".length));
+
+    expect(pressShortcut(view, "Enter", { shiftKey: true })).toBe(true);
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    typeText(view, "Next");
+    expect(container.querySelector(".ProseMirror blockquote br")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote")).toHaveTextContent("QuoteNext");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
     await settleMarkdownListener();
   });
 

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -1,3 +1,4 @@
+import type { Ctx } from "@milkdown/kit/ctx";
 import { emphasisSchema, inlineCodeSchema, strongSchema } from "@milkdown/kit/preset/commonmark";
 import { strikethroughSchema } from "@milkdown/kit/preset/gfm";
 import type { Mark, MarkType, Node as ProseNode } from "@milkdown/kit/prose/model";
@@ -5,20 +6,20 @@ import { type EditorState, Plugin, PluginKey, TextSelection } from "@milkdown/ki
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
-type LiveMarkdownKind = "strong" | "emphasis" | "inlineCode" | "strikethrough" | "highlight";
+export type LiveMarkdownKind = "strong" | "emphasis" | "inlineCode" | "strikethrough" | "highlight";
 
 export type MarkraLiveMarkdownOptions = {
   highlight?: boolean;
 };
 
-type LiveMarkdownSpec = {
+export type LiveMarkdownSpec = {
   markers: string[];
   pattern: RegExp;
   marks: LiveMarkdownMark[];
   kinds?: LiveMarkdownKind[];
 };
 
-type LiveMarkdownMark = {
+export type LiveMarkdownMark = {
   kind: LiveMarkdownKind;
   markType: MarkType;
   getAttr?: (marker: string) => Record<string, unknown>;
@@ -444,7 +445,7 @@ function findActiveLiveMarkdownRange(state: EditorState, specs: LiveMarkdownSpec
   };
 }
 
-function finalizeActiveLiveMarkdown(view: EditorView, specs: LiveMarkdownSpec[]) {
+export function finalizeActiveLiveMarkdown(view: EditorView, specs: LiveMarkdownSpec[]) {
   const active = findActiveLiveMarkdownRange(view.state, specs);
   if (!active) return false;
 
@@ -539,8 +540,8 @@ function moveCursorOverLiveMarkdownDelimiter(
   return true;
 }
 
-export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}) => $prose((ctx) => {
-  const specs: LiveMarkdownSpec[] = [
+export function markraLiveMarkdownSpecs(ctx: Ctx, options: MarkraLiveMarkdownOptions = {}): LiveMarkdownSpec[] {
+  return [
     {
       markers: ["`"],
       pattern: /`[^`\n]*?`/g,
@@ -664,6 +665,10 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       ]
     }
   ];
+}
+
+export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}) => $prose((ctx) => {
+  const specs = markraLiveMarkdownSpecs(ctx, options);
   const managedMarkTypes = getManagedMarkTypes(specs);
 
   return new Plugin({

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -38,6 +38,7 @@ import {
   type MarkdownFormattingShortcutAction,
   type ParsedKeyboardShortcut
 } from "@markra/shared";
+import { finalizeActiveLiveMarkdown, markraLiveMarkdownSpecs } from "./input-rules.ts";
 
 export const markdownShortcutActions = keyboardShortcutActions;
 export const defaultMarkdownShortcuts = defaultKeyboardShortcuts;
@@ -253,6 +254,7 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
   const orderedList = orderedListSchema.type(ctx);
   const blockquote = blockquoteSchema.type(ctx);
   const codeBlock = codeBlockSchema.type(ctx);
+  const liveMarkdownSpecs = markraLiveMarkdownSpecs(ctx);
   const shortcuts = normalizeMarkdownShortcuts(configuredShortcuts);
   const shortcutCommands: Record<MarkdownFormattingShortcutAction, Command> = {
     bold: toggleMark(strong),
@@ -277,6 +279,13 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
 
         // Support both Milkdown-style shortcuts and common document-editor aliases.
         if (event.key === "Enter" && !hasModifier && selectionIsInsideNodeType(view.state.selection, blockquote)) {
+          const finalizedLiveMarkdown = finalizeActiveLiveMarkdown(view, liveMarkdownSpecs);
+          if (finalizedLiveMarkdown) {
+            event.preventDefault();
+            view.focus();
+            return true;
+          }
+
           const handled = exitBlockquoteAtEnd(view, blockquote, paragraph);
           if (handled) {
             event.preventDefault();

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -13,7 +13,7 @@ import {
 import { strikethroughSchema } from "@milkdown/kit/preset/gfm";
 import { exitCode, lift, setBlockType, toggleMark, wrapIn } from "@milkdown/kit/prose/commands";
 import { redo, undo } from "@milkdown/kit/prose/history";
-import type { NodeType } from "@milkdown/kit/prose/model";
+import type { NodeType, ResolvedPos } from "@milkdown/kit/prose/model";
 import type { Command, Selection } from "@milkdown/kit/prose/state";
 import { NodeSelection, Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
@@ -99,6 +99,46 @@ function selectionIsEmptyTextBlock(selection: Selection) {
 
 function selectionIsEmptyBlockquote(selection: Selection, blockquote: NodeType) {
   return selectionIsEmptyTextBlock(selection) && selectionIsInsideNodeType(selection, blockquote);
+}
+
+function ancestorDepthOfNodeType($position: ResolvedPos, nodeType: NodeType) {
+  for (let depth = $position.depth; depth > 0; depth -= 1) {
+    if ($position.node(depth).type === nodeType) return depth;
+  }
+
+  return null;
+}
+
+function blockquoteExitDepth(selection: Selection, blockquote: NodeType) {
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+  if (!selection.$from.parent.isTextblock) return null;
+  if (selection.$from.parentOffset !== selection.$from.parent.content.size) return null;
+
+  const blockquoteDepth = ancestorDepthOfNodeType(selection.$from, blockquote);
+  if (blockquoteDepth === null) return null;
+  if (selection.$from.after(selection.$from.depth) !== selection.$from.end(blockquoteDepth)) return null;
+
+  return blockquoteDepth;
+}
+
+function exitBlockquoteAtEnd(view: EditorView, blockquote: NodeType, paragraph: NodeType) {
+  const blockquoteDepth = blockquoteExitDepth(view.state.selection, blockquote);
+  if (blockquoteDepth === null) return false;
+
+  if (selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
+    return runCommand(view, lift);
+  }
+
+  const insertAt = view.state.selection.$from.after(blockquoteDepth);
+  const transaction = view.state.tr.insert(insertAt, paragraph.create());
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, insertAt + 1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
 }
 
 function emptyTopLevelParagraphAfterTable(view: EditorView, paragraph: NodeType) {
@@ -236,10 +276,18 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
         const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
 
         // Support both Milkdown-style shortcuts and common document-editor aliases.
-        if (event.key === "Enter" && !hasModifier && selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
-          event.preventDefault();
-          view.focus();
-          return true;
+        if (event.key === "Enter" && !hasModifier && selectionIsInsideNodeType(view.state.selection, blockquote)) {
+          const handled = exitBlockquoteAtEnd(view, blockquote, paragraph);
+          if (handled) {
+            event.preventDefault();
+            return true;
+          }
+
+          if (selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
+            event.preventDefault();
+            view.focus();
+            return true;
+          }
         } else if (event.key === "Backspace" && !hasModifier && selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
           const handled = runCommand(view, lift);
           if (!handled) return false;


### PR DESCRIPTION
## Summary
- Exit blockquote formatting when pressing `Enter` at the end of an empty or non-empty quote.
- Keep `Shift+Enter` inside the current quote as an in-quote line break.
- Preserve existing quote editing behavior before the quote end and when finalizing live inline Markdown.
- Update Markdown editor tests for the new quote Enter behavior and regression boundaries.

## Why
The previous shortcut handler swallowed `Enter` in empty blockquotes and kept the cursor inside blockquotes at the end of quoted content, which made quote line breaks feel stuck and unintuitive.

A follow-up regression check found that quote exit could preempt live Markdown finalization inside quotes. This PR now finalizes active inline Markdown first, then exits the quote on the next `Enter`, matching the existing editor behavior outside quotes.

## Validation
- `pnpm exec vitest run src/components/MarkdownPaper.test.tsx -t "quote formatting"` passed: 8 tests.
- `pnpm exec vitest run src/components/MarkdownPaper.test.tsx` passed: 266 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm test` passed.
- `pnpm build` passed.
- GitHub PR checks passed: Frontend, Tauri Rust, Vercel, Vercel Preview Comments.

Closes #182
