### PR TITLE
fix(editor): scope Shift+Tab list lifting

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6531,6 +6531,33 @@ describe("MarkdownPaper editing", () => {
     expect(markdown).not.toContain(">   - First detail\n>     Second detail");
   });
 
+  it("keeps callout continuation Shift+Tab undoable as one step", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - s",
+      ">   - sa",
+      ">   - sd",
+      ">     - sad",
+      ">     - sad",
+      ">     - First detail",
+      ">       Second detail"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second detail"));
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+    expect(serializeMarkdown(view.state.doc)).toContain(">     - First detail\n>   - Second detail");
+
+    expect(pressShortcut(view, "z", { metaKey: true })).toBe(true);
+    expect(serializeMarkdown(view.state.doc)).toContain(">     - First detail\n>       Second detail");
+    expect(serializeMarkdown(view.state.doc)).not.toContain(">     - First detail\n>   - Second detail");
+
+    expect(pressShortcut(view, "z", { metaKey: true, shiftKey: true })).toBe(true);
+    expect(serializeMarkdown(view.state.doc)).toContain(">     - First detail\n>   - Second detail");
+  });
+
   it("continues typed list items inside callouts on Enter", async () => {
     const { container, editor, view } = await renderEditor("> [!WARNING]\n>");
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5222,6 +5222,90 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("lifts only the current list item with Shift+Tab", async () => {
+    const source = ["- Parent", "  - First child", "  - Second child", "- After"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "First child"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    const topLevelItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li"));
+    const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li > ul > li"));
+    expect(topLevelItems).toHaveLength(4);
+    expect(topLevelItems[0]).toHaveTextContent("Parent");
+    expect(topLevelItems[1]).toHaveTextContent("First child");
+    expect(topLevelItems[2]).toHaveTextContent("Second child");
+    expect(topLevelItems[3]).toHaveTextContent("After");
+    expect(nestedItems).toHaveLength(0);
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown.split("\n").filter((line) => line.length > 0)).toEqual([
+      "- Parent",
+      "- First child",
+      "- Second child",
+      "- After"
+    ]);
+    expect(markdown).not.toContain("- First child\n  - Second child");
+  });
+
+  it("lifts only the active list continuation line with Shift+Tab", async () => {
+    const source = [
+      "- s",
+      "  - sa",
+      "  - sd",
+      "    - sad",
+      "    - sad",
+      "    - First detail",
+      "      Second detail"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second detail"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    const markdown = serializeMarkdown(view.state.doc);
+    const lines = markdown.split("\n").filter((line) => line.length > 0);
+    expect(lines).toContain("    - First detail");
+    expect(lines).toContain("  - Second detail");
+    expect(lines).not.toContain("  - First detail");
+    expect(lines).not.toContain("    Second detail");
+  });
+
+  it("keeps list continuation Shift+Tab undoable as one step", async () => {
+    const source = [
+      "- s",
+      "  - sa",
+      "  - sd",
+      "    - sad",
+      "    - sad",
+      "    - First detail",
+      "      Second detail"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second detail"));
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toContain(
+      "  - Second detail"
+    );
+
+    expect(pressShortcut(view, "z", { metaKey: true })).toBe(true);
+    let lines = serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0);
+    expect(lines).toContain("    - First detail");
+    expect(lines).toContain("      Second detail");
+    expect(lines).not.toContain("  - Second detail");
+
+    expect(pressShortcut(view, "z", { metaKey: true, shiftKey: true })).toBe(true);
+    lines = serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0);
+    expect(lines).toContain("    - First detail");
+    expect(lines).toContain("  - Second detail");
+  });
+
   it("exits a terminal code block so text can be added below it", async () => {
     const source = ["## Pull image", "", "```", "sudo docker pull image", "```"].join("\n");
     const { editor, view } = await renderEditor(source);

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6473,6 +6473,64 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("> - First\n> - Second");
   });
 
+  it("lifts only the current callout list item with Shift+Tab", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - First child",
+      ">   - Second child",
+      "> - After"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "First child"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    const topLevelItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li")
+    );
+    const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout > ul > li > ul > li"
+    ));
+    expect(topLevelItems).toHaveLength(4);
+    expect(topLevelItems[0]).toHaveTextContent("Parent");
+    expect(topLevelItems[1]).toHaveTextContent("First child");
+    expect(topLevelItems[2]).toHaveTextContent("Second child");
+    expect(topLevelItems[3]).toHaveTextContent("After");
+    expect(nestedItems).toHaveLength(0);
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain("> - Parent\n> - First child\n> - Second child\n> - After");
+    expect(markdown).not.toContain("> - First child\n>   - Second child");
+  });
+
+  it("lifts only the active callout continuation paragraph with Shift+Tab", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - s",
+      ">   - sa",
+      ">   - sd",
+      ">     - sad",
+      ">     - sad",
+      ">     - First detail",
+      ">       Second detail"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second detail"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain(">     - First detail\n>   - Second detail");
+    expect(markdown).not.toContain(">   - First detail\n>     Second detail");
+  });
+
   it("continues typed list items inside callouts on Enter", async () => {
     const { container, editor, view } = await renderEditor("> [!WARNING]\n>");
 

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -13,7 +13,7 @@ import {
 import { strikethroughSchema } from "@milkdown/kit/preset/gfm";
 import { exitCode, lift, setBlockType, toggleMark, wrapIn } from "@milkdown/kit/prose/commands";
 import { redo, undo } from "@milkdown/kit/prose/history";
-import type { NodeType, ResolvedPos } from "@milkdown/kit/prose/model";
+import { Fragment, type Node as ProseNode, type NodeType, type ResolvedPos } from "@milkdown/kit/prose/model";
 import type { Command, Selection } from "@milkdown/kit/prose/state";
 import { NodeSelection, Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
@@ -30,6 +30,7 @@ import {
   matchesKeyboardShortcut,
   matchesKeyboardShortcutEvent,
   normalizeKeyboardShortcuts,
+  parseMarkdownCalloutMarker,
   parseKeyboardShortcut,
   isKeyboardShortcutModKey,
   type KeyboardShortcutAction,
@@ -78,6 +79,299 @@ function selectionIsInsideNodeType(
 
     return false;
   });
+}
+
+function blockquoteHasCalloutMarker(node: ProseNode) {
+  const firstChild = node.firstChild;
+  if (!firstChild?.isTextblock) return false;
+
+  return parseMarkdownCalloutMarker(firstChild.textContent) !== null;
+}
+
+function selectionIsInsideCallout(selection: Selection, blockquote: NodeType) {
+  const positions = [selection.$from, selection.$to];
+
+  return positions.every(($pos) => {
+    for (let depth = $pos.depth; depth > 0; depth -= 1) {
+      const node = $pos.node(depth);
+      if (node.type === blockquote && blockquoteHasCalloutMarker(node)) return true;
+    }
+
+    return false;
+  });
+}
+
+function nodeIsList(node: ProseNode) {
+  return node.type.name === "bullet_list" || node.type.name === "ordered_list";
+}
+
+type ListItemContext = {
+  from: number;
+  item: ProseNode;
+  itemDepth: number;
+  itemIndex: number;
+  parentList: ProseNode;
+  parentListDepth: number;
+  to: number;
+};
+
+function listItemContext(selection: Selection, listItem: NodeType): ListItemContext | null {
+  const fromDepth = ancestorDepthOfNodeType(selection.$from, listItem);
+  const toDepth = ancestorDepthOfNodeType(selection.$to, listItem);
+  if (fromDepth === null || toDepth === null) return null;
+
+  const from = selection.$from.before(fromDepth);
+  const to = selection.$from.after(fromDepth);
+  if (selection.$to.before(toDepth) !== from || selection.$to.after(toDepth) !== to) return null;
+
+  return {
+    from,
+    item: selection.$from.node(fromDepth),
+    itemDepth: fromDepth,
+    itemIndex: selection.$from.index(fromDepth - 1),
+    parentList: selection.$from.node(fromDepth - 1),
+    parentListDepth: fromDepth - 1,
+    to
+  };
+}
+
+function listItemHasChildList(item: ProseNode) {
+  for (let index = 0; index < item.childCount; index += 1) {
+    if (nodeIsList(item.child(index))) return true;
+  }
+
+  return false;
+}
+
+function listItemIsNested(context: ListItemContext, listItem: NodeType, selection: Selection) {
+  return context.parentListDepth > 0 && selection.$from.node(context.parentListDepth - 1).type === listItem;
+}
+
+function liftCreatesChildListFromFollowingSiblings(selection: Selection, listItem: NodeType) {
+  const context = listItemContext(selection, listItem);
+  if (!context) return false;
+  if (!listItemIsNested(context, listItem, selection)) return false;
+  if (listItemHasChildList(context.item)) return false;
+
+  return context.itemIndex < context.parentList.childCount - 1;
+}
+
+function splitCurrentListItemChildLists(view: EditorView, listItem: NodeType) {
+  const { selection } = view.state;
+  const context = listItemContext(selection, listItem);
+  if (!context) return false;
+
+  const retainedChildren: ProseNode[] = [];
+  const promotedItems: ProseNode[] = [];
+  context.item.forEach((child) => {
+    if (nodeIsList(child)) {
+      child.forEach((item) => promotedItems.push(item));
+      return;
+    }
+
+    retainedChildren.push(child);
+  });
+  if (promotedItems.length === 0 || retainedChildren.length === 0) return false;
+
+  const retainedItem = context.item.type.create(
+    context.item.attrs,
+    Fragment.fromArray(retainedChildren),
+    context.item.marks
+  );
+  const replacement = Fragment.fromArray([retainedItem, ...promotedItems]);
+  const transaction = view.state.tr.replaceWith(context.from, context.to, replacement);
+  const selectionPosition = Math.min(selection.from, transaction.doc.content.size);
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function continuationBlockContext(selection: Selection, listItem: NodeType) {
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const context = listItemContext(selection, listItem);
+  if (!context) return null;
+
+  const blockDepth = context.itemDepth + 1;
+  if (selection.$from.depth !== blockDepth || selection.$to.depth !== blockDepth) return null;
+
+  const childIndex = selection.$from.index(context.itemDepth);
+  if (childIndex <= 0) return null;
+
+  const child = context.item.child(childIndex);
+  if (!child.isTextblock) return null;
+  if (selection.$to.index(context.itemDepth) !== childIndex) return null;
+
+  return {
+    ...context,
+    blockFrom: selection.$from.before(blockDepth),
+    childIndex
+  };
+}
+
+function splitCurrentListItemContinuationBlock(view: EditorView, listItem: NodeType) {
+  const context = continuationBlockContext(view.state.selection, listItem);
+  if (!context) return false;
+
+  const retainedChildren: ProseNode[] = [];
+  const activeChildren: ProseNode[] = [];
+  context.item.forEach((child, _offset, index) => {
+    if (index < context.childIndex) {
+      retainedChildren.push(child);
+      return;
+    }
+
+    activeChildren.push(child);
+  });
+  if (retainedChildren.length === 0 || activeChildren.length === 0) return false;
+
+  const retainedItem = context.item.type.create(
+    context.item.attrs,
+    Fragment.fromArray(retainedChildren),
+    context.item.marks
+  );
+  const activeItem = context.item.type.create(
+    context.item.attrs,
+    Fragment.fromArray(activeChildren),
+    context.item.marks
+  );
+  const selectionOffset = view.state.selection.from - context.blockFrom;
+  const activeBlockFrom = context.from + retainedItem.nodeSize + 1;
+  const transaction = view.state.tr.replaceWith(
+    context.from,
+    context.to,
+    Fragment.fromArray([retainedItem, activeItem])
+  );
+  const selectionPosition = Math.min(activeBlockFrom + selectionOffset, transaction.doc.content.size);
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function lineBreakContinuationContext(selection: Selection, listItem: NodeType) {
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const context = listItemContext(selection, listItem);
+  if (!context) return null;
+
+  const blockDepth = context.itemDepth + 1;
+  if (selection.$from.depth !== blockDepth || selection.$to.depth !== blockDepth) return null;
+
+  const childIndex = selection.$from.index(context.itemDepth);
+  const child = context.item.child(childIndex);
+  if (!child.isTextblock) return null;
+
+  let splitOffset: number | null = null;
+  let splitSize = 0;
+  child.forEach((inlineNode, offset) => {
+    const inlineEnd = offset + inlineNode.nodeSize;
+    if (inlineNode.type.name === "hardbreak" && inlineEnd <= selection.$from.parentOffset) {
+      splitOffset = offset;
+      splitSize = inlineNode.nodeSize;
+    }
+  });
+  if (splitOffset === null) return null;
+
+  const beforeContent = child.content.cut(0, splitOffset);
+  const activeContent = child.content.cut(splitOffset + splitSize);
+  if (beforeContent.size === 0 || activeContent.size === 0) return null;
+
+  return {
+    ...context,
+    activeContent,
+    activeOffset: selection.$from.parentOffset - (splitOffset + splitSize),
+    beforeContent,
+    child,
+    childIndex
+  };
+}
+
+function splitCurrentListItemLineBreak(view: EditorView, listItem: NodeType) {
+  const context = lineBreakContinuationContext(view.state.selection, listItem);
+  if (!context) return false;
+
+  const retainedChildren: ProseNode[] = [];
+  const activeChildren: ProseNode[] = [];
+  context.item.forEach((child, _offset, index) => {
+    if (index < context.childIndex) {
+      retainedChildren.push(child);
+      return;
+    }
+
+    if (index === context.childIndex) {
+      retainedChildren.push(context.child.type.create(context.child.attrs, context.beforeContent, context.child.marks));
+      activeChildren.push(context.child.type.create(context.child.attrs, context.activeContent, context.child.marks));
+      return;
+    }
+
+    activeChildren.push(child);
+  });
+  if (retainedChildren.length === 0 || activeChildren.length === 0) return false;
+
+  const retainedItem = context.item.type.create(
+    context.item.attrs,
+    Fragment.fromArray(retainedChildren),
+    context.item.marks
+  );
+  const activeItem = context.item.type.create(
+    context.item.attrs,
+    Fragment.fromArray(activeChildren),
+    context.item.marks
+  );
+  const activeBlockFrom = context.from + retainedItem.nodeSize + 1;
+  const transaction = view.state.tr.replaceWith(
+    context.from,
+    context.to,
+    Fragment.fromArray([retainedItem, activeItem])
+  );
+  const selectionPosition = Math.min(activeBlockFrom + 1 + context.activeOffset, transaction.doc.content.size);
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function liftCalloutListItem(listItem: NodeType, blockquote: NodeType): Command {
+  return (state, dispatch, view) => {
+    const isCalloutListItem = selectionIsInsideCallout(state.selection, blockquote);
+    if (
+      isCalloutListItem &&
+      dispatch &&
+      view &&
+      (splitCurrentListItemLineBreak(view, listItem) || splitCurrentListItemContinuationBlock(view, listItem))
+    ) {
+      const handled = liftCalloutListItem(listItem, blockquote)(view.state, view.dispatch, view);
+      return handled || true;
+    }
+
+    const shouldSplitLiftedChildren =
+      isCalloutListItem &&
+      liftCreatesChildListFromFollowingSiblings(state.selection, listItem);
+
+    if (!shouldSplitLiftedChildren || !dispatch || !view) {
+      return liftListItem(listItem)(state, dispatch, view);
+    }
+
+    const handled = liftListItem(listItem)(state, dispatch, view);
+    if (!handled) return false;
+
+    splitCurrentListItemChildLists(view, listItem);
+    return true;
+  };
 }
 
 function toggleBlockquote(blockquote: ReturnType<typeof blockquoteSchema.type>): Command {
@@ -320,7 +614,10 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
           return true;
         } else if (event.key === "Tab" && !event.metaKey && !event.ctrlKey && !event.altKey) {
           if (selectionIsInsideNodeType(view.state.selection, listItem)) {
-            const handled = runCommand(view, event.shiftKey ? liftListItem(listItem) : sinkListItem(listItem));
+            const handled = runCommand(
+              view,
+              event.shiftKey ? liftCalloutListItem(listItem, blockquote) : sinkListItem(listItem)
+            );
             if (!handled) view.focus();
 
             event.preventDefault();

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -30,7 +30,6 @@ import {
   matchesKeyboardShortcut,
   matchesKeyboardShortcutEvent,
   normalizeKeyboardShortcuts,
-  parseMarkdownCalloutMarker,
   parseKeyboardShortcut,
   isKeyboardShortcutModKey,
   type KeyboardShortcutAction,
@@ -75,26 +74,6 @@ function selectionIsInsideNodeType(
   return positions.every(($pos) => {
     for (let depth = $pos.depth; depth > 0; depth -= 1) {
       if ($pos.node(depth).type === nodeType) return true;
-    }
-
-    return false;
-  });
-}
-
-function blockquoteHasCalloutMarker(node: ProseNode) {
-  const firstChild = node.firstChild;
-  if (!firstChild?.isTextblock) return false;
-
-  return parseMarkdownCalloutMarker(firstChild.textContent) !== null;
-}
-
-function selectionIsInsideCallout(selection: Selection, blockquote: NodeType) {
-  const positions = [selection.$from, selection.$to];
-
-  return positions.every(($pos) => {
-    for (let depth = $pos.depth; depth > 0; depth -= 1) {
-      const node = $pos.node(depth);
-      if (node.type === blockquote && blockquoteHasCalloutMarker(node)) return true;
     }
 
     return false;
@@ -345,22 +324,18 @@ function splitCurrentListItemLineBreak(view: EditorView, listItem: NodeType) {
   return true;
 }
 
-function liftCalloutListItem(listItem: NodeType, blockquote: NodeType): Command {
+function liftCurrentListItem(listItem: NodeType): Command {
   return (state, dispatch, view) => {
-    const isCalloutListItem = selectionIsInsideCallout(state.selection, blockquote);
     if (
-      isCalloutListItem &&
       dispatch &&
       view &&
       (splitCurrentListItemLineBreak(view, listItem) || splitCurrentListItemContinuationBlock(view, listItem))
     ) {
-      const handled = liftCalloutListItem(listItem, blockquote)(view.state, view.dispatch, view);
+      const handled = liftCurrentListItem(listItem)(view.state, view.dispatch, view);
       return handled || true;
     }
 
-    const shouldSplitLiftedChildren =
-      isCalloutListItem &&
-      liftCreatesChildListFromFollowingSiblings(state.selection, listItem);
+    const shouldSplitLiftedChildren = liftCreatesChildListFromFollowingSiblings(state.selection, listItem);
 
     if (!shouldSplitLiftedChildren || !dispatch || !view) {
       return liftListItem(listItem)(state, dispatch, view);
@@ -616,7 +591,7 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
           if (selectionIsInsideNodeType(view.state.selection, listItem)) {
             const handled = runCommand(
               view,
-              event.shiftKey ? liftCalloutListItem(listItem, blockquote) : sinkListItem(listItem)
+              event.shiftKey ? liftCurrentListItem(listItem) : sinkListItem(listItem)
             );
             if (!handled) view.focus();
 


### PR DESCRIPTION
## Summary
- Keep Shift+Tab from moving adjacent nested list items into the lifted item
- Split the active hard-break line or continuation paragraph into its own list item before lifting it
- Apply the scoped lifting behavior to both ordinary lists and callout lists
- Add regression coverage for ordinary list, callout list, and undo/redo cases

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "lifts only the current list item|lifts only the active list continuation line|keeps list continuation Shift\+Tab undoable"`
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "callout.*Shift\+Tab|Shift\+Tab.*callout|nests and lifts callout list items"`
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx`
- `pnpm -r --if-present test`
- `pnpm -r --if-present build`

Refs #224