### PR TITLE
fix(editor): support horizontal rule block dragging

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -516,6 +516,87 @@ function mockTopLevelBlockDragLayout(view: EditorView, container: HTMLElement) {
   );
 }
 
+function mockThinHorizontalRuleBlockDragLayout(view: EditorView, container: HTMLElement) {
+  const blocks = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > *"));
+  const positions = topLevelBlockPositions(view);
+  const blockRects = [
+    {
+      bottom: 128,
+      height: 28,
+      left: 160,
+      right: 640,
+      top: 100,
+      width: 480,
+      x: 160,
+      y: 100,
+      toJSON: () => ({})
+    },
+    {
+      bottom: 141,
+      height: 1,
+      left: 160,
+      right: 640,
+      top: 140,
+      width: 480,
+      x: 160,
+      y: 140,
+      toJSON: () => ({})
+    },
+    {
+      bottom: 188,
+      height: 28,
+      left: 160,
+      right: 640,
+      top: 160,
+      width: 480,
+      x: 160,
+      y: 160,
+      toJSON: () => ({})
+    }
+  ] as DOMRect[];
+  const originalPosAtCoords = view.posAtCoords.bind(view);
+
+  if (blocks.length !== blockRects.length || positions.length !== blockRects.length) {
+    throw new Error("Expected a paragraph, horizontal rule, and paragraph block.");
+  }
+
+  for (const [index, block] of blocks.entries()) {
+    block.getBoundingClientRect = vi.fn(() => blockRects[index]);
+  }
+
+  view.dom.getBoundingClientRect = vi.fn(() => ({
+    bottom: 260,
+    height: 180,
+    left: 160,
+    right: 640,
+    top: 90,
+    width: 480,
+    x: 160,
+    y: 90,
+    toJSON: () => ({})
+  } as DOMRect));
+
+  Object.defineProperty(view, "posAtCoords", {
+    configurable: true,
+    value: ({ left, top }: { left: number; top: number }) => {
+      if (left < 160 || left > 640) return null;
+
+      const index = blockRects.findIndex((rect) => top >= rect.top && top <= rect.bottom);
+      if (index < 0) return null;
+
+      const position = positions[index];
+      return { inside: position, pos: position + 1 };
+    }
+  });
+
+  return () => {
+    Object.defineProperty(view, "posAtCoords", {
+      configurable: true,
+      value: originalPosAtCoords
+    });
+  };
+}
+
 function mockListItemBlockDragLayout(view: EditorView, container: HTMLElement) {
   return mockBlockDragLayout(
     view,
@@ -2497,6 +2578,48 @@ describe("MarkdownPaper editing", () => {
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toBe("Second\n\nFirst\n\nThird\n");
+    restoreLayout();
+  });
+
+  it("reorders a horizontal rule from a nearby gutter hover", async () => {
+    const { container, editor, view } = await renderEditor("First\n\n---\n\nSecond");
+    const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const paper = surface?.closest<HTMLElement>(".markdown-paper");
+    expect(surface?.querySelector("hr")).toBeInTheDocument();
+    expect(paper).toBeInTheDocument();
+
+    fireEvent.pointerMove(paper!, {
+      clientX: 136,
+      clientY: 146
+    });
+
+    const handle = screen.getByRole("button", { name: "Drag block" });
+    expect(handle.closest(".markra-block-toolbar")).toHaveAttribute("data-show", "true");
+
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 136,
+      clientY: 146,
+      pointerId: 9
+    });
+    fireEvent.pointerMove(document, {
+      buttons: 1,
+      clientX: 136,
+      clientY: 180,
+      pointerId: 9
+    });
+    expect(paper!.querySelector(".markra-block-drop-indicator")).toHaveAttribute("data-show", "true");
+    fireEvent.pointerUp(document, {
+      button: 0,
+      clientX: 136,
+      clientY: 180,
+      pointerId: 9
+    });
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe("First\n\nSecond\n\n---\n");
     restoreLayout();
   });
 

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -36,6 +36,16 @@ type MarkdownTreeNode = {
   value?: unknown;
 };
 
+type MarkdownStringifySettings = {
+  rule?: "*" | "-" | "_" | null;
+  ruleRepetition?: number | null;
+  ruleSpaces?: boolean | null;
+};
+
+type RemarkProcessorData = {
+  settings?: MarkdownStringifySettings;
+};
+
 const blankParagraphContainerTypes = new Set(["blockquote", "listItem", "root"]);
 
 const markraBlockImageSchema = imageSchema.extendSchema((previous) => (ctx) => ({
@@ -272,7 +282,23 @@ const markraBlockImageRemarkPlugin = $remark("markraBlockImageRemark", () => () 
   liftImageParagraphs(tree);
 });
 
+function markraMarkdownStyleRemark(this: { data: () => RemarkProcessorData }) {
+  const data = this.data();
+  data.settings = {
+    ...data.settings,
+    rule: "-",
+    ruleRepetition: 3,
+    ruleSpaces: false
+  };
+}
+
+const markraMarkdownStyleRemarkPlugin = $remark<"markraMarkdownStyleRemark", undefined>(
+  "markraMarkdownStyleRemark",
+  () => markraMarkdownStyleRemark
+);
+
 export const markraCommonmark = [
+  markraMarkdownStyleRemarkPlugin,
   markraBlankParagraphRemarkPlugin,
   markraBlockImageRemarkPlugin,
   commonmarkSchema,

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -3084,7 +3084,18 @@
   }
 
   .markdown-paper hr {
-    @apply my-8 border-0 border-t border-(--border-default);
+    @apply my-8 border-0;
+    height: 12px;
+    cursor: pointer;
+    background: linear-gradient(var(--border-default), var(--border-default)) center / 100% 1px no-repeat;
+  }
+
+  .markdown-paper hr:hover {
+    background: linear-gradient(color-mix(in srgb, var(--border-default) 72%, var(--text-secondary)), color-mix(in srgb, var(--border-default) 72%, var(--text-secondary))) center / 100% 2px no-repeat;
+  }
+
+  .markdown-paper hr.ProseMirror-selectednode {
+    outline: none;
   }
 
   .ai-chat-markdown {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -162,6 +162,23 @@ describe("editor stylesheet", () => {
     expect(imageSelectionStyles).not.toContain("outline-none");
   });
 
+  it("gives horizontal rules a forgiving hit target without heavy selected-node feedback", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const ruleStart = styles.indexOf(".markdown-paper hr {");
+    const ruleEnd = styles.indexOf(".ai-chat-markdown", ruleStart);
+    const ruleStyles = styles.slice(ruleStart, ruleEnd);
+
+    expect(ruleStart).toBeGreaterThanOrEqual(0);
+    expect(ruleEnd).toBeGreaterThan(ruleStart);
+    expect(ruleStyles).toContain("height:");
+    expect(ruleStyles).toContain("cursor: pointer");
+    expect(ruleStyles).toContain("background:");
+    expect(ruleStyles).toContain(".markdown-paper hr:hover");
+    expect(ruleStyles).toContain(".markdown-paper hr.ProseMirror-selectednode");
+    expect(ruleStyles).toContain("outline: none");
+    expect(ruleStyles).toContain("100% 2px");
+  });
+
   it("suppresses editor selection chrome while document search is open", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const searchChromeStart = styles.indexOf(".editor-content-slot[data-document-search-open=\"true\"]");

--- a/packages/editor/src/block-drag.ts
+++ b/packages/editor/src/block-drag.ts
@@ -42,7 +42,7 @@ const movableNodeNames = new Set([
   "blockquote",
   "code_block",
   "heading",
-  "horizontal_rule",
+  "hr",
   "image",
   "list_item",
   "paragraph",
@@ -51,6 +51,7 @@ const movableNodeNames = new Set([
 const listNodeNames = new Set(["bullet_list", "ordered_list"]);
 const priorityNodeNames = ["list_item", "blockquote"];
 const tableNodeNames = new Set(["table", "table_cell", "table_header", "table_row"]);
+const thinMovableNodeNames = new Set(["hr"]);
 
 const defaultBlockDragLabels: BlockDragLabels = {
   addBlock: "Add block below",
@@ -70,6 +71,7 @@ const dropIndicatorInset = 2;
 const dropIndicatorMaxWidth = 640;
 const edgeScrollMaxStep = 28;
 const edgeScrollThreshold = 72;
+const thinBlockHitPadding = 12;
 const listNestOffset = 36;
 
 function normalizeBlockDragLabels(labels: Partial<BlockDragLabels> | undefined): BlockDragLabels {
@@ -570,6 +572,43 @@ function dragGhostText(range: BlockDragRange) {
   return `${label.slice(0, dragGhostTextLimit - 3)}...`;
 }
 
+function verticalDistanceFromRect(top: number, rect: DOMRect) {
+  if (top < rect.top) return rect.top - top;
+  if (top > rect.bottom) return top - rect.bottom;
+
+  return 0;
+}
+
+function thinBlockRangeNearPoint(view: EditorView, top: number) {
+  let closestRange: BlockDragRange | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  view.state.doc.forEach((node, offset) => {
+    if (!thinMovableNodeNames.has(node.type.name)) return;
+
+    const dom = targetFromEventTarget(view.nodeDOM(offset));
+    const rect = dom?.getBoundingClientRect();
+    if (!rect) return;
+
+    const distance = verticalDistanceFromRect(top, rect);
+    if (distance > thinBlockHitPadding || distance >= closestDistance) return;
+
+    const range = findMovableBlockAtPosition(view.state, offset);
+    if (!range) return;
+
+    closestRange = range;
+    closestDistance = distance;
+  });
+
+  return closestRange;
+}
+
+function blockToolbarTop(range: BlockDragRange, element: Element, rect: DOMRect) {
+  if (thinMovableNodeNames.has(range.node.type.name)) return rect.top + rect.height / 2;
+
+  return contentBoxFirstLineCenterTop(element, rect);
+}
+
 function scrollContainerFor(viewDom: HTMLElement, ownerDocument: Document) {
   const paperScroll = viewDom.closest<HTMLElement>(".paper-scroll");
   if (paperScroll) return paperScroll;
@@ -923,6 +962,9 @@ class MarkraBlockDragView {
   };
 
   private rangeFromPoint(left: number, top: number) {
+    const thinBlockRange = thinBlockRangeNearPoint(this.view, top);
+    if (thinBlockRange) return thinBlockRange;
+
     let position: ReturnType<EditorView["posAtCoords"]>;
     try {
       position = this.view.posAtCoords({
@@ -1009,7 +1051,7 @@ class MarkraBlockDragView {
 
     const rect = dom.getBoundingClientRect();
     const left = Math.max(8, editorRect.left - blockToolbarGutterOffset);
-    const top = contentBoxFirstLineCenterTop(dom, rect);
+    const top = blockToolbarTop(range, dom, rect);
 
     this.toolbar.style.left = `${Math.round(left)}px`;
     this.toolbar.style.top = `${Math.round(top)}px`;


### PR DESCRIPTION
## Summary
- Add horizontal rules to the block drag flow using the actual Milkdown `hr` node name.
- Add a small vertical tolerance so thin horizontal rules can reveal the block toolbar from nearby gutter hover.
- Keep horizontal rule visuals subtle: invisible hit target, hover feedback, no large selected-node outline.
- Serialize thematic breaks as `---` so moving a rule does not rewrite it to `***`.

## Why
- Fixes the selection and movement issues reported in #232. The previous block whitelist used `horizontal_rule`, but Milkdown renders thematic breaks as `hr`, so rules were skipped by block management.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx src/styles.test.ts -t "horizontal rule|horizontal rules"` passed: 57 files, 1085 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/editor test` passed: 3 tests.
- `git diff --cached --check` passed before commit.

## Risk
- Low. The new coordinate tolerance is scoped to thin movable nodes (`hr`) and leaves the existing block drag path for normal blocks unchanged.

Closes #232