### PR TITLE
fix(editor): improve callout and table editing

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -271,11 +271,12 @@ function pressEnter(view: EditorView) {
   return view.someProp("handleKeyDown", (handler) => handler(view, event));
 }
 
-function pressBackspace(view: EditorView) {
+function pressBackspace(view: EditorView, options: Pick<KeyboardEventInit, "repeat"> = {}) {
   const event = new KeyboardEvent("keydown", {
     key: "Backspace",
     bubbles: true,
-    cancelable: true
+    cancelable: true,
+    ...options
   });
   return view.someProp("handleKeyDown", (handler) => handler(view, event));
 }
@@ -1266,12 +1267,12 @@ describe("MarkdownPaper editing", () => {
     expect(checkboxes).toHaveLength(2);
     expect(checkboxes[0]).toBeChecked();
     expect(checkboxes[1]).not.toBeChecked();
-    expect(serializeMarkdown(view.state.doc)).toBe("* [x] Finish mock draft\n* [ ] Review mock copy\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- [x] Finish mock draft\n- [ ] Review mock copy\n");
 
     fireEvent.click(checkboxes[1]);
 
     expect(checkboxes[1]).toBeChecked();
-    expect(serializeMarkdown(view.state.doc)).toBe("* [x] Finish mock draft\n* [x] Review mock copy\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- [x] Finish mock draft\n- [x] Review mock copy\n");
   });
 
   it("turns typed GFM task list syntax into a checkbox", async () => {
@@ -1285,7 +1286,7 @@ describe("MarkdownPaper editing", () => {
     expect(checkbox).toBeInTheDocument();
     expect(checkbox).not.toBeChecked();
     expect(container.querySelector(".ProseMirror li")).toHaveTextContent("a");
-    expect(serializeMarkdown(view.state.doc)).toContain("* [ ] a");
+    expect(serializeMarkdown(view.state.doc)).toContain("- [ ] a");
   });
 
   it.each([
@@ -3017,7 +3018,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("* Second\n\n* First\n\n* Third\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- Second\n\n- First\n\n- Third\n");
     restoreLayout();
   });
 
@@ -3110,7 +3111,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("Intro\n\n* First\n\nOutro\n\n* Second\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("Intro\n\n- First\n\nOutro\n\n- Second\n");
     restoreLayout();
   });
 
@@ -3151,7 +3152,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n* Intro\n\n* Second\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- First\n\n- Intro\n\n- Second\n");
     restoreLayout();
   });
 
@@ -3192,7 +3193,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n  * Intro\n\n* Second\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- First\n\n  - Intro\n\n- Second\n");
     restoreLayout();
   });
 
@@ -3227,7 +3228,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\n  * Third\n\n* Second\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- First\n\n  - Third\n\n- Second\n");
     restoreLayout();
   });
 
@@ -3320,8 +3321,8 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
     const latestMarkdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "");
     expect(latestMarkdown).not.toContain("<br");
-    expect(latestMarkdown).toContain("* First");
-    expect(latestMarkdown).toContain("* Second");
+    expect(latestMarkdown).toContain("- First");
+    expect(latestMarkdown).toContain("- Second");
     restoreLayout();
   });
 
@@ -3447,7 +3448,7 @@ describe("MarkdownPaper editing", () => {
     typeText(view, "Inserted");
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("* First\n\nInserted\n\n* Second\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("- First\n\nInserted\n\n- Second\n");
     restoreLayout();
   });
 
@@ -3553,6 +3554,50 @@ describe("MarkdownPaper editing", () => {
       ])
     );
     expect(container.querySelector(".ProseMirror .selectedCell")).not.toBeInTheDocument();
+  });
+
+  it("deletes a whole table from the visual controls", async () => {
+    const initialTable = ["| Field | Value |", "| --- | --- |", "| Name | Markra |"].join("\n");
+    const { container, editor, view } = await renderEditor(initialTable);
+
+    expect(container.querySelector(".ProseMirror table")).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Delete table" }));
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).not.toBeInTheDocument());
+    typeText(view, "After table");
+
+    expect(container.querySelector(".ProseMirror")).toHaveTextContent("After table");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("After table\n");
+    await settleMarkdownListener();
+  });
+
+  it("keeps a table when right-clicking the delete table control", async () => {
+    const initialTable = ["| Field | Value |", "| --- | --- |", "| Name | Markra |"].join("\n");
+    const { container, editor, view } = await renderEditor(initialTable);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdownBeforeRightClick = serializeMarkdown(view.state.doc);
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Delete table" }), { button: 2 });
+
+    expect(container.querySelector(".ProseMirror table")).toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).toBe(markdownBeforeRightClick);
+    await settleMarkdownListener();
+  });
+
+  it("keeps a table when ctrl-clicking the delete table control", async () => {
+    const initialTable = ["| Field | Value |", "| --- | --- |", "| Name | Markra |"].join("\n");
+    const { container, editor, view } = await renderEditor(initialTable);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdownBeforeContextClick = serializeMarkdown(view.state.doc);
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Delete table" }), { button: 0, ctrlKey: true });
+
+    expect(container.querySelector(".ProseMirror table")).toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).toBe(markdownBeforeContextClick);
+    await settleMarkdownListener();
   });
 
   it("places the row delete control at the hovered row right edge", async () => {
@@ -5173,7 +5218,7 @@ describe("MarkdownPaper editing", () => {
     expect(topLevelItems).toHaveLength(1);
     expect(nestedItems).toHaveLength(1);
     expect(nestedItems[0]).toHaveTextContent("Second");
-    expect(serializeMarkdown(view.state.doc)).toContain("  * Second");
+    expect(serializeMarkdown(view.state.doc)).toContain("  - Second");
     await settleMarkdownListener();
   });
 
@@ -6205,6 +6250,203 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain(source);
   });
 
+  it("renders Typora-exported escaped alert markers as callouts with nested lists", async () => {
+    const source = [
+      "> **\\[!NOTE]**",
+      ">",
+      "> - Synthetic parent",
+      ">",
+      ">   - Nested detail"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+
+    expect(callout).toBeInTheDocument();
+    expect(callout).toHaveAttribute("data-callout-type", "note");
+    expect(callout?.querySelector(".markra-callout-title")).toHaveTextContent("Note");
+    expect(callout?.querySelectorAll("ul li")).toHaveLength(2);
+    expect(callout?.querySelector("ul ul li")).toHaveTextContent("Nested detail");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> [!NOTE]");
+    expect(markdown).not.toContain("\\[!NOTE]");
+    expect(markdown).not.toContain("**[!NOTE]**");
+  });
+
+  it("continues callout list items when pressing Enter", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> - First");
+
+    moveCursor(view, findTextPosition(view, "First", "First".length));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(true);
+
+    typeText(view, "Second");
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    expect(callout?.querySelectorAll("ul li")).toHaveLength(2);
+    expect(callout).toHaveTextContent("First");
+    expect(callout).toHaveTextContent("Second");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> - First\n> - Second");
+  });
+
+  it("exits callout lists on Enter from an empty list item", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> - First");
+
+    moveCursor(view, findTextPosition(view, "First", "First".length));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(true);
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(false);
+
+    typeText(view, "After list");
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    expect(callout?.querySelectorAll("ul li")).toHaveLength(1);
+    expect(callout).toHaveTextContent("First");
+    expect(callout).toHaveTextContent("After list");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> - First\n>\n> After list");
+  });
+
+  it("exits callouts on Enter from a blank body line after a list", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> - First");
+
+    moveCursor(view, findTextPosition(view, "First", "First".length));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(true);
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(false);
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+
+    typeText(view, "After callout");
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    expect(callout?.querySelectorAll("ul li")).toHaveLength(1);
+    expect(callout).toHaveTextContent("First");
+    expect(callout).not.toHaveTextContent("After callout");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> - First\n\nAfter callout");
+  });
+
+  it("keeps callout list source tight after exiting the list with Enter", async () => {
+    const onMarkdownChange = vi.fn();
+    const { editor, view } = await renderEditor("> [!NOTE]\n>", { onMarkdownChange });
+
+    typeText(view, "- 1");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "21");
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "21");
+    expect(pressEnter(view)).toBe(true);
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "Synthetic details");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> - 1\n> - 21\n> - 21\n>\n> Synthetic details");
+    expect(markdown).not.toContain("> - 1\n>\n> - 21");
+    expect(markdown).not.toContain("> - 21\n>\n> - 21");
+
+    await settleMarkdownListener();
+    const savedMarkdown = onMarkdownChange.mock.lastCall?.[0] ?? "";
+    expect(savedMarkdown).toContain("> - 1\n> - 21\n> - 21\n>\n> Synthetic details");
+    expect(savedMarkdown).not.toContain("> - 1\n>\n> - 21");
+    expect(savedMarkdown).not.toContain("> - 21\n>\n> - 21");
+  });
+
+  it("keeps loaded callout list source tight when the marker has a blank body line", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - First",
+      ">",
+      "> - Second",
+      ">",
+      "> - Third"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+
+    expect(markdown).toContain("> - First\n> - Second\n> - Third");
+    expect(markdown).not.toContain("> - First\n>\n> - Second");
+    expect(markdown).not.toContain("> - Second\n>\n> - Third");
+  });
+
+  it("nests and lifts callout list items with Tab like ordinary lists", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> - First\n> - Second");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    let topLevelItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li")
+    );
+    let nestedItems = Array.from(container.querySelectorAll<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout > ul > li > ul > li"
+    ));
+    expect(topLevelItems).toHaveLength(1);
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Second");
+    expect(serializeMarkdown(view.state.doc)).toContain("> - First\n>   - Second");
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    topLevelItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li")
+    );
+    nestedItems = Array.from(container.querySelectorAll<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout > ul > li > ul > li"
+    ));
+    expect(topLevelItems).toHaveLength(2);
+    expect(nestedItems).toHaveLength(0);
+    expect(topLevelItems[1]).toHaveTextContent("Second");
+    expect(serializeMarkdown(view.state.doc)).toContain("> - First\n> - Second");
+  });
+
+  it("continues typed list items inside callouts on Enter", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>");
+
+    typeText(view, "- Synthetic item");
+
+    const listItem = container.querySelector(".ProseMirror blockquote.markra-callout ul li");
+    expect(listItem).toHaveTextContent("Synthetic item");
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "Second item");
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    expect(callout?.querySelectorAll("ul li")).toHaveLength(2);
+    expect(callout?.querySelectorAll("ul li")[1]).toHaveTextContent("Second item");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> - Synthetic item\n> - Second item");
+  });
+
   it("leaves GitHub-style alert blockquotes plain when the extension is disabled", async () => {
     const { container } = await renderEditor("> [!NOTE]\n> Keep this in mind.", {
       extendedSyntax: {
@@ -6890,6 +7132,10 @@ describe("MarkdownPaper editing", () => {
 
     expect(bullet.container.querySelector(".ProseMirror ul li")).toHaveTextContent("item");
     expect(bullet.container.querySelector(".ProseMirror")?.textContent).toBe("item");
+    {
+      const serializeMarkdown = bullet.editor.action((ctx) => ctx.get(serializerCtx));
+      expect(serializeMarkdown(bullet.view.state.doc)).toBe("- item\n");
+    }
 
     const ordered = await renderEditor();
     typeText(ordered.view, "1. item");
@@ -7056,6 +7302,34 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("runs slash commands from a callout body line", async () => {
+    const { container, view } = await renderEditor("> [!WARNING]\n>\n> ");
+
+    moveCursor(view, findLastTextBlockCursor(view));
+    typeText(view, "/ta");
+
+    const tableOption = await screen.findByRole("option", { name: "Table" });
+    fireEvent.mouseDown(tableOption);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror blockquote.markra-callout table")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("/ta");
+    await settleMarkdownListener();
+  });
+
+  it("runs selected slash commands from a callout body line with Enter", async () => {
+    const { container, view } = await renderEditor("> [!WARNING]\n>\n> ");
+
+    moveCursor(view, findLastTextBlockCursor(view));
+    typeText(view, "/co");
+
+    expect(await screen.findByRole("option", { name: "Code Block" })).toHaveAttribute("aria-selected", "true");
+    expect(pressEnter(view)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror blockquote.markra-callout .markra-code-block")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("/co");
+    await settleMarkdownListener();
+  });
+
   it("inserts a note callout from the slash command menu", async () => {
     const { container, editor, view } = await renderEditor();
 
@@ -7138,18 +7412,42 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("exits callout body content when pressing Enter", async () => {
+  it("continues callout body content when pressing Enter", async () => {
     const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> First line");
 
     moveCursor(view, findTextPosition(view, "First line", "First line".length));
 
     expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "Second line");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line");
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("Second line");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n>\n> Second line");
+    await settleMarkdownListener();
+  });
+
+  it("removes the trailing empty callout line when Enter exits after body content", async () => {
+    const { container, editor, view } = await renderEditor("> [!WARNING]\n>\n> First line");
+
+    moveCursor(view, findTextPosition(view, "First line", "First line".length));
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(3);
+
+    expect(pressEnter(view)).toBe(true);
     expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    expect(container.querySelectorAll(".ProseMirror blockquote.markra-callout p")).toHaveLength(2);
 
     typeText(view, "After callout");
 
-    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line");
-    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("After callout");
+    const callout = container.querySelector(".ProseMirror blockquote.markra-callout");
+    expect(callout).toHaveTextContent("First line");
+    expect(callout).not.toHaveTextContent("After callout");
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n\nAfter callout");
@@ -7161,6 +7459,8 @@ describe("MarkdownPaper editing", () => {
 
     moveCursor(view, findTextPosition(view, "First line", "First line".length));
 
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
     expect(pressEnter(view)).toBe(true);
     expect(selectionHasAncestor(view, "blockquote")).toBe(false);
 
@@ -7292,6 +7592,116 @@ describe("MarkdownPaper editing", () => {
     const markdown = serializeMarkdown(view.state.doc);
     expect(markdown).toContain("After delete");
     expect(markdown).not.toContain("[!NOTE]");
+    await settleMarkdownListener();
+  });
+
+  it("keeps an emptied callout editable when Backspace is repeating", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> Synthetic detail");
+    const bodyFrom = findTextPosition(view, "Synthetic detail");
+
+    selectText(view, bodyFrom, bodyFrom + "Synthetic detail".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(pressBackspace(view, { repeat: true })).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "After repeat");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("After repeat");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!NOTE]\n>\n> After repeat");
+    await settleMarkdownListener();
+  });
+
+  it("keeps an emptied callout editable while Backspace is held", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> A");
+    const bodyFrom = findTextPosition(view, "A");
+
+    moveCursor(view, bodyFrom + 1);
+
+    expect(pressBackspace(view)).not.toBe(true);
+    const deleteTransaction = view.state.tr.delete(bodyFrom, bodyFrom + 1);
+    view.dispatch(
+      deleteTransaction
+        .setSelection(TextSelection.create(deleteTransaction.doc, bodyFrom))
+        .scrollIntoView()
+    );
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(pressBackspace(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, "After hold");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("After hold");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!NOTE]\n>\n> After hold");
+    await settleMarkdownListener();
+  });
+
+  it("keeps the cursor in a callout after deleting the last body line", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> First line\n>\n> Second line\n\nAfter callout");
+    const bodyFrom = findTextPosition(view, "Second line");
+
+    selectText(view, bodyFrom, bodyFrom + "Second line".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    expect(pressBackspace(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line");
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("Second line");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+
+    typeText(view, " continued");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("First line continued");
+    expect(container.querySelector(".ProseMirror")).toHaveTextContent("After callout");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!NOTE]\n>\n> First line continued\n\nAfter callout");
+    await settleMarkdownListener();
+  });
+
+  it("keeps the cursor in a callout list after deleting an emptied list item", async () => {
+    const { container, editor, view } = await renderEditor("> [!NOTE]\n>\n> - One\n> - Two");
+    const itemFrom = findTextPosition(view, "Two");
+
+    selectText(view, itemFrom, itemFrom + "Two".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(true);
+
+    focusEditor(view);
+    expect(fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true })).toBe(false);
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(false);
+
+    focusEditor(view);
+    expect(fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true })).toBe(false);
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(true);
+
+    typeText(view, " continued");
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toHaveTextContent("One continued");
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toHaveTextContent("Two");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!NOTE]\n>\n> - One continued");
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { defaultValueCtx, Editor, editorViewCtx, editorViewOptionsCtx, rootCtx, serializerCtx } from "@milkdown/kit/core";
+import {
+  defaultValueCtx,
+  Editor,
+  editorViewCtx,
+  editorViewOptionsCtx,
+  remarkStringifyOptionsCtx,
+  rootCtx,
+  serializerCtx
+} from "@milkdown/kit/core";
 import { history } from "@milkdown/kit/plugin/history";
 import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
 import { Plugin } from "@milkdown/kit/prose/state";
@@ -169,6 +177,7 @@ function MilkdownEditorSurface({
     alignRight: t(language, "editor.table.alignRight"),
     deleteColumn: t(language, "editor.table.deleteColumn"),
     deleteRow: t(language, "editor.table.deleteRow"),
+    deleteTable: t(language, "editor.table.deleteTable"),
     adjustTable: t(language, "editor.table.adjustTable"),
     resizeTableTo: t(language, "editor.table.resizeTableTo"),
     tableColumns: t(language, "editor.table.columns"),
@@ -241,6 +250,10 @@ function MilkdownEditorSurface({
         .config((ctx) => {
           ctx.set(rootCtx, root);
           ctx.set(defaultValueCtx, initialContentRef.current);
+          ctx.update(remarkStringifyOptionsCtx, (options) => ({
+            ...options,
+            bullet: "-" as const
+          }));
           ctx.update(editorViewOptionsCtx, (options) => ({
             ...options,
             attributes: {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2126,6 +2126,25 @@
     color: var(--text-heading);
   }
 
+  .markdown-paper .markra-table-delete-table {
+    @apply static size-6 rounded-md border-transparent text-[0] shadow-none;
+    background: transparent;
+    box-shadow: none;
+    color: var(--text-secondary);
+  }
+
+  .markdown-paper .markra-table-delete-table:hover,
+  .markdown-paper .markra-table-delete-table:focus-visible {
+    background: color-mix(in srgb, oklch(63.7% 0.237 25.331) 10%, transparent);
+    border-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 70%, transparent);
+    box-shadow: none;
+    color: oklch(57.7% 0.245 27.325);
+  }
+
+  .markdown-paper .markra-table-delete-table-icon {
+    @apply size-3.5;
+  }
+
   .markdown-paper .markra-table-align-icon {
     @apply flex w-3.5 flex-col gap-0.75;
   }

--- a/packages/editor/src/callout.ts
+++ b/packages/editor/src/callout.ts
@@ -1,8 +1,10 @@
 import { SerializerReady, serializerCtx } from "@milkdown/kit/core";
 import type { Ctx, MilkdownPlugin } from "@milkdown/kit/ctx";
-import { blockquoteSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import { blockquoteSchema, listItemSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import { splitBlock } from "@milkdown/kit/prose/commands";
 import type { Node as ProseNode, ResolvedPos } from "@milkdown/kit/prose/model";
-import { Plugin, TextSelection, type EditorState } from "@milkdown/kit/prose/state";
+import { liftListItem, splitListItem } from "@milkdown/kit/prose/schema-list";
+import { Plugin, TextSelection, type Command, type EditorState } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import { $prose, $remark } from "@milkdown/kit/utils";
 import {
@@ -124,6 +126,39 @@ function hasModifier(event: KeyboardEvent) {
   return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
 }
 
+function runCommand(view: EditorView, command: Command) {
+  const handled = command(view.state, view.dispatch, view);
+
+  if (handled) {
+    view.focus();
+  }
+
+  return handled;
+}
+
+function selectionIsInEmptyTextBlock(state: EditorState) {
+  const { selection } = state;
+  return (
+    selection instanceof TextSelection &&
+    selection.empty &&
+    selection.$from.parent.isTextblock &&
+    selection.$from.parent.content.size === 0
+  );
+}
+
+function selectionIsAtSlashCommandEnd(state: EditorState) {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock || $from.parent.type.spec.code) return false;
+
+  const beforeCursor = $from.parent.textContent.slice(0, $from.parentOffset);
+  const afterCursor = $from.parent.textContent.slice($from.parentOffset);
+
+  return afterCursor.length === 0 && /^\/[^\s/]*$/u.test(beforeCursor);
+}
+
 function insertCalloutSourceLineBreak(view: EditorView) {
   const callout = findCalloutAtSelection(view);
   if (!callout) return false;
@@ -190,6 +225,19 @@ function findCalloutAtSelection(view: EditorView): CalloutBlock | null {
   return findCalloutInState(view.state);
 }
 
+function positionHasAncestorNodeName($pos: ResolvedPos, nodeName: string) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    if ($pos.node(depth).type.name === nodeName) return true;
+  }
+
+  return false;
+}
+
+function selectionIsInsideNodeName(state: EditorState, nodeName: string) {
+  const { selection } = state;
+  return [selection.$from, selection.$to].every(($pos) => positionHasAncestorNodeName($pos, nodeName));
+}
+
 function emptySelectionBlockRange(view: EditorView) {
   const { selection } = view.state;
   if (!(selection instanceof TextSelection) || !selection.empty) return null;
@@ -204,18 +252,23 @@ function emptySelectionBlockRange(view: EditorView) {
 function adjacentCalloutTextPosition(callout: CalloutBlock, emptyBlockFrom: number, direction: "backward" | "forward") {
   let fallbackPosition: number | null = null;
 
-  callout.blockquote.forEach((child, offset, index) => {
-    if (!child.isTextblock || index === 0 || child.content.size === 0) return;
+  callout.blockquote.descendants((child, offset) => {
+    if (!child.isTextblock) return true;
 
     const childFrom = callout.blockquoteFrom + 1 + offset;
+    if (childFrom >= callout.markerBlockFrom && childFrom < callout.markerBlockTo) return false;
+    if (child.content.size === 0) return false;
+
     if (direction === "backward" && childFrom < emptyBlockFrom) {
       fallbackPosition = childFrom + 1 + child.content.size;
-      return;
+      return false;
     }
 
     if (direction === "forward" && fallbackPosition === null && childFrom > emptyBlockFrom) {
       fallbackPosition = childFrom + 1;
     }
+
+    return false;
   });
 
   return fallbackPosition;
@@ -247,8 +300,15 @@ function exitCalloutBlock(
   paragraph: ReturnType<typeof paragraphSchema.type>
 ) {
   const transaction = view.state.tr;
+  const hasVisibleBodyContent = calloutVisibleText(callout).length > 0;
+  const selectedEmptyBodyRange = hasVisibleBodyContent ? emptySelectionBlockRange(view) : null;
 
-  if (calloutVisibleText(callout).length === 0 && callout.blockquote.childCount > 1) {
+  if (selectedEmptyBodyRange) {
+    transaction.delete(
+      transaction.mapping.map(selectedEmptyBodyRange.from),
+      transaction.mapping.map(selectedEmptyBodyRange.to)
+    );
+  } else if (!hasVisibleBodyContent && callout.blockquote.childCount > 1) {
     const [, ...extraBodyRanges] = calloutBodyTextBlockRanges(callout);
 
     for (const range of extraBodyRanges.reverse()) {
@@ -390,6 +450,42 @@ function deleteEmptyCalloutBlock(
   );
   view.focus();
   return true;
+}
+
+function keepDeleteHoldInsideEmptyCallout(
+  view: EditorView,
+  callout: CalloutBlock,
+  event: KeyboardEvent,
+  deleteHoldStartedInsideNonEmptyCallout: boolean
+) {
+  if (!event.repeat && !deleteHoldStartedInsideNonEmptyCallout) return false;
+  if (calloutVisibleText(callout).length > 0) return false;
+  if (!emptySelectionBlockRange(view)) return false;
+
+  view.focus();
+  return true;
+}
+
+function continueCalloutListItemOnEnter(
+  view: EditorView,
+  listItem: ReturnType<typeof listItemSchema.type>
+) {
+  if (selectionIsInEmptyTextBlock(view.state)) return runCommand(view, liftListItem(listItem));
+
+  return runCommand(view, splitListItem(listItem));
+}
+
+function handleCalloutEnter(
+  view: EditorView,
+  callout: CalloutBlock,
+  paragraph: ReturnType<typeof paragraphSchema.type>,
+  listItem: ReturnType<typeof listItemSchema.type>
+) {
+  if (selectionIsInMarkerLine(view.state, callout)) return exitCalloutBlock(view, callout, paragraph);
+  if (selectionIsInsideNodeName(view.state, "list_item")) return continueCalloutListItemOnEnter(view, listItem);
+  if (selectionIsInEmptyTextBlock(view.state)) return exitCalloutBlock(view, callout, paragraph);
+
+  return runCommand(view, splitBlock);
 }
 
 function markerOnlyCalloutsInDoc(doc: ProseNode) {
@@ -631,6 +727,8 @@ function buildCalloutDecorations(doc: ProseNode) {
 export const markraCalloutPlugin = $prose((ctx) => {
   const paragraph = paragraphSchema.type(ctx);
   const blockquote = blockquoteSchema.type(ctx);
+  const listItem = listItemSchema.type(ctx);
+  let deleteHoldStartedInsideNonEmptyCallout = false;
 
   return new Plugin({
     view: (view) => {
@@ -661,6 +759,15 @@ export const markraCalloutPlugin = $prose((ctx) => {
     },
     props: {
       decorations: (state) => buildCalloutDecorations(state.doc),
+      handleDOMEvents: {
+        keyup: (_view, event) => {
+          if (isDeleteKey(event)) {
+            deleteHoldStartedInsideNonEmptyCallout = false;
+          }
+
+          return false;
+        }
+      },
       handleKeyDown: (view, event) => {
         if (isEnterKey(event)) {
           if (event.altKey || event.ctrlKey || event.metaKey) return false;
@@ -672,9 +779,12 @@ export const markraCalloutPlugin = $prose((ctx) => {
             return true;
           }
 
+          if (selectionIsAtSlashCommandEnd(view.state)) return false;
+
           const callout = findCalloutAtSelection(view);
+
           const handled = callout
-            ? exitCalloutBlock(view, callout, paragraph)
+            ? handleCalloutEnter(view, callout, paragraph, listItem)
             : replaceRawCalloutMarkerLine(view, paragraph, blockquote);
           if (!handled) return false;
 
@@ -687,8 +797,15 @@ export const markraCalloutPlugin = $prose((ctx) => {
 
         const callout = findCalloutAtSelection(view);
         if (!callout) return false;
+        if (selectionIsInsideNodeName(view.state, "list_item")) return false;
+        if (calloutVisibleText(callout).length > 0) {
+          deleteHoldStartedInsideNonEmptyCallout = true;
+        }
 
-        const handled = removeEmptyCalloutLine(view, callout, event.key) || deleteEmptyCalloutBlock(view, callout, paragraph);
+        const handled =
+          removeEmptyCalloutLine(view, callout, event.key) ||
+          keepDeleteHoldInsideEmptyCallout(view, callout, event, deleteHoldStartedInsideNonEmptyCallout) ||
+          deleteEmptyCalloutBlock(view, callout, paragraph);
         if (!handled) return false;
 
         event.preventDefault();

--- a/packages/editor/src/table-controls.ts
+++ b/packages/editor/src/table-controls.ts
@@ -13,6 +13,7 @@ type TableControlLabels = {
   alignRight: string;
   deleteColumn: string;
   deleteRow: string;
+  deleteTable: string;
   adjustTable: string;
   resizeTableTo: string;
   tableColumns: string;
@@ -30,6 +31,7 @@ const defaultTableControlLabels: TableControlLabels = {
   alignRight: "Align table right",
   deleteColumn: "Delete column",
   deleteRow: "Delete row",
+  deleteTable: "Delete table",
   adjustTable: "Adjust table",
   resizeTableTo: "Resize table to {columns} columns by {rows} rows",
   tableColumns: "Table columns",
@@ -51,6 +53,10 @@ function elementFromEventTarget(target: EventTarget | null) {
 
 function tableCellFromEventTarget(target: EventTarget | null) {
   return elementFromEventTarget(target)?.closest<HTMLTableCellElement>("th, td") ?? null;
+}
+
+function isPrimaryMouseButton(event: MouseEvent) {
+  return event.button === 0 && !event.ctrlKey;
 }
 
 function createTableControlButton(
@@ -104,6 +110,26 @@ function createTableSizeIcon(ownerDocument: Document) {
   return icon;
 }
 
+function createDeleteTableIcon(ownerDocument: Document) {
+  const icon = ownerDocument.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("class", "markra-table-delete-table-icon");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+
+  for (const pathData of ["M3 6h18", "M8 6V4h8v2", "M19 6l-1 14H6L5 6", "M10 11v6", "M14 11v6"]) {
+    const path = ownerDocument.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", pathData);
+    icon.append(path);
+  }
+
+  return icon;
+}
+
 function clampTableSize(value: number, min: number, max: number) {
   if (!Number.isFinite(value)) return min;
 
@@ -134,6 +160,7 @@ class MarkraTableNodeView {
   private readonly addRowButton: HTMLButtonElement;
   private readonly deleteColumnButton: HTMLButtonElement;
   private readonly deleteRowButton: HTMLButtonElement;
+  private readonly deleteTableButton: HTMLButtonElement;
   private hoveredCell: { column: number; row: number } | null = null;
   private pendingSize: TableSize = { columns: 1, rows: 1 };
 
@@ -204,6 +231,14 @@ class MarkraTableNodeView {
       "-",
       this.handleDeleteRowMouseDown
     );
+    this.deleteTableButton = createTableControlButton(
+      view.dom.ownerDocument,
+      "markra-table-delete-table",
+      labels.deleteTable,
+      "",
+      this.handleDeleteTableMouseDown
+    );
+    this.deleteTableButton.append(createDeleteTableIcon(view.dom.ownerDocument));
 
     this.dom.className = "tableWrapper markra-table-controls-wrapper";
     this.alignControls.className = "markra-table-align-controls";
@@ -218,7 +253,7 @@ class MarkraTableNodeView {
     this.dom.addEventListener("mouseleave", this.hideDeleteControls);
     this.table.append(this.contentDOM);
     this.sizeControls.append(this.sizeButton);
-    this.alignControls.append(this.sizeControls, ...this.alignButtons);
+    this.alignControls.append(this.sizeControls, ...this.alignButtons, this.deleteTableButton);
     this.dom.append(
       this.alignControls,
       this.table,
@@ -249,7 +284,8 @@ class MarkraTableNodeView {
           this.alignControls.contains(target) ||
           this.addRowButton.contains(target) ||
           this.deleteColumnButton.contains(target) ||
-          this.deleteRowButton.contains(target))
+          this.deleteRowButton.contains(target) ||
+          this.deleteTableButton.contains(target))
     );
   }
 
@@ -263,7 +299,8 @@ class MarkraTableNodeView {
         this.alignControls.contains(target) ||
         this.addRowButton.contains(target) ||
         this.deleteColumnButton.contains(target) ||
-        this.deleteRowButton.contains(target))
+        this.deleteRowButton.contains(target) ||
+        this.deleteTableButton.contains(target))
     );
   }
 
@@ -290,6 +327,7 @@ class MarkraTableNodeView {
     this.addRowButton.removeEventListener("mousedown", this.handleAddRowMouseDown);
     this.deleteColumnButton.removeEventListener("mousedown", this.handleDeleteColumnMouseDown);
     this.deleteRowButton.removeEventListener("mousedown", this.handleDeleteRowMouseDown);
+    this.deleteTableButton.removeEventListener("mousedown", this.handleDeleteTableMouseDown);
   }
 
   private createSizeInput(label: string, max: number) {
@@ -346,6 +384,8 @@ class MarkraTableNodeView {
   }
 
   private readonly handleSizeButtonMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -376,6 +416,8 @@ class MarkraTableNodeView {
   };
 
   private readonly handleSizeCellMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
     this.resizeTableTo(this.sizeFromTarget(event.currentTarget));
@@ -401,12 +443,16 @@ class MarkraTableNodeView {
   };
 
   private readonly handleAddColumnMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
     this.insertColumnAfterTable();
   };
 
   private readonly handleAlignMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -418,21 +464,35 @@ class MarkraTableNodeView {
   };
 
   private readonly handleAddRowMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
     this.insertRowAfterTable();
   };
 
   private readonly handleDeleteColumnMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
     this.deleteHoveredColumn();
   };
 
   private readonly handleDeleteRowMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
     event.preventDefault();
     event.stopPropagation();
     this.deleteHoveredRow();
+  };
+
+  private readonly handleDeleteTableMouseDown = (event: MouseEvent) => {
+    if (!isPrimaryMouseButton(event)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.deleteTable();
   };
 
   private readonly handleMouseMove = (event: MouseEvent) => {
@@ -770,6 +830,23 @@ class MarkraTableNodeView {
       const nextRow = Math.min(targetRow, map.height - 2);
       this.view.dispatch(this.moveTransactionCursorToCell(tr.scrollIntoView(), tablePosition, nextRow, targetColumn));
     });
+    this.hideDeleteControls();
+    this.view.focus();
+  }
+
+  private deleteTable() {
+    const tablePosition = this.tablePosition();
+    if (tablePosition === false) return;
+
+    const paragraph = this.view.state.schema.nodes.paragraph;
+    if (!paragraph) return;
+
+    let tr = this.view.state.tr
+      .replaceWith(tablePosition, tablePosition + this.node.nodeSize, paragraph.create())
+      .scrollIntoView();
+    tr = tr.setSelection(TextSelection.near(tr.doc.resolve(tablePosition + 1), 1));
+    this.view.dispatch(tr);
+    this.hideSizePopover();
     this.hideDeleteControls();
     this.view.focus();
   }

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "Tabelle rechts ausrichten",
   "editor.table.deleteColumn": "Spalte löschen",
   "editor.table.deleteRow": "Zeile löschen",
+  "editor.table.deleteTable": "Tabelle löschen",
   "editor.table.adjustTable": "Tabelle anpassen",
   "editor.table.resizeTableTo": "Tabelle auf {columns} Spalten x {rows} Zeilen anpassen",
   "editor.table.columns": "Tabellenspalten",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -540,6 +540,7 @@ const messages: BaseLocaleMessages = {
   "editor.table.alignRight": "Align table right",
   "editor.table.deleteColumn": "Delete column",
   "editor.table.deleteRow": "Delete row",
+  "editor.table.deleteTable": "Delete table",
   "editor.table.adjustTable": "Adjust table",
   "editor.table.resizeTableTo": "Resize table to {columns} columns by {rows} rows",
   "editor.table.columns": "Table columns",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "Alinear tabla a la derecha",
   "editor.table.deleteColumn": "Eliminar columna",
   "editor.table.deleteRow": "Eliminar fila",
+  "editor.table.deleteTable": "Eliminar tabla",
   "editor.table.adjustTable": "Ajustar tabla",
   "editor.table.resizeTableTo": "Cambiar tabla a {columns} columnas x {rows} filas",
   "editor.table.columns": "Columnas de la tabla",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "Aligner le tableau à droite",
   "editor.table.deleteColumn": "Supprimer la colonne",
   "editor.table.deleteRow": "Supprimer la ligne",
+  "editor.table.deleteTable": "Supprimer le tableau",
   "editor.table.adjustTable": "Ajuster le tableau",
   "editor.table.resizeTableTo": "Redimensionner le tableau en {columns} colonnes x {rows} lignes",
   "editor.table.columns": "Colonnes du tableau",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "Allinea tabella a destra",
   "editor.table.deleteColumn": "Elimina colonna",
   "editor.table.deleteRow": "Elimina riga",
+  "editor.table.deleteTable": "Elimina tabella",
   "editor.table.adjustTable": "Regola tabella",
   "editor.table.resizeTableTo": "Ridimensiona tabella a {columns} colonne x {rows} righe",
   "editor.table.columns": "Colonne tabella",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "表を右揃え",
   "editor.table.deleteColumn": "列を削除",
   "editor.table.deleteRow": "行を削除",
+  "editor.table.deleteTable": "表を削除",
   "editor.table.adjustTable": "表を調整",
   "editor.table.resizeTableTo": "{columns} 列 x {rows} 行に変更",
   "editor.table.columns": "表の列数",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "표 오른쪽 정렬",
   "editor.table.deleteColumn": "열 삭제",
   "editor.table.deleteRow": "행 삭제",
+  "editor.table.deleteTable": "표 삭제",
   "editor.table.adjustTable": "표 조정",
   "editor.table.resizeTableTo": "표를 {columns}열 x {rows}행으로 변경",
   "editor.table.columns": "표 열 수",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "Alinhar tabela à direita",
   "editor.table.deleteColumn": "Excluir coluna",
   "editor.table.deleteRow": "Excluir linha",
+  "editor.table.deleteTable": "Excluir tabela",
   "editor.table.adjustTable": "Ajustar tabela",
   "editor.table.resizeTableTo": "Redimensionar tabela para {columns} colunas x {rows} linhas",
   "editor.table.columns": "Colunas da tabela",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -343,6 +343,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "Выровнять таблицу по правому краю",
   "editor.table.deleteColumn": "Удалить столбец",
   "editor.table.deleteRow": "Удалить строку",
+  "editor.table.deleteTable": "Удалить таблицу",
   "editor.table.adjustTable": "Настроить таблицу",
   "editor.table.resizeTableTo": "Изменить таблицу до {columns} столбцов x {rows} строк",
   "editor.table.columns": "Столбцы таблицы",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -551,6 +551,7 @@ export type I18nKey =
   | "editor.table.alignRight"
   | "editor.table.deleteColumn"
   | "editor.table.deleteRow"
+  | "editor.table.deleteTable"
   | "editor.table.adjustTable"
   | "editor.table.resizeTableTo"
   | "editor.table.columns"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -540,6 +540,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "表格右对齐",
   "editor.table.deleteColumn": "删除列",
   "editor.table.deleteRow": "删除行",
+  "editor.table.deleteTable": "删除表格",
   "editor.table.adjustTable": "调整表格",
   "editor.table.resizeTableTo": "调整为 {columns} 列 x {rows} 行",
   "editor.table.columns": "表格列数",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "editor.table.alignRight": "表格靠右對齊",
   "editor.table.deleteColumn": "刪除欄",
   "editor.table.deleteRow": "刪除列",
+  "editor.table.deleteTable": "刪除表格",
   "editor.table.adjustTable": "調整表格",
   "editor.table.resizeTableTo": "調整為 {columns} 欄 x {rows} 列",
   "editor.table.columns": "表格欄數",

--- a/packages/shared/src/markdown-callout.test.ts
+++ b/packages/shared/src/markdown-callout.test.ts
@@ -25,6 +25,20 @@ describe("markdown callouts", () => {
     ].join("\n"));
   });
 
+  it("normalizes formatted Typora callout markers to GitHub alert syntax", () => {
+    const source = [
+      "> **\\[!NOTE]**",
+      ">",
+      "> Synthetic detail"
+    ].join("\n");
+
+    expect(restoreEscapedMarkdownCalloutMarkers(source)).toBe([
+      "> [!NOTE]",
+      ">",
+      "> Synthetic detail"
+    ].join("\n"));
+  });
+
   it("collapses an empty callout body placeholder to one quoted blank line", () => {
     const htmlPlaceholder = [
       "> [!WARNING]",
@@ -101,6 +115,30 @@ describe("markdown callouts", () => {
       ">",
       ">",
       ""
+    ].join("\n"));
+  });
+
+  it("keeps adjacent callout list starts tight without removing structural blank quote lines", () => {
+    const markdown = [
+      "> [!NOTE]",
+      ">",
+      "> - First",
+      ">",
+      "> - Second",
+      ">",
+      ">   1. Nested detail",
+      ">",
+      "> Paragraph after list"
+    ].join("\n");
+
+    expect(restoreEscapedMarkdownCalloutMarkers(markdown)).toBe([
+      "> [!NOTE]",
+      ">",
+      "> - First",
+      "> - Second",
+      ">   1. Nested detail",
+      ">",
+      "> Paragraph after list"
     ].join("\n"));
   });
 });

--- a/packages/shared/src/markdown-callout.ts
+++ b/packages/shared/src/markdown-callout.ts
@@ -160,12 +160,81 @@ function collapseEmptyCalloutBodyPlaceholders(markdown: string) {
   return collapsedLines.join("\n");
 }
 
+function blockquoteListItemStart(line: string | undefined) {
+  if (line === undefined) return null;
+
+  const match = /^((?:>\s?)+)( *)([-+*]|\d+[.)])\s+/u.exec(lineContentWithoutEnding(line));
+  if (!match) return null;
+
+  return {
+    indent: match[2] ?? "",
+    kind: /^\d/u.test(match[3] ?? "") ? "ordered" : "bullet",
+    quotePrefix: match[1] ?? ""
+  };
+}
+
+function calloutListItemStartsShouldStayTight(
+  previousListItem: NonNullable<ReturnType<typeof blockquoteListItemStart>>,
+  nextListItem: NonNullable<ReturnType<typeof blockquoteListItemStart>>
+) {
+  if (previousListItem.quotePrefix !== nextListItem.quotePrefix) return false;
+  if (previousListItem.indent === nextListItem.indent) return previousListItem.kind === nextListItem.kind;
+
+  return (
+    previousListItem.indent.startsWith(nextListItem.indent) ||
+    nextListItem.indent.startsWith(previousListItem.indent)
+  );
+}
+
+function tightenCalloutSimpleListSpacing(markdown: string) {
+  const lines = markdown.split("\n");
+  const tightenedLines: string[] = [];
+  let inCallout = false;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? "";
+    const quotedContent = blockquoteLineContent(line);
+
+    if (quotedContent === null) {
+      inCallout = false;
+      tightenedLines.push(line);
+      continue;
+    }
+
+    if (parseMarkdownCalloutMarker(quotedContent)) {
+      inCallout = true;
+    }
+
+    const previousListItem = blockquoteListItemStart(tightenedLines[tightenedLines.length - 1]);
+    const nextListItem = blockquoteListItemStart(lines[lineIndex + 1]);
+    const isSimpleListSpacer =
+      inCallout &&
+      lineIsEmptyBlockquote(line) &&
+      previousListItem !== null &&
+      nextListItem !== null &&
+      calloutListItemStartsShouldStayTight(previousListItem, nextListItem);
+
+    if (!isSimpleListSpacer) {
+      tightenedLines.push(line);
+    }
+  }
+
+  return tightenedLines.join("\n");
+}
+
+function restoreFormattedMarkdownCalloutMarkers(markdown: string) {
+  return markdown.replace(
+    /(^|\n)((?:>\s*)+)([*_]{1,3})\\?(\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\])\3(?=\s*(?:\n|$))/giu,
+    "$1$2$4"
+  );
+}
+
 export function restoreEscapedMarkdownCalloutMarkers(markdown: string) {
-  const restoredMarkers = markdown.replace(
+  const restoredMarkers = restoreFormattedMarkdownCalloutMarkers(markdown).replace(
     /(^|\n)((?:>\s*)+)\\(\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\])/giu,
     "$1$2$3"
   );
   return collapseEmptyCalloutBodyPlaceholders(
-    restoreCalloutHardBreakEscapes(restoredMarkers)
+    tightenCalloutSimpleListSpacing(restoreCalloutHardBreakEscapes(restoredMarkers))
   ).replace(/(^|\n)((?:>\s*)+)<br \/>(?=\n|$)/gu, "$1$2");
 }


### PR DESCRIPTION
## Summary
- Keep unordered lists serialized with `-` markers instead of changing them to `*`.
- Normalize Typora-exported formatted callout markers like `> **\\[!NOTE]**` back to GitHub alert syntax.
- Make callout editing follow Typora-style block behavior: `Enter` continues non-empty callout body text or list items, and `Enter` from an empty callout body line exits the callout without leaving that empty line inside the block.
- Let slash commands run from callout body lines, including mouse selection and keyboard `Enter` selection, instead of having callout `Enter` handling consume the command.
- Keep callout list source tight, including nested list items, while preserving structural blank quote lines before normal paragraphs.
- Prevent held/repeated Backspace events from deleting an emptied callout immediately while the key is still down.
- Keep Backspace inside the callout when an emptied list item is lifted out of the list, instead of letting the cursor jump below the callout.
- Add a table toolbar delete-table control with a compact trash icon, localized labels, and primary-click-only activation.

## Why
- Follow-up for #224: callout contents should support normal Markdown blocks such as lists, source mode should not rewrite `-` lists to `*`, slash commands should work inside callouts, and block editing should match Typora expectations.
- Adds the requested whole-table deletion path from the visual table controls.

## Shortcut Behavior
- Create callout: type `> [!warning]` on an empty line and press `Enter`; Markra creates the corresponding callout and moves the cursor into the body.
- `Enter` in non-empty callout body text: create the next editable line inside the callout.
- `Enter` from an empty callout body line: exit the callout and continue below it; the exit-trigger empty line is removed from the callout.
- `Shift+Enter` in callout body text: insert a hard line break inside the current callout line.
- `/` in a callout body line: open slash commands; selecting an option by mouse or pressing `Enter` applies it inside the callout.
- `Enter` in a non-empty callout list item: continue the list like an ordinary list.
- `Enter` in an empty callout list item: exit the list while staying inside the callout body.
- `Tab` / `Shift+Tab` in a callout list item: indent / outdent the item like an ordinary list.
- Holding `Backspace` until a callout becomes empty keeps the empty callout editable; after the key is released, pressing `Backspace` again can still delete the empty callout.
- After deleting a callout list item to an empty line, `Backspace` exits that list item inside the callout; another `Backspace` moves back to the adjacent callout list text instead of jumping below the callout.
- Table toolbar delete control: hover/focus a table and left-click the trash icon to delete the whole table; right-click and `Ctrl`-click are ignored so context-menu clicks do not delete content.

## Validation
- Browser QA on `http://localhost:5173`: typed `> [!warning]`, added body lines `sadas` and `asdsad`, then pressed `Enter` twice; the callout kept only the marker plus the two content paragraphs, selection moved below the block, and source mode had no trailing `>` exit line.
- Browser QA on `http://localhost:5173`: typed `> [!warning]abc`, `Enter`, `def`; content stayed inside the callout, single Backspace presses removed text/lines and only deleted the empty block on a separate final press.
- Browser QA on `http://localhost:5173`: typed a callout list with `- one` / `two`; after deleting `two`, Backspace first exited the empty list item inside the callout, and the next Backspace moved to the previous list item instead of jumping below the callout.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "deletes a whole table from the visual controls|keeps a table when right-clicking the delete table control|keeps a table when ctrl-clicking the delete table control" --reporter verbose` passed: 3 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "table" --reporter verbose` passed: 26 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "runs slash commands from a callout body line|runs selected slash commands from a callout body line with Enter" --reporter verbose` passed: 2 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "slash command|callout" --reporter verbose` passed: 50 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "removes the trailing empty callout line when Enter exits after body content|exits callouts on Enter from a blank body line after a list" --reporter verbose` passed: 2 tests.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/shared test -- markdown-callout --reporter verbose` passed: 6 files, 34 tests.
- `pnpm --filter @markra/shared build` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/desktop build` passed, including Vite production build and vendor chunk verification.
- `pnpm --filter @markra/app test` passed: 57 files, 1064 tests.
