### PR TITLE
fix(app): distinguish nested unordered list markers

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1881,6 +1881,14 @@
     color: var(--editor-text-primary);
   }
 
+  .markdown-paper ul ul {
+    list-style-type: circle;
+  }
+
+  .markdown-paper ul ul ul {
+    list-style-type: square;
+  }
+
   .markdown-paper ol {
     @apply mt-3 mb-6 list-decimal pl-[1.4em] marker:text-(--text-secondary);
     color: var(--editor-text-primary);

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -85,6 +85,15 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .markra-list-collapsed-content");
   });
 
+  it("uses distinct unordered list markers for nested editor lists", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).toContain(".markdown-paper ul ul {");
+    expect(styles).toContain("list-style-type: circle;");
+    expect(styles).toContain(".markdown-paper ul ul ul {");
+    expect(styles).toContain("list-style-type: square;");
+  });
+
   it("shows a quiet inline level list control for the active rendered heading", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const labelStart = styles.indexOf(".markdown-paper .markra-heading-level-control {");


### PR DESCRIPTION
## Summary
- Add nested unordered list marker styles in the Markdown editor paper.
- Keep top-level bullets as discs, second-level bullets as circles, and third-level-and-deeper bullets as squares.
- Cover the stylesheet expectation with a focused test.

## Why
- Nested unordered lists previously used the same marker at every depth, making hierarchy harder to scan.

## Validation
- `pnpm --filter @markra/app test -- src/styles.test.ts --runInBand` passed: 57 test files / 1065 tests.
- `pnpm --filter @markra/app build` passed.

## Related Issues
Closes #229