### PR TITLE
fix(editor): add trailing line after terminal blocks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6234,6 +6234,53 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("| Markra | Editor |");
   });
 
+  it.each([
+    {
+      label: "table",
+      source: ["| Name | Role |", "| --- | --- |", "| Example | Writer |"].join("\n"),
+      terminalType: "table"
+    },
+    {
+      label: "callout",
+      source: "> [!WARNING]\n>\n> Check this first.",
+      terminalType: "blockquote"
+    },
+    {
+      label: "bullet list",
+      source: "- First\n- Second",
+      terminalType: "bullet_list"
+    },
+    {
+      label: "ordered list",
+      source: "1. First\n2. Second",
+      terminalType: "ordered_list"
+    }
+  ])("creates a trailing paragraph after clicking past a terminal $label", async ({ source, terminalType }) => {
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    let trailingAffordance: HTMLElement | null = null;
+
+    await waitFor(() => {
+      trailingAffordance = container.querySelector(".ProseMirror .markra-trailing-paragraph");
+      expect(trailingAffordance).toBeInTheDocument();
+    });
+
+    expect(view.state.doc.child(0).type.name).toBe(terminalType);
+    expect(view.state.doc.child(view.state.doc.childCount - 1).type.name).toBe(terminalType);
+
+    fireEvent.mouseDown(trailingAffordance!);
+
+    await waitFor(() => expect(view.state.doc.child(view.state.doc.childCount - 1).type.name).toBe("paragraph"));
+    expect(view.state.doc.child(view.state.doc.childCount - 1).content.size).toBe(0);
+
+    moveCursor(view, findLastTextBlockCursor(view));
+    typeText(view, "After terminal block");
+
+    expect(view.state.doc.child(view.state.doc.childCount - 1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(view.state.doc.childCount - 1).textContent).toBe("After terminal block");
+    expect(serializeMarkdown(view.state.doc)).toContain("After terminal block");
+  });
+
   it("renders GitHub-style alert blockquotes as callouts while preserving Markdown source", async () => {
     const source = "> [!NOTE]\n> Keep this in mind.";
     const { container, editor, view } = await renderEditor(source);

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -44,6 +44,7 @@ import {
   markraSlashCommands,
   markraTableControlsPlugin,
   markraTaskListPlugin,
+  markraTrailingParagraphPlugin,
   markraTaskListSchema,
   normalizeMarkdownShortcuts,
   serializeLinkImageLiveMarkdown,
@@ -329,6 +330,7 @@ function MilkdownEditorSurface({
           })
         )
         .use(markraTableControlsPlugin(tableControlLabels))
+        .use(markraTrailingParagraphPlugin)
         .use(markraLinkImageLivePlugin(resolveImageSrc))
         .use(markraHeadingLevelPlugin)
         .use(

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -20,3 +20,4 @@ export * from "./shortcuts.ts";
 export * from "./slash-commands.ts";
 export * from "./table-controls.ts";
 export * from "./task-list.ts";
+export * from "./trailing-paragraph.ts";

--- a/packages/editor/src/trailing-paragraph.ts
+++ b/packages/editor/src/trailing-paragraph.ts
@@ -1,0 +1,80 @@
+import { paragraphSchema } from "@milkdown/kit/preset/commonmark";
+import type { Node as ProseNode, NodeType } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+const trailingParagraphKey = new PluginKey("markraTrailingParagraph");
+
+function needsTrailingParagraphAffordance(doc: ProseNode, paragraph: NodeType) {
+  const lastNode = doc.lastChild;
+  if (!lastNode) return false;
+  if (lastNode.type === paragraph) return false;
+  if (lastNode.isTextblock || lastNode.isAtom) return false;
+
+  return doc.canReplaceWith(doc.childCount, doc.childCount, paragraph);
+}
+
+function insertTrailingParagraph(view: EditorView, paragraph: NodeType) {
+  if (!view.editable) return;
+  if (!needsTrailingParagraphAffordance(view.state.doc, paragraph)) return;
+
+  const insertAt = view.state.doc.content.size;
+  const transaction = view.state.tr.insert(insertAt, paragraph.create());
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, insertAt + 1))
+      .scrollIntoView()
+  );
+  view.focus();
+}
+
+function createTrailingParagraphWidget(view: EditorView, paragraph: NodeType) {
+  const widget = view.dom.ownerDocument.createElement("div");
+  widget.className = "markra-trailing-paragraph";
+  widget.contentEditable = "false";
+  widget.dataset.markraTrailingParagraph = "true";
+  widget.setAttribute("aria-hidden", "true");
+  widget.style.cursor = "text";
+  widget.style.display = "block";
+  widget.style.minHeight = "1.65em";
+  widget.style.width = "100%";
+
+  widget.addEventListener("mousedown", (event) => {
+    if (event.button !== 0) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    insertTrailingParagraph(view, paragraph);
+  });
+
+  return widget;
+}
+
+export function createTrailingParagraphPlugin(paragraph: NodeType) {
+  return new Plugin({
+    key: trailingParagraphKey,
+    props: {
+      decorations(state) {
+        if (!needsTrailingParagraphAffordance(state.doc, paragraph)) return DecorationSet.empty;
+
+        return DecorationSet.create(state.doc, [
+          Decoration.widget(
+            state.doc.content.size,
+            (view) => createTrailingParagraphWidget(view, paragraph),
+            {
+              key: "markra-trailing-paragraph",
+              side: 1,
+              stopEvent: (event) => event.type === "mousedown"
+            }
+          )
+        ]);
+      }
+    }
+  });
+}
+
+export const markraTrailingParagraphPlugin = $prose((ctx) =>
+  createTrailingParagraphPlugin(paragraphSchema.type(ctx))
+);


### PR DESCRIPTION
## Summary
- Add a trailing-line editor affordance after terminal container blocks such as tables, callouts, and lists.
- Insert a real paragraph only when the user clicks that trailing line, keeping loaded Markdown content unchanged until explicit editing.
- Cover tables, callouts, unordered lists, and ordered lists with a regression test.

## Why
Terminal non-plain blocks at the end of the document had no top-level text position after them, so users could not click below the final block to create a new blank line.

Fixes #231

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed
- `pnpm --filter @markra/app test` passed
- `pnpm --filter @markra/editor test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/editor build` passed
- `git diff --check` passed