### PR TITLE
fix(titlebar): keep Windows document tabs clickable

### DIFF
--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -288,14 +288,17 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".native-titlebar")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".document-actions")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".native-title-slot")).not.toHaveAttribute("data-tauri-drag-region");
-    expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
+    expect(container.querySelector(".native-titlebar")).toHaveStyle({
+      gridTemplateColumns: "minmax(0,1fr) 164px 384px"
+    });
+    expect(container.querySelector(".windows-titlebar-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     expect(toggleSourceMode).toHaveBeenCalledTimes(1);
   });
 
-  it("reserves AI panel width for Windows titlebar tabs when file actions shift left", () => {
+  it("reserves AI panel width as a separate Windows titlebar column so action hitboxes stay narrow", () => {
     const { container } = render(
       <NativeTitleBar
         aiAgentOpen
@@ -319,9 +322,9 @@ describe("NativeTitleBar", () => {
     );
 
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 548px"
+      gridTemplateColumns: "minmax(0,1fr) 164px 384px"
     });
-    expect(container.querySelector(".windows-titlebar-actions")).toHaveStyle({ transform: "translateX(-384px)" });
+    expect(container.querySelector(".windows-titlebar-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
   });
 
   it("keeps compact Windows file actions clear of the Markra AI panel", () => {

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -517,10 +517,11 @@ export function NativeTitleBar({
 
   if (platform === "windows") {
     if (titleContent) {
-      const windowsTitlebarActionSlotWidth = titlebarSideSlotWidth + (aiAgentOpen ? aiAgentWidth : 0);
       const windowsTitlebarStyle: CSSProperties = {
         ...(markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
-        gridTemplateColumns: `minmax(0,1fr) ${windowsTitlebarActionSlotWidth}px`
+        gridTemplateColumns: aiAgentOpen
+          ? `minmax(0,1fr) ${titlebarSideSlotWidth}px ${aiAgentWidth}px`
+          : `minmax(0,1fr) ${titlebarSideSlotWidth}px`
       };
 
       return (
@@ -532,7 +533,6 @@ export function NativeTitleBar({
           {renderTitleContent("native-title-slot min-w-0 h-10 pr-3 pl-4")}
           <div
             className={`windows-titlebar-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 ${windowsTitlebarActionsTransitionClassName} hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none`}
-            style={windowsTitlebarActionsStyle}
           >
             {renderDocumentActions("document-actions relative flex h-10 items-center justify-end gap-0.5")}
           </div>


### PR DESCRIPTION
## Summary
- Reserve the AI panel width as a separate Windows titlebar grid column when document tabs are visible.
- Keep the Windows titlebar action hitbox limited to the actual action column so it does not cover tabs or the new-tab button.
- Update titlebar tests to lock the non-overlapping layout behavior.

## Why
When the AI panel was open on Windows, the titlebar actions were shifted left with a wide transformed container. The transparent part of that container could sit over the document tabs, making later tabs and the new-tab/close controls stop receiving clicks.

## Validation
- `pnpm --filter @markra/app test` passed
- `pnpm --filter @markra/app build` passed

## Related Issues
Closes #196