### PR TITLE
feat(app): add document replace shortcut

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -4031,7 +4031,34 @@ describe("Markra workspace", () => {
     expect(searchInput).toHaveAttribute("autocapitalize", "none");
     expect(searchInput).toHaveAttribute("autocorrect", "off");
     expect(searchInput).toHaveAttribute("spellcheck", "false");
+    expect(screen.getByRole("button", { name: "Case sensitive" })).toHaveAttribute("title", "Case sensitive");
     expect(container.querySelector(".editor-content-slot")).toHaveAttribute("data-document-search-open", "true");
+  });
+
+  it("opens document replace from the native Windows Ctrl+H keyboard shortcut", async () => {
+    mockedResolveDesktopPlatform.mockReturnValue("windows");
+
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    expect(fireEvent.keyDown(window, { key: "h", ctrlKey: true })).toBe(false);
+
+    expect(screen.getByRole("search", { name: "Find in document" })).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: "Find in document" })).toHaveFocus();
+    expect(screen.getByRole("textbox", { name: "Replace" })).toBeInTheDocument();
+  });
+
+  it("opens document replace from the native macOS Cmd+Option+F keyboard shortcut", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    expect(fireEvent.keyDown(window, { altKey: true, code: "KeyF", key: "ƒ", metaKey: true })).toBe(false);
+
+    expect(screen.getByRole("search", { name: "Find in document" })).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: "Find in document" })).toHaveFocus();
+    expect(screen.getByRole("textbox", { name: "Replace" })).toBeInTheDocument();
   });
 
   it("uses native workspace file count before entering a search query", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -81,6 +81,7 @@ import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
 import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
 import { replaceMovedPath } from "./lib/path-move";
+import { resolveDesktopPlatform } from "./lib/platform";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
 import {
   searchWorkspaceFiles,
@@ -330,6 +331,7 @@ export default function App() {
 }
 
 function WorkspaceApp() {
+  const desktopPlatform = resolveDesktopPlatform();
   const appFeatures = getAppRuntime().features;
   const aiFeatureEnabled = appFeatures.ai;
   const exportFeatureEnabled = appFeatures.export;
@@ -2807,6 +2809,7 @@ function WorkspaceApp() {
     openDocumentSearch: handleDocumentSearchOpen,
     openWorkspaceSearch: handleGlobalSearchOpen,
     openFolder: handleOpenMarkdownFolder,
+    platform: desktopPlatform,
     saveDocument: handleSaveDocument,
     saveDocumentAs,
     toggleAiAgent: aiFeatureEnabled ? handleAiAgentToggle : undefined,

--- a/packages/app/src/components/DocumentSearchBar.tsx
+++ b/packages/app/src/components/DocumentSearchBar.tsx
@@ -178,6 +178,7 @@ export function DocumentSearchBar({
           className="document-search-icon-button"
           aria-label={label.caseSensitive}
           aria-pressed={caseSensitive}
+          title={label.caseSensitive}
           type="button"
           onClick={() => onCaseSensitiveChange(!caseSensitive)}
         >

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -341,4 +341,62 @@ describe("useApplicationShortcuts", () => {
 
     expect(openDocumentReplace).toHaveBeenCalledTimes(1);
   });
+
+  it("opens replace when macOS reports Cmd+Option+F as the option-modified key", () => {
+    const openDocumentReplace = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openDocumentReplace
+      })
+    );
+
+    const handled = fireEvent.keyDown(window, {
+      altKey: true,
+      code: "KeyF",
+      key: "ƒ",
+      metaKey: true
+    });
+
+    expect(handled).toBe(false);
+    expect(openDocumentReplace).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens replace from the native Windows Ctrl+H document replace shortcut", () => {
+    const openDocumentReplace = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openDocumentReplace,
+        platform: "windows"
+      })
+    );
+
+    const handled = fireEvent.keyDown(window, {
+      key: "h",
+      ctrlKey: true
+    });
+
+    expect(handled).toBe(false);
+    expect(openDocumentReplace).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not intercept Ctrl+H on macOS", () => {
+    const openDocumentReplace = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openDocumentReplace,
+        platform: "macos"
+      })
+    );
+
+    const handled = fireEvent.keyDown(window, {
+      ctrlKey: true,
+      key: "h"
+    });
+
+    expect(handled).toBe(true);
+    expect(openDocumentReplace).not.toHaveBeenCalled();
+  });
 });

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -20,6 +20,7 @@ import {
   type AppLanguage
 } from "@markra/shared";
 import { defaultAiQuickActionPrompt } from "../lib/ai-actions";
+import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
 
 type NativeAiQuickActionIntent = Exclude<AiEditIntent, "custom">;
 
@@ -61,6 +62,7 @@ type ApplicationShortcutOptions = {
   openDocumentSearch?: () => unknown | Promise<unknown>;
   openWorkspaceSearch?: () => unknown | Promise<unknown>;
   openFolder: () => unknown | Promise<unknown>;
+  platform?: DesktopPlatform;
   saveDocument: () => unknown | Promise<unknown>;
   saveDocumentAs: () => unknown | Promise<unknown>;
   toggleAiAgent?: () => unknown | Promise<unknown>;
@@ -336,6 +338,7 @@ export function useApplicationShortcuts({
   openDocumentSearch,
   openWorkspaceSearch,
   openFolder,
+  platform = resolveDesktopPlatform(),
   saveDocument,
   saveDocumentAs,
   toggleAiAgent,
@@ -374,11 +377,15 @@ export function useApplicationShortcuts({
       }
 
       const key = event.key.toLowerCase();
-      if (key === "f" && event.shiftKey && !event.altKey && openWorkspaceSearch) {
+      const isPhysicalFKey = key === "f" || event.code === "KeyF";
+      const isCtrlDocumentReplaceShortcut =
+        platform !== "macos" && key === "h" && event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey;
+
+      if (isPhysicalFKey && event.shiftKey && !event.altKey && openWorkspaceSearch) {
         event.preventDefault();
         event.stopPropagation();
         openWorkspaceSearch();
-      } else if (key === "f" && !event.shiftKey) {
+      } else if (isPhysicalFKey && !event.shiftKey) {
         event.preventDefault();
         event.stopPropagation();
         if (event.altKey) {
@@ -386,6 +393,10 @@ export function useApplicationShortcuts({
         } else {
           openDocumentSearch?.();
         }
+      } else if (isCtrlDocumentReplaceShortcut && openDocumentReplace) {
+        event.preventDefault();
+        event.stopPropagation();
+        openDocumentReplace();
       } else if (event.altKey) {
         return;
       } else if (key === "s" && event.shiftKey) {
@@ -426,6 +437,7 @@ export function useApplicationShortcuts({
     openDocumentSearch,
     openWorkspaceSearch,
     openFolder,
+    platform,
     saveDocument,
     saveDocumentAs,
     toggleAiAgent,

--- a/packages/shared/src/keyboard-shortcuts.test.ts
+++ b/packages/shared/src/keyboard-shortcuts.test.ts
@@ -20,4 +20,10 @@ describe("keyboard shortcuts", () => {
       toggleDocumentHistory: "Mod+Alt+H"
     }).toggleDocumentHistory).toBe("Mod+Alt+H");
   });
+
+  it("reserves Mod+H for the document replace shortcut", () => {
+    expect(normalizeKeyboardShortcuts({
+      toggleDocumentHistory: "Mod+H"
+    }).toggleDocumentHistory).toBe(defaultKeyboardShortcuts.toggleDocumentHistory);
+  });
 });

--- a/packages/shared/src/keyboard-shortcuts.ts
+++ b/packages/shared/src/keyboard-shortcuts.ts
@@ -80,6 +80,7 @@ const reservedKeyboardShortcutChords = new Set([
   "Mod+,",
   "Mod+A",
   "Mod+C",
+  "Mod+H",
   "Mod+N",
   "Mod+O",
   "Mod+P",


### PR DESCRIPTION
## Summary
- Add platform-native document replace shortcuts: Ctrl+H on Windows/Linux and Cmd+Option+F on macOS.
- Support macOS Cmd+Option+F even when Option changes the reported key value.
- Leave macOS Ctrl+H Backspace/delete behavior alone.
- Add a hover title to the case-sensitive Aa button in the document search bar.
- Reserve Mod+H from configurable shortcuts so custom app shortcuts do not collide with native H shortcuts.
- Cover the shortcut, macOS key event compatibility, tooltip, and reserved-shortcut behavior with tests.

## Validation
- `pnpm --filter @markra/shared exec vitest run src/keyboard-shortcuts.test.ts --environment jsdom --globals`
- `pnpm --filter @markra/app exec vitest run src/hooks/useNativeBindings.test.tsx`
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx`
- `pnpm --filter @markra/shared build`
- `pnpm --filter @markra/app build`

## Notes
- Default Markra shortcuts do not conflict: document history remains Mod+Shift+H.
- On macOS, use Cmd+Option+F for document replace; Ctrl+H remains the text-system Backspace/delete behavior.
- Global search is left unchanged because it currently has search-only behavior; a global replace shortcut would need a separate workspace replace design.

Closes #208
