### PR TITLE
feat(search): add workspace content search

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2093,7 +2093,7 @@ describe("Markra workspace", () => {
   });
 
   it("switches between unmodified folder files without asking to discard changes", async () => {
-    const guidePath = "/mock-files/vault/docs/guide.md";
+    const guidePath = "/mock-files/vault/guide.md";
     const notesPath = "/mock-files/vault/docs/notes.md";
     mockedOpenNativeMarkdownPath.mockResolvedValue({
       kind: "folder",
@@ -4031,6 +4031,36 @@ describe("Markra workspace", () => {
     expect(searchInput).toHaveAttribute("autocorrect", "off");
     expect(searchInput).toHaveAttribute("spellcheck", "false");
     expect(container.querySelector(".editor-content-slot")).toHaveAttribute("data-document-search-open", "true");
+  });
+
+  it("does not open document search after opening a workspace search result", async () => {
+    const guidePath = "/mock-files/vault/docs/guide.md";
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      name: "vault",
+      path: mockFolderPath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "guide.md", path: guidePath, relativePath: "guide.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nSynthetic alpha note.",
+      name: "guide.md",
+      path: guidePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true, shiftKey: true });
+    expect(await screen.findByRole("button", { name: "guide.md" })).toBeInTheDocument();
+
+    expect(fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true })).toBe(false);
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search workspace" }), {
+      target: { value: "alpha" }
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Open guide.md line 3" }));
+
+    expect(await screen.findByText("Guide")).toBeInTheDocument();
+    expect(screen.queryByRole("search", { name: "Find in document" })).not.toBeInTheDocument();
   });
 
   it("does not open the AI command when visual document search focuses a match", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -17,6 +17,7 @@ import { AiAgentPanel } from "./components/AiAgentPanel";
 import { AiSelectionToolbar } from "./components/AiSelectionToolbar";
 import { DocumentHistoryDialog } from "./components/DocumentHistoryDialog";
 import { DocumentSearchBar } from "./components/DocumentSearchBar";
+import { GlobalSearchPanel } from "./components/GlobalSearchPanel";
 import { ImagePreview } from "./components/ImagePreview";
 import {
   MarkdownExportDocument,
@@ -81,6 +82,11 @@ import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
 import { replaceMovedPath } from "./lib/path-move";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
+import {
+  searchWorkspaceFiles,
+  type WorkspaceSearchResponse,
+  type WorkspaceSearchResult
+} from "./lib/workspace-search";
 import type {
   SelectionHeadingLevel,
   SelectionFormattingAction,
@@ -150,6 +156,11 @@ const sideDocumentPaneKeyboardStepPercent = 5;
 const sideDocumentMainPanePercentMin = 35;
 const sideDocumentMainPanePercentMax = 70;
 const defaultSideDocumentMainPanePercent = 50;
+const emptyWorkspaceSearchResponse: WorkspaceSearchResponse = {
+  results: [],
+  searchedFileCount: 0,
+  unreadableFileCount: 0
+};
 
 type ImageDocumentTab = NativeMarkdownFolderFile & {
   id: string;
@@ -345,6 +356,11 @@ function WorkspaceApp() {
   const [documentSearchActiveIndex, setDocumentSearchActiveIndex] = useState(0);
   const [documentSearchRevealRevision, setDocumentSearchRevealRevision] = useState(0);
   const [visualDocumentSearchMatches, setVisualDocumentSearchMatches] = useState<SearchRange[]>([]);
+  const [globalSearchOpen, setGlobalSearchOpen] = useState(false);
+  const [globalSearchQuery, setGlobalSearchQuery] = useState("");
+  const [globalSearchCaseSensitive, setGlobalSearchCaseSensitive] = useState(false);
+  const [globalSearchLoading, setGlobalSearchLoading] = useState(false);
+  const [globalSearchResponse, setGlobalSearchResponse] = useState<WorkspaceSearchResponse>(emptyWorkspaceSearchResponse);
   const [documentHistoryOpen, setDocumentHistoryOpen] = useState(false);
   const [documentHistoryRefreshKey, setDocumentHistoryRefreshKey] = useState(0);
   const [splitVisualPanePercent, setSplitVisualPanePercent] = useState(defaultSplitVisualPanePercent);
@@ -1812,6 +1828,80 @@ function WorkspaceApp() {
     setActiveImageFile(null);
     await openTreeMarkdownFile(file);
   }, [captureActiveDocumentViewState, openImageTab, openTreeMarkdownFile]);
+  const handleGlobalSearchOpen = useCallback(() => {
+    setGlobalSearchOpen(true);
+  }, []);
+  const handleGlobalSearchClose = useCallback(() => {
+    setGlobalSearchOpen(false);
+  }, []);
+  const handleGlobalSearchQueryChange = useCallback((query: string) => {
+    setGlobalSearchQuery(query);
+  }, []);
+  const handleGlobalSearchCaseSensitiveChange = useCallback((caseSensitive: boolean) => {
+    setGlobalSearchCaseSensitive(caseSensitive);
+  }, []);
+  const handleGlobalSearchResultOpen = useCallback(async (result: WorkspaceSearchResult) => {
+    setGlobalSearchOpen(false);
+    await handleOpenTreeFile(result.file);
+    if (!documentSearchOpen) return;
+
+    setDocumentSearchQuery(globalSearchQuery.trim());
+    setDocumentSearchCaseSensitive(globalSearchCaseSensitive);
+    setDocumentSearchReplaceOpen(false);
+    setDocumentSearchActiveIndex(result.matchIndex);
+    setDocumentSearchRevealRevision((current) => current + 1);
+  }, [documentSearchOpen, globalSearchCaseSensitive, globalSearchQuery, handleOpenTreeFile]);
+  useEffect(() => {
+    const query = globalSearchQuery.trim();
+    if (!globalSearchOpen || !query) {
+      setGlobalSearchLoading(false);
+      setGlobalSearchResponse({
+        ...emptyWorkspaceSearchResponse,
+        searchedFileCount: fileTreeFiles.filter((file) => file.kind !== "asset" && file.kind !== "folder").length
+      });
+      return;
+    }
+
+    let active = true;
+    setGlobalSearchLoading(true);
+
+    searchWorkspaceFiles(fileTreeFiles, query, {
+      caseSensitive: globalSearchCaseSensitive,
+      readFile: async (path) => {
+        if (!activeImageFile && document.path === path) {
+          return {
+            content: document.content,
+            path
+          };
+        }
+
+        const file = await readNativeMarkdownFile(path);
+
+        return {
+          content: file.content,
+          path: file.path
+        };
+      }
+    }).then((response) => {
+      if (active) setGlobalSearchResponse(response);
+    }).catch(() => {
+      if (active) setGlobalSearchResponse(emptyWorkspaceSearchResponse);
+    }).finally(() => {
+      if (active) setGlobalSearchLoading(false);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    activeImageFile,
+    document.content,
+    document.path,
+    fileTreeFiles,
+    globalSearchCaseSensitive,
+    globalSearchOpen,
+    globalSearchQuery
+  ]);
   const handleOpenTreeFileToSide = useCallback(async (file: NativeMarkdownFolderFile) => {
     captureActiveDocumentViewState();
 
@@ -2623,6 +2713,7 @@ function WorkspaceApp() {
     openDocument: handleOpenMarkdownFile,
     openDocumentReplace: handleDocumentReplaceOpen,
     openDocumentSearch: handleDocumentSearchOpen,
+    openWorkspaceSearch: handleGlobalSearchOpen,
     openFolder: handleOpenMarkdownFolder,
     saveDocument: handleSaveDocument,
     saveDocumentAs,
@@ -3000,6 +3091,21 @@ function WorkspaceApp() {
               onDragOver={handleEditorContentDragOver}
               onDrop={handleEditorContentDrop}
             >
+              {globalSearchOpen ? (
+                <GlobalSearchPanel
+                  caseSensitive={globalSearchCaseSensitive}
+                  language={appLanguage.language}
+                  loading={globalSearchLoading}
+                  query={globalSearchQuery}
+                  results={globalSearchResponse.results}
+                  searchedFileCount={globalSearchResponse.searchedFileCount}
+                  unreadableFileCount={globalSearchResponse.unreadableFileCount}
+                  onCaseSensitiveChange={handleGlobalSearchCaseSensitiveChange}
+                  onClose={handleGlobalSearchClose}
+                  onOpenResult={handleGlobalSearchResultOpen}
+                  onQueryChange={handleGlobalSearchQueryChange}
+                />
+              ) : null}
               {documentSearchOpen && documentSearchAvailable ? (
                 <DocumentSearchBar
                   activeIndex={normalizedDocumentSearchActiveIndex}

--- a/packages/app/src/components/GlobalSearchPanel.test.tsx
+++ b/packages/app/src/components/GlobalSearchPanel.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { GlobalSearchPanel } from "./GlobalSearchPanel";
+import type { WorkspaceSearchResult } from "../lib/workspace-search";
+
+const result = {
+  columnNumber: 7,
+  file: {
+    name: "guide.md",
+    path: "/mock-vault/guide.md",
+    relativePath: "docs/guide.md"
+  },
+  id: "/mock-vault/guide.md:0",
+  lineNumber: 3,
+  lineText: "First alpha note",
+  match: { from: 6, to: 11 },
+  matchIndex: 0,
+  snippet: "First alpha note"
+} satisfies WorkspaceSearchResult;
+
+const secondResult = {
+  columnNumber: 12,
+  file: result.file,
+  id: "/mock-vault/guide.md:24",
+  lineNumber: 5,
+  lineText: "Second alpha entry",
+  match: { from: 37, to: 42 },
+  matchIndex: 1,
+  snippet: "Second alpha entry"
+} satisfies WorkspaceSearchResult;
+
+const otherFileResult = {
+  columnNumber: 1,
+  file: {
+    name: "notes.md",
+    path: "/mock-vault/notes.md",
+    relativePath: "notes.md"
+  },
+  id: "/mock-vault/notes.md:0",
+  lineNumber: 1,
+  lineText: "alpha in root",
+  match: { from: 0, to: 5 },
+  matchIndex: 0,
+  snippet: "alpha in root"
+} satisfies WorkspaceSearchResult;
+
+describe("GlobalSearchPanel", () => {
+  it("groups workspace search results by file and opens a selected match", () => {
+    const openResult = vi.fn();
+    render(
+      <GlobalSearchPanel
+        caseSensitive={false}
+        language="en"
+        loading={false}
+        query="alpha"
+        results={[result, secondResult, otherFileResult]}
+        searchedFileCount={2}
+        unreadableFileCount={0}
+        onCaseSensitiveChange={() => {}}
+        onClose={() => {}}
+        onOpenResult={openResult}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Search workspace" });
+    const results = within(dialog).getByRole("list", { name: "Search results" });
+
+    expect(within(dialog).getByRole("searchbox", { name: "Search workspace" })).toHaveValue("alpha");
+    expect(within(dialog).getByText("3 results")).toBeInTheDocument();
+
+    const guideGroup = within(results).getByRole("group", { name: "docs/guide.md search results" });
+    expect(within(guideGroup).getByRole("button", { name: "Collapse docs/guide.md search results" })).toHaveTextContent("2");
+    expect(within(guideGroup).getByText("guide.md")).toBeInTheDocument();
+    expect(within(guideGroup).getByText("docs /")).toBeInTheDocument();
+    expect(within(guideGroup).getByRole("button", { name: "Open docs/guide.md line 3" })).toHaveTextContent("First alpha note");
+    expect(within(guideGroup).getByRole("button", { name: "Open docs/guide.md line 5" })).toHaveTextContent("Second alpha entry");
+
+    const notesGroup = within(results).getByRole("group", { name: "notes.md search results" });
+    expect(within(notesGroup).getByRole("button", { name: "Collapse notes.md search results" })).toHaveTextContent("1");
+    expect(within(notesGroup).queryByText("/")).not.toBeInTheDocument();
+
+    fireEvent.click(within(guideGroup).getByRole("button", { name: "Open docs/guide.md line 3" }));
+
+    expect(openResult).toHaveBeenCalledWith(result);
+  });
+
+  it("highlights matching text in search result snippets", () => {
+    render(
+      <GlobalSearchPanel
+        caseSensitive={false}
+        language="en"
+        loading={false}
+        query="alpha"
+        results={[result]}
+        searchedFileCount={1}
+        unreadableFileCount={0}
+        onCaseSensitiveChange={() => {}}
+        onClose={() => {}}
+        onOpenResult={() => {}}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const snippet = within(screen.getByRole("button", { name: "Open docs/guide.md line 3" }))
+      .getByText((_, element) => element?.tagName.toLowerCase() === "span" && element.textContent === "First alpha note");
+    const highlight = snippet.querySelector("mark");
+
+    expect(highlight).toHaveTextContent("alpha");
+    expect(highlight).toHaveClass("global-search-match");
+  });
+
+  it("toggles case-sensitive search", () => {
+    const setCaseSensitive = vi.fn();
+    render(
+      <GlobalSearchPanel
+        caseSensitive={false}
+        language="en"
+        loading={false}
+        query=""
+        results={[]}
+        searchedFileCount={0}
+        unreadableFileCount={0}
+        onCaseSensitiveChange={setCaseSensitive}
+        onClose={() => {}}
+        onOpenResult={() => {}}
+        onQueryChange={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Case sensitive" }));
+
+    expect(setCaseSensitive).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/app/src/components/GlobalSearchPanel.tsx
+++ b/packages/app/src/components/GlobalSearchPanel.tsx
@@ -1,0 +1,347 @@
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { CaseSensitive, ChevronDown, ChevronRight, Loader2, Search, X } from "lucide-react";
+import { findSearchRanges, type AppLanguage } from "@markra/shared";
+import type { WorkspaceSearchResult } from "../lib/workspace-search";
+
+type GlobalSearchPanelProps = {
+  caseSensitive: boolean;
+  language?: AppLanguage;
+  loading: boolean;
+  query: string;
+  results: readonly WorkspaceSearchResult[];
+  searchedFileCount: number;
+  unreadableFileCount: number;
+  onCaseSensitiveChange: (caseSensitive: boolean) => unknown;
+  onClose: () => unknown;
+  onOpenResult: (result: WorkspaceSearchResult) => unknown;
+  onQueryChange: (query: string) => unknown;
+};
+
+const labels: Record<string, {
+  caseSensitive: string;
+  close: string;
+  empty: string;
+  files: (count: number) => string;
+  collapseFile: (path: string) => string;
+  expandFile: (path: string) => string;
+  fileSearchResults: (path: string) => string;
+  loading: string;
+  noResults: string;
+  openResult: (path: string, line: number) => string;
+  placeholder: string;
+  results: string;
+  resultCount: (count: number) => string;
+  searchWorkspace: string;
+  showMoreMatches: (count: number) => string;
+  unreadable: (count: number) => string;
+}> = {
+  en: {
+    caseSensitive: "Case sensitive",
+    close: "Close search",
+    empty: "Type to search",
+    files: (count) => `${count} file${count === 1 ? "" : "s"}`,
+    collapseFile: (path) => `Collapse ${path} search results`,
+    expandFile: (path) => `Expand ${path} search results`,
+    fileSearchResults: (path) => `${path} search results`,
+    loading: "Searching...",
+    noResults: "No results",
+    openResult: (path, line) => `Open ${path} line ${line}`,
+    placeholder: "Search files",
+    results: "Search results",
+    resultCount: (count) => `${count} result${count === 1 ? "" : "s"}`,
+    searchWorkspace: "Search workspace",
+    showMoreMatches: (count) => `show ${count} more match${count === 1 ? "" : "es"}`,
+    unreadable: (count) => `${count} unreadable`
+  },
+  "zh-CN": {
+    caseSensitive: "区分大小写",
+    close: "关闭搜索",
+    empty: "输入关键词搜索",
+    files: (count) => `${count} 个文件`,
+    collapseFile: (path) => `折叠 ${path} 的搜索结果`,
+    expandFile: (path) => `展开 ${path} 的搜索结果`,
+    fileSearchResults: (path) => `${path} 搜索结果`,
+    loading: "搜索中...",
+    noResults: "没有结果",
+    openResult: (path, line) => `打开 ${path} 第 ${line} 行`,
+    placeholder: "搜索文件内容",
+    results: "搜索结果",
+    resultCount: (count) => `${count} 个结果`,
+    searchWorkspace: "全局搜索",
+    showMoreMatches: (count) => `显示另外 ${count} 个匹配`,
+    unreadable: (count) => `${count} 个文件不可读`
+  },
+  "zh-TW": {
+    caseSensitive: "區分大小寫",
+    close: "關閉搜尋",
+    empty: "輸入關鍵字搜尋",
+    files: (count) => `${count} 個檔案`,
+    collapseFile: (path) => `摺疊 ${path} 的搜尋結果`,
+    expandFile: (path) => `展開 ${path} 的搜尋結果`,
+    fileSearchResults: (path) => `${path} 搜尋結果`,
+    loading: "搜尋中...",
+    noResults: "沒有結果",
+    openResult: (path, line) => `開啟 ${path} 第 ${line} 行`,
+    placeholder: "搜尋檔案內容",
+    results: "搜尋結果",
+    resultCount: (count) => `${count} 個結果`,
+    searchWorkspace: "全域搜尋",
+    showMoreMatches: (count) => `顯示另外 ${count} 個相符項目`,
+    unreadable: (count) => `${count} 個檔案無法讀取`
+  }
+};
+
+type GlobalSearchResultGroup = {
+  file: WorkspaceSearchResult["file"];
+  results: WorkspaceSearchResult[];
+};
+
+const collapsedGroupPreviewCount = 4;
+
+function globalSearchLabels(language: AppLanguage) {
+  return labels[language] ?? labels.en;
+}
+
+function groupSearchResultsByFile(results: readonly WorkspaceSearchResult[]) {
+  const groups = new Map<string, GlobalSearchResultGroup>();
+
+  results.forEach((result) => {
+    const currentGroup = groups.get(result.file.path);
+    if (currentGroup) {
+      currentGroup.results.push(result);
+      return;
+    }
+
+    groups.set(result.file.path, {
+      file: result.file,
+      results: [result]
+    });
+  });
+
+  return Array.from(groups.values());
+}
+
+function directoryLabelFromRelativePath(relativePath: string) {
+  const normalizedPath = relativePath.replaceAll("\\", "/");
+  const lastSeparatorIndex = normalizedPath.lastIndexOf("/");
+  if (lastSeparatorIndex < 0) return null;
+
+  const directory = normalizedPath.slice(0, lastSeparatorIndex).trim();
+  return directory ? `${directory} /` : null;
+}
+
+function renderHighlightedSnippet(snippet: string, query: string, caseSensitive: boolean) {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return snippet;
+
+  const ranges = findSearchRanges(snippet, normalizedQuery, { caseSensitive });
+  if (ranges.length === 0) return snippet;
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+
+  ranges.forEach((range, index) => {
+    if (range.from > cursor) nodes.push(snippet.slice(cursor, range.from));
+
+    nodes.push(
+      <mark
+        className="global-search-match rounded-xs bg-(--accent-soft) px-0.5 font-bold text-(--text-heading)"
+        key={`${range.from}:${range.to}:${index}`}
+      >
+        {snippet.slice(range.from, range.to)}
+      </mark>
+    );
+    cursor = range.to;
+  });
+
+  if (cursor < snippet.length) nodes.push(snippet.slice(cursor));
+
+  return nodes;
+}
+
+export function GlobalSearchPanel({
+  caseSensitive,
+  language = "en",
+  loading,
+  query,
+  results,
+  searchedFileCount,
+  unreadableFileCount,
+  onCaseSensitiveChange,
+  onClose,
+  onOpenResult,
+  onQueryChange
+}: GlobalSearchPanelProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const label = globalSearchLabels(language);
+  const [collapsedFilePaths, setCollapsedFilePaths] = useState<Set<string>>(() => new Set());
+  const [expandedPreviewFilePaths, setExpandedPreviewFilePaths] = useState<Set<string>>(() => new Set());
+  const resultGroups = useMemo(() => groupSearchResultsByFile(results), [results]);
+  const showNoResults = query.trim().length > 0 && !loading && results.length === 0;
+  const statusText = loading ? label.loading : label.resultCount(results.length);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Escape") return;
+
+    event.preventDefault();
+    onClose();
+  };
+
+  const toggleFileGroup = (path: string) => {
+    setCollapsedFilePaths((current) => {
+      const next = new Set(current);
+
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+
+      return next;
+    });
+  };
+
+  const expandFilePreview = (path: string) => {
+    setExpandedPreviewFilePaths((current) => new Set(current).add(path));
+  };
+
+  return (
+    <div
+      className="global-search-panel absolute left-1/2 top-14 z-50 flex w-[min(calc(100%-2rem),640px)] -translate-x-1/2 flex-col overflow-hidden rounded-md border border-(--border-strong) bg-(--bg-secondary)/98 text-[12px] text-(--text-primary) shadow-[0_18px_58px_rgba(0,0,0,0.18)] backdrop-blur-sm"
+      role="dialog"
+      aria-label={label.searchWorkspace}
+    >
+      <div className="flex min-w-0 items-center gap-1.5 border-b border-(--border-default) p-2">
+        <Search aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={15} />
+        <input
+          className="h-8 min-w-0 flex-1 rounded-sm border border-(--border-default) bg-(--bg-primary) px-2 text-[12px] text-(--text-heading) outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-(--text-secondary) focus:border-(--accent) focus:shadow-[0_0_0_2px_var(--accent-soft)]"
+          aria-label={label.searchWorkspace}
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect="off"
+          placeholder={label.placeholder}
+          ref={inputRef}
+          role="searchbox"
+          spellCheck={false}
+          type="search"
+          value={query}
+          onChange={(event) => onQueryChange(event.currentTarget.value)}
+          onKeyDown={handleSearchKeyDown}
+        />
+        <button
+          className="document-search-icon-button"
+          aria-label={label.caseSensitive}
+          aria-pressed={caseSensitive}
+          type="button"
+          onClick={() => onCaseSensitiveChange(!caseSensitive)}
+        >
+          <CaseSensitive aria-hidden="true" size={14} />
+        </button>
+        <button
+          className="document-search-icon-button"
+          aria-label={label.close}
+          type="button"
+          onClick={onClose}
+        >
+          <X aria-hidden="true" size={14} />
+        </button>
+      </div>
+      <div className="flex min-h-0 max-h-[min(52vh,420px)] flex-col">
+        <div className="flex h-8 shrink-0 items-center gap-2 border-b border-(--border-default) px-3 text-[11px] font-[560] text-(--text-secondary)">
+          {loading ? <Loader2 aria-hidden="true" className="animate-spin" size={13} /> : null}
+          <span>{statusText}</span>
+          <span>{label.files(searchedFileCount)}</span>
+          {unreadableFileCount > 0 ? <span>{label.unreadable(unreadableFileCount)}</span> : null}
+        </div>
+        {results.length > 0 ? (
+          <ul
+            className="m-0 min-h-0 list-none overflow-y-auto px-2 py-1"
+            role="list"
+            aria-label={label.results}
+          >
+            {resultGroups.map((group) => {
+              const collapsed = collapsedFilePaths.has(group.file.path);
+              const previewExpanded = expandedPreviewFilePaths.has(group.file.path);
+              const visibleResults = previewExpanded
+                ? group.results
+                : group.results.slice(0, collapsedGroupPreviewCount);
+              const hiddenResultCount = group.results.length - visibleResults.length;
+              const directoryLabel = directoryLabelFromRelativePath(group.file.relativePath);
+
+              return (
+                <li className="border-b border-(--border-default) last:border-b-0" key={group.file.path}>
+                  <section role="group" aria-label={label.fileSearchResults(group.file.relativePath)}>
+                    <button
+                      className="grid w-full cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 bg-transparent px-1.5 py-2 text-left outline-none transition-[background-color,color] duration-150 hover:bg-(--bg-hover) focus-visible:bg-(--bg-active) focus-visible:ring-2 focus-visible:ring-(--accent)"
+                      aria-expanded={!collapsed}
+                      aria-label={
+                        collapsed
+                          ? label.expandFile(group.file.relativePath)
+                          : label.collapseFile(group.file.relativePath)
+                      }
+                      type="button"
+                      onClick={() => toggleFileGroup(group.file.path)}
+                    >
+                      {collapsed
+                        ? <ChevronRight aria-hidden="true" className="text-(--text-secondary)" size={14} />
+                        : <ChevronDown aria-hidden="true" className="text-(--text-secondary)" size={14} />}
+                      <span className="min-w-0 truncate text-[14px] font-[720] text-(--text-heading)">
+                        {group.file.name}
+                      </span>
+                      <span className="rounded-sm bg-(--bg-active) px-2 py-0.5 text-[12px] font-[620] tabular-nums text-(--text-heading)">
+                        {group.results.length}
+                      </span>
+                    </button>
+                    {!collapsed ? (
+                      <div className="pb-2 pl-7 pr-1">
+                        {directoryLabel ? (
+                          <div className="mb-1 truncate font-mono text-[11px] text-(--text-secondary)">
+                            {directoryLabel}
+                          </div>
+                        ) : null}
+                        <ul className="m-0 list-none p-0" role="list" aria-label={`${group.file.relativePath} matches`}>
+                          {visibleResults.map((result) => (
+                            <li key={result.id}>
+                              <button
+                                className="block w-full cursor-pointer rounded-sm border-0 bg-transparent px-0 py-1 text-left outline-none transition-[background-color,color] duration-150 hover:bg-(--bg-hover) focus-visible:bg-(--bg-active) focus-visible:ring-2 focus-visible:ring-(--accent)"
+                                aria-label={label.openResult(result.file.relativePath, result.lineNumber)}
+                                type="button"
+                                onClick={() => onOpenResult(result)}
+                              >
+                                <span className="block min-w-0 truncate font-mono text-[12px] leading-5 text-(--text-primary)">
+                                  {renderHighlightedSnippet(result.snippet, query, caseSensitive)}
+                                </span>
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                        {hiddenResultCount > 0 ? (
+                          <button
+                            className="mt-0.5 cursor-pointer rounded-sm border-0 bg-transparent px-0 py-1 text-left text-[12px] font-[560] text-(--text-secondary) outline-none transition-colors duration-150 hover:text-(--text-heading) focus-visible:text-(--text-heading) focus-visible:ring-2 focus-visible:ring-(--accent)"
+                            type="button"
+                            onClick={() => expandFilePreview(group.file.path)}
+                          >
+                            {label.showMoreMatches(hiddenResultCount)}
+                          </button>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </section>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <div className="flex min-h-24 items-center justify-center px-4 py-8 text-[12px] font-[560] text-(--text-secondary)">
+            {showNoResults ? label.noResults : label.empty}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -305,6 +305,25 @@ describe("useApplicationShortcuts", () => {
     expect(openDocumentSearch).toHaveBeenCalledTimes(1);
   });
 
+  it("intercepts the workspace search shortcut", () => {
+    const openWorkspaceSearch = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openWorkspaceSearch
+      })
+    );
+
+    const handled = fireEvent.keyDown(window, {
+      key: "f",
+      metaKey: true,
+      shiftKey: true
+    });
+
+    expect(handled).toBe(false);
+    expect(openWorkspaceSearch).toHaveBeenCalledTimes(1);
+  });
+
   it("opens replace from the document search shortcut with Alt", () => {
     const openDocumentReplace = vi.fn();
     renderHook(() =>

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -59,6 +59,7 @@ type ApplicationShortcutOptions = {
   openDocument: () => unknown | Promise<unknown>;
   openDocumentReplace?: () => unknown | Promise<unknown>;
   openDocumentSearch?: () => unknown | Promise<unknown>;
+  openWorkspaceSearch?: () => unknown | Promise<unknown>;
   openFolder: () => unknown | Promise<unknown>;
   saveDocument: () => unknown | Promise<unknown>;
   saveDocumentAs: () => unknown | Promise<unknown>;
@@ -333,6 +334,7 @@ export function useApplicationShortcuts({
   openDocument,
   openDocumentReplace,
   openDocumentSearch,
+  openWorkspaceSearch,
   openFolder,
   saveDocument,
   saveDocumentAs,
@@ -372,7 +374,11 @@ export function useApplicationShortcuts({
       }
 
       const key = event.key.toLowerCase();
-      if (key === "f" && !event.shiftKey) {
+      if (key === "f" && event.shiftKey && !event.altKey && openWorkspaceSearch) {
+        event.preventDefault();
+        event.stopPropagation();
+        openWorkspaceSearch();
+      } else if (key === "f" && !event.shiftKey) {
         event.preventDefault();
         event.stopPropagation();
         if (event.altKey) {
@@ -418,6 +424,7 @@ export function useApplicationShortcuts({
     openDocument,
     openDocumentReplace,
     openDocumentSearch,
+    openWorkspaceSearch,
     openFolder,
     saveDocument,
     saveDocumentAs,

--- a/packages/app/src/lib/workspace-search.test.ts
+++ b/packages/app/src/lib/workspace-search.test.ts
@@ -1,0 +1,122 @@
+import { searchWorkspaceFiles, type WorkspaceSearchFile } from "./workspace-search";
+
+const workspaceFiles = [
+  { name: "guide.md", path: "/mock-vault/guide.md", relativePath: "guide.md" },
+  { name: "media", path: "/mock-vault/media", relativePath: "media", kind: "folder" },
+  { name: "diagram.png", path: "/mock-vault/media/diagram.png", relativePath: "media/diagram.png", kind: "asset" },
+  { name: "release.md", path: "/mock-vault/release.md", relativePath: "release.md" }
+] satisfies WorkspaceSearchFile[];
+
+describe("workspace search", () => {
+  it("searches markdown file content and ignores folders and assets", async () => {
+    const readFile = vi.fn(async (path: string) => ({
+      content: path.endsWith("guide.md")
+        ? "# Alpha guide\nbeta notes\nanother alpha marker"
+        : "release plan\nALPHA rollout",
+      path
+    }));
+
+    const search = await searchWorkspaceFiles(workspaceFiles, "alpha", {
+      maxMatches: 10,
+      maxMatchesPerFile: 5,
+      readFile
+    });
+
+    expect(readFile).toHaveBeenCalledTimes(2);
+    expect(readFile).toHaveBeenNthCalledWith(1, "/mock-vault/guide.md");
+    expect(readFile).toHaveBeenNthCalledWith(2, "/mock-vault/release.md");
+    expect(search.searchedFileCount).toBe(2);
+    expect(search.unreadableFileCount).toBe(0);
+    expect(search.results.map((result) => ({
+      columnNumber: result.columnNumber,
+      lineNumber: result.lineNumber,
+      lineText: result.lineText,
+      matchIndex: result.matchIndex,
+      relativePath: result.file.relativePath
+    }))).toEqual([
+      {
+        columnNumber: 3,
+        lineNumber: 1,
+        lineText: "# Alpha guide",
+        matchIndex: 0,
+        relativePath: "guide.md"
+      },
+      {
+        columnNumber: 9,
+        lineNumber: 3,
+        lineText: "another alpha marker",
+        matchIndex: 1,
+        relativePath: "guide.md"
+      },
+      {
+        columnNumber: 1,
+        lineNumber: 2,
+        lineText: "ALPHA rollout",
+        matchIndex: 0,
+        relativePath: "release.md"
+      }
+    ]);
+  });
+
+  it("honors case-sensitive search", async () => {
+    const search = await searchWorkspaceFiles(workspaceFiles, "alpha", {
+      caseSensitive: true,
+      maxMatches: 10,
+      maxMatchesPerFile: 5,
+      readFile: async (path) => ({
+        content: path.endsWith("guide.md") ? "Alpha\nalpha" : "ALPHA",
+        path
+      })
+    });
+
+    expect(search.results.map((result) => ({
+      lineText: result.lineText,
+      relativePath: result.file.relativePath
+    }))).toEqual([
+      {
+        lineText: "alpha",
+        relativePath: "guide.md"
+      }
+    ]);
+  });
+
+  it("centers snippets around late matches before the line is visually truncated", async () => {
+    const lateMatchLine = [
+      "opening segment with unrelated setup",
+      "then another unrelated phrase",
+      "and one more plain section",
+      "finally alpha appears near the end"
+    ].join(" | ");
+    const search = await searchWorkspaceFiles([workspaceFiles[0]], "alpha", {
+      maxMatches: 10,
+      maxMatchesPerFile: 5,
+      readFile: async (path) => ({
+        content: lateMatchLine,
+        path
+      })
+    });
+
+    expect(lateMatchLine.length).toBeLessThan(160);
+    expect(search.results[0]?.snippet).toContain("alpha");
+    expect(search.results[0]?.snippet).toMatch(/^\.\.\./);
+    expect(search.results[0]?.snippet).not.toContain("opening segment");
+  });
+
+  it("counts unreadable files even after the result limit is reached", async () => {
+    const search = await searchWorkspaceFiles(workspaceFiles, "alpha", {
+      maxMatches: 1,
+      maxMatchesPerFile: 5,
+      readFile: async (path) => {
+        if (path.endsWith("release.md")) throw new Error("mock unreadable file");
+
+        return {
+          content: "alpha",
+          path
+        };
+      }
+    });
+
+    expect(search.results).toHaveLength(1);
+    expect(search.unreadableFileCount).toBe(1);
+  });
+});

--- a/packages/app/src/lib/workspace-search.ts
+++ b/packages/app/src/lib/workspace-search.ts
@@ -1,0 +1,155 @@
+import { findSearchRanges, type SearchRange } from "@markra/shared";
+import type { NativeMarkdownFolderFile } from "./tauri";
+
+export type WorkspaceSearchFile = Pick<NativeMarkdownFolderFile, "kind" | "name" | "path" | "relativePath">;
+
+export type WorkspaceSearchResult = {
+  columnNumber: number;
+  file: WorkspaceSearchFile;
+  id: string;
+  lineNumber: number;
+  lineText: string;
+  match: SearchRange;
+  matchIndex: number;
+  snippet: string;
+};
+
+export type WorkspaceSearchResponse = {
+  results: WorkspaceSearchResult[];
+  searchedFileCount: number;
+  unreadableFileCount: number;
+};
+
+type WorkspaceSearchReadResult = {
+  content: string;
+  path: string;
+};
+
+type WorkspaceSearchOptions = {
+  caseSensitive?: boolean;
+  maxMatches?: number;
+  maxMatchesPerFile?: number;
+  readFile: (path: string) => Promise<WorkspaceSearchReadResult>;
+};
+
+const defaultMaxMatches = 80;
+const defaultMaxMatchesPerFile = 8;
+const snippetMaxLength = 96;
+
+export function isWorkspaceSearchableFile(file: WorkspaceSearchFile) {
+  return file.kind !== "asset" && file.kind !== "folder";
+}
+
+export async function searchWorkspaceFiles(
+  files: readonly WorkspaceSearchFile[],
+  query: string,
+  options: WorkspaceSearchOptions
+): Promise<WorkspaceSearchResponse> {
+  const normalizedQuery = query.trim();
+  const searchableFiles = files.filter(isWorkspaceSearchableFile);
+  const maxMatches = Math.max(0, options.maxMatches ?? defaultMaxMatches);
+  const maxMatchesPerFile = Math.max(0, options.maxMatchesPerFile ?? defaultMaxMatchesPerFile);
+
+  if (!normalizedQuery || maxMatches === 0 || maxMatchesPerFile === 0) {
+    return {
+      results: [],
+      searchedFileCount: searchableFiles.length,
+      unreadableFileCount: 0
+    };
+  }
+
+  const searched = await Promise.all(
+    searchableFiles.map(async (file) => {
+      try {
+        const read = await options.readFile(file.path);
+
+        return {
+          file,
+          matches: findWorkspaceSearchResults(file, read.content, normalizedQuery, {
+            caseSensitive: options.caseSensitive,
+            maxMatchesPerFile
+          }),
+          unreadable: false
+        };
+      } catch {
+        return {
+          file,
+          matches: [] as WorkspaceSearchResult[],
+          unreadable: true
+        };
+      }
+    })
+  );
+
+  const results: WorkspaceSearchResult[] = [];
+  const unreadableFileCount = searched.filter((item) => item.unreadable).length;
+
+  for (const item of searched) {
+    for (const match of item.matches) {
+      if (results.length >= maxMatches) break;
+      results.push(match);
+    }
+
+    if (results.length >= maxMatches) break;
+  }
+
+  return {
+    results,
+    searchedFileCount: searchableFiles.length,
+    unreadableFileCount
+  };
+}
+
+function findWorkspaceSearchResults(
+  file: WorkspaceSearchFile,
+  content: string,
+  query: string,
+  options: { caseSensitive?: boolean; maxMatchesPerFile: number }
+) {
+  const ranges = findSearchRanges(content, query, {
+    caseSensitive: options.caseSensitive
+  }).slice(0, options.maxMatchesPerFile);
+
+  return ranges.map((range, matchIndex) => {
+    const line = lineForSearchRange(content, range);
+
+    return {
+      columnNumber: line.columnNumber,
+      file,
+      id: `${file.path}:${range.from}`,
+      lineNumber: line.lineNumber,
+      lineText: line.text,
+      match: range,
+      matchIndex,
+      snippet: workspaceSearchSnippet(line.text, line.columnNumber, range.to - range.from)
+    } satisfies WorkspaceSearchResult;
+  });
+}
+
+function lineForSearchRange(content: string, range: SearchRange) {
+  const lineStart = content.lastIndexOf("\n", Math.max(0, range.from - 1)) + 1;
+  const lineEndIndex = content.indexOf("\n", range.from);
+  const lineEnd = lineEndIndex >= 0 ? lineEndIndex : content.length;
+  const lineNumber = content.slice(0, range.from).split("\n").length;
+
+  return {
+    columnNumber: range.from - lineStart + 1,
+    lineNumber,
+    text: content.slice(lineStart, lineEnd)
+  };
+}
+
+function workspaceSearchSnippet(lineText: string, columnNumber: number, matchLength: number) {
+  const normalizedLine = lineText.trimEnd();
+  if (normalizedLine.length <= snippetMaxLength) return normalizedLine;
+
+  const matchStart = Math.max(0, columnNumber - 1);
+  const matchEnd = matchStart + matchLength;
+  const radius = Math.floor((snippetMaxLength - matchLength) / 2);
+  const start = Math.max(0, matchStart - radius);
+  const end = Math.min(normalizedLine.length, matchEnd + radius);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < normalizedLine.length ? "..." : "";
+
+  return `${prefix}${normalizedLine.slice(start, end)}${suffix}`;
+}


### PR DESCRIPTION
## Summary
- Add workspace-wide content search opened with Cmd/Ctrl+Shift+F.
- Add a grouped global search panel with per-file counts, highlighted matches, expandable previews, and case-sensitive search.
- Search markdown content through a focused workspace search helper, ignoring folders/assets and counting unreadable files.
- Keep opening a global result from popping the document search bar unless it was already open.

## Why
- Closes #194 by making it possible to search across all files in the current workspace.

## Validation
- `pnpm --filter @markra/app test -- App.test.tsx GlobalSearchPanel useNativeBindings workspace-search` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification
- Visual smoke: opened the Vite desktop app in local Chrome via Playwright, invoked Cmd+Shift+F, typed `alpha`, and confirmed the global search dialog/input rendered; the dev page logged one 404 resource request.

## Risk
- Search reads each searchable file in the loaded file tree for every query update, with result limits applied; very large workspaces may need debounce or indexing later.

## Related Issues
- Closes #194
