### PR TITLE
fix(editor): stabilize callout deletion and edit history

### DIFF
--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -14,6 +14,8 @@ const OPEN_RECENT_FILE_COMMAND_PREFIX: &str = "openRecentFile:";
 const CLEAR_RECENT_FILES_COMMAND: &str = "clearRecentFiles";
 const SETTINGS_WINDOW_COMMAND: &str = "openSettings";
 const CHECK_FOR_UPDATES_COMMAND: &str = "checkForUpdates";
+const EDIT_UNDO_COMMAND: &str = "editUndo";
+const EDIT_REDO_COMMAND: &str = "editRedo";
 const MARKRA_GITHUB_URL: &str = "https://github.com/murongg/markra";
 
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
@@ -229,9 +231,16 @@ fn create_edit_submenu<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     labels: crate::menu_labels::MenuLabels,
 ) -> tauri::Result<Submenu<R>> {
+    let undo = app_menu_item(app, EDIT_UNDO_COMMAND, labels.undo, "CmdOrCtrl+Z")?;
+    let redo = app_menu_item(
+        app,
+        EDIT_REDO_COMMAND,
+        labels.redo,
+        "CmdOrCtrl+Shift+Z",
+    )?;
+
     SubmenuBuilder::with_id(app, "markra:edit", labels.edit)
-        .undo_with_text(labels.undo)
-        .redo_with_text(labels.redo)
+        .items(&[&undo, &redo])
         .separator()
         .cut_with_text(labels.cut)
         .copy_with_text(labels.copy)
@@ -720,6 +729,8 @@ pub(crate) fn is_frontend_menu_command(command: &str) -> bool {
         command,
         CHECK_FOR_UPDATES_COMMAND
             | CLEAR_RECENT_FILES_COMMAND
+            | EDIT_UNDO_COMMAND
+            | EDIT_REDO_COMMAND
             | "openDocument"
             | "openFolder"
             | "openQuickOpen"
@@ -776,6 +787,8 @@ mod tests {
         assert!(is_frontend_menu_command("openDocument"));
         assert!(is_frontend_menu_command("openRecentFile:0"));
         assert!(is_frontend_menu_command("clearRecentFiles"));
+        assert!(is_frontend_menu_command("editUndo"));
+        assert!(is_frontend_menu_command("editRedo"));
         assert!(is_frontend_menu_command("openFolder"));
         assert!(is_frontend_menu_command("openQuickOpen"));
         assert!(is_frontend_menu_command("closeDocument"));

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -232,12 +232,7 @@ fn create_edit_submenu<R: tauri::Runtime>(
     labels: crate::menu_labels::MenuLabels,
 ) -> tauri::Result<Submenu<R>> {
     let undo = app_menu_item(app, EDIT_UNDO_COMMAND, labels.undo, "CmdOrCtrl+Z")?;
-    let redo = app_menu_item(
-        app,
-        EDIT_REDO_COMMAND,
-        labels.redo,
-        "CmdOrCtrl+Shift+Z",
-    )?;
+    let redo = app_menu_item(app, EDIT_REDO_COMMAND, labels.redo, "CmdOrCtrl+Shift+Z")?;
 
     SubmenuBuilder::with_id(app, "markra:edit", labels.edit)
         .items(&[&undo, &redo])

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -43,6 +43,8 @@ export type NativeEditorContextMenuOptions = {
 
 export type NativeStaticMenuCommand =
   | "checkForUpdates"
+  | "editUndo"
+  | "editRedo"
   | "openDocument"
   | "openFolder"
   | "openQuickOpen"

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7752,6 +7752,272 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("removes an emptied nested callout list item without leaving a child list", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent one",
+      ">   - Child one",
+      ">   - Child two",
+      "> - Parent two",
+      ">   - Nested child",
+      "> - Parent three",
+      "> - Parent four"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const childFrom = findTextPosition(view, "Nested child");
+
+    selectText(view, childFrom, childFrom + "Nested child".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(selectionHasAncestor(view, "list_item")).toBe(true);
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    const topList = callout?.querySelector<HTMLElement>("ul");
+    const topLevelItems = Array.from(topList?.children ?? []).filter(
+      (child): child is HTMLLIElement => child instanceof HTMLLIElement
+    );
+    const parentTwo = topLevelItems.find((item) => item.textContent?.includes("Parent two"));
+
+    expect(parentTwo).toBeDefined();
+    expect(parentTwo?.querySelector("ul, ol")).not.toBeInTheDocument();
+    expect(parentTwo?.querySelector(".markra-list-toggle-button")).not.toBeInTheDocument();
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> - Parent one\n>   - Child one\n>   - Child two");
+    expect(markdown).toContain("> - Parent two\n> - Parent three");
+    expect(markdown).not.toContain("Nested child");
+    expect(markdown).not.toContain("> - Parent two\n>   -");
+    await settleMarkdownListener();
+  });
+
+  it("removes the first emptied callout list item instead of leaving an empty bullet", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - First",
+      "> - Second",
+      "> - Third"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const firstFrom = findTextPosition(view, "First");
+
+    selectText(view, firstFrom, firstFrom + "First".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    const topList = callout?.querySelector<HTMLElement>("ul");
+    const topLevelItems = Array.from(topList?.children ?? []).filter(
+      (child): child is HTMLLIElement => child instanceof HTMLLIElement
+    );
+
+    expect(topLevelItems).toHaveLength(2);
+    expect(topLevelItems[0]).toHaveTextContent("Second");
+    expect(topLevelItems[1]).toHaveTextContent("Third");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> - Second\n> - Third");
+    expect(markdown).not.toContain("First");
+    expect(markdown).not.toContain("> -\n> - Second");
+    await settleMarkdownListener();
+  });
+
+  it("removes the first emptied nested callout list item instead of leaving an empty bullet", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - First child",
+      ">   - Second child",
+      "> - After"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const firstChildFrom = findTextPosition(view, "First child");
+
+    selectText(view, firstChildFrom, firstChildFrom + "First child".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    const nestedItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li > ul > li")
+    );
+
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Second child");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> - Parent\n>   - Second child\n> - After");
+    expect(markdown).not.toContain("First child");
+    expect(markdown).not.toContain(">   -\n>   - Second child");
+    await settleMarkdownListener();
+  });
+
+  it("promotes child list items when deleting an emptied callout list parent", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Keep",
+      "> - Parent",
+      ">   - Child one",
+      ">   - Child two",
+      "> - After"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const parentFrom = findTextPosition(view, "Parent");
+
+    selectText(view, parentFrom, parentFrom + "Parent".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    const callout = container.querySelector<HTMLElement>(".ProseMirror blockquote.markra-callout");
+    const topList = callout?.querySelector<HTMLElement>("ul");
+    const topLevelItems = Array.from(topList?.children ?? []).filter(
+      (child): child is HTMLLIElement => child instanceof HTMLLIElement
+    );
+
+    expect(topLevelItems).toHaveLength(4);
+    expect(topLevelItems[0]).toHaveTextContent("Keep");
+    expect(topLevelItems[1]).toHaveTextContent("Child one");
+    expect(topLevelItems[2]).toHaveTextContent("Child two");
+    expect(topLevelItems[3]).toHaveTextContent("After");
+    expect(topLevelItems.some((item) => item.textContent?.trim().length === 0)).toBe(false);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> - Keep\n> - Child one\n> - Child two\n> - After");
+    expect(markdown).not.toContain("Parent");
+    expect(markdown).not.toContain("> -\n>   - Child one");
+    await settleMarkdownListener();
+  });
+
+  it("keeps empty callout list cleanup in its own undo and redo step", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Keep",
+      "> - Parent",
+      ">   - Child one",
+      ">   - Child two",
+      "> - After"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const parentFrom = findTextPosition(view, "Parent");
+
+    selectText(view, parentFrom, parentFrom + "Parent".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    expect(serializeMarkdown(view.state.doc)).toContain("> - Keep\n> - Child one\n> - Child two\n> - After");
+
+    expect(pressShortcut(view, "z", { metaKey: true })).toBe(true);
+
+    const undoMarkdown = serializeMarkdown(view.state.doc);
+    expect(undoMarkdown).toContain("> - Keep");
+    expect(undoMarkdown).toContain("> -");
+    expect(undoMarkdown).toContain(">   - Child one\n>   - Child two\n> - After");
+    expect(undoMarkdown).not.toContain("Parent");
+
+    expect(pressShortcut(view, "z", { metaKey: true, shiftKey: true })).toBe(true);
+
+    const redoMarkdown = serializeMarkdown(view.state.doc);
+    expect(redoMarkdown).toContain("> - Keep\n> - Child one\n> - Child two\n> - After");
+    expect(redoMarkdown).not.toContain("> -\n>   - Child one");
+    await settleMarkdownListener();
+  });
+
+  it("keeps first nested callout list item cleanup redoable", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - First child",
+      ">   - Second child",
+      "> - After"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const firstChildFrom = findTextPosition(view, "First child");
+
+    selectText(view, firstChildFrom, firstChildFrom + "First child".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    expect(serializeMarkdown(view.state.doc)).toContain("> - Parent\n>   - Second child\n> - After");
+
+    expect(pressShortcut(view, "z", { metaKey: true })).toBe(true);
+
+    const undoMarkdown = serializeMarkdown(view.state.doc);
+    expect(undoMarkdown).toContain("> - Parent");
+    expect(undoMarkdown).toContain(">   -");
+    expect(undoMarkdown).toContain(">   - Second child\n> - After");
+    expect(undoMarkdown).not.toContain("First child");
+
+    expect(pressShortcut(view, "z", { metaKey: true, shiftKey: true })).toBe(true);
+
+    const redoMarkdown = serializeMarkdown(view.state.doc);
+    expect(redoMarkdown).toContain("> - Parent\n>   - Second child\n> - After");
+    expect(redoMarkdown).not.toContain(">   -\n>   - Second child");
+    await settleMarkdownListener();
+  });
+
+  it("promotes nested child list items when deleting an emptied nested callout list parent", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Root",
+      ">   - Parent",
+      ">     - Grandchild one",
+      ">     - Grandchild two",
+      ">   - Nested after",
+      "> - After"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const parentFrom = findTextPosition(view, "Parent");
+
+    selectText(view, parentFrom, parentFrom + "Parent".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    const nestedItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li > ul > li")
+    );
+
+    expect(nestedItems).toHaveLength(3);
+    expect(nestedItems[0]).toHaveTextContent("Grandchild one");
+    expect(nestedItems[1]).toHaveTextContent("Grandchild two");
+    expect(nestedItems[2]).toHaveTextContent("Nested after");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain(
+      "> - Root\n>   - Grandchild one\n>   - Grandchild two\n>   - Nested after\n> - After"
+    );
+    expect(markdown).not.toContain("Parent");
+    expect(markdown).not.toContain(">   -\n>     - Grandchild one");
+    await settleMarkdownListener();
+  });
+
   it("removes one empty callout body line before deleting an otherwise empty callout", async () => {
     const { container, view } = await renderEditor("> [!NOTE]\n>\n>");
 

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -85,6 +85,24 @@ describe("useNativeMenuHandlers", () => {
     });
   });
 
+  it("routes native edit history commands through editor shortcuts", () => {
+    const runEditorShortcut = vi.fn();
+    const { result } = renderHook(() =>
+      useNativeMenuHandlers({
+        ...baseOptions,
+        runEditorShortcut
+      })
+    );
+
+    result.current.editUndo?.();
+    result.current.editRedo?.();
+
+    expect(runEditorShortcut).toHaveBeenNthCalledWith(1, "z");
+    expect(runEditorShortcut).toHaveBeenNthCalledWith(2, "z", {
+      shiftKey: true
+    });
+  });
+
   it("routes the native all-folds command through the configured editor shortcut", () => {
     const runEditorShortcut = vi.fn();
     const { result } = renderHook(() =>

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -173,6 +173,8 @@ export function useNativeMenuHandlers({
         openFolder: () => latestOptionsRef.current.openFolder(),
         saveDocument: () => latestOptionsRef.current.saveDocument(),
         saveDocumentAs: () => latestOptionsRef.current.saveDocumentAs(),
+        editUndo: () => latestOptionsRef.current.runEditorShortcut("z"),
+        editRedo: () => latestOptionsRef.current.runEditorShortcut("z", { shiftKey: true }),
         formatBold: () => runMarkdownShortcut("bold"),
         formatItalic: () => runMarkdownShortcut("italic"),
         formatStrikethrough: () => runMarkdownShortcut("strikethrough"),

--- a/packages/app/src/lib/tauri/menu.ts
+++ b/packages/app/src/lib/tauri/menu.ts
@@ -31,6 +31,8 @@ export type NativeEditorContextMenuOptions = {
 
 export type NativeStaticMenuCommand =
   | "checkForUpdates"
+  | "editUndo"
+  | "editRedo"
   | "openDocument"
   | "openFolder"
   | "openQuickOpen"

--- a/packages/editor/src/callout.ts
+++ b/packages/editor/src/callout.ts
@@ -2,7 +2,8 @@ import { SerializerReady, serializerCtx } from "@milkdown/kit/core";
 import type { Ctx, MilkdownPlugin } from "@milkdown/kit/ctx";
 import { blockquoteSchema, listItemSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
 import { splitBlock } from "@milkdown/kit/prose/commands";
-import type { Node as ProseNode, ResolvedPos } from "@milkdown/kit/prose/model";
+import { closeHistory } from "@milkdown/kit/prose/history";
+import { Fragment, type Node as ProseNode, type ResolvedPos } from "@milkdown/kit/prose/model";
 import { liftListItem, splitListItem } from "@milkdown/kit/prose/schema-list";
 import { Plugin, TextSelection, type Command, type EditorState } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
@@ -233,9 +234,204 @@ function positionHasAncestorNodeName($pos: ResolvedPos, nodeName: string) {
   return false;
 }
 
+function ancestorDepthByNodeName($pos: ResolvedPos, nodeName: string) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    if ($pos.node(depth).type.name === nodeName) return depth;
+  }
+
+  return null;
+}
+
 function selectionIsInsideNodeName(state: EditorState, nodeName: string) {
   const { selection } = state;
   return [selection.$from, selection.$to].every(($pos) => positionHasAncestorNodeName($pos, nodeName));
+}
+
+function isListNode(node: ProseNode) {
+  return node.type.name === "bullet_list" || node.type.name === "ordered_list";
+}
+
+type EmptyListItemContext = {
+  $from: ResolvedPos;
+  from: number;
+  itemIndex: number;
+  listItem: ProseNode;
+  listItemDepth: number;
+  parentList: ProseNode;
+  parentListDepth: number;
+  to: number;
+};
+
+function emptyListItemContext(state: EditorState): EmptyListItemContext | null {
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+  if (!selection.$from.parent.isTextblock || selection.$from.parent.content.size > 0) return null;
+
+  const { $from } = selection;
+  const listItemDepth = ancestorDepthByNodeName($from, "list_item");
+  if (listItemDepth === null) return null;
+
+  const parentListDepth = listItemDepth - 1;
+  if (parentListDepth <= 0) return null;
+
+  const parentList = $from.node(parentListDepth);
+  if (!isListNode(parentList)) return null;
+
+  return {
+    $from,
+    from: $from.before(listItemDepth),
+    itemIndex: $from.index(parentListDepth),
+    listItem: $from.node(listItemDepth),
+    listItemDepth,
+    parentList,
+    parentListDepth,
+    to: $from.after(listItemDepth)
+  };
+}
+
+function firstTextBlockStartPosition(node: ProseNode, nodeFrom: number) {
+  let position: number | null = null;
+
+  node.descendants((child, offset) => {
+    if (!child.isTextblock) return true;
+
+    position = nodeFrom + offset + 2;
+    return false;
+  });
+
+  return position;
+}
+
+function firstTextBlockEndPosition(node: ProseNode, nodeFrom: number) {
+  let position: number | null = null;
+
+  node.descendants((child, offset) => {
+    if (!child.isTextblock) return true;
+
+    position = nodeFrom + offset + 2 + child.content.size;
+    return false;
+  });
+
+  return position;
+}
+
+function listItemHasOnlyEmptyTextBlocksAndLists(listItem: ProseNode) {
+  let valid = true;
+
+  listItem.forEach((child) => {
+    if (isListNode(child)) return;
+    if (!child.isTextblock || child.content.size > 0) valid = false;
+  });
+
+  return valid;
+}
+
+function childListItems(listItem: ProseNode) {
+  const items: ProseNode[] = [];
+
+  listItem.forEach((child) => {
+    if (!isListNode(child)) return;
+
+    child.forEach((item) => {
+      items.push(item);
+    });
+  });
+
+  return items;
+}
+
+function promoteEmptyListItemChildren(view: EditorView) {
+  const context = emptyListItemContext(view.state);
+  if (!context) return false;
+  if (!listItemHasOnlyEmptyTextBlocksAndLists(context.listItem)) return false;
+
+  const promotedItems = childListItems(context.listItem);
+  if (promotedItems.length === 0) return false;
+
+  const transaction = closeHistory(view.state.tr.replaceWith(context.from, context.to, Fragment.fromArray(promotedItems)));
+  const selectionPosition = Math.min(context.from + 2, transaction.doc.content.size);
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function removeFirstEmptyLeafListItem(view: EditorView) {
+  const context = emptyListItemContext(view.state);
+  if (!context) return false;
+  if (context.listItem.childCount !== 1) return false;
+  if (context.itemIndex !== 0 || context.parentList.childCount <= 1) return false;
+
+  const nextItem = context.parentList.child(context.itemIndex + 1);
+  const nextItemPosition = firstTextBlockStartPosition(nextItem, context.to) ?? context.to + 1;
+  const transaction = closeHistory(view.state.tr.delete(context.from, context.to));
+  const mappedSelectionPosition = Math.min(
+    Math.max(transaction.mapping.map(nextItemPosition, -1), 1),
+    transaction.doc.content.size
+  );
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.near(transaction.doc.resolve(mappedSelectionPosition), 1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function emptyNestedLeafListRange(state: EditorState) {
+  const context = emptyListItemContext(state);
+  if (!context) return null;
+  if (context.listItem.childCount !== 1) return null;
+  if (context.parentList.childCount !== 1) return null;
+
+  const parentListItemDepth = context.parentListDepth - 1;
+  if (parentListItemDepth <= 0 || context.$from.node(parentListItemDepth).type.name !== "list_item") return null;
+
+  const parentListItemFrom = context.$from.before(parentListItemDepth);
+  const selectionPosition =
+    firstTextBlockEndPosition(context.$from.node(parentListItemDepth), parentListItemFrom) ??
+    parentListItemFrom + 1;
+
+  return {
+    from: context.$from.before(context.parentListDepth),
+    selectionPosition,
+    to: context.$from.after(context.parentListDepth)
+  };
+}
+
+function removeEmptyNestedCalloutListItem(view: EditorView) {
+  const range = emptyNestedLeafListRange(view.state);
+  if (!range) return false;
+
+  const transaction = closeHistory(view.state.tr.delete(range.from, range.to));
+  const mappedSelectionPosition = Math.min(
+    Math.max(transaction.mapping.map(range.selectionPosition, -1), 1),
+    transaction.doc.content.size
+  );
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.near(transaction.doc.resolve(mappedSelectionPosition), -1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function removeEmptyCalloutListItem(view: EditorView) {
+  return (
+    promoteEmptyListItemChildren(view) ||
+    removeFirstEmptyLeafListItem(view) ||
+    removeEmptyNestedCalloutListItem(view)
+  );
 }
 
 function emptySelectionBlockRange(view: EditorView) {
@@ -797,7 +993,14 @@ export const markraCalloutPlugin = $prose((ctx) => {
 
         const callout = findCalloutAtSelection(view);
         if (!callout) return false;
-        if (selectionIsInsideNodeName(view.state, "list_item")) return false;
+        if (selectionIsInsideNodeName(view.state, "list_item")) {
+          const handled = removeEmptyCalloutListItem(view);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        }
+
         if (calloutVisibleText(callout).length > 0) {
           deleteHoldStartedInsideNonEmptyCallout = true;
         }


### PR DESCRIPTION
## Summary
- Fix callout list cleanup when deleting empty first or nested list items.
- Promote child list items when an emptied callout list parent is removed instead of leaving an empty bullet.
- Keep callout list cleanup in its own undo/redo history step.
- Route native Edit menu Undo/Redo through the active editor shortcuts so menu commands match keyboard shortcuts.

## Why
- Empty list item cleanup inside callouts could fall through default list behavior, leaving stale bullets, child lists, or spacing artifacts.
- The custom cleanup transaction could also merge into the previous text deletion, so undo removed too much and redo could not reliably replay the cleanup.
- The macOS Edit menu used Tauri's system undo/redo items, which did not emit Markra's frontend menu command. Keyboard redo worked because it was handled directly by the editor, while clicking the menu item did not reach the editor history command.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useNativeBindings.test.tsx -t "routes native edit history commands"` passed
- `cargo test recognizes_frontend_menu_commands` passed
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check` passed
- `pnpm --filter @markra/desktop exec vitest run src/runtime/tauri/menu.test.ts` passed
- `pnpm --filter @markra/app exec vitest run src/hooks/useNativeBindings.test.tsx` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/app test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop test` passed
- `pnpm --filter @markra/desktop build` passed
- `cargo test` passed
- `git diff --check` passed

## Related Issues
- Refs #224
