### PR TITLE
feat(editor): add Mermaid diagram zoom

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -1432,6 +1432,7 @@ describe("MarkdownPaper editing", () => {
     const copyButton = container.querySelector<HTMLElement>(".ProseMirror .markra-code-copy-button");
     const languageControl = container.querySelector<HTMLElement>(".ProseMirror .markra-code-language-control");
     const preview = container.querySelector<HTMLElement>(".ProseMirror .markra-mermaid-render");
+    const zoomButton = screen.getByRole("button", { name: "Enlarge Mermaid diagram" });
     const sourcePre = container.querySelector<HTMLElement>(".ProseMirror .markra-code-block pre");
 
     expect(codeBlock).toHaveAttribute("data-language", "mermaid");
@@ -1439,6 +1440,7 @@ describe("MarkdownPaper editing", () => {
     expect(copyButton).toHaveAttribute("hidden");
     expect(languageControl).toHaveAttribute("hidden");
     expect(preview).not.toHaveAttribute("hidden");
+    expect(zoomButton).not.toHaveAttribute("hidden");
 
     fireEvent.click(preview!);
 
@@ -1448,6 +1450,7 @@ describe("MarkdownPaper editing", () => {
     expect(sourcePre).not.toHaveAttribute("hidden");
     expect(lineNumbers).not.toHaveAttribute("hidden");
     expect(preview).toHaveAttribute("hidden");
+    expect(zoomButton).toHaveAttribute("hidden");
     expect(container.querySelector(".ProseMirror .markra-code-content")).toHaveTextContent("flowchart TD");
 
     view.dispatch(
@@ -1460,10 +1463,39 @@ describe("MarkdownPaper editing", () => {
       expect(copyButton).toHaveAttribute("hidden");
       expect(languageControl).toHaveAttribute("hidden");
       expect(preview).not.toHaveAttribute("hidden");
+      expect(zoomButton).not.toHaveAttribute("hidden");
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain(source);
+  });
+
+  it("opens an enlarged Mermaid diagram from the zoom control without editing the source", async () => {
+    const source = ["```mermaid", "flowchart TD", "  A --> B", "```"].join("\n");
+    const { container } = await renderEditor(source);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-mermaid-render svg")).toBeInTheDocument();
+    });
+    const codeBlock = container.querySelector<HTMLElement>(".ProseMirror .markra-code-block");
+    const zoomButton = screen.getByRole("button", { name: "Enlarge Mermaid diagram" });
+
+    fireEvent.click(zoomButton);
+
+    expect(codeBlock).toHaveAttribute("data-mermaid-mode", "preview");
+
+    const dialog = screen.getByRole("dialog", { name: "Enlarged Mermaid diagram" });
+    const enlargedDiagram = dialog.querySelector(".markra-mermaid-zoom-content svg");
+
+    expect(within(dialog).queryByRole("img", { name: "Enlarged Mermaid diagram" })).not.toBeInTheDocument();
+    expect(enlargedDiagram).toBeInTheDocument();
+    expect(enlargedDiagram).toHaveAttribute("id", expect.stringContaining("markra-editor-mermaid"));
+    expect(enlargedDiagram).toHaveClass("markra-mermaid-zoom-svg");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "Enlarged Mermaid diagram" })).not.toBeInTheDocument();
+    expect(zoomButton).toHaveFocus();
   });
 
   it("returns a single Mermaid block to preview mode from the source control", async () => {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2882,6 +2882,39 @@
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
   }
 
+  .markdown-paper .markra-mermaid-zoom-button {
+    @apply absolute top-2 right-2 z-[3] grid size-7 cursor-pointer place-items-center rounded-md border border-(--border-default) p-0 outline-none transition-[opacity,transform,color,background-color,border-color,box-shadow] duration-150 ease-out;
+    background: var(--editor-code-control-bg);
+    border-color: var(--editor-border);
+    color: var(--editor-text-secondary);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-0.125rem);
+  }
+
+  .markdown-paper .markra-mermaid-zoom-button[hidden] {
+    display: none;
+  }
+
+  .markdown-paper .markra-code-block[data-mermaid-mode="preview"]:hover .markra-mermaid-zoom-button {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .markdown-paper .markra-mermaid-zoom-button:hover {
+    background: var(--editor-bg-secondary);
+    border-color: var(--editor-border-strong);
+    color: var(--editor-text-heading);
+  }
+
+  .markdown-paper .markra-mermaid-zoom-button:focus-visible {
+    background: var(--editor-bg-secondary);
+    border-color: var(--editor-border-strong);
+    color: var(--editor-text-heading);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
   .markdown-paper .markra-mermaid-render {
     @apply mx-4 mb-4 rounded border border-(--border-default) bg-(--bg-primary) p-4;
     grid-column: 1 / -1;
@@ -2914,6 +2947,53 @@
     background: color-mix(in srgb, oklch(65% 0.19 29) 8%, var(--editor-code-bg));
     color: oklch(46% 0.17 29);
     text-align: left;
+  }
+
+  .markra-mermaid-zoom-dialog {
+    @apply fixed inset-0 z-50 grid place-items-center p-4;
+    background: color-mix(in srgb, oklch(23% 0.02 260) 72%, transparent);
+  }
+
+  .markra-mermaid-zoom-panel {
+    @apply relative max-h-[88vh] w-full overflow-auto rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-2xl;
+    background: var(--editor-paper-bg, var(--bg-primary));
+    border-color: color-mix(in srgb, var(--editor-border-strong, var(--border-strong)) 82%, transparent);
+    color: var(--editor-text-primary, var(--text-primary));
+    max-width: min(92vw, 80rem);
+  }
+
+  .markra-mermaid-zoom-close-button {
+    @apply sticky top-3 ml-auto mr-3 grid size-8 cursor-pointer place-items-center rounded-md border border-(--border-default) bg-(--bg-primary) p-0 text-(--text-secondary) outline-none transition-[color,background-color,border-color,box-shadow] duration-150 ease-out;
+    background: var(--editor-code-control-bg, var(--bg-primary));
+    border-color: var(--editor-border, var(--border-default));
+    color: var(--editor-text-secondary, var(--text-secondary));
+    z-index: 1;
+  }
+
+  .markra-mermaid-zoom-close-button:hover {
+    background: var(--editor-bg-secondary, var(--bg-hover));
+    border-color: var(--editor-border-strong, var(--border-strong));
+    color: var(--editor-text-heading, var(--text-heading));
+  }
+
+  .markra-mermaid-zoom-close-button:focus-visible {
+    background: var(--editor-bg-secondary, var(--bg-hover));
+    border-color: var(--editor-border-strong, var(--border-strong));
+    color: var(--editor-text-heading, var(--text-heading));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
+  .markra-mermaid-zoom-content {
+    @apply px-8 pb-8 pt-2;
+  }
+
+  .markra-mermaid-zoom-svg {
+    display: block;
+    width: min(100%, 72rem);
+    min-width: min(48rem, calc(100vw - 5rem));
+    max-width: none;
+    height: auto;
+    margin: 0 auto;
   }
 
   .markdown-paper .markra-code-block code {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -306,6 +306,18 @@ describe("editor stylesheet", () => {
     const mermaidFoldStart = styles.indexOf(".markdown-paper .markra-code-block[data-mermaid-mode=\"preview\"]");
     const mermaidFoldEnd = styles.indexOf(".markdown-paper .markra-mermaid-render {");
     const mermaidFoldStyles = styles.slice(mermaidFoldStart, mermaidFoldEnd);
+    const mermaidZoomRevealStart = styles.indexOf(
+      ".markdown-paper .markra-code-block[data-mermaid-mode=\"preview\"]:hover .markra-mermaid-zoom-button"
+    );
+    const mermaidZoomRevealEnd = styles.indexOf(".markdown-paper .markra-mermaid-zoom-button:hover");
+    const mermaidZoomRevealStyles = styles.slice(mermaidZoomRevealStart, mermaidZoomRevealEnd);
+    const mermaidZoomHoverStart = styles.indexOf(".markdown-paper .markra-mermaid-zoom-button:hover");
+    const mermaidZoomHoverEnd = styles.indexOf("\n  }\n", mermaidZoomHoverStart) + "\n  }\n".length;
+    const mermaidZoomHoverStyles = styles.slice(mermaidZoomHoverStart, mermaidZoomHoverEnd);
+    const mermaidZoomCloseHoverStart = styles.indexOf(".markra-mermaid-zoom-close-button:hover");
+    const mermaidZoomCloseHoverEnd =
+      styles.indexOf("\n  }\n", mermaidZoomCloseHoverStart) + "\n  }\n".length;
+    const mermaidZoomCloseHoverStyles = styles.slice(mermaidZoomCloseHoverStart, mermaidZoomCloseHoverEnd);
 
     expect(mermaidFoldStyles).toContain(".markra-code-line-numbers");
     expect(mermaidFoldStyles).toContain("pre");
@@ -314,6 +326,15 @@ describe("editor stylesheet", () => {
     expect(mermaidFoldStyles).toContain("border-color: transparent");
     expect(mermaidFoldStyles).toContain(".markra-code-language-control");
     expect(styles).toContain(".markdown-paper .markra-mermaid-preview-button");
+    expect(styles).toContain(".markdown-paper .markra-mermaid-zoom-button");
+    expect(mermaidZoomRevealStyles).not.toContain(":focus-within");
+    expect(mermaidZoomRevealStyles).toContain("opacity: 1");
+    expect(mermaidZoomRevealStyles).toContain("pointer-events: auto");
+    expect(mermaidZoomHoverStyles).not.toContain(":focus-visible");
+    expect(mermaidZoomHoverStyles).not.toContain("box-shadow");
+    expect(mermaidZoomCloseHoverStyles).not.toContain(":focus-visible");
+    expect(mermaidZoomCloseHoverStyles).not.toContain("box-shadow");
+    expect(styles).toContain(".markra-mermaid-zoom-dialog");
     expect(styles).toContain(
       ".markdown-paper .markra-code-block[data-mermaid-mode=\"preview\"] .markra-mermaid-render"
     );

--- a/packages/editor/src/code-block.ts
+++ b/packages/editor/src/code-block.ts
@@ -115,6 +115,46 @@ const checkIconChildren: SvgChildSpec[] = [
     }
   }
 ];
+const expandIconChildren: SvgChildSpec[] = [
+  {
+    tag: "path",
+    attributes: {
+      d: "M15 3h6v6"
+    }
+  },
+  {
+    tag: "path",
+    attributes: {
+      d: "m21 3-7 7"
+    }
+  },
+  {
+    tag: "path",
+    attributes: {
+      d: "M9 21H3v-6"
+    }
+  },
+  {
+    tag: "path",
+    attributes: {
+      d: "m3 21 7-7"
+    }
+  }
+];
+const closeIconChildren: SvgChildSpec[] = [
+  {
+    tag: "path",
+    attributes: {
+      d: "M18 6 6 18"
+    }
+  },
+  {
+    tag: "path",
+    attributes: {
+      d: "m6 6 12 12"
+    }
+  }
+];
 
 function normalizeCodeLanguage(language: unknown) {
   if (typeof language !== "string") return "";
@@ -429,7 +469,10 @@ class MarkraCodeBlockNodeView implements NodeView {
   private readonly code: HTMLElement;
   private readonly mermaidPreview: HTMLElement;
   private readonly mermaidPreviewButton: HTMLButtonElement;
+  private readonly mermaidZoomButton: HTMLButtonElement;
   private readonly mermaidThemeObserver: MutationObserver | null = null;
+  private mermaidZoomDialog: HTMLElement | null = null;
+  private mermaidZoomFocusTarget: HTMLElement | null = null;
   private mermaidSourceEditing = false;
   private mermaidRenderSignature = "";
   private mermaidRenderToken = 0;
@@ -449,6 +492,7 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.code = view.dom.ownerDocument.createElement("code");
     this.mermaidPreview = view.dom.ownerDocument.createElement("div");
     this.mermaidPreviewButton = view.dom.ownerDocument.createElement("button");
+    this.mermaidZoomButton = view.dom.ownerDocument.createElement("button");
     this.contentDOM = this.code;
 
     this.dom.className = "markra-code-block";
@@ -488,6 +532,13 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.mermaidPreviewButton.setAttribute("aria-label", "Preview Mermaid diagram");
     this.mermaidPreviewButton.title = "Preview Mermaid diagram";
     this.mermaidPreviewButton.textContent = "Preview";
+    this.mermaidZoomButton.className = "markra-mermaid-zoom-button";
+    this.mermaidZoomButton.type = "button";
+    this.mermaidZoomButton.contentEditable = "false";
+    this.mermaidZoomButton.hidden = true;
+    this.mermaidZoomButton.setAttribute("aria-label", "Enlarge Mermaid diagram");
+    this.mermaidZoomButton.title = "Enlarge Mermaid diagram";
+    this.mermaidZoomButton.append(createIcon(view.dom.ownerDocument, "markra-mermaid-zoom-icon", expandIconChildren));
 
     this.populateLanguageOptions();
     this.copyButton.addEventListener("click", this.handleCopyClick);
@@ -496,6 +547,7 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.mermaidPreview.addEventListener("click", this.handleMermaidPreviewClick);
     this.mermaidPreview.addEventListener("keydown", this.handleMermaidPreviewKeyDown);
     this.mermaidPreviewButton.addEventListener("click", this.handleMermaidPreviewButtonClick);
+    this.mermaidZoomButton.addEventListener("click", this.handleMermaidZoomButtonClick);
     view.dom.ownerDocument.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
     view.dom.ownerDocument.addEventListener("selectionchange", this.handleDocumentSelectionChange);
     this.mermaidThemeObserver = this.createMermaidThemeObserver();
@@ -506,6 +558,7 @@ class MarkraCodeBlockNodeView implements NodeView {
       this.pre,
       this.mermaidPreview,
       this.mermaidPreviewButton,
+      this.mermaidZoomButton,
       this.copyButton,
       this.languageControl
     );
@@ -531,6 +584,7 @@ class MarkraCodeBlockNodeView implements NodeView {
       targetIsInside(event.target, this.lineNumbers) ||
       targetIsInside(event.target, this.mermaidPreview) ||
       targetIsInside(event.target, this.mermaidPreviewButton) ||
+      targetIsInside(event.target, this.mermaidZoomButton) ||
       targetIsInside(event.target, this.languageControl);
   }
 
@@ -540,21 +594,25 @@ class MarkraCodeBlockNodeView implements NodeView {
       mutation.target === this.lineNumbers ||
       mutation.target === this.mermaidPreview ||
       mutation.target === this.mermaidPreviewButton ||
+      mutation.target === this.mermaidZoomButton ||
       targetIsInside(mutation.target, this.copyButton) ||
       targetIsInside(mutation.target, this.lineNumbers) ||
       targetIsInside(mutation.target, this.mermaidPreview) ||
       targetIsInside(mutation.target, this.mermaidPreviewButton) ||
+      targetIsInside(mutation.target, this.mermaidZoomButton) ||
       targetIsInside(mutation.target, this.languageControl);
   }
 
   destroy() {
     this.mermaidRenderToken += 1;
+    this.closeMermaidZoom({ restoreFocus: false });
     this.copyButton.removeEventListener("click", this.handleCopyClick);
     this.languageSelect.removeEventListener("change", this.handleLanguageChange);
     this.code.removeEventListener("keydown", this.handleCodeKeyDown);
     this.mermaidPreview.removeEventListener("click", this.handleMermaidPreviewClick);
     this.mermaidPreview.removeEventListener("keydown", this.handleMermaidPreviewKeyDown);
     this.mermaidPreviewButton.removeEventListener("click", this.handleMermaidPreviewButtonClick);
+    this.mermaidZoomButton.removeEventListener("click", this.handleMermaidZoomButtonClick);
     this.dom.ownerDocument.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
     this.dom.ownerDocument.removeEventListener("selectionchange", this.handleDocumentSelectionChange);
     this.mermaidThemeObserver?.disconnect();
@@ -573,6 +631,7 @@ class MarkraCodeBlockNodeView implements NodeView {
       delete this.dom.dataset.mermaidMode;
       this.mermaidPreview.hidden = true;
       this.mermaidPreviewButton.hidden = true;
+      this.mermaidZoomButton.hidden = true;
       this.copyButton.hidden = false;
       this.languageControl.hidden = false;
       return;
@@ -583,6 +642,7 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.dom.dataset.mermaidMode = showSource ? "source" : "preview";
     this.mermaidPreview.hidden = showSource || !hasSource;
     this.mermaidPreviewButton.hidden = !showSource || !hasSource;
+    this.mermaidZoomButton.hidden = showSource || !hasSource || !this.mermaidPreview.querySelector("svg");
     this.copyButton.hidden = hideCodeChrome;
     this.languageControl.hidden = hideCodeChrome;
   }
@@ -594,6 +654,8 @@ class MarkraCodeBlockNodeView implements NodeView {
     this.mermaidPreview.removeAttribute("data-error");
     this.mermaidPreview.setAttribute("aria-busy", "false");
     this.mermaidPreview.replaceChildren();
+    this.mermaidZoomButton.hidden = true;
+    this.closeMermaidZoom({ restoreFocus: false });
     this.syncMermaidDisplayMode();
   }
 
@@ -648,6 +710,7 @@ class MarkraCodeBlockNodeView implements NodeView {
       this.mermaidPreview.innerHTML = svg;
       this.mermaidPreview.classList.toggle("markra-mermaid-render-empty", !svg);
       this.mermaidPreview.setAttribute("aria-busy", "false");
+      if (this.mermaidZoomDialog) this.updateMermaidZoomDiagram();
       this.syncMermaidDisplayMode();
     } catch (error) {
       if (token !== this.mermaidRenderToken) return;
@@ -660,8 +723,87 @@ class MarkraCodeBlockNodeView implements NodeView {
       this.mermaidPreview.dataset.error = error instanceof Error ? error.message : "Unknown Mermaid render error";
       this.mermaidPreview.setAttribute("aria-busy", "false");
       this.mermaidPreview.replaceChildren(message);
+      this.closeMermaidZoom({ restoreFocus: false });
       this.syncMermaidDisplayMode();
     }
+  }
+
+  private cloneMermaidPreviewSvg() {
+    const svg = this.mermaidPreview.querySelector("svg");
+    if (!svg) return null;
+
+    const clone = svg.cloneNode(true) as SVGSVGElement;
+    clone.classList.add("markra-mermaid-zoom-svg");
+    clone.removeAttribute("style");
+    clone.removeAttribute("width");
+    clone.removeAttribute("height");
+    return clone;
+  }
+
+  private updateMermaidZoomDiagram() {
+    const content = this.mermaidZoomDialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-content");
+    if (!content) return;
+
+    const svg = this.cloneMermaidPreviewSvg();
+    if (!svg) {
+      this.closeMermaidZoom({ restoreFocus: false });
+      return;
+    }
+
+    content.replaceChildren(svg);
+  }
+
+  private openMermaidZoom() {
+    const svg = this.cloneMermaidPreviewSvg();
+    if (!svg) return;
+
+    this.closeMermaidZoom({ restoreFocus: false });
+
+    const ownerDocument = this.dom.ownerDocument;
+    const dialog = ownerDocument.createElement("div");
+    const panel = ownerDocument.createElement("div");
+    const closeButton = ownerDocument.createElement("button");
+    const content = ownerDocument.createElement("div");
+
+    dialog.className = "markra-mermaid-zoom-dialog";
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-label", "Enlarged Mermaid diagram");
+    panel.className = "markra-mermaid-zoom-panel";
+    closeButton.className = "markra-mermaid-zoom-close-button";
+    closeButton.type = "button";
+    closeButton.setAttribute("aria-label", "Close enlarged Mermaid diagram");
+    closeButton.title = "Close enlarged Mermaid diagram";
+    closeButton.append(createIcon(ownerDocument, "markra-mermaid-zoom-close-icon", closeIconChildren));
+    content.className = "markra-mermaid-zoom-content";
+
+    content.append(svg);
+    panel.append(closeButton, content);
+    dialog.append(panel);
+    dialog.addEventListener("mousedown", this.handleMermaidZoomDialogMouseDown);
+    closeButton.addEventListener("click", this.handleMermaidZoomCloseClick);
+    ownerDocument.addEventListener("keydown", this.handleMermaidZoomKeyDown, true);
+    (this.view.dom.closest(".markdown-paper") ?? ownerDocument.body).append(dialog);
+
+    this.mermaidZoomDialog = dialog;
+    this.mermaidZoomFocusTarget = this.mermaidZoomButton;
+    closeButton.focus();
+  }
+
+  private closeMermaidZoom({ restoreFocus = true }: { restoreFocus?: boolean } = {}) {
+    const dialog = this.mermaidZoomDialog;
+    if (!dialog) return;
+
+    const closeButton = dialog.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-close-button");
+    dialog.removeEventListener("mousedown", this.handleMermaidZoomDialogMouseDown);
+    closeButton?.removeEventListener("click", this.handleMermaidZoomCloseClick);
+    this.dom.ownerDocument.removeEventListener("keydown", this.handleMermaidZoomKeyDown, true);
+    dialog.remove();
+    this.mermaidZoomDialog = null;
+
+    const focusTarget = this.mermaidZoomFocusTarget;
+    this.mermaidZoomFocusTarget = null;
+    if (restoreFocus && focusTarget?.isConnected) focusTarget.focus();
   }
 
   private activateMermaidSourceEditing() {
@@ -721,6 +863,31 @@ class MarkraCodeBlockNodeView implements NodeView {
   private readonly handleMermaidPreviewButtonClick = (event: MouseEvent) => {
     event.preventDefault();
     this.deactivateMermaidSourceEditing();
+  };
+
+  private readonly handleMermaidZoomButtonClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    this.openMermaidZoom();
+  };
+
+  private readonly handleMermaidZoomDialogMouseDown = (event: MouseEvent) => {
+    if (event.target !== this.mermaidZoomDialog) return;
+
+    event.preventDefault();
+    this.closeMermaidZoom();
+  };
+
+  private readonly handleMermaidZoomCloseClick = (event: MouseEvent) => {
+    event.preventDefault();
+    this.closeMermaidZoom();
+  };
+
+  private readonly handleMermaidZoomKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+
+    event.preventDefault();
+    this.closeMermaidZoom();
   };
 
   private readonly handleCodeKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- Add a hover/focus zoom icon for rendered Mermaid diagrams.
- Keep clicking the diagram body as the source-editing affordance.
- Open the rendered SVG in a themed, scrollable enlarged dialog with close and Escape support.

## Why
- Makes large flowcharts easier to inspect without changing the existing edit interaction.

Closes #200

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t "Mermaid"`
- `pnpm --filter @markra/app test -- src/styles.test.ts`
- `pnpm --filter @markra/editor build && pnpm --filter @markra/app build`
- `pnpm --filter @markra/web build`
- `git diff --check`

## Risk
- Low. The change is scoped to Mermaid code block preview controls and is covered by editor behavior tests.
