### PR TITLE
fix(editor): stabilize callout enter handling

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3900,6 +3900,101 @@ describe("Markra workspace", () => {
     expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
   });
 
+  it("keeps callout body line breaks when switching from source to visual mode", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+    fireEvent.change(sourceEditor, {
+      target: {
+        value: "> [!WARNING]\n>\n> First line\n> Second line"
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+
+    await waitFor(() => {
+      expect(document.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    });
+    const bodyParagraph = document.querySelector<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout p:nth-of-type(2)"
+    );
+
+    const hardbreak = bodyParagraph?.querySelector<HTMLElement>('span.markra-hardbreak[data-type="hardbreak"]');
+    expect(hardbreak?.querySelector("br")).toBeInTheDocument();
+    expect(hardbreak).toHaveTextContent("");
+    expect(bodyParagraph).toHaveTextContent("First lineSecond line");
+  });
+
+  it("keeps explicit empty callout body lines when switching source and visual modes", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    const source = "> [!WARNING]\n>\n>";
+    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
+      target: {
+        value: source
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(3);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(source);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(3);
+    });
+  });
+
+  it("keeps trailing empty callout body lines after content when switching source and visual modes", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    const source = "> [!WARNING]\n>\n> Synthetic details\n>\n>";
+    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
+      target: {
+        value: source
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(4);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(source);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(4);
+    });
+  });
+
   it("shows a large-file notice instead of rendering oversized markdown in visual mode", async () => {
     const largeContent = `# Oversized file\n\n${"Synthetic paragraph. ".repeat(110_000)}`;
     mockedGetStoredWorkspaceState.mockResolvedValue({

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -86,6 +86,7 @@ import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath
 import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
 import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
+import { aiCommandSelection, automaticAiSelection } from "./lib/ai-selection";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
 import { replaceMovedPath } from "./lib/path-move";
@@ -278,18 +279,6 @@ function aiResultSignature(result: AiDiffResult) {
 
 function aiPreviewActionKey(result: AiDiffResult, previewId?: string) {
   return previewId ? `preview${aiResultSignatureSeparator}${previewId}` : `result${aiResultSignatureSeparator}${aiResultSignature(result)}`;
-}
-
-function explicitAiTextSelection(selection: AiSelectionContext | null | undefined) {
-  if (selection?.source !== "selection" || !selection.text.trim()) return null;
-
-  return selection;
-}
-
-function aiCommandTextSelection(selection: AiSelectionContext | null | undefined) {
-  if (!selection?.text.trim()) return null;
-
-  return selection;
 }
 
 function selectionAnchorsEqual(left: SelectionAnchor | null, right: SelectionAnchor | null) {
@@ -1233,7 +1222,9 @@ function WorkspaceApp() {
     openAiAgentPanel();
   }, [activeAiAgentSessionId, aiAgentSessions, createInitializedAiAgentSession, openAiAgentPanel, selectWorkspaceSession]);
   const handleTextSelectionChange = useCallback((selection: AiSelectionContext | null) => {
-    updateActiveAiSelection(selection);
+    const automaticSelection = automaticAiSelection(selection);
+
+    updateActiveAiSelection(automaticSelection);
     clearAiSelectionToolbarCopySuccess();
     setAiSelectionToolbarActiveActions([]);
     setAiSelectionToolbarHeadingLevel(null);
@@ -1257,7 +1248,7 @@ function WorkspaceApp() {
       return;
     }
 
-    if (selection.source !== "selection") {
+    if (!automaticSelection) {
       setAiSelectionToolbarAnchor(null);
       editor.clearAiSelection();
       if (aiResultsRef.current.length === 0) aiCommand.closeAiCommand();
@@ -1301,7 +1292,7 @@ function WorkspaceApp() {
         getEditorSelectionAnchor() ?? selectionAnchorFromDomSelection(window.getSelection())
       );
     } else if (!hideInlineAiCommandForAgentPanel) {
-      aiCommand.openAiCommand(selection);
+      aiCommand.openAiCommand(automaticSelection);
       return;
     } else {
       setAiSelectionToolbarAnchor(null);
@@ -1309,7 +1300,7 @@ function WorkspaceApp() {
     }
 
     if (showQuickInput && !hideInlineAiCommandForAgentPanel) {
-      aiCommand.openAiCommand(selection);
+      aiCommand.openAiCommand(automaticSelection);
     }
   }, [
     aiAgentOpen,
@@ -1338,7 +1329,7 @@ function WorkspaceApp() {
     aiContextMenuActionRef.current = (intent: AiQuickActionIntent, prompt: string) => {
       if (!aiFeatureEnabled || sourceSurfaceActive || readOnlyMode) return;
 
-      const selection = explicitAiTextSelection(getActiveAiSelection()) ?? explicitAiTextSelection(getEditorSelection());
+      const selection = automaticAiSelection(getActiveAiSelection()) ?? automaticAiSelection(getEditorSelection());
       if (!selection) return;
 
       holdAiSelection(selection);
@@ -1388,7 +1379,7 @@ function WorkspaceApp() {
     if (!aiFeatureEnabled) return false;
     if (sourceSurfaceActive || readOnlyMode) return false;
 
-    const selection = explicitAiTextSelection(getActiveAiSelection()) ?? explicitAiTextSelection(getEditorSelection());
+    const selection = automaticAiSelection(getActiveAiSelection()) ?? automaticAiSelection(getEditorSelection());
 
     return Boolean(selection);
   }, [aiFeatureEnabled, getActiveAiSelection, getEditorSelection, readOnlyMode, sourceSurfaceActive]);
@@ -1404,7 +1395,7 @@ function WorkspaceApp() {
 
     if (sourceSurfaceActive || readOnlyMode) return;
 
-    const selection = aiCommandTextSelection(getActiveAiSelection()) ?? aiCommandTextSelection(getEditorSelection());
+    const selection = aiCommandSelection(getActiveAiSelection()) ?? aiCommandSelection(getEditorSelection());
     if (!selection) return;
 
     updateActiveAiSelection(selection);
@@ -1422,7 +1413,7 @@ function WorkspaceApp() {
     updateActiveAiSelection
   ]);
   const handleAiCommandSelectionContextFocus = useCallback(() => {
-    const selection = aiCommandTextSelection(getActiveAiSelection()) ?? aiCommandTextSelection(getEditorSelection());
+    const selection = aiCommandSelection(getActiveAiSelection()) ?? aiCommandSelection(getEditorSelection());
     if (!selection) return;
 
     holdAiSelection(selection);

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -4193,6 +4193,32 @@ describe("MarkdownPaper editing", () => {
     expect(onTextSelectionChange).not.toHaveBeenCalled();
   });
 
+  it("does not notify transient selections while IME input is composing", async () => {
+    const onTextSelectionChange = vi.fn();
+    const { view } = await renderEditor("Synthetic IME text.", { onTextSelectionChange });
+    const from = findTextPosition(view, "IME");
+    const to = from + "IME".length;
+    const composingDescriptor = Object.getOwnPropertyDescriptor(view, "composing");
+
+    Object.defineProperty(view, "composing", {
+      configurable: true,
+      value: true
+    });
+
+    try {
+      onTextSelectionChange.mockClear();
+      selectText(view, from, to);
+
+      expect(onTextSelectionChange).not.toHaveBeenCalled();
+    } finally {
+      if (composingDescriptor) {
+        Object.defineProperty(view, "composing", composingDescriptor);
+      } else {
+        delete (view as unknown as { composing?: boolean }).composing;
+      }
+    }
+  });
+
   it("selects the current code block content with Ctrl+A inside the code editor", async () => {
     const source = ["Before", "", "```ts", "const answer = 42;", "return answer;", "```", "", "After"].join("\n");
     const { container, view } = await renderEditor(source);
@@ -6203,6 +6229,115 @@ describe("MarkdownPaper editing", () => {
     expect(markerLine).toHaveTextContent("[!NOTE]");
   });
 
+  it("marks marker-only callout source lines before body content exists", async () => {
+    const { container } = await renderEditor("> [!WARNING]");
+
+    const markerLine = container.querySelector<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout .markra-callout-marker-line"
+    );
+    const sourceMarker = container.querySelector<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout .markra-callout-source-marker"
+    );
+
+    expect(markerLine).toBeInTheDocument();
+    expect(markerLine).toHaveTextContent("[!WARNING]");
+    expect(sourceMarker).toBeInTheDocument();
+    expect(sourceMarker).toHaveTextContent("[!WARNING]");
+  });
+
+  it("preserves an explicit empty callout body line", async () => {
+    const source = "> [!WARNING]\n>";
+    const { container, editor, view } = await renderEditor(source);
+
+    const callout = container.querySelector(".ProseMirror blockquote.markra-callout");
+    const bodyParagraph = container.querySelector(".ProseMirror blockquote.markra-callout p:nth-of-type(2)");
+    expect(callout).toBeInTheDocument();
+    expect(bodyParagraph).toBeInTheDocument();
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+
+    moveCursor(view, findLastTextBlockCursor(view));
+    typeText(view, "Synthetic details");
+
+    expect(callout).toHaveTextContent("Synthetic details");
+    expect(serializeMarkdown(view.state.doc)).toBe("> [!WARNING]\n>\n> Synthetic details\n");
+    await settleMarkdownListener();
+  });
+
+  it("moves a cursor from the hidden callout marker line into the empty body", async () => {
+    const source = "> [!NOTE]\n>";
+    const { container, editor, view } = await renderEditor(source);
+
+    moveCursor(view, findTextPosition(view, "[!NOTE]", "[!NOTE]".length));
+
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+
+    typeText(view, "Synthetic details");
+
+    const callout = container.querySelector(".ProseMirror blockquote.markra-callout");
+    expect(callout).toHaveTextContent("Synthetic details");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("> [!NOTE]\n>\n> Synthetic details\n");
+    await settleMarkdownListener();
+  });
+
+  it("starts an empty loaded callout with the cursor in the editable body", async () => {
+    const source = "> [!NOTE]\n>";
+    const { container, editor, view } = await renderEditor(source);
+
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+
+    typeText(view, "Synthetic details");
+
+    const callout = container.querySelector(".ProseMirror blockquote.markra-callout");
+    expect(callout).toHaveTextContent("Synthetic details");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("> [!NOTE]\n>\n> Synthetic details\n");
+    await settleMarkdownListener();
+  });
+
+  it("preserves two explicit empty callout body lines", async () => {
+    const source = "> [!WARNING]\n>\n>";
+    const { container, editor, view } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(3);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it("preserves trailing empty callout body lines after content", async () => {
+    const source = "> [!WARNING]\n>\n> Synthetic details\n>\n>";
+    const { container, editor, view } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(4);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it("keeps an empty callout body line when pressing Enter to exit", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>");
+
+    moveCursor(view, findLastTextBlockCursor(view));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(2);
+
+    typeText(view, "After callout");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("> [!NOTE]\n>\n\nAfter callout\n");
+    await settleMarkdownListener();
+  });
+
   it("keeps same-paragraph callout content visible", async () => {
     const { container } = await renderEditor("> [!WARNING]\n> Check before publishing.");
 
@@ -6958,16 +7093,219 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("removes an empty callout when pressing Backspace from its body", async () => {
-    const { container, view } = await renderEditor("> [!NOTE]\n> ");
-    moveCursor(view, findLastTextBlockCursor(view));
+  it("exits a typed callout when pressing Enter from the empty body", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    typeText(view, "> [!WARNING]");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout .markra-callout-marker-line")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout .markra-callout-source-marker")).toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+
+    focusEditor(view);
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    typeText(view, "After callout");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("After callout");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n\nAfter callout");
+    await settleMarkdownListener();
+  });
+
+  it("exits a marker-only callout when pressing Enter before body content exists", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]");
+
+    moveCursor(view, findTextPosition(view, "[!WARNING]", "[!WARNING]".length));
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    typeText(view, "After callout");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("After callout");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n\nAfter callout");
+    await settleMarkdownListener();
+  });
+
+  it("exits callout body content when pressing Enter", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> First line");
+
+    moveCursor(view, findTextPosition(view, "First line", "First line".length));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    typeText(view, "After callout");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line");
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("After callout");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n\nAfter callout");
+    await settleMarkdownListener();
+  });
+
+  it("keeps a typed quote below a callout outside the callout block", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> First line");
+
+    moveCursor(view, findTextPosition(view, "First line", "First line".length));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    typeText(view, "> ");
+
+    const callout = container.querySelector(".ProseMirror blockquote.markra-callout");
+    const blockquotes = container.querySelectorAll(".ProseMirror blockquote");
+    expect(callout).toHaveTextContent("First line");
+    expect(callout).not.toHaveTextContent(">");
+    expect(blockquotes).toHaveLength(2);
+    expect(blockquotes[1]).not.toHaveClass("markra-callout");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "Plain quote");
+
+    expect(callout).not.toHaveTextContent("Plain quote");
+    expect(blockquotes[1]).toHaveTextContent("Plain quote");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n\n> Plain quote");
+    await settleMarkdownListener();
+  });
+
+  it("keeps Shift+Enter line breaks inside callout body content without hard-break escapes", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> First line");
+
+    moveCursor(view, findTextPosition(view, "First line", "First line".length));
+
+    expect(pressShortcut(view, "Enter", { shiftKey: true })).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "Second line");
+
+    const bodyParagraph = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout p:nth-of-type(2)");
+    const hardbreak = bodyParagraph?.querySelector<HTMLElement>('span.markra-hardbreak[data-type="hardbreak"]');
+    expect(hardbreak?.querySelector("br")).toBeInTheDocument();
+    expect(hardbreak).toHaveTextContent("");
+    const bodyHardbreak = view.state.doc.resolve(findTextPosition(view, "Second line")).parent.child(1);
+    expect(bodyHardbreak.type.name).toBe("hardbreak");
+    expect(bodyHardbreak.attrs.isInline).toBe(true);
+    expect(bodyHardbreak.attrs.renderLineBreak).toBe(true);
+    expect(bodyParagraph).toHaveTextContent("First lineSecond line");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> [!WARNING]\n>\n> First line\n> Second line");
+    expect(markdown).not.toContain("> First line\n>\n> Second line");
+    expect(markdown).not.toContain("\\");
+    await settleMarkdownListener();
+  });
+
+  it("restores serialized callout body line breaks when loading Markdown source", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> First line\n> Second line");
+
+    const bodyParagraph = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout p:nth-of-type(2)");
+    const hardbreak = bodyParagraph?.querySelector<HTMLElement>('span.markra-hardbreak[data-type="hardbreak"]');
+    expect(hardbreak?.querySelector("br")).toBeInTheDocument();
+    expect(hardbreak).toHaveTextContent("");
+    const bodyHardbreak = view.state.doc.resolve(findTextPosition(view, "Second line")).parent.child(1);
+    expect(bodyHardbreak.type.name).toBe("hardbreak");
+    expect(bodyHardbreak.attrs.isInline).toBe(true);
+    expect(bodyHardbreak.attrs.renderLineBreak).toBe(true);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n> Second line");
+    await settleMarkdownListener();
+  });
+
+  it("finalizes a raw callout marker line into an editable callout on Enter", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    insertTextDirectly(view, "> [!WARNING]");
+
+    focusEditor(view);
+    expect(fireEvent.keyDown(view.dom, { key: "Enter" })).toBe(false);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "Synthetic details");
+
+    const callout = container.querySelector(".ProseMirror blockquote.markra-callout");
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveTextContent("Synthetic details");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> Synthetic details");
+    await settleMarkdownListener();
+  });
+
+  it("keeps an empty callout editable after deleting its final body text", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> Synthetic detail");
+    const bodyFrom = findTextPosition(view, "Synthetic detail");
+
+    selectText(view, bodyFrom, bodyFrom + "Synthetic detail".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "Synthetic detail");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("Synthetic detail");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!NOTE]\n>\n> Synthetic detail");
+    await settleMarkdownListener();
+  });
+
+  it("deletes an empty callout when pressing Backspace from its body", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> Synthetic detail");
+    const bodyFrom = findTextPosition(view, "Synthetic detail");
+
+    selectText(view, bodyFrom, bodyFrom + "Synthetic detail".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
 
     expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
     expect(pressBackspace(view)).toBe(true);
 
-    expect(container.querySelector(".ProseMirror blockquote")).not.toBeInTheDocument();
-    expect(container.querySelector(".ProseMirror p")).toHaveTextContent("");
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    typeText(view, "After delete");
+
+    expect(container.querySelector(".ProseMirror")).toHaveTextContent("After delete");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("After delete");
+    expect(markdown).not.toContain("[!NOTE]");
     await settleMarkdownListener();
+  });
+
+  it("removes one empty callout body line before deleting an otherwise empty callout", async () => {
+    const { container, view } = await renderEditor("> [!NOTE]\n>\n>");
+
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(3);
+
+    moveCursor(view, findLastTextBlockCursor(view));
+    expect(pressBackspace(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(2);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
   });
 
   it("keeps the cursor inside a callout when deleting an empty middle line", async () => {

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -12,6 +12,7 @@ import {
   markraAiSelectionHoldPlugin,
   markraBlockDragPlugin,
   markraCalloutPlugin,
+  markraCalloutRemarkPlugin,
   markraCalloutSerializerPlugin,
   markraClipboardImagePluginWithOptions,
   markraCodeBlockPlugin,
@@ -285,6 +286,7 @@ function MilkdownEditorSurface({
         .use(markraCalloutSerializerPlugin);
 
       if (githubAlertsEnabled) {
+        editor.use(markraCalloutRemarkPlugin);
         editor.use(markraCalloutPlugin);
       }
 

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -1,5 +1,7 @@
 import {
   commands as commonmarkCommands,
+  hardbreakAttr,
+  hardbreakSchema,
   imageSchema,
   inputRules as commonmarkInputRules,
   keymap as commonmarkKeymap,
@@ -21,6 +23,7 @@ import { Plugin } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose, $remark } from "@milkdown/kit/utils";
 import type { AiSelectionContext } from "@markra/ai";
+import { parseMarkdownCalloutMarker } from "@markra/shared";
 import { readAiSelectionContextFromView } from "../hooks/useEditorController";
 
 type MarkdownTreeNode = {
@@ -54,6 +57,54 @@ const markraBlockImageSchema = imageSchema.extendSchema((previous) => (ctx) => (
   }
 }));
 
+function hardbreakDomAttrs(attrs: Record<string, unknown>) {
+  const existingClass = typeof attrs.class === "string" && attrs.class.length > 0 ? attrs.class : "";
+  return {
+    ...attrs,
+    class: ["markra-hardbreak", existingClass].filter(Boolean).join(" ")
+  };
+}
+
+const markraHardbreakSchema = hardbreakSchema.extendSchema((previous) => (ctx) => {
+  const baseSchema = previous(ctx);
+
+  return {
+    ...baseSchema,
+    attrs: {
+      ...baseSchema.attrs,
+      renderLineBreak: {
+        default: false,
+        validate: "boolean"
+      }
+    },
+    parseDOM: [
+      {
+        tag: 'span.markra-hardbreak[data-type="hardbreak"]',
+        getAttrs: () => ({ isInline: true, renderLineBreak: true })
+      },
+      ...(baseSchema.parseDOM ?? [])
+    ],
+    parseMarkdown: {
+      match: ({ type }) => type === "break",
+      runner: (state, node, type) => {
+        const data = node.data as undefined | { isInline?: boolean; renderLineBreak?: boolean };
+        state.addNode(type, {
+          isInline: Boolean(data?.isInline),
+          renderLineBreak: Boolean(data?.renderLineBreak)
+        });
+      }
+    },
+    toDOM: (node) => {
+      if (!(node.attrs.isInline && node.attrs.renderLineBreak)) {
+        return baseSchema.toDOM?.(node) ?? ["br", ctx.get(hardbreakAttr.key)(node)];
+      }
+
+      const attrs = hardbreakDomAttrs(ctx.get(hardbreakAttr.key)(node));
+      return ["span", attrs, ["br"]];
+    }
+  };
+});
+
 function lineNumber(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -75,6 +126,31 @@ function blankParagraphNode(): MarkdownTreeNode {
   };
 }
 
+function markdownNodeText(node: MarkdownTreeNode): string {
+  if (typeof node.value === "string") return node.value;
+  return node.children?.map(markdownNodeText).join("") ?? "";
+}
+
+function appendExplicitEmptyCalloutBodyLines(node: MarkdownTreeNode, children: MarkdownTreeNode[]) {
+  if (node.type !== "blockquote") return;
+
+  const firstChild = children[0];
+  if (firstChild?.type !== "paragraph" || !parseMarkdownCalloutMarker(markdownNodeText(firstChild))) return;
+
+  const nodeEndLine = lineNumber(node.position?.end?.line);
+  let lastChildEndLine: number | null = null;
+  for (let childIndex = children.length - 1; childIndex >= 0; childIndex -= 1) {
+    lastChildEndLine = lineNumber(children[childIndex]?.position?.end?.line);
+    if (lastChildEndLine !== null) break;
+  }
+  if (nodeEndLine === null || lastChildEndLine === null) return;
+
+  const trailingEmptyBodyLines = Math.max(0, nodeEndLine - lastChildEndLine);
+  for (let lineIndex = 0; lineIndex < trailingEmptyBodyLines; lineIndex += 1) {
+    children.push(blankParagraphNode());
+  }
+}
+
 function preserveBlankParagraphs(node: MarkdownTreeNode) {
   if (!Array.isArray(node.children)) return;
 
@@ -94,6 +170,9 @@ function preserveBlankParagraphs(node: MarkdownTreeNode) {
 
     children.push(child);
   });
+
+  appendExplicitEmptyCalloutBodyLines(node, children);
+
   node.children = children;
 }
 
@@ -198,6 +277,7 @@ export const markraCommonmark = [
   markraBlockImageRemarkPlugin,
   commonmarkSchema,
   markraBlockImageSchema,
+  markraHardbreakSchema,
   commonmarkInputRules,
   commonmarkCommands,
   commonmarkKeymap,
@@ -228,6 +308,10 @@ function selectionIsInsideNodeName(selection: Selection, nodeName: string) {
   return [selection.$from, selection.$to].every(($pos) => positionHasAncestorNodeName($pos, nodeName));
 }
 
+function editorViewIsComposing(view: EditorView) {
+  return Boolean((view as EditorView & { composing?: boolean }).composing);
+}
+
 export function markraTextSelectionObserverPlugin(
   onTextSelectionChange: (selection: AiSelectionContext | null) => unknown
 ) {
@@ -235,6 +319,8 @@ export function markraTextSelectionObserverPlugin(
     let lastSignature = "";
 
     const notifySelectionChange = (view: EditorView, options: { requireFocusForEmptySelection: boolean }) => {
+      if (editorViewIsComposing(view)) return;
+
       const { selection } = view.state;
 
       if (selectionIsInsideNodeName(selection, "code_block")) {

--- a/packages/app/src/lib/ai-selection.test.ts
+++ b/packages/app/src/lib/ai-selection.test.ts
@@ -1,0 +1,36 @@
+import type { AiSelectionContext } from "@markra/ai";
+import { automaticAiSelection, aiCommandSelection } from "./ai-selection";
+
+function selection(overrides: Partial<AiSelectionContext> = {}): AiSelectionContext {
+  return {
+    cursor: 14,
+    from: 2,
+    source: "selection",
+    text: "Synthetic selected text",
+    to: 25,
+    ...overrides
+  };
+}
+
+describe("AI selection helpers", () => {
+  it("keeps real selected text available for automatic AI surfaces", () => {
+    const selectedText = selection();
+
+    expect(automaticAiSelection(selectedText)).toBe(selectedText);
+  });
+
+  it("does not promote cursor block context into automatic AI surfaces", () => {
+    expect(automaticAiSelection(selection({ source: "block" }))).toBeNull();
+  });
+
+  it("keeps cursor block context available for explicit AI commands", () => {
+    const blockContext = selection({ source: "block" });
+
+    expect(aiCommandSelection(blockContext)).toBe(blockContext);
+  });
+
+  it("ignores empty selection text", () => {
+    expect(automaticAiSelection(selection({ text: "  " }))).toBeNull();
+    expect(aiCommandSelection(selection({ text: "  " }))).toBeNull();
+  });
+});

--- a/packages/app/src/lib/ai-selection.ts
+++ b/packages/app/src/lib/ai-selection.ts
@@ -1,0 +1,13 @@
+import type { AiSelectionContext } from "@markra/ai";
+
+export function automaticAiSelection(selection: AiSelectionContext | null | undefined) {
+  if (selection?.source !== "selection" || !selection.text.trim()) return null;
+
+  return selection;
+}
+
+export function aiCommandSelection(selection: AiSelectionContext | null | undefined) {
+  if (!selection?.text.trim()) return null;
+
+  return selection;
+}

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1860,6 +1860,8 @@
   .markdown-paper blockquote.markra-callout p {
     @apply mb-3;
     color: var(--editor-text-primary);
+    cursor: text;
+    min-height: 1lh;
   }
 
   .markdown-paper blockquote.markra-callout p:first-of-type {
@@ -2467,14 +2469,9 @@
     display: inline;
     overflow: visible;
     background: transparent;
-    color: transparent;
-    font-size: 0;
-    line-height: 0;
-  }
-
-  .markdown-paper .markra-math-source-active[data-type="hardbreak"]::after {
-    content: "\A";
-    white-space: pre;
+    color: inherit;
+    font-size: inherit;
+    line-height: inherit;
   }
 
   .markdown-paper .markra-math-token-delimiter {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -236,8 +236,9 @@ describe("editor stylesheet", () => {
     expect(activeSourceStyles).toContain("box-decoration-break: clone");
     expect(activeBreakStart).toBeGreaterThanOrEqual(0);
     expect(activeBreakEnd).toBeGreaterThan(activeBreakStart);
-    expect(activeBreakStyles).toContain("font-size: 0");
-    expect(activeBreakStyles).toContain('content: "\\A"');
+    expect(activeBreakStyles).toContain("font-size: inherit");
+    expect(activeBreakStyles).toContain("line-height: inherit");
+    expect(activeBreakStyles).not.toContain('content: "\\A"');
     expect(activeBreakStyles).not.toContain("display: block");
     expect(styles).toContain(".markdown-paper .markra-math-render-active-preview");
     expect(styles).toContain("margin-top");

--- a/packages/editor/src/callout.ts
+++ b/packages/editor/src/callout.ts
@@ -1,10 +1,10 @@
 import { SerializerReady, serializerCtx } from "@milkdown/kit/core";
 import type { Ctx, MilkdownPlugin } from "@milkdown/kit/ctx";
-import { paragraphSchema } from "@milkdown/kit/preset/commonmark";
-import type { Node as ProseNode } from "@milkdown/kit/prose/model";
-import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
+import { blockquoteSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode, ResolvedPos } from "@milkdown/kit/prose/model";
+import { Plugin, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
-import { $prose } from "@milkdown/kit/utils";
+import { $prose, $remark } from "@milkdown/kit/utils";
 import {
   markdownCalloutDefinitions,
   markdownCalloutMarkerForType,
@@ -26,6 +26,13 @@ type CalloutBlock = {
   markerTo: number;
 };
 
+type MarkdownTreeNode = {
+  children?: MarkdownTreeNode[];
+  data?: Record<string, unknown>;
+  type?: string;
+  value?: unknown;
+};
+
 const calloutTypeOrder: MarkdownCalloutType[] = ["note", "tip", "important", "warning", "caution"];
 
 type MarkdownSerializer = (doc: ProseNode) => string;
@@ -38,6 +45,42 @@ export const markraCalloutSerializerPlugin: MilkdownPlugin = (ctx: Ctx) => async
 
   return () => {};
 };
+
+function nodeText(node: MarkdownTreeNode): string {
+  if (typeof node.value === "string") return node.value;
+  return node.children?.map(nodeText).join("") ?? "";
+}
+
+function markCalloutBreaks(node: MarkdownTreeNode) {
+  if (node.type === "break") {
+    node.data = {
+      ...node.data,
+      renderLineBreak: true
+    };
+    return;
+  }
+
+  node.children?.forEach(markCalloutBreaks);
+}
+
+function markCalloutHardbreaks(tree: MarkdownTreeNode) {
+  if (!Array.isArray(tree.children)) return;
+
+  for (const child of tree.children) {
+    markCalloutHardbreaks(child);
+  }
+
+  if (tree.type !== "blockquote") return;
+
+  const firstParagraph = tree.children.find((child) => child.type === "paragraph");
+  if (!firstParagraph || !parseMarkdownCalloutMarker(nodeText(firstParagraph))) return;
+
+  tree.children.forEach(markCalloutBreaks);
+}
+
+export const markraCalloutRemarkPlugin = $remark("markraCalloutRemark", () => () => (tree) => {
+  markCalloutHardbreaks(tree as unknown as MarkdownTreeNode);
+});
 
 function firstTextMarkerRange(blockquote: ProseNode, blockquoteFrom: number): CalloutBlock | null {
   const firstBlock = blockquote.firstChild;
@@ -73,8 +116,30 @@ function isDeleteKey(event: KeyboardEvent) {
   return event.key === "Backspace" || event.key === "Delete";
 }
 
+function isEnterKey(event: KeyboardEvent) {
+  return event.key === "Enter";
+}
+
 function hasModifier(event: KeyboardEvent) {
   return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+}
+
+function insertCalloutSourceLineBreak(view: EditorView) {
+  const callout = findCalloutAtSelection(view);
+  if (!callout) return false;
+  if (!(view.state.selection instanceof TextSelection)) return false;
+
+  const hardbreak = view.state.schema.nodes.hardbreak;
+  if (!hardbreak) return false;
+
+  view.dispatch(
+    view.state.tr
+      .setMeta("hardbreak", true)
+      .replaceSelectionWith(hardbreak.create({ isInline: true, renderLineBreak: true }))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
 }
 
 function calloutVisibleText(callout: CalloutBlock) {
@@ -94,8 +159,8 @@ function calloutVisibleText(callout: CalloutBlock) {
   return text.trim();
 }
 
-function findCalloutAtSelection(view: EditorView): CalloutBlock | null {
-  const { selection } = view.state;
+function findCalloutInState(state: EditorState): CalloutBlock | null {
+  const { selection } = state;
   if (!(selection instanceof TextSelection) || !selection.empty) return null;
 
   const { $from } = selection;
@@ -109,20 +174,20 @@ function findCalloutAtSelection(view: EditorView): CalloutBlock | null {
   return null;
 }
 
-function removeEmptyCallout(view: EditorView, callout: CalloutBlock, paragraph: ReturnType<typeof paragraphSchema.type>) {
-  if (calloutVisibleText(callout).length > 0) return false;
+function findCalloutAncestorAtPosition($pos: ResolvedPos) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (node.type.name !== "blockquote") continue;
 
-  const transaction = view.state.tr.replaceWith(callout.blockquoteFrom, callout.blockquoteTo, paragraph.create());
-  const selectionPosition = Math.min(callout.blockquoteFrom + 1, transaction.doc.content.size);
+    const callout = firstTextMarkerRange(node, $pos.before(depth));
+    if (callout) return callout;
+  }
 
-  view.dispatch(
-    transaction
-      .setSelection(TextSelection.create(transaction.doc, selectionPosition))
-      .scrollIntoView()
-  );
-  view.focus();
+  return null;
+}
 
-  return true;
+function findCalloutAtSelection(view: EditorView): CalloutBlock | null {
+  return findCalloutInState(view.state);
 }
 
 function emptySelectionBlockRange(view: EditorView) {
@@ -156,6 +221,109 @@ function adjacentCalloutTextPosition(callout: CalloutBlock, emptyBlockFrom: numb
   return fallbackPosition;
 }
 
+function calloutBodyTextBlockRanges(callout: CalloutBlock) {
+  const ranges: Array<{ from: number; to: number }> = [];
+
+  callout.blockquote.forEach((child, offset, index) => {
+    if (index === 0 || !child.isTextblock) return;
+
+    const from = callout.blockquoteFrom + 1 + offset;
+    ranges.push({
+      from,
+      to: from + child.nodeSize
+    });
+  });
+
+  return ranges;
+}
+
+function calloutHasBodyBlocks(callout: CalloutBlock) {
+  return callout.blockquote.childCount > 1;
+}
+
+function exitCalloutBlock(
+  view: EditorView,
+  callout: CalloutBlock,
+  paragraph: ReturnType<typeof paragraphSchema.type>
+) {
+  const transaction = view.state.tr;
+
+  if (calloutVisibleText(callout).length === 0 && callout.blockquote.childCount > 1) {
+    const [, ...extraBodyRanges] = calloutBodyTextBlockRanges(callout);
+
+    for (const range of extraBodyRanges.reverse()) {
+      transaction.delete(
+        transaction.mapping.map(range.from),
+        transaction.mapping.map(range.to)
+      );
+    }
+  }
+
+  const insertAt = transaction.mapping.map(callout.blockquoteTo);
+  transaction.insert(insertAt, paragraph.create());
+  const selectionPosition = Math.min(insertAt + 1, transaction.doc.content.size);
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, selectionPosition))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function rawCalloutMarkerLineAtSelection(view: EditorView) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock) return null;
+  if ($from.parentOffset !== $from.parent.content.size) return null;
+
+  const quoteMatch = /^\s*>\s*(.*?)\s*$/u.exec($from.parent.textContent);
+  if (!quoteMatch) return null;
+
+  const marker = parseMarkdownCalloutMarker(quoteMatch[1] ?? "");
+  if (!marker) return null;
+
+  const quotedText = quoteMatch[1] ?? "";
+  const afterMarker = quotedText.slice(quotedText.indexOf(marker.source) + marker.source.length);
+  if (afterMarker.trim().length > 0) return null;
+
+  return {
+    marker,
+    from: $from.before($from.depth),
+    to: $from.after($from.depth)
+  };
+}
+
+function replaceRawCalloutMarkerLine(
+  view: EditorView,
+  paragraph: ReturnType<typeof paragraphSchema.type>,
+  blockquote: ReturnType<typeof blockquoteSchema.type>
+) {
+  const rawLine = rawCalloutMarkerLineAtSelection(view);
+  if (!rawLine) return false;
+
+  const markerParagraph = paragraph.create(
+    null,
+    view.state.schema.text(markdownCalloutMarkerForType(rawLine.marker.type))
+  );
+  const bodyParagraph = paragraph.create();
+  const callout = blockquote.create(null, [markerParagraph, bodyParagraph]);
+  let transaction = view.state.tr.replaceWith(rawLine.from, rawLine.to, callout);
+  const selectionPosition = Math.min(rawLine.from + 1 + markerParagraph.nodeSize + 1, transaction.doc.content.size);
+
+  transaction = transaction
+    .setSelection(TextSelection.create(transaction.doc, selectionPosition))
+    .scrollIntoView();
+  view.dispatch(transaction);
+  view.focus();
+
+  return true;
+}
+
 function removeEmptyCalloutLine(view: EditorView, callout: CalloutBlock, key: KeyboardEvent["key"]) {
   const emptyBlock = emptySelectionBlockRange(view);
   if (!emptyBlock) return false;
@@ -164,10 +332,35 @@ function removeEmptyCalloutLine(view: EditorView, callout: CalloutBlock, key: Ke
   const targetPosition =
     adjacentCalloutTextPosition(callout, emptyBlock.from, direction) ??
     adjacentCalloutTextPosition(callout, emptyBlock.from, direction === "forward" ? "backward" : "forward");
-  if (targetPosition === null) return false;
+
+  if (targetPosition !== null) {
+    const transaction = view.state.tr.delete(emptyBlock.from, emptyBlock.to);
+    const mappedTargetPosition = transaction.mapping.map(targetPosition);
+
+    view.dispatch(
+      transaction
+        .setSelection(TextSelection.create(transaction.doc, mappedTargetPosition))
+        .scrollIntoView()
+    );
+    view.focus();
+
+    return true;
+  }
+
+  const bodyRanges = calloutBodyTextBlockRanges(callout);
+  if (bodyRanges.length <= 1) return false;
+
+  const emptyBlockIndex = bodyRanges.findIndex((range) => range.from === emptyBlock.from && range.to === emptyBlock.to);
+  if (emptyBlockIndex === -1) return false;
+
+  const adjacentRange =
+    direction === "forward"
+      ? bodyRanges[emptyBlockIndex + 1] ?? bodyRanges[emptyBlockIndex - 1]
+      : bodyRanges[emptyBlockIndex - 1] ?? bodyRanges[emptyBlockIndex + 1];
+  if (!adjacentRange) return false;
 
   const transaction = view.state.tr.delete(emptyBlock.from, emptyBlock.to);
-  const mappedTargetPosition = transaction.mapping.map(targetPosition);
+  const mappedTargetPosition = transaction.mapping.map(adjacentRange.from + 1);
 
   view.dispatch(
     transaction
@@ -177,6 +370,167 @@ function removeEmptyCalloutLine(view: EditorView, callout: CalloutBlock, key: Ke
   view.focus();
 
   return true;
+}
+
+function deleteEmptyCalloutBlock(
+  view: EditorView,
+  callout: CalloutBlock,
+  paragraph: ReturnType<typeof paragraphSchema.type>
+) {
+  if (calloutVisibleText(callout).length > 0) return false;
+  if (!emptySelectionBlockRange(view)) return false;
+
+  const transaction = view.state.tr.replaceWith(callout.blockquoteFrom, callout.blockquoteTo, paragraph.create());
+  const selectionPosition = Math.min(callout.blockquoteFrom + 1, transaction.doc.content.size);
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, selectionPosition))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
+function markerOnlyCalloutsInDoc(doc: ProseNode) {
+  const callouts: CalloutBlock[] = [];
+
+  doc.descendants((node, position) => {
+    if (node.type.name !== "blockquote") return;
+
+    const callout = firstTextMarkerRange(node, position);
+    if (!callout || calloutHasBodyBlocks(callout) || !callout.markerLineIsEmpty) return false;
+
+    callouts.push(callout);
+    return false;
+  });
+
+  return callouts;
+}
+
+function selectionIsInMarkerLine(state: EditorState, callout: CalloutBlock) {
+  if (!(state.selection instanceof TextSelection) || !state.selection.empty) return false;
+
+  return state.selection.from >= callout.markerBlockFrom && state.selection.from <= callout.markerBlockTo - 1;
+}
+
+function firstCalloutBodyTextPosition(callout: CalloutBlock) {
+  const [firstBodyRange] = calloutBodyTextBlockRanges(callout);
+  return firstBodyRange ? firstBodyRange.from + 1 : null;
+}
+
+function moveHiddenMarkerSelectionToCalloutBody(state: EditorState) {
+  const callout = findCalloutInState(state);
+  if (!callout || !callout.markerLineIsEmpty || !selectionIsInMarkerLine(state, callout)) return null;
+
+  const bodyTextPosition = firstCalloutBodyTextPosition(callout);
+  if (bodyTextPosition === null) return null;
+
+  return state.tr
+    .setSelection(TextSelection.create(state.doc, bodyTextPosition))
+    .scrollIntoView();
+}
+
+function dispatchHiddenMarkerSelectionToCalloutBody(view: EditorView) {
+  const transaction = moveHiddenMarkerSelectionToCalloutBody(view.state);
+  if (transaction) view.dispatch(transaction);
+}
+
+function selectionIsQuoteShortcutAfterCallout(state: EditorState, paragraph: ReturnType<typeof paragraphSchema.type>) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const { $from } = selection;
+  if ($from.depth !== 1 || $from.parent.type !== paragraph) return false;
+  if ($from.parent.textContent !== ">" || $from.parentOffset !== $from.parent.content.size) return false;
+
+  const index = $from.index(0);
+  if (index <= 0) return false;
+
+  const previousNode = state.doc.child(index - 1);
+  return previousNode.type.name === "blockquote" && firstTextMarkerRange(previousNode, 0) !== null;
+}
+
+function trailingEmptySelectionInCallout(state: EditorState) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+  if (!selection.$from.parent.isTextblock || selection.$from.parent.content.size > 0) return null;
+
+  const callout = findCalloutInState(state);
+  if (!callout || calloutVisibleText(callout).length === 0) return null;
+  if (selection.$from.after(selection.$from.depth) !== callout.blockquoteTo - 1) return null;
+
+  return {
+    callout,
+    from: selection.$from.before(selection.$from.depth),
+    to: selection.$from.after(selection.$from.depth)
+  };
+}
+
+function splitTypedQuoteAfterCallout(
+  oldState: EditorState,
+  newState: EditorState,
+  paragraph: ReturnType<typeof paragraphSchema.type>,
+  blockquote: ReturnType<typeof blockquoteSchema.type>
+) {
+  if (!selectionIsQuoteShortcutAfterCallout(oldState, paragraph)) return null;
+
+  const trailingEmptyBlock = trailingEmptySelectionInCallout(newState);
+  if (!trailingEmptyBlock) return null;
+
+  const transaction = newState.tr.delete(trailingEmptyBlock.from, trailingEmptyBlock.to);
+  const insertAt = transaction.mapping.map(trailingEmptyBlock.callout.blockquoteTo, -1);
+  transaction.insert(insertAt, blockquote.create(null, paragraph.create()));
+  transaction.setSelection(TextSelection.create(transaction.doc, Math.min(insertAt + 2, transaction.doc.content.size)));
+
+  return transaction.scrollIntoView();
+}
+
+function appendBodyToMarkerOnlyCallout(
+  state: EditorState,
+  paragraph: ReturnType<typeof paragraphSchema.type>
+) {
+  const callouts = markerOnlyCalloutsInDoc(state.doc).filter((callout) =>
+    selectionIsInMarkerLine(state, callout)
+  );
+  if (callouts.length === 0) return null;
+
+  const transaction = state.tr;
+  let bodySelectionPosition: number | null = null;
+
+  for (const callout of callouts) {
+    const insertAt = transaction.mapping.map(callout.markerBlockTo, 1);
+    transaction.insert(insertAt, paragraph.create());
+    bodySelectionPosition = Math.min(insertAt + 1, transaction.doc.content.size);
+  }
+
+  if (!transaction.docChanged) return null;
+
+  if (bodySelectionPosition !== null) {
+    transaction.setSelection(TextSelection.create(transaction.doc, bodySelectionPosition));
+  }
+
+  return transaction.scrollIntoView();
+}
+
+function normalizeCalloutHardbreaks(state: EditorState) {
+  const hardbreak = state.schema.nodes.hardbreak;
+  if (!hardbreak) return null;
+
+  const transaction = state.tr;
+  let changed = false;
+
+  state.doc.descendants((node, position) => {
+    if (node.type !== hardbreak || (node.attrs.isInline === true && node.attrs.renderLineBreak === true)) return;
+
+    const callout = findCalloutAncestorAtPosition(state.doc.resolve(position));
+    if (!callout) return;
+
+    transaction.setNodeMarkup(position, undefined, { ...node.attrs, isInline: true, renderLineBreak: true }, node.marks);
+    changed = true;
+  });
+
+  return changed ? transaction : null;
 }
 
 function createCalloutTypeSelect(
@@ -253,7 +607,10 @@ function buildCalloutDecorations(doc: ProseNode) {
       Decoration.widget(callout.blockquoteFrom + 1, createCalloutHeader(callout), {
         key: `markra-callout-header-${callout.blockquoteFrom}-${callout.marker.type}`,
         side: -1
-      }),
+      })
+    );
+
+    decorations.push(
       Decoration.inline(callout.markerFrom, callout.markerTo, {
         class: "markra-callout-source-marker"
       })
@@ -273,18 +630,66 @@ function buildCalloutDecorations(doc: ProseNode) {
 
 export const markraCalloutPlugin = $prose((ctx) => {
   const paragraph = paragraphSchema.type(ctx);
+  const blockquote = blockquoteSchema.type(ctx);
 
   return new Plugin({
+    view: (view) => {
+      dispatchHiddenMarkerSelectionToCalloutBody(view);
+
+      return {
+        update: (updatedView, previousState) => {
+          if (
+            updatedView.state.doc.eq(previousState.doc) &&
+            updatedView.state.selection.eq(previousState.selection)
+          ) return;
+
+          dispatchHiddenMarkerSelectionToCalloutBody(updatedView);
+        }
+      };
+    },
+    appendTransaction: (transactions, oldState, newState) => {
+      const markerSelectionTransaction = moveHiddenMarkerSelectionToCalloutBody(newState);
+      if (markerSelectionTransaction) return markerSelectionTransaction;
+
+      if (!transactions.some((transaction) => transaction.docChanged)) return null;
+
+      return (
+        appendBodyToMarkerOnlyCallout(newState, paragraph) ??
+        normalizeCalloutHardbreaks(newState) ??
+        splitTypedQuoteAfterCallout(oldState, newState, paragraph, blockquote)
+      );
+    },
     props: {
       decorations: (state) => buildCalloutDecorations(state.doc),
       handleKeyDown: (view, event) => {
-        if (!isDeleteKey(event) || hasModifier(event)) return false;
+        if (isEnterKey(event)) {
+          if (event.altKey || event.ctrlKey || event.metaKey) return false;
+          if (event.shiftKey) {
+            const handled = insertCalloutSourceLineBreak(view);
+            if (!handled) return false;
+
+            event.preventDefault();
+            return true;
+          }
+
+          const callout = findCalloutAtSelection(view);
+          const handled = callout
+            ? exitCalloutBlock(view, callout, paragraph)
+            : replaceRawCalloutMarkerLine(view, paragraph, blockquote);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        }
+
+        if (hasModifier(event)) return false;
+        if (!isDeleteKey(event)) return false;
 
         const callout = findCalloutAtSelection(view);
         if (!callout) return false;
 
-        const handled = removeEmptyCallout(view, callout, paragraph);
-        if (!handled && !removeEmptyCalloutLine(view, callout, event.key)) return false;
+        const handled = removeEmptyCalloutLine(view, callout, event.key) || deleteEmptyCalloutBlock(view, callout, paragraph);
+        if (!handled) return false;
 
         event.preventDefault();
         return true;

--- a/packages/shared/src/markdown-callout.test.ts
+++ b/packages/shared/src/markdown-callout.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { restoreEscapedMarkdownCalloutMarkers } from "./markdown-callout.ts";
+
+describe("markdown callouts", () => {
+  it("removes hard-break escapes inside callout blockquotes only", () => {
+    const source = [
+      "> [!WARNING]",
+      ">",
+      "> First line\\",
+      "> Second line",
+      "",
+      "> Ordinary quote\\",
+      "> next line"
+    ].join("\n");
+
+    expect(restoreEscapedMarkdownCalloutMarkers(source)).toBe([
+      "> [!WARNING]",
+      ">",
+      "> First line",
+      "> Second line",
+      "",
+      "> Ordinary quote\\",
+      "> next line"
+    ].join("\n"));
+  });
+
+  it("collapses an empty callout body placeholder to one quoted blank line", () => {
+    const htmlPlaceholder = [
+      "> [!WARNING]",
+      ">",
+      "> <br />",
+      ""
+    ].join("\n");
+
+    const emptyParagraphPlaceholder = [
+      "> [!WARNING]",
+      ">",
+      ">",
+      ""
+    ].join("\n");
+
+    const expected = [
+      "> [!WARNING]",
+      ">",
+      ""
+    ].join("\n");
+
+    expect(restoreEscapedMarkdownCalloutMarkers(htmlPlaceholder)).toBe(expected);
+    expect(restoreEscapedMarkdownCalloutMarkers(emptyParagraphPlaceholder)).toBe(expected);
+  });
+
+  it("collapses doubled trailing empty callout body placeholders", () => {
+    const twoEmptyBodyLines = [
+      "> [!WARNING]",
+      ">",
+      ">",
+      ">",
+      ">",
+      ""
+    ].join("\n");
+
+    const threeEmptyBodyLines = [
+      "> [!WARNING]",
+      ">",
+      ">",
+      ">",
+      ">",
+      ">",
+      ">",
+      ""
+    ].join("\n");
+    const twoEmptyBodyLinesAfterContent = [
+      "> [!WARNING]",
+      ">",
+      "> Synthetic details",
+      ">",
+      ">",
+      ">",
+      ">",
+      ""
+    ].join("\n");
+
+    expect(restoreEscapedMarkdownCalloutMarkers(twoEmptyBodyLines)).toBe([
+      "> [!WARNING]",
+      ">",
+      ">",
+      ""
+    ].join("\n"));
+    expect(restoreEscapedMarkdownCalloutMarkers(threeEmptyBodyLines)).toBe([
+      "> [!WARNING]",
+      ">",
+      ">",
+      ">",
+      ""
+    ].join("\n"));
+    expect(restoreEscapedMarkdownCalloutMarkers(twoEmptyBodyLinesAfterContent)).toBe([
+      "> [!WARNING]",
+      ">",
+      "> Synthetic details",
+      ">",
+      ">",
+      ""
+    ].join("\n"));
+  });
+});

--- a/packages/shared/src/markdown-callout.ts
+++ b/packages/shared/src/markdown-callout.ts
@@ -59,9 +59,113 @@ export function markdownCalloutMarkerForType(type: MarkdownCalloutType) {
   return `[!${markdownCalloutDefinitions[type].marker}]`;
 }
 
+function lineContentWithoutEnding(line: string) {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function blockquoteLineContent(line: string) {
+  const match = /^((?:>\s*)+)(.*)$/u.exec(lineContentWithoutEnding(line));
+  return match?.[2] ?? null;
+}
+
+function restoreCalloutHardBreakEscapes(markdown: string) {
+  const lines = markdown.split("\n");
+  let inCallout = false;
+
+  return lines.map((line, index) => {
+    const content = lineContentWithoutEnding(line);
+    const lineEnding = line.slice(content.length);
+    const quotedContent = blockquoteLineContent(line);
+
+    if (quotedContent === null) {
+      inCallout = false;
+      return line;
+    }
+
+    if (parseMarkdownCalloutMarker(quotedContent)) {
+      inCallout = true;
+    }
+
+    const nextLine = lines[index + 1];
+    const nextIsBlockquote = nextLine !== undefined && blockquoteLineContent(nextLine) !== null;
+    if (inCallout && nextIsBlockquote && content.endsWith("\\")) {
+      return `${content.slice(0, -1)}${lineEnding}`;
+    }
+
+    return line;
+  }).join("\n");
+}
+
+function lineIsEmptyBlockquote(line: string | undefined) {
+  if (line === undefined) return false;
+
+  const quotedContent = blockquoteLineContent(line);
+  return quotedContent !== null && quotedContent.trim().length === 0;
+}
+
+function lineIsEmptyCalloutBodyPlaceholder(line: string | undefined) {
+  if (lineIsEmptyBlockquote(line)) return true;
+
+  const quotedContent = line === undefined ? null : blockquoteLineContent(line);
+  return quotedContent?.trim() === "<br />";
+}
+
+function emptyBlockquoteLineFor(line: string) {
+  const match = /^((?:>\s*)+)/u.exec(lineContentWithoutEnding(line));
+  return match?.[1]?.trimEnd() || ">";
+}
+
+function collapseEmptyCalloutBodyPlaceholders(markdown: string) {
+  const lines = markdown.split("\n");
+  const collapsedLines: string[] = [];
+  let inCallout = false;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? "";
+    const quotedContent = blockquoteLineContent(line);
+    if (quotedContent === null) {
+      inCallout = false;
+      collapsedLines.push(line);
+      continue;
+    }
+
+    if (parseMarkdownCalloutMarker(quotedContent)) {
+      inCallout = true;
+    }
+
+    collapsedLines.push(line);
+    if (!inCallout || lineIsEmptyCalloutBodyPlaceholder(line)) continue;
+
+    let placeholderEndLine = lineIndex + 1;
+    while (lineIsEmptyCalloutBodyPlaceholder(lines[placeholderEndLine])) {
+      placeholderEndLine += 1;
+    }
+
+    const placeholderCount = placeholderEndLine - lineIndex - 1;
+    const afterPlaceholdersLine = lines[placeholderEndLine];
+    const placeholdersAreAtCalloutEnd =
+      afterPlaceholdersLine === undefined ||
+      afterPlaceholdersLine.length === 0 ||
+      blockquoteLineContent(afterPlaceholdersLine) === null;
+
+    if (placeholderCount >= 2 && placeholderCount % 2 === 0 && placeholdersAreAtCalloutEnd) {
+      const emptyLine = emptyBlockquoteLineFor(lines[lineIndex + 1] ?? ">");
+      for (let count = 0; count < placeholderCount / 2; count += 1) {
+        collapsedLines.push(emptyLine);
+      }
+      lineIndex = placeholderEndLine - 1;
+    }
+  }
+
+  return collapsedLines.join("\n");
+}
+
 export function restoreEscapedMarkdownCalloutMarkers(markdown: string) {
-  return markdown.replace(
+  const restoredMarkers = markdown.replace(
     /(^|\n)((?:>\s*)+)\\(\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\])/giu,
     "$1$2$3"
+  );
+  return collapseEmptyCalloutBodyPlaceholders(
+    restoreCalloutHardBreakEscapes(restoredMarkers)
   ).replace(/(^|\n)((?:>\s*)+)<br \/>(?=\n|$)/gu, "$1$2");
 }


### PR DESCRIPTION
## Summary
- Stabilize GitHub-style callouts so `Enter` exits the callout, `Shift+Enter` inserts a line break inside the callout body, and Backspace from the final empty body line deletes the block deliberately.
- Preserve explicit empty callout body lines across source/visual mode switches, including marker-only empty blocks and trailing empty body lines after content.
- Move selections that land on the hidden callout marker line back into the editable body, so `> [!note]\n>` remains directly typable after switching back to visual mode.
- Keep `> Space` typed below a callout as a separate ordinary quote instead of merging into the previous callout.
- Prevent AI quick surfaces from flashing during normal typing by ignoring block cursor context for automatic AI surfaces and suppressing transient IME composing selections.
- Normalize callout hardbreak rendering/serialization so saved Markdown does not gain `\\` escapes or extra blank lines.

## Why
- Empty GitHub Alert blockquotes need a real editable body paragraph even when the source is just `> [!note]\n>`.
- Milkdown can place the restored selection on the hidden marker line after source/visual transitions; that makes the visual block appear empty but not directly editable.
- Chinese IME composition can temporarily expose a non-empty editor selection while the user is still typing; treating that as selected text caused the AI quick surface to flicker.
- Callout hardbreaks need a stable inline DOM shape for consistent caret height and source round-tripping.

## Validation
- Current head: `59f0b556`
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "does not notify transient selections while IME input is composing|notifies when the user selects text in the editor|waits until pointer text selection settles before notifying selected text|reports the current text block through the selection callback when only the cursor moves" --reporter verbose` passed
- `pnpm --filter @markra/app exec vitest run src/lib/ai-selection.test.ts --reporter verbose` passed
- `pnpm --filter @markra/app exec vitest run src/App.ai.test.tsx -t "opens the inline AI command from the keyboard shortcut at the current block|moves structurally complex inline prompts into the Markra AI panel|hides the complex inline prompt panel suggestion" --reporter verbose` passed
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "starts an empty loaded callout with the cursor in the editable body|moves a cursor from the hidden callout marker line into the empty body" --reporter verbose` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app test` passed, 57 files and 1045 tests. The run printed existing jsdom `Window.scrollBy()` warnings but exited 0.

Fixes #224