### PR TITLE
fix(app): keep floating menus visible and dismissible

### DIFF
--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -539,7 +539,7 @@ describe("Markra AI workspace", () => {
     const agentPanel = screen.getByRole("complementary", { name: "Markra AI" });
 
     fireEvent.click(within(agentPanel).getByRole("button", { name: "Sessions" }));
-    fireEvent.click(await within(agentPanel).findByRole("menuitemradio", { name: /DeepSeek session/ }));
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: /DeepSeek session/ }));
 
     await waitFor(() =>
       expect(mockedSaveStoredAiSettings).toHaveBeenCalledWith(
@@ -619,7 +619,7 @@ describe("Markra AI workspace", () => {
     expect(webSearch).toHaveAttribute("aria-pressed", "true");
 
     fireEvent.click(within(agentPanel).getByRole("button", { name: "Sessions" }));
-    fireEvent.click(await within(agentPanel).findByRole("menuitem", { name: "New session" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "New session" }));
 
     await waitFor(() => expect(mockedInitializeStoredAiAgentSession).toHaveBeenCalledWith("session-new", null, {
       agentModelId: "gpt-5.5",

--- a/packages/app/src/components/AiAgentSessionMenu.test.tsx
+++ b/packages/app/src/components/AiAgentSessionMenu.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AiAgentSessionMenu } from "./AiAgentSessionMenu";
+import { agentSessionSummary } from "../test/ai-fixtures";
+
+function setViewport(width: number, height: number) {
+  const originalInnerHeight = window.innerHeight;
+  const originalInnerWidth = window.innerWidth;
+
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: height });
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+
+  return () => {
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: originalInnerHeight });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
+  };
+}
+
+describe("AiAgentSessionMenu", () => {
+  it("keeps the session menu inside the viewport near the bottom edge", () => {
+    const restoreViewport = setViewport(800, 640);
+
+    try {
+      render(
+        <AiAgentSessionMenu
+          activeSessionId="session-b"
+          language="en"
+          sessions={[
+            agentSessionSummary({ id: "session-a", title: "Plan cleanup" }),
+            agentSessionSummary({ id: "session-b", title: "Draft proposal" })
+          ]}
+          onCreateSession={vi.fn()}
+          onSelectSession={vi.fn()}
+        />
+      );
+
+      const trigger = screen.getByRole("button", { name: "Sessions" });
+      vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+        bottom: 628,
+        height: 32,
+        left: 720,
+        right: 752,
+        top: 596,
+        width: 32,
+        x: 720,
+        y: 596,
+        toJSON: () => ({})
+      });
+
+      fireEvent.click(trigger);
+
+      const menu = screen.getByRole("menu", { name: "Sessions" });
+      expect(menu).toHaveClass("fixed");
+      expect(Number.parseInt(menu.style.top, 10)).toBeLessThan(596);
+      expect(menu.style.maxHeight).toBe("580px");
+      expect(menu.style.overflowY).toBe("auto");
+    } finally {
+      restoreViewport();
+    }
+  });
+});

--- a/packages/app/src/components/AiAgentSessionMenu.tsx
+++ b/packages/app/src/components/AiAgentSessionMenu.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent
+} from "react";
+import { createPortal } from "react-dom";
 import { Archive, ArchiveRestore, Check, History, MessageSquarePlus, PencilLine, Search, Trash2 } from "lucide-react";
 import { Button, IconButton, PopoverSurface, SearchInput } from "@markra/ui";
 import { t, type AppLanguage, type I18nKey } from "@markra/shared";
 import type { StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
+import { anchoredPopoverStyle } from "../lib/anchored-popover";
 import { confirmNativeAiAgentSessionDelete } from "../lib/tauri";
 
 const menuExitDurationMs = 140;
@@ -29,9 +39,12 @@ export function AiAgentSessionMenu({
   onSelectSession
 }: AiAgentSessionMenuProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
   const [open, setOpen] = useState(false);
   const [menuVisible, setMenuVisible] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties | null>(null);
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
   const [query, setQuery] = useState("");
@@ -81,22 +94,54 @@ export function AiAgentSessionMenu({
     }, menuExitDurationMs);
   }, [menuVisible, open]);
 
+  const positionMenu = (trigger: HTMLButtonElement) => {
+    setMenuStyle(
+      anchoredPopoverStyle(trigger, menuRef.current, {
+        align: "end",
+        fallbackSize: {
+          height: 400,
+          width: 288
+        },
+        gap: 8
+      })
+    );
+  };
+
+  useLayoutEffect(() => {
+    if (!open || !menuVisible) return;
+
+    const trigger = triggerRef.current;
+    if (trigger) positionMenu(trigger);
+  }, [filteredSessions.length, menuVisible, open, showArchived]);
+
   useEffect(() => {
     if (!open) return;
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (rootRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+
+      setOpen(false);
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false);
     };
+    const handleLayoutChange = () => {
+      const trigger = triggerRef.current;
+      if (trigger) positionMenu(trigger);
+    };
 
     window.addEventListener("pointerdown", handlePointerDown);
     window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", handleLayoutChange);
+    window.addEventListener("scroll", handleLayoutChange, true);
 
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", handleLayoutChange);
+      window.removeEventListener("scroll", handleLayoutChange, true);
     };
   }, [open]);
 
@@ -136,9 +181,184 @@ export function AiAgentSessionMenu({
     await onDeleteSession?.(sessionId);
   };
 
+  const menu =
+    menuVisible && menuStyle && typeof document !== "undefined"
+      ? createPortal(
+          <PopoverSurface
+            ref={menuRef}
+            className="fixed z-40 w-72 overflow-hidden rounded-xl"
+            style={menuStyle}
+            open={open}
+            openClassName="pointer-events-auto translate-y-0 opacity-100"
+            closedClassName="pointer-events-none -translate-y-1 opacity-0"
+            role="menu"
+            aria-label={label("app.aiAgentSessions")}
+          >
+            <div className="border-b border-(--border-default) p-1.5">
+              <Button
+                className="w-full justify-start rounded-lg bg-(--bg-secondary) text-left font-semibold text-(--text-primary) hover:border-(--border-strong)"
+                size="md"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  onCreateSession?.();
+                }}
+              >
+                <MessageSquarePlus aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
+                <span className="truncate">{label("app.aiAgentNewSession")}</span>
+              </Button>
+              <div className="mt-1.5 grid grid-cols-[minmax(0,1fr)_auto] gap-1.5">
+                <SearchInput
+                  aria-label={label("app.aiAgentSearchSessions")}
+                  className="rounded-lg text-(--text-primary) focus:ring-0"
+                  icon={<Search size={13} />}
+                  size="sm"
+                  value={query}
+                  placeholder={label("app.aiAgentSearchSessions")}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                />
+                <IconButton
+                  className={`rounded-lg ${
+                    showArchived
+                      ? "border-(--accent) bg-(--accent-soft) text-(--accent)"
+                      : "border-(--border-default) bg-(--bg-primary) text-(--text-secondary) hover:border-(--border-strong) hover:text-(--text-heading)"
+                  }`}
+                  label={showArchived ? label("app.aiAgentHideArchivedSessions") : label("app.aiAgentShowArchivedSessions")}
+                  pressed={showArchived}
+                  size="icon-md"
+                  variant="secondary"
+                  onClick={() => setShowArchived((current) => !current)}
+                >
+                  <Archive aria-hidden="true" size={13} />
+                </IconButton>
+              </div>
+            </div>
+            <div className="max-h-80 overflow-auto p-1.5">
+              {filteredSessions.length > 0 ? (
+                <div className="grid gap-1">
+                  {filteredSessions.map((session) => {
+                    const active = session.id === activeSessionId;
+                    const sessionTitle = session.title ?? label("app.aiAgentSessionUntitled");
+                    const editing = editingSessionId === session.id;
+                    const archived = session.archivedAt !== null;
+
+                    return (
+                      <div
+                        className={`relative rounded-lg border transition-[background-color,border-color,color] duration-150 ease-out ${
+                          active
+                            ? "border-(--accent) bg-(--accent-soft) text-(--text-heading)"
+                            : archived
+                              ? "border-transparent bg-transparent text-(--text-secondary) opacity-75 hover:border-(--border-default) hover:bg-(--bg-hover) hover:text-(--text-heading) hover:opacity-100"
+                              : "border-transparent bg-transparent text-(--text-primary) hover:border-(--border-default) hover:bg-(--bg-hover) hover:text-(--text-heading)"
+                        }`}
+                        key={session.id}
+                      >
+                        {editing ? (
+                          <div className="grid gap-1 px-3 py-2">
+                            <input
+                              aria-label={label("app.aiAgentRenameSessionInput")}
+                              autoFocus
+                              className="h-8 rounded-md border border-(--accent) bg-(--bg-primary) px-2 text-[12px] leading-5 font-[620] text-(--text-primary) outline-none"
+                              type="text"
+                              value={editingTitle}
+                              onBlur={() => commitRename(session.id)}
+                              onChange={(event) => setEditingTitle(event.target.value)}
+                              onKeyDown={(event: ReactKeyboardEvent<HTMLInputElement>) => {
+                                if (event.key === "Enter") {
+                                  event.preventDefault();
+                                  commitRename(session.id);
+                                  return;
+                                }
+
+                                if (event.key === "Escape") {
+                                  event.preventDefault();
+                                  cancelRename();
+                                }
+                              }}
+                            />
+                            <span className="truncate text-[11px] leading-4 text-(--text-secondary)">
+                              {formatter.format(session.updatedAt)}
+                            </span>
+                          </div>
+                        ) : (
+                          <>
+                            <button
+                              className="grid w-full cursor-pointer gap-0.5 rounded-lg px-3 py-2 pr-24 text-left"
+                              type="button"
+                              role="menuitemradio"
+                              aria-checked={active}
+                              onClick={() => {
+                                setOpen(false);
+                                onSelectSession?.(session.id);
+                              }}
+                            >
+                              <span className="flex min-w-0 items-center gap-2">
+                                <span className="min-w-0 flex-1 truncate text-[12px] leading-5 font-[620]">
+                                  {sessionTitle}
+                                </span>
+                                {active ? <Check aria-hidden="true" className="shrink-0 text-(--accent)" size={14} /> : null}
+                              </span>
+                              <span className="truncate text-[11px] leading-4 text-(--text-secondary)">
+                                {formatter.format(session.updatedAt)}
+                              </span>
+                            </button>
+                            <div className="absolute top-2 right-2 flex items-center gap-1">
+                              <IconButton
+                                className="hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
+                                label={`${label("app.aiAgentRenameSession")} ${sessionTitle}`}
+                                size="icon-xs"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  setEditingSessionId(session.id);
+                                  setEditingTitle(sessionTitle);
+                                }}
+                              >
+                                <PencilLine aria-hidden="true" size={12} />
+                              </IconButton>
+                              <IconButton
+                                className="hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
+                                label={`${archived ? label("app.aiAgentRestoreSession") : label("app.aiAgentArchiveSession")} ${sessionTitle}`}
+                                size="icon-xs"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  onArchiveSession?.(session.id, !archived);
+                                }}
+                              >
+                                {archived ? <ArchiveRestore aria-hidden="true" size={12} /> : <Archive aria-hidden="true" size={12} />}
+                              </IconButton>
+                              <IconButton
+                                className="hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
+                                label={`${label("app.aiAgentDeleteSession")} ${sessionTitle}`}
+                                size="icon-xs"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  requestDeleteSession(session.id, sessionTitle).catch(() => {});
+                                }}
+                              >
+                                <Trash2 aria-hidden="true" size={12} />
+                              </IconButton>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="m-0 px-2 py-3 text-[12px] leading-5 text-(--text-secondary)">
+                  {sessions.length > 0 ? label("app.aiAgentNoMatchingSessions") : label("app.aiAgentNoSessions")}
+                </p>
+              )}
+            </div>
+          </PopoverSurface>,
+          document.body
+        )
+      : null;
+
   return (
     <div className="relative" ref={rootRef}>
       <button
+        ref={triggerRef}
         className={`inline-flex size-8 cursor-pointer items-center justify-center rounded-lg border-0 bg-transparent p-0 text-(--text-secondary) transition-[background-color,color] duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none ${
           open ? "bg-(--bg-hover) text-(--text-heading)" : ""
         }`}
@@ -146,177 +366,14 @@ export function AiAgentSessionMenu({
         aria-label={label("app.aiAgentSessions")}
         aria-expanded={open}
         aria-haspopup="menu"
-        onClick={() => setOpen((current) => !current)}
+        onClick={(event) => {
+          if (!open) positionMenu(event.currentTarget);
+          setOpen(!open);
+        }}
       >
         <History aria-hidden="true" size={15} />
       </button>
-      {menuVisible ? (
-        <PopoverSurface
-          className="absolute top-[calc(100%+8px)] right-0 z-40 w-72 overflow-hidden rounded-xl"
-          open={open}
-          openClassName="pointer-events-auto translate-y-0 opacity-100"
-          closedClassName="pointer-events-none -translate-y-1 opacity-0"
-          role="menu"
-          aria-label={label("app.aiAgentSessions")}
-        >
-          <div className="border-b border-(--border-default) p-1.5">
-            <Button
-              className="w-full justify-start rounded-lg bg-(--bg-secondary) text-left font-semibold text-(--text-primary) hover:border-(--border-strong)"
-              size="md"
-              role="menuitem"
-              onClick={() => {
-                setOpen(false);
-                onCreateSession?.();
-              }}
-            >
-              <MessageSquarePlus aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
-              <span className="truncate">{label("app.aiAgentNewSession")}</span>
-            </Button>
-            <div className="mt-1.5 grid grid-cols-[minmax(0,1fr)_auto] gap-1.5">
-              <SearchInput
-                aria-label={label("app.aiAgentSearchSessions")}
-                className="rounded-lg text-(--text-primary) focus:ring-0"
-                icon={<Search size={13} />}
-                size="sm"
-                value={query}
-                placeholder={label("app.aiAgentSearchSessions")}
-                onChange={(event) => setQuery(event.currentTarget.value)}
-              />
-              <IconButton
-                className={`rounded-lg ${
-                  showArchived
-                    ? "border-(--accent) bg-(--accent-soft) text-(--accent)"
-                    : "border-(--border-default) bg-(--bg-primary) text-(--text-secondary) hover:border-(--border-strong) hover:text-(--text-heading)"
-                }`}
-                label={showArchived ? label("app.aiAgentHideArchivedSessions") : label("app.aiAgentShowArchivedSessions")}
-                pressed={showArchived}
-                size="icon-md"
-                variant="secondary"
-                onClick={() => setShowArchived((current) => !current)}
-              >
-                <Archive aria-hidden="true" size={13} />
-              </IconButton>
-            </div>
-          </div>
-          <div className="max-h-80 overflow-auto p-1.5">
-            {filteredSessions.length > 0 ? (
-              <div className="grid gap-1">
-                {filteredSessions.map((session) => {
-                  const active = session.id === activeSessionId;
-                  const sessionTitle = session.title ?? label("app.aiAgentSessionUntitled");
-                  const editing = editingSessionId === session.id;
-                  const archived = session.archivedAt !== null;
-
-                  return (
-                    <div
-                      className={`relative rounded-lg border transition-[background-color,border-color,color] duration-150 ease-out ${
-                        active
-                          ? "border-(--accent) bg-(--accent-soft) text-(--text-heading)"
-                          : archived
-                            ? "border-transparent bg-transparent text-(--text-secondary) opacity-75 hover:border-(--border-default) hover:bg-(--bg-hover) hover:text-(--text-heading) hover:opacity-100"
-                            : "border-transparent bg-transparent text-(--text-primary) hover:border-(--border-default) hover:bg-(--bg-hover) hover:text-(--text-heading)"
-                      }`}
-                      key={session.id}
-                    >
-                      {editing ? (
-                        <div className="grid gap-1 px-3 py-2">
-                          <input
-                            aria-label={label("app.aiAgentRenameSessionInput")}
-                            autoFocus
-                            className="h-8 rounded-md border border-(--accent) bg-(--bg-primary) px-2 text-[12px] leading-5 font-[620] text-(--text-primary) outline-none"
-                            type="text"
-                            value={editingTitle}
-                            onBlur={() => commitRename(session.id)}
-                            onChange={(event) => setEditingTitle(event.target.value)}
-                            onKeyDown={(event: ReactKeyboardEvent<HTMLInputElement>) => {
-                              if (event.key === "Enter") {
-                                event.preventDefault();
-                                commitRename(session.id);
-                                return;
-                              }
-
-                              if (event.key === "Escape") {
-                                event.preventDefault();
-                                cancelRename();
-                              }
-                            }}
-                          />
-                          <span className="truncate text-[11px] leading-4 text-(--text-secondary)">
-                            {formatter.format(session.updatedAt)}
-                          </span>
-                        </div>
-                      ) : (
-                        <>
-                          <button
-                            className="grid w-full cursor-pointer gap-0.5 rounded-lg px-3 py-2 pr-24 text-left"
-                            type="button"
-                            role="menuitemradio"
-                            aria-checked={active}
-                            onClick={() => {
-                              setOpen(false);
-                              onSelectSession?.(session.id);
-                            }}
-                          >
-                            <span className="flex min-w-0 items-center gap-2">
-                              <span className="min-w-0 flex-1 truncate text-[12px] leading-5 font-[620]">
-                                {sessionTitle}
-                              </span>
-                              {active ? <Check aria-hidden="true" className="shrink-0 text-(--accent)" size={14} /> : null}
-                            </span>
-                            <span className="truncate text-[11px] leading-4 text-(--text-secondary)">
-                              {formatter.format(session.updatedAt)}
-                            </span>
-                          </button>
-                          <div className="absolute top-2 right-2 flex items-center gap-1">
-                            <IconButton
-                              className="hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
-                              label={`${label("app.aiAgentRenameSession")} ${sessionTitle}`}
-                              size="icon-xs"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                setEditingSessionId(session.id);
-                                setEditingTitle(sessionTitle);
-                              }}
-                            >
-                              <PencilLine aria-hidden="true" size={12} />
-                            </IconButton>
-                            <IconButton
-                              className="hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
-                              label={`${archived ? label("app.aiAgentRestoreSession") : label("app.aiAgentArchiveSession")} ${sessionTitle}`}
-                              size="icon-xs"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                onArchiveSession?.(session.id, !archived);
-                              }}
-                            >
-                              {archived ? <ArchiveRestore aria-hidden="true" size={12} /> : <Archive aria-hidden="true" size={12} />}
-                            </IconButton>
-                            <IconButton
-                              className="hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
-                              label={`${label("app.aiAgentDeleteSession")} ${sessionTitle}`}
-                              size="icon-xs"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                requestDeleteSession(session.id, sessionTitle).catch(() => {});
-                              }}
-                            >
-                              <Trash2 aria-hidden="true" size={12} />
-                            </IconButton>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <p className="m-0 px-2 py-3 text-[12px] leading-5 text-(--text-secondary)">
-                {sessions.length > 0 ? label("app.aiAgentNoMatchingSessions") : label("app.aiAgentNoSessions")}
-              </p>
-            )}
-          </div>
-        </PopoverSurface>
-      ) : null}
+      {menu}
     </div>
   );
 }

--- a/packages/app/src/components/AiModelPicker.test.tsx
+++ b/packages/app/src/components/AiModelPicker.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AiModelPicker, type AiModelPickerOption } from "./AiModelPicker";
+
+const models: AiModelPickerOption[] = [
+  {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    providerId: "openai",
+    providerName: "OpenAI",
+    providerType: "openai"
+  },
+  {
+    id: "claude-synthetic",
+    name: "Claude Synthetic",
+    providerId: "anthropic",
+    providerName: "Anthropic",
+    providerType: "anthropic"
+  }
+];
+
+function setViewport(width: number, height: number) {
+  const originalInnerHeight = window.innerHeight;
+  const originalInnerWidth = window.innerWidth;
+
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: height });
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+
+  return () => {
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: originalInnerHeight });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
+  };
+}
+
+describe("AiModelPicker", () => {
+  it("keeps the subtitle model listbox inside the viewport near the bottom edge", () => {
+    const restoreViewport = setViewport(800, 640);
+
+    try {
+      render(
+        <AiModelPicker
+          ariaLabel="AI model"
+          models={models}
+          selectedModelId="gpt-5.5"
+          selectedProviderId="openai"
+          variant="subtitle"
+          onSelect={vi.fn()}
+          translate={(key) => key}
+        />
+      );
+
+      const trigger = screen.getByRole("combobox", { name: "AI model" });
+      vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+        bottom: 628,
+        height: 32,
+        left: 360,
+        right: 440,
+        top: 596,
+        width: 80,
+        x: 360,
+        y: 596,
+        toJSON: () => ({})
+      });
+
+      fireEvent.click(trigger);
+
+      const listbox = screen.getByRole("listbox", { name: "AI model" });
+      expect(listbox).toHaveClass("fixed");
+      expect(Number.parseInt(listbox.style.top, 10)).toBeLessThan(596);
+      expect(listbox.style.maxHeight).toBe("582px");
+      expect(listbox.style.overflowY).toBe("auto");
+    } finally {
+      restoreViewport();
+    }
+  });
+});

--- a/packages/app/src/components/AiModelPicker.tsx
+++ b/packages/app/src/components/AiModelPicker.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import { Check, ChevronDown } from "lucide-react";
 import { AiProviderBadge } from "./AiProviderBadge";
 import { PopoverSurface } from "@markra/ui";
 import type { AiProviderApiStyle, AiProviderConfig } from "../lib/settings/app-settings";
 import type { I18nKey } from "@markra/shared";
+import { anchoredPopoverStyle } from "../lib/anchored-popover";
 
 const menuExitDurationMs = 140;
 
@@ -37,9 +39,12 @@ export function AiModelPicker({
   translate
 }: AiModelPickerProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
   const [open, setOpen] = useState(false);
   const [menuVisible, setMenuVisible] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties | null>(null);
   const selectedValue =
     selectedProviderId && selectedModelId ? getAiModelOptionValue(selectedProviderId, selectedModelId) : "";
   const selectedModel = useMemo(
@@ -66,22 +71,55 @@ export function AiModelPicker({
     }, menuExitDurationMs);
   }, [menuVisible, open]);
 
+  const positionMenu = (trigger: HTMLButtonElement) => {
+    setMenuStyle(
+      anchoredPopoverStyle(trigger, menuRef.current, {
+        align: variant === "subtitle" ? "center" : "end",
+        fallbackSize: {
+          height: variant === "subtitle" ? 64 : 288,
+          width: variant === "subtitle" ? 248 : 272
+        },
+        gap: variant === "subtitle" ? 6 : 8,
+        placement: variant === "subtitle" ? "bottom" : "top"
+      })
+    );
+  };
+
+  useLayoutEffect(() => {
+    if (!open || !menuVisible) return;
+
+    const trigger = triggerRef.current;
+    if (trigger) positionMenu(trigger);
+  }, [menuVisible, models.length, open, variant]);
+
   useEffect(() => {
     if (!open) return;
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (rootRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+
+      setOpen(false);
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false);
     };
+    const handleLayoutChange = () => {
+      const trigger = triggerRef.current;
+      if (trigger) positionMenu(trigger);
+    };
 
     window.addEventListener("pointerdown", handlePointerDown);
     window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", handleLayoutChange);
+    window.addEventListener("scroll", handleLayoutChange, true);
 
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", handleLayoutChange);
+      window.removeEventListener("scroll", handleLayoutChange, true);
     };
   }, [open]);
 
@@ -105,17 +143,69 @@ export function AiModelPicker({
       : "min-w-0 truncate text-[12px] leading-5 font-[560]";
   const menuClassName =
     variant === "subtitle"
-      ? "absolute top-[calc(100%+6px)] left-1/2 z-40 max-h-72 w-62 -translate-x-1/2 overflow-auto rounded-lg p-1"
-      : "absolute right-0 bottom-[calc(100%+8px)] z-40 max-h-72 w-68 overflow-auto rounded-lg p-1";
+      ? "fixed z-40 w-62 overflow-auto rounded-lg p-1"
+      : "fixed z-40 w-68 overflow-auto rounded-lg p-1";
 
   const handleSelect = (providerId: string, modelId: string) => {
     setOpen(false);
     onSelect?.(providerId, modelId);
   };
 
+  const menu =
+    menuVisible && menuStyle && typeof document !== "undefined"
+      ? createPortal(
+          <PopoverSurface
+            ref={menuRef}
+            className={menuClassName}
+            style={menuStyle}
+            open={open}
+            openClassName="pointer-events-auto scale-100 opacity-100"
+            closedClassName="pointer-events-none scale-[0.98] opacity-0"
+            role="listbox"
+            aria-label={ariaLabel}
+          >
+            {models.map((model) => {
+              const modelValue = getAiModelOptionValue(model.providerId, model.id);
+              const active = modelValue === selectedValue;
+
+              return (
+                <button
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-[background-color,color,transform] duration-150 ease-out ${
+                    active
+                      ? "bg-(--bg-hover) text-(--text-heading)"
+                      : "text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading)"
+                  }`}
+                  key={modelValue}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  onClick={() => handleSelect(model.providerId, model.id)}
+                >
+                  <span className="shrink-0 scale-75">
+                    <AiProviderBadge provider={buildProviderBadge(model)} translate={translate} />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[12px] leading-5 font-[560]">
+                    {`${model.providerName} · ${model.name}`}
+                  </span>
+                  {active ? (
+                    <Check
+                      aria-hidden="true"
+                      className="shrink-0 text-(--accent) transition-[opacity,transform] duration-150 ease-out"
+                      size={14}
+                    />
+                  ) : null}
+                </button>
+              );
+            })}
+          </PopoverSurface>,
+          document.body
+        )
+      : null;
+
   return (
     <div className="relative min-w-0" ref={rootRef}>
       <button
+        ref={triggerRef}
         className={triggerClassName}
         type="button"
         role="combobox"
@@ -123,7 +213,10 @@ export function AiModelPicker({
         aria-expanded={open}
         aria-haspopup="listbox"
         disabled={disabled || models.length === 0 || !onSelect}
-        onClick={() => setOpen((current) => !current)}
+        onClick={(event) => {
+          if (!open) positionMenu(event.currentTarget);
+          setOpen(!open);
+        }}
       >
         <span className="shrink-0 scale-[0.68]">
           <AiProviderBadge provider={buildProviderBadge(selectedModel)} translate={translate} />
@@ -135,50 +228,7 @@ export function AiModelPicker({
           size={12}
         />
       </button>
-      {menuVisible ? (
-        <PopoverSurface
-          className={menuClassName}
-          open={open}
-          openClassName="pointer-events-auto scale-100 opacity-100"
-          closedClassName="pointer-events-none scale-[0.98] opacity-0"
-          role="listbox"
-          aria-label={ariaLabel}
-        >
-          {models.map((model) => {
-            const modelValue = getAiModelOptionValue(model.providerId, model.id);
-            const active = modelValue === selectedValue;
-
-            return (
-              <button
-                className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-[background-color,color,transform] duration-150 ease-out ${
-                  active
-                    ? "bg-(--bg-hover) text-(--text-heading)"
-                    : "text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading)"
-                }`}
-                key={modelValue}
-                type="button"
-                role="option"
-                aria-selected={active}
-                onClick={() => handleSelect(model.providerId, model.id)}
-              >
-                <span className="shrink-0 scale-75">
-                  <AiProviderBadge provider={buildProviderBadge(model)} translate={translate} />
-                </span>
-                <span className="min-w-0 flex-1 truncate text-[12px] leading-5 font-[560]">
-                  {`${model.providerName} · ${model.name}`}
-                </span>
-                {active ? (
-                  <Check
-                    aria-hidden="true"
-                    className="shrink-0 text-(--accent) transition-[opacity,transform] duration-150 ease-out"
-                    size={14}
-                  />
-                ) : null}
-              </button>
-            );
-          })}
-        </PopoverSurface>
-      ) : null}
+      {menu}
     </div>
   );
 }

--- a/packages/app/src/components/AiSelectionToolbar.test.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.test.tsx
@@ -162,6 +162,54 @@ describe("AiSelectionToolbar", () => {
     expect(headingMenu).toHaveClass("fixed");
   });
 
+  it("keeps the heading level menu inside the viewport near the bottom edge", () => {
+    const originalInnerHeight = window.innerHeight;
+    const originalInnerWidth = window.innerWidth;
+
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 640 });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+
+    try {
+      render(
+        <AiSelectionToolbar
+          activeHeadingLevel={2}
+          anchor={anchor}
+          language="en"
+          open
+          onCopySelection={vi.fn()}
+          onInsertLink={vi.fn()}
+          onOpenCommand={vi.fn()}
+          onRunFormattingAction={vi.fn()}
+          onRunAction={vi.fn()}
+          onSetHeadingLevel={vi.fn()}
+        />
+      );
+
+      const headingButton = screen.getByRole("button", { name: "Heading Level H2" });
+      vi.spyOn(headingButton, "getBoundingClientRect").mockReturnValue({
+        bottom: 628,
+        height: 32,
+        left: 120,
+        right: 152,
+        top: 596,
+        width: 32,
+        x: 120,
+        y: 596,
+        toJSON: () => ({})
+      });
+
+      fireEvent.click(headingButton);
+
+      const headingMenu = screen.getByRole("menu", { name: "Heading Level" });
+      expect(Number.parseInt(headingMenu.style.top, 10)).toBeLessThan(596);
+      expect(headingMenu.style.maxHeight).toBe("584px");
+      expect(headingMenu.style.overflowY).toBe("auto");
+    } finally {
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: originalInnerHeight });
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
+    }
+  });
+
   it("keeps the heading level menu available outside headings", () => {
     const { rerender } = render(
       <AiSelectionToolbar

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -36,6 +36,7 @@ import {
   type AiQuickActionId,
   type AiQuickActionPrompts
 } from "../lib/ai-actions";
+import { anchoredPopoverStyle } from "../lib/anchored-popover";
 import type { SelectionAnchor } from "../lib/selection-anchor";
 import {
   selectionHeadingLevels,
@@ -183,16 +184,15 @@ export function AiSelectionToolbar({
   const headingLevelMenuRef = useRef<HTMLDivElement | null>(null);
 
   const positionHeadingLevelMenu = (button: HTMLButtonElement) => {
-    const buttonRect = button.getBoundingClientRect();
-    const menuWidthPx = 112;
-    const viewportPaddingPx = 8;
-    const maxLeft = Math.max(viewportPaddingPx, window.innerWidth - menuWidthPx - viewportPaddingPx);
-    const left = Math.min(Math.max(buttonRect.left, viewportPaddingPx), maxLeft);
-
-    setHeadingLevelMenuStyle({
-      left: `${Math.round(left)}px`,
-      top: `${Math.round(buttonRect.bottom + 4)}px`
-    });
+    setHeadingLevelMenuStyle(
+      anchoredPopoverStyle(button, headingLevelMenuRef.current, {
+        fallbackSize: {
+          height: 76,
+          width: 112
+        },
+        gap: 4
+      })
+    );
   };
 
   useEffect(() => {

--- a/packages/app/src/components/ContextMenu.test.tsx
+++ b/packages/app/src/components/ContextMenu.test.tsx
@@ -118,6 +118,41 @@ describe("ContextMenu", () => {
     expect(getMenu()).toBeNull();
   });
 
+  it("limits the main menu height when opened near the viewport bottom", () => {
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(300);
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(400);
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (this: HTMLElement) {
+      if (this.hasAttribute("data-markra-context-menu")) return 500;
+
+      return 28;
+    });
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(function (this: HTMLElement) {
+      if (this.hasAttribute("data-markra-context-menu")) return 216;
+
+      return 32;
+    });
+
+    showContextMenu(document, {
+      entries: Array.from({ length: 24 }, (_, index) => ({
+        id: `markra:test:item-${index + 1}`,
+        kind: "item" as const,
+        label: `Item ${index + 1}`,
+        onSelect: vi.fn()
+      })),
+      position: {
+        x: 120,
+        y: 260
+      }
+    });
+
+    const menu = getMenu() as HTMLElement | null;
+
+    expect(menu).not.toBeNull();
+    expect(menu?.style.top).toBe("8px");
+    expect(menu?.style.maxHeight).toBe("252px");
+    expect(menu?.style.overflowY).toBe("auto");
+  });
+
   it("keeps submenus inside the viewport when their anchor is near the bottom", () => {
     vi.spyOn(window, "innerHeight", "get").mockReturnValue(220);
     vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (this: HTMLElement) {

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -8,6 +8,7 @@ import {
 import { ChevronRight } from "lucide-react";
 import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
+import { popoverPosition } from "@markra/shared";
 
 export type ContextMenuEntry = ContextMenuItem | ContextMenuSeparator | ContextMenuSubmenu;
 
@@ -232,14 +233,34 @@ export function ContextMenu({ ariaLabel, entries, onClose, position }: ContextMe
     const viewportHeight = windowTarget?.innerHeight ?? 768;
     const width = menu.offsetWidth || defaultContextMenuWidth;
     const height = menu.offsetHeight || defaultContextMenuHeight;
-    const left = Math.max(contextMenuViewportMargin, Math.min(position.x, viewportWidth - width - contextMenuViewportMargin));
-    const top = Math.max(contextMenuViewportMargin, Math.min(position.y, viewportHeight - height - contextMenuViewportMargin));
+    const positioned = popoverPosition(
+      {
+        bottom: position.y,
+        left: position.x,
+        right: position.x,
+        top: position.y
+      },
+      {
+        height,
+        width
+      },
+      {
+        height: viewportHeight,
+        width: viewportWidth
+      },
+      {
+        gap: 0,
+        margin: contextMenuViewportMargin
+      }
+    );
 
     setMenuStyle({
-      left,
-      top
+      left: positioned.left,
+      maxHeight: positioned.maxHeight,
+      overflowY: "auto",
+      top: positioned.top
     });
-    setSubmenuAlignLeft(left + width + contextSubmenuWidth > viewportWidth - contextMenuViewportMargin);
+    setSubmenuAlignLeft(positioned.left + width + contextSubmenuWidth > viewportWidth - contextMenuViewportMargin);
   }, [position.x, position.y]);
 
   useLayoutEffect(() => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -627,6 +627,46 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(treeRows()).toEqual(["alpha", "zeta", "zed.md", "alpha.md"]);
   });
 
+  it("closes sidebar option menus after clicking outside them", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          { level: 1, title: "Intro" },
+          { level: 2, title: "Setup" }
+        ]}
+        rootName="Obsidian Vault"
+        onCreateFile={() => {}}
+        onCreateFolder={() => {}}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort files" }));
+    expect(screen.getByRole("menu", { name: "Sort files" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole("menu", { name: "Sort files" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    expect(screen.getByRole("menu", { name: "New" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole("menu", { name: "New" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Outline heading levels: All headings" }));
+    expect(screen.getByRole("menu", { name: "Outline heading levels" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole("menu", { name: "Outline heading levels" })).not.toBeInTheDocument();
+  });
+
   it("opens image assets from the file tree and supports renaming them", () => {
     const openFile = vi.fn();
     const renameFile = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -594,6 +594,9 @@ export function MarkdownFileTreeDrawer({
   const resizeCleanupRef = useRef<(() => unknown) | null>(null);
   const outlineResizeCleanupRef = useRef<(() => unknown) | null>(null);
   const fileTreeBodyRef = useRef<HTMLDivElement | null>(null);
+  const fileTreeSortMenuRef = useRef<HTMLDivElement | null>(null);
+  const createMenuRef = useRef<HTMLDivElement | null>(null);
+  const outlineLevelMenuRef = useRef<HTMLDivElement | null>(null);
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set());
   const [hoveredRecentFolderPath, setHoveredRecentFolderPath] = useState<string | null>(null);
   const [focusedRecentFolderActionPath, setFocusedRecentFolderActionPath] = useState<string | null>(null);
@@ -712,6 +715,33 @@ export function MarkdownFileTreeDrawer({
       outlineResizeCleanupRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    if (!fileTreeSortMenuOpen && !createMenuOpen && !outlineLevelMenuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+
+      const openMenuRoots = [
+        fileTreeSortMenuOpen ? fileTreeSortMenuRef.current : null,
+        createMenuOpen ? createMenuRef.current : null,
+        outlineLevelMenuOpen ? outlineLevelMenuRef.current : null
+      ];
+
+      if (openMenuRoots.some((root) => root?.contains(target))) return;
+
+      setFileTreeSortMenuOpen(false);
+      setCreateMenuOpen(false);
+      setOutlineLevelMenuOpen(false);
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [createMenuOpen, fileTreeSortMenuOpen, outlineLevelMenuOpen]);
 
   useEffect(() => {
     const validKeys = new Set(collapsibleOutlineKeys);
@@ -1786,7 +1816,7 @@ export function MarkdownFileTreeDrawer({
                       <Search aria-hidden="true" size={14} />
                     </IconButton>
                   ) : null}
-                  <div className="relative">
+                  <div className="relative" ref={fileTreeSortMenuRef}>
                     <IconButton
                       className="rounded-md"
                       label={label("app.sortMarkdownFiles")}
@@ -1845,7 +1875,7 @@ export function MarkdownFileTreeDrawer({
                   </IconButton>
                 ) : null}
                 {folderActionsAvailable ? (
-                  <div className="relative">
+                  <div className="relative" ref={createMenuRef}>
                     <IconButton
                       className="rounded-md"
                       label={label("app.newMarkdownItem")}
@@ -1976,7 +2006,7 @@ export function MarkdownFileTreeDrawer({
                     </>
                   ) : null}
                   {outlinePanelOpen && outlineItems.length > 0 ? (
-                    <div className="relative">
+                    <div className="relative" ref={outlineLevelMenuRef}>
                       <button
                         className="markdown-file-tree-outline-filter inline-flex h-6 min-w-9 cursor-pointer items-center justify-center gap-1 rounded-sm border border-transparent bg-transparent px-1.5 text-[12px] leading-none font-[560] text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
                         type="button"

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -3685,6 +3685,45 @@ describe("MarkdownPaper editing", () => {
     );
   });
 
+  it("renders the table size picker outside the table wrapper", async () => {
+    const initialTable = ["| Field | Value |", "| --- | --- |", "| Name | Markra |"].join("\n");
+    await renderEditor(initialTable);
+    const restoreInnerHeight = window.innerHeight;
+    const restoreInnerWidth = window.innerWidth;
+
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 640 });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+
+    const sizeButton = screen.getByRole("button", { name: "Adjust table" });
+    vi.spyOn(sizeButton, "getBoundingClientRect").mockReturnValue({
+      bottom: 72,
+      height: 24,
+      left: 48,
+      right: 72,
+      top: 48,
+      width: 24,
+      x: 48,
+      y: 48,
+      toJSON: () => ({})
+    });
+
+    fireEvent.mouseDown(sizeButton);
+
+    const popover = document.querySelector<HTMLElement>(".markra-table-size-popover");
+    expect(popover).not.toBeNull();
+    expect(popover?.parentElement).toBe(document.body);
+    expect(popover).toHaveStyle({
+      left: "48px",
+      maxHeight: "552px",
+      overflowY: "auto",
+      position: "fixed",
+      top: "80px"
+    });
+
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: restoreInnerHeight });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: restoreInnerWidth });
+  });
+
   it("renders AI replacement comparison inside the editor", async () => {
     const { container, view } = await renderEditor("Original text");
     const from = findTextPosition(view, "Original");
@@ -6761,6 +6800,36 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps the slash command menu inside the viewport when opened near the bottom", async () => {
+    const { view } = await renderEditor();
+    const innerHeight = vi.spyOn(window, "innerHeight", "get").mockReturnValue(640);
+    const innerWidth = vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    const offsetHeight = vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(700);
+    const offsetWidth = vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(240);
+    const coordsAtPos = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 578,
+      left: 120,
+      right: 140,
+      top: 560
+    });
+
+    try {
+      typeText(view, "/");
+
+      const menu = await screen.findByRole("listbox", { name: "Slash commands" });
+
+      expect(Number.parseFloat(menu.style.top)).toBeLessThan(560);
+      expect(menu.style.maxHeight).toBe("544px");
+      expect(menu.style.overflowY).toBe("auto");
+    } finally {
+      coordsAtPos.mockRestore();
+      offsetWidth.mockRestore();
+      offsetHeight.mockRestore();
+      innerWidth.mockRestore();
+      innerHeight.mockRestore();
+    }
+  });
+
   it("closes the document link completion menu after clicking outside it", async () => {
     const { container, view } = await renderEditor("", {
       documentPath: "/vault/current.md",
@@ -6779,6 +6848,42 @@ describe("MarkdownPaper editing", () => {
     await waitFor(() => expect(screen.queryByRole("listbox", { name: "Document links" })).not.toBeInTheDocument());
     expect(container.querySelector(".ProseMirror")?.textContent).toBe("[[guide");
     await settleMarkdownListener();
+  });
+
+  it("keeps the document link completion menu inside the viewport when opened near the bottom", async () => {
+    const { view } = await renderEditor("", {
+      documentPath: "/vault/current.md",
+      workspaceFiles: [
+        { name: "guide.md", path: "/vault/guide.md", relativePath: "guide.md" },
+        { name: "guide-two.md", path: "/vault/guide-two.md", relativePath: "guide-two.md" }
+      ]
+    });
+    const innerHeight = vi.spyOn(window, "innerHeight", "get").mockReturnValue(640);
+    const innerWidth = vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    const offsetHeight = vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(700);
+    const offsetWidth = vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(240);
+    const coordsAtPos = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 578,
+      left: 120,
+      right: 140,
+      top: 560
+    });
+
+    try {
+      typeText(view, "[[guide");
+
+      const menu = await screen.findByRole("listbox", { name: "Document links" });
+
+      expect(Number.parseFloat(menu.style.top)).toBeLessThan(560);
+      expect(menu.style.maxHeight).toBe("544px");
+      expect(menu.style.overflowY).toBe("auto");
+    } finally {
+      coordsAtPos.mockRestore();
+      offsetWidth.mockRestore();
+      offsetHeight.mockRestore();
+      innerWidth.mockRestore();
+      innerHeight.mockRestore();
+    }
   });
 
   it("filters slash commands and inserts a code block from the keyboard", async () => {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6747,6 +6747,40 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("closes the slash command menu after clicking outside it", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "/");
+
+    expect(await screen.findByRole("listbox", { name: "Slash commands" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => expect(screen.queryByRole("listbox", { name: "Slash commands" })).not.toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("/");
+    await settleMarkdownListener();
+  });
+
+  it("closes the document link completion menu after clicking outside it", async () => {
+    const { container, view } = await renderEditor("", {
+      documentPath: "/vault/current.md",
+      workspaceFiles: [
+        { name: "guide.md", path: "/vault/guide.md", relativePath: "guide.md" },
+        { name: "notes.md", path: "/vault/notes.md", relativePath: "notes.md" }
+      ]
+    });
+
+    typeText(view, "[[guide");
+
+    expect(await screen.findByRole("listbox", { name: "Document links" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => expect(screen.queryByRole("listbox", { name: "Document links" })).not.toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("[[guide");
+    await settleMarkdownListener();
+  });
+
   it("filters slash commands and inserts a code block from the keyboard", async () => {
     const { container, view } = await renderEditor();
 

--- a/packages/app/src/components/document-link-completion.ts
+++ b/packages/app/src/components/document-link-completion.ts
@@ -1,6 +1,7 @@
 import { Plugin, PluginKey, type EditorState } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
+import { popoverPosition } from "@markra/shared";
 import {
   documentLinkCompletionFiles,
   markdownDocumentLinkHrefForFile,
@@ -126,10 +127,28 @@ function renderMenuOption(ownerDocument: Document, file: MarkdownDocumentLinkFil
 function positionMenu(view: EditorView, active: ActiveCompletion, menu: HTMLElement) {
   try {
     const coords = view.coordsAtPos(active.to);
-    menu.style.left = `${Math.max(8, coords.left)}px`;
-    menu.style.top = `${coords.bottom + 8}px`;
+    const ownerWindow = view.dom.ownerDocument.defaultView ?? window;
+    const position = popoverPosition(
+      coords,
+      {
+        height: menu.offsetHeight || 280,
+        width: menu.offsetWidth || 240
+      },
+      {
+        height: ownerWindow.innerHeight,
+        width: ownerWindow.innerWidth
+      },
+      { gap: 8, margin: 8 }
+    );
+
+    menu.style.left = `${position.left}px`;
+    menu.style.maxHeight = `${position.maxHeight}px`;
+    menu.style.overflowY = "auto";
+    menu.style.top = `${position.top}px`;
   } catch {
     menu.style.left = "8px";
+    menu.style.maxHeight = "";
+    menu.style.overflowY = "";
     menu.style.top = "8px";
   }
 }

--- a/packages/app/src/components/document-link-completion.ts
+++ b/packages/app/src/components/document-link-completion.ts
@@ -240,13 +240,25 @@ export function markraDocumentLinkCompletionPlugin(options: DocumentLinkCompleti
           insertDocumentLink(view, active, file, options);
         };
 
+        const handleDocumentPointerDown = (event: PointerEvent) => {
+          const active = completionKey.getState(view.state)?.active ?? null;
+          if (!active) return;
+
+          const target = event.target instanceof Node ? event.target : null;
+          if (target && menu.contains(target)) return;
+
+          view.dispatch(view.state.tr.setMeta(completionKey, { type: "close" } satisfies CompletionMeta));
+        };
+
         menu.addEventListener("mousedown", handleMouseDown);
+        ownerDocument.addEventListener("pointerdown", handleDocumentPointerDown, true);
         ownerDocument.body.append(menu);
         update(view);
 
         return {
           destroy() {
             menu.removeEventListener("mousedown", handleMouseDown);
+            ownerDocument.removeEventListener("pointerdown", handleDocumentPointerDown, true);
             menu.remove();
           },
           update

--- a/packages/app/src/lib/anchored-popover.ts
+++ b/packages/app/src/lib/anchored-popover.ts
@@ -1,0 +1,33 @@
+import type { CSSProperties } from "react";
+import { popoverPosition, type PopoverPositionOptions, type PopoverSize } from "@markra/shared";
+
+type AnchoredPopoverStyleOptions = PopoverPositionOptions & {
+  fallbackSize: PopoverSize;
+};
+
+export function anchoredPopoverStyle(
+  anchorElement: Element,
+  popoverElement: HTMLElement | null,
+  options: AnchoredPopoverStyleOptions
+): CSSProperties {
+  const { fallbackSize, ...positionOptions } = options;
+  const position = popoverPosition(
+    anchorElement.getBoundingClientRect(),
+    {
+      height: popoverElement?.offsetHeight || fallbackSize.height,
+      width: popoverElement?.offsetWidth || fallbackSize.width
+    },
+    {
+      height: window.innerHeight,
+      width: window.innerWidth
+    },
+    positionOptions
+  );
+
+  return {
+    left: `${position.left}px`,
+    maxHeight: `${position.maxHeight}px`,
+    overflowY: "auto",
+    top: `${position.top}px`
+  };
+}

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2059,54 +2059,54 @@
     @apply block rounded-[1px] border border-current;
   }
 
-  .markdown-paper .markra-table-size-popover {
-    @apply absolute top-7 left-0 z-30 rounded-lg border border-(--border-default) p-3;
+  .markra-table-size-popover {
+    @apply fixed z-70 rounded-lg border border-(--border-default) p-3;
     background: color-mix(in srgb, var(--bg-primary) 98%, var(--bg-secondary));
     box-shadow:
       0 18px 40px rgba(0, 0, 0, 0.16),
       0 2px 8px rgba(0, 0, 0, 0.08);
   }
 
-  .markdown-paper .markra-table-size-grid {
+  .markra-table-size-grid {
     @apply grid gap-1;
     grid-template-columns: repeat(8, 0.875rem);
   }
 
-  .markdown-paper .markra-table-size-cell {
+  .markra-table-size-cell {
     @apply size-3.5 rounded-[2px] border border-(--border-default) p-0 transition-[background-color,border-color] duration-100 ease-out;
     background: var(--bg-secondary);
   }
 
-  .markdown-paper .markra-table-size-cell:hover,
-  .markdown-paper .markra-table-size-cell:focus-visible {
+  .markra-table-size-cell:hover,
+  .markra-table-size-cell:focus-visible {
     @apply outline-none;
     border-color: var(--text-secondary);
   }
 
-  .markdown-paper .markra-table-size-cell-active {
+  .markra-table-size-cell-active {
     background: color-mix(in srgb, var(--text-secondary) 46%, var(--bg-secondary));
     border-color: color-mix(in srgb, var(--text-secondary) 66%, var(--border-default));
   }
 
-  .markdown-paper .markra-table-size-footer {
+  .markra-table-size-footer {
     @apply mt-3 flex items-center justify-center gap-2 border-t border-(--border-default) pt-3;
   }
 
-  .markdown-paper .markra-table-size-input {
+  .markra-table-size-input {
     @apply h-7 w-10 rounded-sm border border-(--border-default) bg-(--bg-primary) px-1 text-center text-sm leading-none text-(--text-primary) outline-none focus-visible:border-(--border-strong);
   }
 
-  .markdown-paper .markra-table-size-input::-webkit-outer-spin-button,
-  .markdown-paper .markra-table-size-input::-webkit-inner-spin-button {
+  .markra-table-size-input::-webkit-outer-spin-button,
+  .markra-table-size-input::-webkit-inner-spin-button {
     margin: 0;
     appearance: none;
   }
 
-  .markdown-paper .markra-table-size-input[type="number"] {
+  .markra-table-size-input[type="number"] {
     appearance: textfield;
   }
 
-  .markdown-paper .markra-table-size-separator {
+  .markra-table-size-separator {
     @apply text-sm text-(--text-secondary);
   }
 

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -120,11 +120,11 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .markra-table-align-controls");
     expect(styles).toContain(".markdown-paper .markra-table-size-controls");
     expect(styles).toContain(".markdown-paper .markra-table-size-button[aria-expanded=\"true\"]");
-    expect(styles).toContain(".markdown-paper .markra-table-size-popover");
-    expect(styles).toContain(".markdown-paper .markra-table-size-grid");
+    expect(styles).toContain(".markra-table-size-popover");
+    expect(styles).toContain(".markra-table-size-grid");
     expect(styles).toContain("grid-template-columns: repeat(8, 0.875rem)");
-    expect(styles).toContain(".markdown-paper .markra-table-size-cell-active");
-    expect(styles).toContain(".markdown-paper .markra-table-size-input");
+    expect(styles).toContain(".markra-table-size-cell-active");
+    expect(styles).toContain(".markra-table-size-input");
     expect(styles).toContain(".markdown-paper .markra-table-align-button[aria-pressed=\"true\"]");
     expect(styles).toContain(".markdown-paper .markra-table-align-icon-left");
     expect(styles).toContain(".markdown-paper .markra-table-align-icon-center");

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -19,7 +19,7 @@ import { Plugin, PluginKey, TextSelection, type Command, type EditorState, type 
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { wrapInList } from "@milkdown/kit/prose/schema-list";
 import { $prose } from "@milkdown/kit/utils";
-import { markdownCalloutMarkerForType, type MarkdownCalloutType } from "@markra/shared";
+import { markdownCalloutMarkerForType, popoverPosition, type MarkdownCalloutType } from "@markra/shared";
 
 export type SlashCommandId =
   | "paragraph"
@@ -432,16 +432,28 @@ function runSelectedSlashCommand(view: EditorView, commands: SlashCommandSpec[])
 function positionMenu(menu: HTMLElement, view: EditorView, range: SlashCommandRange) {
   try {
     const coords = view.coordsAtPos(range.to);
-    const margin = 10;
-    const width = menu.offsetWidth || 240;
-    const height = menu.offsetHeight || 220;
-    const left = Math.min(Math.max(coords.left, margin), Math.max(window.innerWidth - width - margin, margin));
-    const top = Math.min(coords.bottom + 8, Math.max(window.innerHeight - height - margin, margin));
+    const ownerWindow = view.dom.ownerDocument.defaultView ?? window;
+    const position = popoverPosition(
+      coords,
+      {
+        height: menu.offsetHeight || 220,
+        width: menu.offsetWidth || 240
+      },
+      {
+        height: ownerWindow.innerHeight,
+        width: ownerWindow.innerWidth
+      },
+      { gap: 8, margin: 8 }
+    );
 
-    menu.style.left = `${left}px`;
-    menu.style.top = `${top}px`;
+    menu.style.left = `${position.left}px`;
+    menu.style.maxHeight = `${position.maxHeight}px`;
+    menu.style.overflowY = "auto";
+    menu.style.top = `${position.top}px`;
   } catch {
     menu.style.left = "12px";
+    menu.style.maxHeight = "";
+    menu.style.overflowY = "";
     menu.style.top = "12px";
   }
 }

--- a/packages/editor/src/slash-commands.ts
+++ b/packages/editor/src/slash-commands.ts
@@ -455,6 +455,7 @@ function elementFromEventTarget(target: EventTarget | null) {
 
 class SlashCommandMenuView {
   private readonly menu: HTMLDivElement;
+  private readonly ownerDocument: Document;
   private view: EditorView;
 
   constructor(
@@ -463,7 +464,8 @@ class SlashCommandMenuView {
     private readonly labels: SlashCommandLabels
   ) {
     this.view = view;
-    this.menu = view.dom.ownerDocument.createElement("div");
+    this.ownerDocument = view.dom.ownerDocument;
+    this.menu = this.ownerDocument.createElement("div");
     this.menu.className = "markra-slash-menu";
     this.menu.setAttribute("aria-label", labels.menu);
     this.menu.setAttribute("role", "listbox");
@@ -471,6 +473,7 @@ class SlashCommandMenuView {
     this.menu.addEventListener("mousedown", this.handleMouseDown);
     this.menu.addEventListener("click", this.handleClick);
     this.menu.addEventListener("mouseover", this.handleMouseOver);
+    this.ownerDocument.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
   }
 
   update(view: EditorView) {
@@ -492,6 +495,7 @@ class SlashCommandMenuView {
     this.menu.removeEventListener("mousedown", this.handleMouseDown);
     this.menu.removeEventListener("click", this.handleClick);
     this.menu.removeEventListener("mouseover", this.handleMouseOver);
+    this.ownerDocument.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
     this.detach();
   }
 
@@ -566,6 +570,16 @@ class SlashCommandMenuView {
     if (event.button !== 0) return;
 
     this.runCommandFromMouseEvent(event);
+  };
+
+  private readonly handleDocumentPointerDown = (event: PointerEvent) => {
+    const state = slashCommandsKey.getState(this.view.state);
+    if (!state?.active) return;
+
+    const target = elementFromEventTarget(event.target);
+    if (target && this.menu.contains(target)) return;
+
+    closeSlashCommandMenu(this.view);
   };
 
   private runCommandFromMouseEvent(event: MouseEvent) {

--- a/packages/editor/src/table-controls.ts
+++ b/packages/editor/src/table-controls.ts
@@ -2,6 +2,7 @@ import { $prose } from "@milkdown/kit/utils";
 import type { Node as ProseNode } from "@milkdown/kit/prose/model";
 import { Plugin, TextSelection, type Transaction } from "@milkdown/kit/prose/state";
 import type { EditorView, ViewMutationRecord } from "@milkdown/kit/prose/view";
+import { popoverPosition } from "@markra/shared";
 import { addColumnAfter, addRowAfter, deleteColumn, deleteRow, TableMap } from "prosemirror-tables";
 
 type TableControlLabels = {
@@ -38,6 +39,7 @@ const defaultTableControlLabels: TableControlLabels = {
 const tableAlignments: TableAlignment[] = ["left", "center", "right"];
 const tableSizePickerColumns = 8;
 const tableSizePickerRows = 10;
+const tableSizePopoverFallbackSize = { height: 248, width: 184 };
 
 function controlTargetFromEvent(event: Event) {
   return event.target instanceof Node ? event.target : null;
@@ -215,7 +217,7 @@ class MarkraTableNodeView {
     this.dom.addEventListener("mousemove", this.handleMouseMove);
     this.dom.addEventListener("mouseleave", this.hideDeleteControls);
     this.table.append(this.contentDOM);
-    this.sizeControls.append(this.sizeButton, this.sizePopover);
+    this.sizeControls.append(this.sizeButton);
     this.alignControls.append(this.sizeControls, ...this.alignButtons);
     this.dom.append(
       this.alignControls,
@@ -233,6 +235,7 @@ class MarkraTableNodeView {
 
     this.node = nextNode;
     this.updateAlignmentButtons();
+    if (!this.sizePopover.hidden) this.positionSizePopover();
     return true;
   }
 
@@ -242,6 +245,7 @@ class MarkraTableNodeView {
       target &&
         (this.addColumnButton.contains(target) ||
           this.sizeControls.contains(target) ||
+          this.sizePopover.contains(target) ||
           this.alignControls.contains(target) ||
           this.addRowButton.contains(target) ||
           this.deleteColumnButton.contains(target) ||
@@ -255,6 +259,7 @@ class MarkraTableNodeView {
       target instanceof Node &&
       (this.addColumnButton.contains(target) ||
         this.sizeControls.contains(target) ||
+        this.sizePopover.contains(target) ||
         this.alignControls.contains(target) ||
         this.addRowButton.contains(target) ||
         this.deleteColumnButton.contains(target) ||
@@ -266,6 +271,8 @@ class MarkraTableNodeView {
     this.dom.removeEventListener("mousemove", this.handleMouseMove);
     this.dom.removeEventListener("mouseleave", this.hideDeleteControls);
     this.view.dom.ownerDocument.removeEventListener("mousedown", this.handleDocumentMouseDown, true);
+    this.removeSizePopoverLayoutListeners();
+    this.sizePopover.remove();
     this.sizeButton.removeEventListener("mousedown", this.handleSizeButtonMouseDown);
     for (const cell of this.sizeCells) {
       cell.removeEventListener("mouseenter", this.handleSizeCellMouseEnter);
@@ -351,9 +358,13 @@ class MarkraTableNodeView {
 
   private readonly handleDocumentMouseDown = (event: MouseEvent) => {
     const target = controlTargetFromEvent(event);
-    if (target && this.sizeControls.contains(target)) return;
+    if (target && (this.sizeControls.contains(target) || this.sizePopover.contains(target))) return;
 
     this.hideSizePopover();
+  };
+
+  private readonly handleSizePopoverLayoutChange = () => {
+    if (!this.sizePopover.hidden) this.positionSizePopover();
   };
 
   private readonly handleSizeCellMouseEnter = (event: MouseEvent) => {
@@ -439,19 +450,57 @@ class MarkraTableNodeView {
 
   private showSizePopover() {
     const map = TableMap.get(this.node);
+    this.view.dom.ownerDocument.body.append(this.sizePopover);
     this.sizePopover.hidden = false;
     this.sizeButton.ariaExpanded = "true";
+    this.positionSizePopover();
     this.updatePendingSize({
       columns: Math.min(map.width, tableSizePickerColumns),
       rows: Math.min(map.height, tableSizePickerRows)
     });
     this.view.dom.ownerDocument.addEventListener("mousedown", this.handleDocumentMouseDown, true);
+    this.addSizePopoverLayoutListeners();
   }
 
   private hideSizePopover() {
     this.sizePopover.hidden = true;
     this.sizeButton.ariaExpanded = "false";
+    this.sizePopover.remove();
     this.view.dom.ownerDocument.removeEventListener("mousedown", this.handleDocumentMouseDown, true);
+    this.removeSizePopoverLayoutListeners();
+  }
+
+  private positionSizePopover() {
+    const windowTarget = this.view.dom.ownerDocument.defaultView;
+    const position = popoverPosition(
+      this.sizeButton.getBoundingClientRect(),
+      {
+        height: this.sizePopover.offsetHeight || tableSizePopoverFallbackSize.height,
+        width: this.sizePopover.offsetWidth || tableSizePopoverFallbackSize.width
+      },
+      {
+        height: windowTarget?.innerHeight ?? 768,
+        width: windowTarget?.innerWidth ?? 1024
+      }
+    );
+
+    this.sizePopover.style.left = `${position.left}px`;
+    this.sizePopover.style.maxHeight = `${position.maxHeight}px`;
+    this.sizePopover.style.overflowY = "auto";
+    this.sizePopover.style.position = "fixed";
+    this.sizePopover.style.top = `${position.top}px`;
+  }
+
+  private addSizePopoverLayoutListeners() {
+    const windowTarget = this.view.dom.ownerDocument.defaultView;
+    windowTarget?.addEventListener("resize", this.handleSizePopoverLayoutChange);
+    windowTarget?.addEventListener("scroll", this.handleSizePopoverLayoutChange, true);
+  }
+
+  private removeSizePopoverLayoutListeners() {
+    const windowTarget = this.view.dom.ownerDocument.defaultView;
+    windowTarget?.removeEventListener("resize", this.handleSizePopoverLayoutChange);
+    windowTarget?.removeEventListener("scroll", this.handleSizePopoverLayoutChange, true);
   }
 
   private sizeFromTarget(target: EventTarget | null): TableSize {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./keyboard-shortcuts.ts";
 export * from "./markdown-callout.ts";
 export * from "./number.ts";
 export * from "./path.ts";
+export * from "./popover.ts";
 export * from "./record.ts";
 export * from "./runtime.ts";
 export * from "./search.ts";

--- a/packages/shared/src/popover.test.ts
+++ b/packages/shared/src/popover.test.ts
@@ -1,0 +1,58 @@
+import { popoverPosition } from "./popover";
+
+describe("popoverPosition", () => {
+  it("places a popover below the anchor when there is room", () => {
+    expect(
+      popoverPosition(
+        { bottom: 120, left: 50, right: 70, top: 96 },
+        { height: 160, width: 240 },
+        { height: 600, width: 800 }
+      )
+    ).toEqual({
+      left: 50,
+      maxHeight: 464,
+      placement: "bottom",
+      top: 128
+    });
+  });
+
+  it("flips a popover above the anchor when the lower viewport would clip it", () => {
+    expect(
+      popoverPosition(
+        { bottom: 578, left: 120, right: 140, top: 560 },
+        { height: 220, width: 240 },
+        { height: 640, width: 800 }
+      )
+    ).toEqual({
+      left: 120,
+      maxHeight: 544,
+      placement: "top",
+      top: 332
+    });
+  });
+
+  it("clamps a popover inside the horizontal viewport margin", () => {
+    expect(
+      popoverPosition(
+        { bottom: 120, left: 300, right: 320, top: 96 },
+        { height: 160, width: 120 },
+        { height: 600, width: 360 }
+      ).left
+    ).toBe(232);
+  });
+
+  it("limits height when neither side has enough vertical room", () => {
+    expect(
+      popoverPosition(
+        { bottom: 220, left: 80, right: 100, top: 200 },
+        { height: 500, width: 240 },
+        { height: 300, width: 800 }
+      )
+    ).toEqual({
+      left: 80,
+      maxHeight: 184,
+      placement: "top",
+      top: 8
+    });
+  });
+});

--- a/packages/shared/src/popover.ts
+++ b/packages/shared/src/popover.ts
@@ -1,0 +1,79 @@
+export type PopoverAnchorRect = Pick<DOMRectReadOnly, "bottom" | "left" | "right" | "top">;
+
+export type PopoverSize = {
+  height: number;
+  width: number;
+};
+
+export type PopoverViewport = {
+  height: number;
+  width: number;
+};
+
+export type PopoverAlignment = "center" | "end" | "start";
+export type PopoverPlacement = "bottom" | "top";
+
+export type PopoverPositionOptions = {
+  align?: PopoverAlignment;
+  gap?: number;
+  margin?: number;
+  placement?: PopoverPlacement;
+};
+
+export type PopoverPosition = {
+  left: number;
+  maxHeight: number;
+  placement: PopoverPlacement;
+  top: number;
+};
+
+function alignedLeft(anchor: PopoverAnchorRect, width: number, align: PopoverAlignment) {
+  if (align === "center") return (anchor.left + anchor.right - width) / 2;
+  if (align === "end") return anchor.right - width;
+
+  return anchor.left;
+}
+
+function clampPosition(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function popoverPosition(
+  anchor: PopoverAnchorRect,
+  size: PopoverSize,
+  viewport: PopoverViewport,
+  options: PopoverPositionOptions = {}
+): PopoverPosition {
+  const margin = options.margin ?? 8;
+  const gap = options.gap ?? 8;
+  const width = Math.max(0, size.width);
+  const height = Math.max(0, size.height);
+  const viewportWidth = Math.max(0, viewport.width);
+  const viewportHeight = Math.max(0, viewport.height);
+  const bottomTop = anchor.bottom + gap;
+  const topTop = anchor.top - gap - height;
+  const bottomSpace = Math.max(0, viewportHeight - margin - bottomTop);
+  const topSpace = Math.max(0, anchor.top - gap - margin);
+  const preferredPlacement = options.placement ?? "bottom";
+  const placement = preferredPlacement === "bottom" && height > bottomSpace && topSpace > bottomSpace
+    ? "top"
+    : preferredPlacement === "top" && height > topSpace && bottomSpace > topSpace
+      ? "bottom"
+      : preferredPlacement;
+  const availableHeight = placement === "top" ? topSpace : bottomSpace;
+  const top = placement === "top"
+    ? clampPosition(topTop, margin, Math.max(margin, viewportHeight - margin - height))
+    : clampPosition(bottomTop, margin, Math.max(margin, viewportHeight - margin));
+  const left = clampPosition(
+    alignedLeft(anchor, width, options.align ?? "start"),
+    margin,
+    Math.max(margin, viewportWidth - margin - width)
+  );
+
+  return {
+    left: Math.round(left),
+    maxHeight: Math.round(availableHeight),
+    placement,
+    top: Math.round(top)
+  };
+}

--- a/packages/ui/src/PopoverSurface.tsx
+++ b/packages/ui/src/PopoverSurface.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from "react";
+import { forwardRef, type ComponentPropsWithoutRef } from "react";
 
 import { mergeClassNames } from "./classes";
 
@@ -8,16 +8,17 @@ export type PopoverSurfaceProps = ComponentPropsWithoutRef<"div"> & {
   openClassName?: string;
 };
 
-export function PopoverSurface({
+export const PopoverSurface = forwardRef<HTMLDivElement, PopoverSurfaceProps>(function PopoverSurface({
   children,
   className,
   closedClassName = "pointer-events-none opacity-0",
   open,
   openClassName = "pointer-events-auto opacity-100",
   ...props
-}: PopoverSurfaceProps) {
+}, ref) {
   return (
     <div
+      ref={ref}
       className={mergeClassNames(
         "border border-(--border-default) bg-(--bg-primary) shadow-(--ai-command-popover-shadow) transition-[opacity,transform] duration-140 ease-out motion-reduce:transition-none",
         open ? openClassName : closedClassName,
@@ -28,4 +29,4 @@ export function PopoverSurface({
       {children}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
- Close sidebar sort, new item, outline level, editor slash command, and document-link completion menus on outside click.
- Add shared viewport-aware popover positioning for anchored floating menus, with flipping, horizontal clamping, and max-height limits.
- Apply the shared positioning to slash commands, document-link completion, selection heading levels, AI model/session menus, context menus, and the table size picker.
- Render container-sensitive menus through `fixed`/body-mounted surfaces so they are not clipped by editor, sidebar, or AI panel overflow.

## Validation
- `pnpm --filter @markra/shared test` passed
- `pnpm --filter @markra/shared build` passed
- `pnpm --filter @markra/ui test` passed
- `pnpm --filter @markra/ui build` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx src/components/AiModelPicker.test.tsx src/components/AiAgentSessionMenu.test.tsx src/components/AiSelectionToolbar.test.tsx src/components/ContextMenu.test.tsx src/App.ai.test.tsx src/styles.test.ts` passed (50 files / 974 tests)
- `pnpm --filter @markra/desktop build` passed

Closes #207
