### PR TITLE
fix(app): position context submenus within viewport

### DIFF
--- a/packages/app/src/components/ContextMenu.test.tsx
+++ b/packages/app/src/components/ContextMenu.test.tsx
@@ -11,6 +11,20 @@ function getMenuItemById(id: string) {
   return item;
 }
 
+function testRect(rect: Partial<DOMRect>): DOMRect {
+  return {
+    bottom: rect.bottom ?? 0,
+    height: rect.height ?? 0,
+    left: rect.left ?? 0,
+    right: rect.right ?? 0,
+    top: rect.top ?? 0,
+    width: rect.width ?? 0,
+    x: rect.x ?? rect.left ?? 0,
+    y: rect.y ?? rect.top ?? 0,
+    toJSON: () => ({})
+  };
+}
+
 describe("ContextMenu", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -91,11 +105,86 @@ describe("ContextMenu", () => {
     expect(submenuButton).toHaveAttribute("aria-haspopup", "menu");
     expect(submenuButton.querySelector("svg")).not.toBeNull();
     expect(submenuButton).not.toHaveTextContent(">");
-    expect(document.querySelector("[data-menu-submenu-id='markra:test:submenu']")).toHaveAttribute("role", "menu");
+    const submenu = document.querySelector<HTMLElement>("[data-menu-submenu-id='markra:test:submenu']");
+    const submenuBridge = document.querySelector<HTMLElement>("[data-menu-submenu-bridge-id='markra:test:submenu']");
+
+    expect(submenu).toHaveAttribute("role", "menu");
+    expect(submenu?.style.left).toBe("calc(100% + 8px)");
+    expect(submenuBridge?.style.width).toBe("8px");
 
     getMenuItemById("markra:test:child").click();
 
     expect(childSelect).toHaveBeenCalledTimes(1);
     expect(getMenu()).toBeNull();
+  });
+
+  it("keeps submenus inside the viewport when their anchor is near the bottom", () => {
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(220);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (this: HTMLElement) {
+      if (this.hasAttribute("data-menu-submenu-id")) return 120;
+      if (this.hasAttribute("data-markra-context-menu")) return 180;
+
+      return 28;
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+      if (this.getAttribute("data-menu-item-id") === "markra:test:submenu") {
+        return testRect({
+          bottom: 198,
+          height: 28,
+          left: 8,
+          right: 224,
+          top: 170,
+          width: 216
+        });
+      }
+
+      return testRect({
+        bottom: 36,
+        height: 28,
+        left: 8,
+        right: 224,
+        top: 8,
+        width: 216
+      });
+    });
+
+    showContextMenu(document, {
+      entries: [
+        {
+          entries: [
+            {
+              id: "markra:test:child-1",
+              kind: "item",
+              label: "Child 1",
+              onSelect: vi.fn()
+            },
+            {
+              id: "markra:test:child-2",
+              kind: "item",
+              label: "Child 2",
+              onSelect: vi.fn()
+            },
+            {
+              id: "markra:test:child-3",
+              kind: "item",
+              label: "Child 3",
+              onSelect: vi.fn()
+            }
+          ],
+          id: "markra:test:submenu",
+          kind: "submenu",
+          label: "More"
+        }
+      ],
+      position: {
+        x: 8,
+        y: 8
+      }
+    });
+
+    const submenu = document.querySelector<HTMLElement>("[data-menu-submenu-id='markra:test:submenu']");
+
+    expect(submenu).not.toBeNull();
+    expect(submenu?.style.top).toBe("-78px");
   });
 });

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -58,6 +58,11 @@ const defaultContextMenuWidth = 216;
 const defaultContextMenuHeight = 320;
 const contextMenuViewportMargin = 8;
 const contextSubmenuWidth = 216;
+const contextSubmenuGap = 8;
+const contextSubmenuPreferredTop = -4;
+const contextMenuRowHeight = 28;
+const contextMenuSeparatorHeight = 9;
+const contextMenuPaddingHeight = 8;
 
 let activeContextMenuCleanup: (() => unknown) | null = null;
 
@@ -177,6 +182,35 @@ export function showContextMenu(documentTarget: Document, options: ShowContextMe
 export function closeActiveContextMenu() {
   activeContextMenuCleanup?.();
   activeContextMenuCleanup = null;
+}
+
+function estimateContextMenuEntriesHeight(entries: ContextMenuEntry[]) {
+  return entries.reduce((height, entry) => {
+    if (entry.kind === "separator") return height + contextMenuSeparatorHeight;
+
+    return height + contextMenuRowHeight;
+  }, contextMenuPaddingHeight);
+}
+
+function contextSubmenuTop(anchorTop: number, submenuHeight: number, viewportHeight: number) {
+  const minTop = contextMenuViewportMargin - anchorTop;
+  const maxTop = viewportHeight - contextMenuViewportMargin - submenuHeight - anchorTop;
+  if (maxTop < minTop) return minTop;
+
+  return Math.max(minTop, Math.min(contextSubmenuPreferredTop, maxTop));
+}
+
+function contextSubmenuHorizontalStyle(submenuAlignLeft: boolean): CSSProperties {
+  const offset = `calc(100% + ${contextSubmenuGap}px)`;
+
+  return submenuAlignLeft ? { right: offset } : { left: offset };
+}
+
+function contextSubmenuBridgeStyle(submenuAlignLeft: boolean): CSSProperties {
+  return {
+    ...(submenuAlignLeft ? { right: "100%" } : { left: "100%" }),
+    width: `${contextSubmenuGap}px`
+  };
 }
 
 export function ContextMenu({ ariaLabel, entries, onClose, position }: ContextMenuProps) {
@@ -341,11 +375,31 @@ type ContextSubmenuProps = {
 };
 
 function ContextSubmenu({ entry, onClose, submenuAlignLeft }: ContextSubmenuProps) {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const submenuRef = useRef<HTMLDivElement | null>(null);
+  const [submenuTop, setSubmenuTop] = useState(contextSubmenuPreferredTop);
   const disabled = Boolean(entry.disabled);
+
+  useLayoutEffect(() => {
+    const button = buttonRef.current;
+    const submenu = submenuRef.current;
+    if (!button || !submenu) return;
+
+    const windowTarget = button.ownerDocument.defaultView;
+    const viewportHeight = windowTarget?.innerHeight ?? 768;
+    const submenuHeight = submenu.offsetHeight || estimateContextMenuEntriesHeight(entry.entries);
+
+    setSubmenuTop(contextSubmenuTop(
+      button.getBoundingClientRect().top,
+      submenuHeight,
+      viewportHeight
+    ));
+  }, [entry.entries]);
 
   return (
     <div className="group/context-menu-submenu relative">
       <button
+        ref={buttonRef}
         className="flex h-7 w-full items-center justify-between gap-4 rounded-md border-0 bg-transparent px-2 text-left font-inherit text-(--text-primary) outline-none transition-[background-color,color,opacity] duration-150 ease-out enabled:cursor-pointer enabled:hover:bg-(--bg-hover) enabled:hover:text-(--text-heading) enabled:focus-visible:bg-(--bg-hover) enabled:focus-visible:text-(--text-heading) disabled:opacity-45"
         aria-haspopup="menu"
         data-menu-item-id={entry.id}
@@ -367,11 +421,20 @@ function ContextSubmenu({ entry, onClose, submenuAlignLeft }: ContextSubmenuProp
         />
       </button>
       <div
-        className={`absolute top-[-4px] hidden min-w-[216px] max-w-[min(280px,calc(100vw-16px))] rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 font-[520] text-(--text-primary) shadow-[0_14px_36px_color-mix(in_srgb,var(--text-heading)_16%,transparent)] outline-none group-hover/context-menu-submenu:block group-focus-within/context-menu-submenu:block ${
-          submenuAlignLeft ? "right-[calc(100%-4px)]" : "left-[calc(100%-4px)]"
-        }`}
+        aria-hidden="true"
+        className="absolute top-0 bottom-0"
+        data-menu-submenu-bridge-id={entry.id}
+        style={contextSubmenuBridgeStyle(submenuAlignLeft)}
+      />
+      <div
+        ref={submenuRef}
+        className="invisible pointer-events-none absolute max-h-[calc(100vh-16px)] min-w-[216px] max-w-[min(280px,calc(100vw-16px))] overflow-y-auto rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 font-[520] text-(--text-primary) opacity-0 shadow-[0_14px_36px_color-mix(in_srgb,var(--text-heading)_16%,transparent)] outline-none group-hover/context-menu-submenu:visible group-hover/context-menu-submenu:pointer-events-auto group-hover/context-menu-submenu:opacity-100 group-focus-within/context-menu-submenu:visible group-focus-within/context-menu-submenu:pointer-events-auto group-focus-within/context-menu-submenu:opacity-100"
         data-menu-submenu-id={entry.id}
         role="menu"
+        style={{
+          top: submenuTop,
+          ...contextSubmenuHorizontalStyle(submenuAlignLeft)
+        }}
       >
         <ContextMenuEntries entries={entry.entries} submenuAlignLeft={submenuAlignLeft} onClose={onClose} />
       </div>


### PR DESCRIPTION
## Summary
- Keep context submenus inside the viewport when their anchor is close to the bottom edge.
- Add an 8px horizontal gap between parent menu items and submenus, with an invisible hover bridge so the submenu stays open while crossing the gap.
- Cover submenu spacing and bottom-edge positioning with focused ContextMenu tests.

## Why
- The export submenu could be clipped by the app window bottom edge.
- The submenu also visually sat too close to the parent menu because it overlapped the parent edge by 4px.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/ContextMenu.test.tsx` passed: 3 passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/desktop test -- apps/desktop/src/runtime/tauri/menu.test.ts` passed: 76 passed.
- `pnpm --filter @markra/desktop build` passed.

## Risk
- Low. The change is scoped to the shared self-drawn context menu positioning and keeps existing hover/focus behavior through a bridge element.
