### PR TITLE
fix(desktop): use supported Pandoc GFM reader

### DIFF
--- a/apps/desktop/src-tauri/src/markdown_files/export.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/export.rs
@@ -415,7 +415,7 @@ fn export_pandoc_file_with_runner(
 
         args.extend([
             "--from".to_string(),
-            "gfm+tex_math_dollars+tex_math_single_backslash".to_string(),
+            "gfm+tex_math_dollars".to_string(),
             "--to".to_string(),
             format.pandoc_writer().to_string(),
             "--output".to_string(),
@@ -702,8 +702,7 @@ mod tests {
                 assert!(args.contains(&"--metadata".to_string()));
                 assert!(args.contains(&"title=Draft Notes".to_string()));
                 assert!(args.windows(2).any(|window| {
-                    window[0] == "--from"
-                        && window[1] == "gfm+tex_math_dollars+tex_math_single_backslash"
+                    window[0] == "--from" && window[1] == "gfm+tex_math_dollars"
                 }));
                 assert!(args
                     .windows(2)


### PR DESCRIPTION
## Summary
- Remove the unsupported `tex_math_single_backslash` extension from the Pandoc GFM reader used by native DOCX/EPUB/LaTeX export.
- Update the native export unit test expectation to match the supported Pandoc reader.

## Why
- Pandoc rejects `gfm+tex_math_dollars+tex_math_single_backslash` because `tex_math_single_backslash` is not supported for `gfm`, causing Markra Pandoc exports to fail even when Pandoc works from the command line.

## Validation
- `cd apps/desktop/src-tauri && cargo test` passed: 108 passed.
- Manual Pandoc smoke test passed locally for DOCX, EPUB, and LaTeX using `pandoc --from gfm+tex_math_dollars` with synthetic markdown.

## Risk
- Low. This keeps the GFM reader and only removes an extension Pandoc does not support for that reader.

Closes #209
