### PR TITLE
fix(app): fix file tree context menu rename

### DIFF
--- a/apps/desktop/src-tauri/src/markdown_files/tree.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/tree.rs
@@ -81,6 +81,10 @@ fn normalize_markdown_tree_rename_file_name(
     file_name: &str,
     source_path: &Path,
 ) -> Result<String, String> {
+    if source_path.is_dir() {
+        return normalize_markdown_tree_folder_name(file_name);
+    }
+
     let trimmed_name = normalize_markdown_tree_single_file_name(file_name)?;
     let candidate = Path::new(&trimmed_name);
     let normalized_name = if candidate.extension().is_some() {
@@ -139,22 +143,6 @@ fn canonical_markdown_tree_root(root_path: &Path) -> Result<PathBuf, String> {
     markdown_tree_root_for_path(root_path)?
         .canonicalize()
         .map_err(|error| error.to_string())
-}
-
-fn canonical_markdown_tree_file(root: &Path, path: &Path) -> Result<PathBuf, String> {
-    let canonical_path = path.canonicalize().map_err(|error| error.to_string())?;
-
-    canonical_path
-        .strip_prefix(root)
-        .map_err(|_| "File is outside the current Markdown folder".to_string())?;
-
-    if !canonical_path.is_file()
-        || !(is_markdown_tree_file(&canonical_path) || is_markdown_tree_asset_file(&canonical_path))
-    {
-        return Err("Path is not a Markdown file or supported image asset".to_string());
-    }
-
-    Ok(canonical_path)
 }
 
 fn canonical_markdown_tree_entry(root: &Path, path: &Path) -> Result<PathBuf, String> {
@@ -331,7 +319,7 @@ pub(crate) fn rename_markdown_tree_file(
 ) -> Result<MarkdownFolderFile, String> {
     let root_path = PathBuf::from(root_path);
     let root = canonical_markdown_tree_root(&root_path)?;
-    let source_path = canonical_markdown_tree_file(&root, &PathBuf::from(path))?;
+    let source_path = canonical_movable_markdown_tree_entry(&root, &PathBuf::from(path))?;
     let normalized_file_name = normalize_markdown_tree_rename_file_name(&file_name, &source_path)?;
     let parent = source_path
         .parent()
@@ -346,7 +334,7 @@ pub(crate) fn rename_markdown_tree_file(
 
     fs::rename(&source_path, &target_path).map_err(|error| error.to_string())?;
 
-    markdown_folder_file(&root, &target_path, markdown_tree_file_kind(&target_path)?)
+    markdown_folder_file(&root, &target_path, markdown_tree_entry_kind(&target_path)?)
 }
 
 #[tauri::command]
@@ -664,6 +652,43 @@ mod tests {
             .expect("image asset should be deleted");
 
         assert!(!assets.join("renamed-image.png").exists());
+
+        fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn renames_markdown_tree_folders_inside_the_root() {
+        let root = std::env::temp_dir().join(format!(
+            "markra-tree-folder-rename-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after epoch")
+                .as_nanos()
+        ));
+        let docs = root.join("docs");
+
+        fs::create_dir_all(&docs).expect("source folder should be created");
+        fs::write(docs.join("readme.md"), "# Readme")
+            .expect("nested markdown file should be created");
+        let canonical_root = root
+            .canonicalize()
+            .expect("test folder should have a canonical path");
+
+        let renamed = rename_markdown_tree_file(
+            root.to_string_lossy().to_string(),
+            docs.to_string_lossy().to_string(),
+            "notes".to_string(),
+        )
+        .expect("markdown folder should be renamed");
+
+        assert_markdown_folder_file(
+            &renamed,
+            MarkdownFolderEntryKind::Folder,
+            &canonical_root.join("notes"),
+            "notes",
+        );
+        assert!(!docs.exists());
+        assert!(root.join("notes").join("readme.md").exists());
 
         fs::remove_dir_all(root).expect("test tree should be removed");
     }

--- a/apps/desktop/src/runtime/tauri/menu.test.ts
+++ b/apps/desktop/src/runtime/tauri/menu.test.ts
@@ -604,7 +604,7 @@ describe("native menu", () => {
     expect(openFileToSide).not.toHaveBeenCalled();
   });
 
-  it("shows a markdown file tree delete action for a folder target", async () => {
+  it("shows markdown file tree rename and delete actions for a folder target", async () => {
     const createFile = vi.fn();
     const createFolder = vi.fn();
     const renameFile = vi.fn();
@@ -623,15 +623,22 @@ describe("native menu", () => {
       renameFile
     }, "en", folder);
 
-    const deleteItem = domMenuItemById("markra:file-tree:delete");
+    const renameItem = domMenuItemById("markra:file-tree:rename");
 
-    expect(deleteItem.textContent).toContain("Delete folder");
-    expect(queryDomMenuItemById("markra:file-tree:rename")).toBeNull();
+    expect(renameItem.textContent).toContain("Rename folder");
+    expect(domMenuItemById("markra:file-tree:delete").textContent).toContain("Delete folder");
 
-    deleteItem.click();
+    renameItem.click();
+    await showNativeMarkdownFileTreeContextMenu({
+      createFile,
+      createFolder,
+      deleteFile,
+      renameFile
+    }, "en", folder);
+    domMenuItemById("markra:file-tree:delete").click();
 
     expect(deleteFile).toHaveBeenCalledWith(folder);
-    expect(renameFile).not.toHaveBeenCalled();
+    expect(renameFile).toHaveBeenCalledWith(folder);
     expect(popup).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/components/ContextMenu.test.tsx
+++ b/packages/app/src/components/ContextMenu.test.tsx
@@ -118,11 +118,11 @@ describe("ContextMenu", () => {
     expect(getMenu()).toBeNull();
   });
 
-  it("limits the main menu height when opened near the viewport bottom", () => {
+  it("keeps the main menu whole instead of adding a scrollbar near the viewport bottom", () => {
     vi.spyOn(window, "innerHeight", "get").mockReturnValue(300);
     vi.spyOn(window, "innerWidth", "get").mockReturnValue(400);
     vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(function (this: HTMLElement) {
-      if (this.hasAttribute("data-markra-context-menu")) return 500;
+      if (this.hasAttribute("data-markra-context-menu")) return 208;
 
       return 28;
     });
@@ -133,7 +133,7 @@ describe("ContextMenu", () => {
     });
 
     showContextMenu(document, {
-      entries: Array.from({ length: 24 }, (_, index) => ({
+      entries: Array.from({ length: 7 }, (_, index) => ({
         id: `markra:test:item-${index + 1}`,
         kind: "item" as const,
         label: `Item ${index + 1}`,
@@ -148,9 +148,9 @@ describe("ContextMenu", () => {
     const menu = getMenu() as HTMLElement | null;
 
     expect(menu).not.toBeNull();
-    expect(menu?.style.top).toBe("8px");
-    expect(menu?.style.maxHeight).toBe("252px");
-    expect(menu?.style.overflowY).toBe("auto");
+    expect(menu?.style.top).toBe("52px");
+    expect(menu?.style.maxHeight).toBe("");
+    expect(menu?.style.overflowY).toBe("");
   });
 
   it("keeps submenus inside the viewport when their anchor is near the bottom", () => {

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -256,8 +256,6 @@ export function ContextMenu({ ariaLabel, entries, onClose, position }: ContextMe
 
     setMenuStyle({
       left: positioned.left,
-      maxHeight: positioned.maxHeight,
-      overflowY: "auto",
       top: positioned.top
     });
     setSubmenuAlignLeft(positioned.left + width + contextSubmenuWidth > viewportWidth - contextMenuViewportMargin);

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -802,6 +802,86 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(renameFile).toHaveBeenCalledWith(markdownFiles[0], "Renamed.md");
   });
 
+  it("keeps the rename input visible until an async rename finishes", async () => {
+    let finishRename: (() => void) | null = null;
+    const renameFile = vi.fn(() => new Promise<void>((resolve) => {
+      finishRename = resolve;
+    }));
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onRenameFile={renameFile}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Untitled.md" }));
+    const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls[0]?.[0];
+    act(() => {
+      contextHandlers?.renameFile?.(markdownFiles[0]);
+    });
+
+    const renameInput = screen.getByRole("textbox", { name: "Rename file" });
+    fireEvent.change(renameInput, { target: { value: "Renamed.md" } });
+    fireEvent.keyDown(renameInput, { key: "Enter" });
+
+    expect(renameFile).toHaveBeenCalledWith(markdownFiles[0], "Renamed.md");
+    expect(screen.getByRole("textbox", { name: "Rename file" })).toHaveValue("Renamed.md");
+    expect(screen.queryByRole("button", { name: "Untitled.md" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      finishRename?.();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("textbox", { name: "Rename file" })).not.toBeInTheDocument();
+  });
+
+  it("supports renaming folders from the file tree context menu", () => {
+    const renameFile = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onRenameFile={renameFile}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const folderButton = screen.getByRole("button", { name: "deploy" });
+    fireEvent.contextMenu(folderButton);
+    const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls[0]?.[0];
+    const folder = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls[0]?.[2];
+
+    act(() => {
+      if (folder) contextHandlers?.renameFile?.(folder);
+    });
+
+    const renameInput = screen.getByRole("textbox", { name: "Rename folder" });
+    fireEvent.change(renameInput, { target: { value: "renamed-deploy" } });
+    fireEvent.keyDown(renameInput, { key: "Enter" });
+
+    expect(renameFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "folder",
+        path: "/vault/deploy"
+      }),
+      "renamed-deploy"
+    );
+  });
+
   it("keeps the empty file tree available for root file creation without an open folder", () => {
     const createFile = vi.fn();
     const createFolder = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -806,9 +806,11 @@ export function MarkdownFileTreeDrawer({
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameFileName, setRenameFileName] = useState("");
+  const renamingPathRef = useRef<string | null>(null);
   const [dragOverTargetPath, setDragOverTargetPath] = useState<string | null>(null);
   const [activeDragFile, setActiveDragFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [collapsedOutlineKeys, setCollapsedOutlineKeys] = useState<Set<string>>(() => new Set());
+  renamingPathRef.current = renamingPath;
   const fileTreeDndSensors = useSensors(
     useSensor(MouseSensor, {
       activationConstraint: {
@@ -1189,9 +1191,14 @@ export function MarkdownFileTreeDrawer({
       return;
     }
 
-    onRenameFile?.(file, normalizedName);
-    setRenamingPath(null);
-    setRenameFileName("");
+    Promise.resolve(onRenameFile?.(file, normalizedName))
+      .catch(() => {})
+      .then(() => {
+        if (renamingPathRef.current !== file.path) return;
+
+        setRenamingPath(null);
+        setRenameFileName("");
+      });
   };
 
   const cancelFileTreeInputs = () => {
@@ -1583,6 +1590,49 @@ export function MarkdownFileTreeDrawer({
     )
   );
 
+  const renderRenameRowContent = (
+    file: NativeMarkdownFolderFile,
+    depth: number,
+    mode: FileTreeRowRenderMode
+  ) => {
+    const folder = file.kind === "folder";
+    const FileIcon = folder ? Folder : file.kind === "asset" ? ImageIcon : FileText;
+    const rowIndentClass = fileTreeRowIndentClass(mode);
+    const rowBranchClass = mode === "nested" ? rowBranchClassForDepth(depth) : "";
+    const rowIndentStyle = fileTreeRowIndentStyle(depth, mode);
+
+    return (
+      <div
+        className={`relative grid h-8 w-full items-center py-0 pr-2 text-[13px] leading-none text-(--text-secondary) ${folder ? "grid-cols-[13px_16px_minmax(0,1fr)] gap-1" : "grid-cols-[17px_minmax(0,1fr)] gap-1.5"} ${rowIndentClass} ${rowBranchClass}`}
+        style={rowIndentStyle}
+      >
+        {folder ? <span aria-hidden="true" /> : null}
+        <FileIcon aria-hidden="true" className="shrink-0" size={folder ? 16 : 15} />
+        <input
+          aria-label={folder ? label("app.renameMarkdownFolder") : label("app.renameMarkdownFile")}
+          autoFocus
+          className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-none text-(--text-primary) outline-none"
+          type="text"
+          value={renameFileName}
+          onChange={(event) => setRenameFileName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              commitRenameFile(file);
+              return;
+            }
+
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setRenamingPath(null);
+              setRenameFileName("");
+            }
+          }}
+        />
+      </div>
+    );
+  };
+
   const renderFolderRowContent = (
     node: FolderNode,
     depth: number,
@@ -1590,6 +1640,7 @@ export function MarkdownFileTreeDrawer({
     mode: FileTreeRowRenderMode
   ) => {
     const folderFile = folderNodeAsFile(node);
+    const renaming = renamingPath === folderFile.path;
     const dropTarget = dragOverTargetPath === dragTargetKey(node.path);
     const folderRowStateClassName = dropTarget
       ? fileTreeDropTargetClassName
@@ -1597,6 +1648,8 @@ export function MarkdownFileTreeDrawer({
     const rowIndentClass = fileTreeRowIndentClass(mode);
     const rowBranchClass = mode === "nested" ? rowBranchClassForDepth(depth) : "";
     const rowIndentStyle = fileTreeRowIndentStyle(depth, mode);
+
+    if (renaming) return renderRenameRowContent(folderFile, depth, mode);
 
     return (
       <FileTreeDropTarget
@@ -1645,37 +1698,7 @@ export function MarkdownFileTreeDrawer({
     const rowBranchClass = mode === "nested" ? rowBranchClassForDepth(depth) : "";
     const rowIndentStyle = fileTreeRowIndentStyle(depth, mode);
 
-    if (renaming) {
-      return (
-        <div
-          className={`relative grid h-8 w-full grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 py-0 pr-2 text-[13px] leading-none text-(--text-secondary) ${rowIndentClass} ${rowBranchClass}`}
-          style={rowIndentStyle}
-        >
-          <FileIcon aria-hidden="true" className="shrink-0" size={15} />
-          <input
-            aria-label={label("app.renameMarkdownFile")}
-            autoFocus
-            className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-none text-(--text-primary) outline-none"
-            type="text"
-            value={renameFileName}
-            onChange={(event) => setRenameFileName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                commitRenameFile(node.file);
-                return;
-              }
-
-              if (event.key === "Escape") {
-                event.preventDefault();
-                setRenamingPath(null);
-                setRenameFileName("");
-              }
-            }}
-          />
-        </div>
-      );
-    }
+    if (renaming) return renderRenameRowContent(node.file, depth, mode);
 
     return (
       <FileTreeDragSource disabled={!dragMoveAvailable} file={node.file}>

--- a/packages/app/src/runtime/context-menu-items.ts
+++ b/packages/app/src/runtime/context-menu-items.ts
@@ -229,6 +229,7 @@ export function createMarkdownFileTreeContextMenuEntries(
   if (fileIsFolder) {
     entries.push(
       contextMenuSeparator(),
+      contextMenuItem(fileTreeId("rename"), label("app.renameMarkdownFolder"), undefined, () => handlers.renameFile?.(file), !handlers.renameFile),
       contextMenuItem(fileTreeId("delete"), label("app.deleteMarkdownFolder"), undefined, () => handlers.deleteFile?.(file), !handlers.deleteFile)
     );
 

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "Ordner erstellen",
   "app.newMarkdownFolderName": "Neuer Ordnername",
   "app.renameMarkdownFile": "Datei umbenennen",
+  "app.renameMarkdownFolder": "Ordner umbenennen",
   "app.deleteMarkdownFile": "Datei löschen",
   "app.confirmDeleteMarkdownFile": "Diese Datei löschen?",
   "app.cancelDeleteMarkdownFile": "Abbrechen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -443,6 +443,7 @@ const messages: BaseLocaleMessages = {
   "app.newMarkdownFolder": "New Folder",
   "app.newMarkdownFolderName": "New folder name",
   "app.renameMarkdownFile": "Rename file",
+  "app.renameMarkdownFolder": "Rename folder",
   "app.deleteMarkdownFile": "Delete file",
   "app.confirmDeleteMarkdownFile": "Delete this file?",
   "app.cancelDeleteMarkdownFile": "Cancel",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "Nueva carpeta",
   "app.newMarkdownFolderName": "Nuevo nombre de carpeta",
   "app.renameMarkdownFile": "Renombrar archivo",
+  "app.renameMarkdownFolder": "Renombrar carpeta",
   "app.deleteMarkdownFile": "Eliminar archivo",
   "app.confirmDeleteMarkdownFile": "¿Eliminar este archivo?",
   "app.cancelDeleteMarkdownFile": "Cancelar",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "Nouveau dossier",
   "app.newMarkdownFolderName": "Nouveau nom de dossier",
   "app.renameMarkdownFile": "Renommer le fichier",
+  "app.renameMarkdownFolder": "Renommer le dossier",
   "app.deleteMarkdownFile": "Supprimer le fichier",
   "app.confirmDeleteMarkdownFile": "Supprimer ce fichier ?",
   "app.cancelDeleteMarkdownFile": "Annuler",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "Nuova cartella",
   "app.newMarkdownFolderName": "Nuovo nome cartella",
   "app.renameMarkdownFile": "Rinomina file",
+  "app.renameMarkdownFolder": "Rinomina cartella",
   "app.deleteMarkdownFile": "Elimina file",
   "app.confirmDeleteMarkdownFile": "Eliminare questo file?",
   "app.cancelDeleteMarkdownFile": "Annulla",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -300,6 +300,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "フォルダを作成",
   "app.newMarkdownFolderName": "新しいフォルダ名",
   "app.renameMarkdownFile": "ファイル名を変更",
+  "app.renameMarkdownFolder": "フォルダ名を変更",
   "app.deleteMarkdownFile": "ファイルを削除",
   "app.confirmDeleteMarkdownFile": "このファイルを削除しますか？",
   "app.cancelDeleteMarkdownFile": "キャンセル",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "폴더 만들기",
   "app.newMarkdownFolderName": "새 폴더 이름",
   "app.renameMarkdownFile": "파일 이름 변경",
+  "app.renameMarkdownFolder": "폴더 이름 변경",
   "app.deleteMarkdownFile": "파일 삭제",
   "app.confirmDeleteMarkdownFile": "이 파일을 삭제할까요?",
   "app.cancelDeleteMarkdownFile": "취소",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "Nova pasta",
   "app.newMarkdownFolderName": "Novo nome da pasta",
   "app.renameMarkdownFile": "Renomear arquivo",
+  "app.renameMarkdownFolder": "Renomear pasta",
   "app.deleteMarkdownFile": "Excluir arquivo",
   "app.confirmDeleteMarkdownFile": "Excluir este arquivo?",
   "app.cancelDeleteMarkdownFile": "Cancelar",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -292,6 +292,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "Создать папку",
   "app.newMarkdownFolderName": "Новое имя папки",
   "app.renameMarkdownFile": "Переименовать файл",
+  "app.renameMarkdownFolder": "Переименовать папку",
   "app.deleteMarkdownFile": "Удалить файл",
   "app.confirmDeleteMarkdownFile": "Удалить этот файл?",
   "app.cancelDeleteMarkdownFile": "Отмена",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -454,6 +454,7 @@ export type I18nKey =
   | "app.newMarkdownFolder"
   | "app.newMarkdownFolderName"
   | "app.renameMarkdownFile"
+  | "app.renameMarkdownFolder"
   | "app.deleteMarkdownFile"
   | "app.confirmDeleteMarkdownFile"
   | "app.cancelDeleteMarkdownFile"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -443,6 +443,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "新建文件夹",
   "app.newMarkdownFolderName": "新文件夹名",
   "app.renameMarkdownFile": "重命名文件",
+  "app.renameMarkdownFolder": "重命名文件夹",
   "app.deleteMarkdownFile": "删除文件",
   "app.confirmDeleteMarkdownFile": "确定删除这个文件吗？",
   "app.cancelDeleteMarkdownFile": "取消",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -300,6 +300,7 @@ const messages: LocaleMessages = {
   "app.newMarkdownFolder": "新增資料夾",
   "app.newMarkdownFolderName": "新資料夾名稱",
   "app.renameMarkdownFile": "重新命名檔案",
+  "app.renameMarkdownFolder": "重新命名資料夾",
   "app.deleteMarkdownFile": "刪除檔案",
   "app.confirmDeleteMarkdownFile": "確定要刪除此檔案嗎？",
   "app.cancelDeleteMarkdownFile": "取消",


### PR DESCRIPTION
## Summary
- Remove scroll behavior from the self-drawn context menu so submenus are not clipped and the menu does not disappear from scrollbar interaction.
- Add folder rename support in the file tree context menu, including localized labels.
- Keep rename inputs visible until async rename/refresh finishes to avoid flashing back to the old file or folder name.
- Allow the native markdown tree rename command to rename folders, not just markdown files and image assets.

## Root Cause
- The context menu was being made scrollable via `maxHeight`/`overflowY`, which clipped absolute-positioned submenus.
- Folder targets could enter frontend rename state, but folder rows did not render the rename input.
- The native rename command rejected folder paths, so committed folder names were silently kept unchanged by the app.
- Rename inputs were cleared immediately on Enter before the async native rename and refresh completed.

## Validation
- `cargo test` passed: 109 tests.
- `cargo test renames_markdown_tree_folders_inside_the_root` passed.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownFileTreeDrawer.test.tsx src/components/ContextMenu.test.tsx` passed: 54 tests.
- `pnpm --filter @markra/desktop exec vitest run src/runtime/tauri/menu.test.ts src/runtime/tauri/file.test.ts` passed: 55 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/desktop build` passed.
- `cargo fmt --check` passed.
- `git diff --cached --check` passed.

Closes #215