### PR TITLE
fix(app): stabilize untitled markdown saves

### DIFF
--- a/apps/desktop/src/runtime/tauri/file.test.ts
+++ b/apps/desktop/src/runtime/tauri/file.test.ts
@@ -587,6 +587,32 @@ describe("native file access", () => {
     });
   });
 
+  it("starts the native save dialog in the open markdown folder for an untitled document", async () => {
+    mockedSave.mockResolvedValue("/mock-files/vault/Untitled.md");
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await expect(
+      saveNativeMarkdownFile({
+        defaultDirectory: "/mock-files/vault",
+        path: null,
+        suggestedName: "Untitled.md",
+        contents: "# Untitled"
+      })
+    ).resolves.toEqual({
+      path: "/mock-files/vault/Untitled.md",
+      name: "Untitled.md"
+    });
+
+    expect(mockedSave).toHaveBeenCalledWith({
+      defaultPath: "/mock-files/vault/Untitled.md",
+      filters: [{ name: "Markdown", extensions: ["md", "markdown", "txt"] }]
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith("write_markdown_file", {
+      path: "/mock-files/vault/Untitled.md",
+      contents: "# Untitled"
+    });
+  });
+
   it("exports rendered HTML through the native save dialog", async () => {
     mockedSave.mockResolvedValue("/mock-files/draft.html");
     mockedInvoke.mockResolvedValue(undefined);

--- a/apps/desktop/src/runtime/tauri/file.ts
+++ b/apps/desktop/src/runtime/tauri/file.ts
@@ -120,6 +120,7 @@ export type NativeMarkdownDroppedTarget =
     };
 
 export type SaveNativeMarkdownFileInput = {
+  defaultDirectory?: string | null;
   historyCursorId?: string;
   path: string | null;
   skipHistorySnapshot?: boolean;
@@ -350,6 +351,19 @@ function treeRootPathFromPath(path: string) {
 function normalizeNativeParentPath(path: string | null | undefined) {
   const trimmedPath = path?.trim();
   return trimmedPath ? trimmedPath : null;
+}
+
+function nativePathSeparator(path: string) {
+  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+}
+
+function nativeDefaultSavePath(defaultDirectory: string | null | undefined, suggestedName: string) {
+  const directory = defaultDirectory?.trim();
+  const name = suggestedName.trim() || "Untitled.md";
+  if (!directory) return name;
+
+  const separator = nativePathSeparator(directory);
+  return `${directory.replace(/[\\/]+$/u, "")}${separator}${name.replace(/^[\\/]+/u, "")}`;
 }
 
 export async function takeNativeOpenedMarkdownPaths(): Promise<string[]> {
@@ -726,6 +740,7 @@ export async function openNativeMarkdownFolder(labels?: NativeMarkdownPickerLabe
 }
 
 export async function saveNativeMarkdownFile({
+  defaultDirectory,
   historyCursorId,
   path,
   skipHistorySnapshot,
@@ -742,7 +757,7 @@ export async function saveNativeMarkdownFile({
   const targetPath =
     path ??
     (await save({
-      defaultPath: suggestedName,
+      defaultPath: nativeDefaultSavePath(defaultDirectory, suggestedName),
       filters: markdownFilters
     }));
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3844,6 +3844,49 @@ describe("Markra workspace", () => {
     );
   });
 
+  it("starts untitled document saves in the open markdown folder", async () => {
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "note.md", path: `${mockFolderPath}/note.md`, relativePath: "note.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Note\n\nExisting file.",
+      name: "note.md",
+      path: `${mockFolderPath}/note.md`
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValue({
+      name: "Untitled.md",
+      path: `${mockFolderPath}/Untitled.md`
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "note.md" }));
+    expect(await screen.findByText("Note")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "New tab" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
+
+    await waitFor(() =>
+      expect(mockedSaveNativeMarkdownFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultDirectory: mockFolderPath,
+          path: null,
+          suggestedName: "Untitled.md"
+        })
+      )
+    );
+  });
+
   it("opens and saves markdown files through native Tauri file APIs", async () => {
     mockOpenMarkdownFile({
       content: "# Native file\n\nOpened from disk.",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -73,7 +73,9 @@ import {
   clampNumber,
   debug,
   findSearchRanges,
+  isMarkdownPath,
   normalizeSearchIndex,
+  parentPathFromPath,
   t,
   type I18nKey,
   type SearchRange
@@ -210,6 +212,14 @@ function documentTabAsFolderFile(tab: MarkdownTabsBarDocumentItem): NativeMarkdo
     path: tab.path,
     relativePath: tab.path
   };
+}
+
+function defaultSaveDirectoryFromFileTree(sourcePath: string | null) {
+  const trimmedSourcePath = sourcePath?.trim();
+  if (!trimmedSourcePath) return null;
+  if (!isMarkdownPath(trimmedSourcePath)) return trimmedSourcePath;
+
+  return parentPathFromPath(trimmedSourcePath);
 }
 
 function persistSideDocumentGroup(group: StoredWorkspaceSideBySideGroup | null) {
@@ -567,6 +577,10 @@ function WorkspaceApp() {
     workspaceLayoutClassName,
     workspaceLayoutStyle
   } = fileTree;
+  const defaultMarkdownSaveDirectory = useMemo(
+    () => defaultSaveDirectoryFromFileTree(fileTreeSourcePath),
+    [fileTreeSourcePath]
+  );
   const confirmDiscardUnsavedChanges = useCallback((currentDocument: { name: string }) => {
     return confirmNativeUnsavedMarkdownDocumentDiscard(currentDocument.name, {
       cancelLabel: translate("app.cancelDiscardUnsavedMarkdownDocument"),
@@ -691,6 +705,7 @@ function WorkspaceApp() {
   const markdownDocument = useMarkdownDocument({
     beforeNativeAppExit: beforeNativeAppExitBackup,
     confirmDiscardUnsavedChanges,
+    defaultSaveDirectory: defaultMarkdownSaveDirectory,
     documentTabsEnabled: editorPreferences.preferences.showDocumentTabs,
     editorReady: isDocumentEditorReady,
     getCurrentMarkdown: readCurrentMarkdownForDocument,

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1030,6 +1030,36 @@ describe("MarkdownFileTreeDrawer", () => {
     }
   });
 
+  it("starts toolbar create actions inside the selected folder", () => {
+    const createFolder = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/deploy/deploy.md"
+        files={[
+          ...markdownFiles,
+          { name: "notes.md", path: "/vault/docs/notes.md", relativePath: "docs/notes.md" }
+        ]}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onCreateFolder={createFolder}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "docs" }));
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New Folder" }));
+    const newFolderInput = screen.getByRole("textbox", { name: "New folder name" });
+    fireEvent.change(newFolderInput, { target: { value: "Research" } });
+    fireEvent.keyDown(newFolderInput, { key: "Enter" });
+
+    expect(createFolder).toHaveBeenCalledWith("Research", "/vault/docs");
+  });
+
   it("starts root create actions at the tree root when the current file is in the root folder", () => {
     const createFile = vi.fn();
     const createFolder = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -508,6 +508,22 @@ function collectMarkdownFolderPaths(nodes: TreeNode[]) {
   return paths;
 }
 
+function collectMarkdownFolderTargetPaths(nodes: TreeNode[]) {
+  const paths: string[] = [];
+
+  const collect = (treeNodes: TreeNode[]) => {
+    treeNodes.forEach((node) => {
+      if (node.type !== "folder") return;
+
+      if (node.path) paths.push(node.path);
+      collect(node.children);
+    });
+  };
+
+  collect(nodes);
+  return paths;
+}
+
 function outlineItemKey(item: MarkdownOutlineItem, index: number) {
   return `${index}:${item.level}:${item.title}`;
 }
@@ -793,6 +809,7 @@ export function MarkdownFileTreeDrawer({
   const [creatingFile, setCreatingFile] = useState(false);
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [creatingParentPath, setCreatingParentPath] = useState<string | null>(null);
+  const [selectedCreateParentPath, setSelectedCreateParentPath] = useState<string | null>(null);
   const [creatingTemplate, setCreatingTemplate] = useState<MarkdownTemplate | null>(null);
   const [creatingTemplateStartedAt, setCreatingTemplateStartedAt] = useState<Date | null>(null);
   const [newFileName, setNewFileName] = useState("");
@@ -873,6 +890,7 @@ export function MarkdownFileTreeDrawer({
     setFileTreeScrollOffset((current) => current === nextOffset ? current : nextOffset);
   }, []);
   const folderPaths = useMemo(() => collectMarkdownFolderPaths(fullTree), [fullTree]);
+  const folderTargetPaths = useMemo(() => collectMarkdownFolderTargetPaths(fullTree), [fullTree]);
   const availableMarkdownTemplates = useMemo(() => mergeMarkdownTemplates(customTemplates), [customTemplates]);
   const outlineMaxLevel = outlineLevelFilter === "all" ? null : outlineLevelFilter;
   const outlineRenderItems = useMemo(() => buildOutlineRenderItems(outlineItems, outlineMaxLevel), [outlineItems, outlineMaxLevel]);
@@ -913,7 +931,7 @@ export function MarkdownFileTreeDrawer({
 
     return normalizedParentPath;
   }, [rootPath]);
-  const activeCreateParentPath = useMemo(() => {
+  const currentDocumentCreateParentPath = useMemo(() => {
     const normalizedRootPath = rootPath ? normalizeMovedPath(rootPath) : null;
     const currentParentPath = currentPath ? parentPathFromPath(currentPath) : null;
     if (!normalizedRootPath || !currentParentPath) return null;
@@ -925,6 +943,7 @@ export function MarkdownFileTreeDrawer({
 
     return null;
   }, [currentPath, normalizeTreeCreateParentPath, rootPath]);
+  const activeCreateParentPath = selectedCreateParentPath ?? currentDocumentCreateParentPath;
   const recentFolderChoices = recentFolders.slice(0, 5);
   const recentFolderAreaVisible = recentFolderChoices.length > 0 && Boolean(onOpenRecentFolder);
   const tabbedSidebarLayout = sidebarLayoutMode === "tabs";
@@ -950,6 +969,16 @@ export function MarkdownFileTreeDrawer({
       outlineResizeCleanupRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    if (!selectedCreateParentPath) return;
+
+    const normalizedSelectedParentPath = normalizeMovedPath(selectedCreateParentPath);
+    const selectedFolderStillExists = folderTargetPaths.some((folderPath) =>
+      normalizeMovedPath(folderPath) === normalizedSelectedParentPath
+    );
+    if (!selectedFolderStillExists) setSelectedCreateParentPath(null);
+  }, [folderTargetPaths, selectedCreateParentPath]);
 
   useEffect(() => {
     if (filePanelVisible) return;
@@ -1670,7 +1699,10 @@ export function MarkdownFileTreeDrawer({
                 type="button"
                 aria-expanded={expanded}
                 onContextMenu={(event) => openContextMenu(event, folderFile, node.path)}
-                onClick={() => toggleFolder(node.relativePath)}
+                onClick={() => {
+                  setSelectedCreateParentPath(normalizeTreeCreateParentPath(node.path));
+                  toggleFolder(node.relativePath);
+                }}
                 {...dragSource.attributes}
                 {...dragSource.listeners}
               >
@@ -1713,6 +1745,7 @@ export function MarkdownFileTreeDrawer({
             title={node.file.path}
             onContextMenu={(event) => openContextMenu(event, node.file)}
             onClick={() => {
+              setSelectedCreateParentPath(null);
               onOpenFile(node.file);
             }}
             {...dragSource.attributes}

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -1323,6 +1323,41 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
   });
 
+  it("recreates the editor when an untitled document receives a saved path", async () => {
+    let editor: Editor | null = null;
+    const savedContent = "# Scratch\n\nSaved immediately.";
+    const { container, rerender } = render(
+      <MarkdownPaper
+        documentKey="untitled:0"
+        documentPath={null}
+        initialContent=""
+        onEditorReady={(instance) => {
+          editor = instance;
+        }}
+        onMarkdownChange={() => {}}
+        revision={0}
+      />
+    );
+
+    await waitFor(() => expect(editor).not.toBeNull());
+    expect(container.querySelector(".ProseMirror")).not.toHaveTextContent("Saved immediately.");
+
+    rerender(
+      <MarkdownPaper
+        documentKey="untitled:0"
+        documentPath="/mock-files/scratch.md"
+        initialContent={savedContent}
+        onEditorReady={(instance) => {
+          editor = instance;
+        }}
+        onMarkdownChange={() => {}}
+        revision={0}
+      />
+    );
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror")).toHaveTextContent("Saved immediately."));
+  });
+
   it("renders fenced code blocks with syntax highlighting and line numbers", async () => {
     const source = ["```ts", "const answer = 42;", "return answer;", "```"].join("\n");
     const { container, editor, view } = await renderEditor(source);

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -85,7 +85,7 @@ export function MarkdownPaper({
     ...(bottomOverlayInset > 0 ? { paddingBottom: `${bottomOverlayInset}px` } : {})
   } satisfies CSSProperties;
   const topInsetClassName = topInset === "tabs" ? "pt-24 max-[900px]:pt-20" : "pt-14 max-[900px]:pt-10";
-  const editorInstanceKey = `${documentKey ?? documentPath ?? "untitled"}:${revision}`;
+  const editorInstanceKey = `${documentKey ?? "untitled"}:${documentPath ?? "unsaved"}:${revision}`;
 
   return (
     <section

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1677,6 +1677,49 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("keeps an untitled edit visible when save starts before the tab state flushes", async () => {
+    const savedPath = "/mock-files/scratch.md";
+    const savedContent = "# Scratch\n\nSaved immediately.";
+    mockedSaveNativeMarkdownFile.mockResolvedValue({
+      name: "scratch.md",
+      path: savedPath
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => savedContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      result.current.handleMarkdownChange(savedContent);
+      await result.current.saveCurrentDocument();
+    });
+
+    expect(mockedSaveNativeMarkdownFile).toHaveBeenCalledWith({
+      contents: savedContent,
+      path: null,
+      suggestedName: "Untitled.md"
+    });
+    expect(result.current.document).toMatchObject({
+      content: savedContent,
+      dirty: false,
+      name: "scratch.md",
+      path: savedPath
+    });
+    expect(result.current.tabs).toEqual([
+      expect.objectContaining({
+        content: savedContent,
+        dirty: false,
+        name: "scratch.md",
+        path: savedPath
+      })
+    ]);
+  });
+
   it("clears a saved file draft after saving the document", async () => {
     const guidePath = "/mock-files/vault/guide.md";
     mockedReadNativeMarkdownFile.mockResolvedValue({

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -288,6 +288,7 @@ function isDeletedDocumentPath(documentPath: string, deletedPath: string) {
 type UseMarkdownDocumentOptions = {
   beforeNativeAppExit?: () => unknown | Promise<unknown>;
   confirmDiscardUnsavedChanges?: (document: DocumentState) => boolean | Promise<boolean>;
+  defaultSaveDirectory?: string | null;
   documentTabsEnabled?: boolean;
   editorReady?: boolean | (() => boolean);
   getCurrentMarkdown: (fallbackContent: string) => string;
@@ -316,9 +317,17 @@ function resolveEditorReady(editorReady: boolean | (() => boolean)) {
   return typeof editorReady === "function" ? editorReady() : editorReady;
 }
 
+function defaultSaveDirectoryInput(defaultSaveDirectory: string | null | undefined, path: string | null) {
+  if (path !== null) return {};
+
+  const directory = defaultSaveDirectory?.trim();
+  return directory ? { defaultDirectory: directory } : {};
+}
+
 export function useMarkdownDocument({
   beforeNativeAppExit,
   confirmDiscardUnsavedChanges,
+  defaultSaveDirectory,
   documentTabsEnabled = false,
   editorReady = true,
   getCurrentMarkdown,
@@ -1175,7 +1184,12 @@ export function useMarkdownDocument({
     if (documentTabsEnabled && targetTabId && !targetTab) return;
 
     const fallbackTabId = targetTabId ?? activeTabIdRef.current ?? fileTabId(savedFile.path);
-    const targetDocument = targetTab ? documentFromTab(targetTab) : documentRef.current;
+    const targetDocument =
+      targetTabId === activeTabIdRef.current
+        ? documentRef.current
+        : targetTab
+          ? documentFromTab(targetTab)
+          : documentRef.current;
     const sourceContent = options.sourceContent ?? contents;
     const contentChangedAfterSaveStarted =
       targetDocument.content !== sourceContent && targetDocument.content !== contents;
@@ -1219,8 +1233,10 @@ export function useMarkdownDocument({
 
       const targetTabId = activeTabIdRef.current;
       const contents = currentMarkdown();
+      const savePath = saveAs ? null : current.path;
       const savedFile = await saveNativeMarkdownFile({
-        path: saveAs ? null : current.path,
+        ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
+        path: savePath,
         suggestedName: current.name || "Untitled.md",
         contents
       });
@@ -1234,7 +1250,7 @@ export function useMarkdownDocument({
       });
       return savedFile;
     },
-    [applySavedCurrentDocument, currentMarkdown]
+    [applySavedCurrentDocument, currentMarkdown, defaultSaveDirectory]
   );
 
   const saveCurrentDocumentContent = useCallback(
@@ -1258,11 +1274,13 @@ export function useMarkdownDocument({
         suggestedName: current.name || "Untitled.md"
       }]);
 
+      const savePath = current.path;
       let savedFile: Awaited<ReturnType<typeof saveNativeMarkdownFile>>;
       try {
         savedFile = await saveNativeMarkdownFile({
+          ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
           historyCursorId: options.historyCursorId,
-          path: current.path,
+          path: savePath,
           skipHistorySnapshot: options.skipHistorySnapshot,
           suggestedName: current.name || "Untitled.md",
           contents
@@ -1293,7 +1311,7 @@ export function useMarkdownDocument({
       }]);
       return savedFile;
     },
-    [applySavedCurrentDocument]
+    [applySavedCurrentDocument, defaultSaveDirectory]
   );
 
   const saveMarkdownTab = useCallback(
@@ -1304,8 +1322,10 @@ export function useMarkdownDocument({
       if (!tab?.open) return null;
 
       const contents = tab.id === activeTabIdRef.current ? currentMarkdown() : tab.content;
+      const savePath = saveAs ? null : tab.path;
       const savedFile = await saveNativeMarkdownFile({
-        path: saveAs ? null : tab.path,
+        ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
+        path: savePath,
         suggestedName: tab.name || "Untitled.md",
         contents
       });
@@ -1342,7 +1362,14 @@ export function useMarkdownDocument({
       });
       return savedFile;
     },
-    [currentMarkdown, onTreeRootFromFilePath, registerWindowRestoreState, rememberRecentMarkdownFile, syncActiveDocumentFromEditor]
+    [
+      currentMarkdown,
+      defaultSaveDirectory,
+      onTreeRootFromFilePath,
+      registerWindowRestoreState,
+      rememberRecentMarkdownFile,
+      syncActiveDocumentFromEditor
+    ]
   );
 
   const handleSaveClick = useCallback(() => {

--- a/packages/app/src/lib/tauri/file.ts
+++ b/packages/app/src/lib/tauri/file.ts
@@ -67,6 +67,7 @@ export type NativeMarkdownDroppedTarget =
     };
 
 export type SaveNativeMarkdownFileInput = {
+  defaultDirectory?: string | null;
   historyCursorId?: string;
   path: string | null;
   skipHistorySnapshot?: boolean;

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   isRecord,
   joinApiUrl,
   normalizeNullableString,
+  parentPathFromPath,
   pathNameFromPath,
   stableTextKey
 } from ".";
@@ -59,6 +60,11 @@ describe("utilities", () => {
     expect(pathNameFromPath(null)).toBe("No folder");
     expect(folderNameFromDocumentPath("/vault/docs/readme.md")).toBe("docs");
     expect(folderNameFromDocumentPath(null)).toBe("No folder");
+    expect(parentPathFromPath("/vault/docs/readme.md")).toBe("/vault/docs");
+    expect(parentPathFromPath("/readme.md")).toBe("/");
+    expect(parentPathFromPath("C:\\vault\\docs\\readme.md")).toBe("C:\\vault\\docs");
+    expect(parentPathFromPath("C:\\readme.md")).toBe("C:\\");
+    expect(parentPathFromPath("readme.md")).toBeNull();
   });
 
   it("builds stable short text keys", () => {

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -13,6 +13,20 @@ export function folderNameFromDocumentPath(path: string | null) {
   return parts.at(-2) ?? "Files";
 }
 
+export function parentPathFromPath(path: string | null | undefined) {
+  const normalizedPath = path?.trim();
+  if (!normalizedPath) return null;
+
+  const lastSeparatorIndex = Math.max(normalizedPath.lastIndexOf("/"), normalizedPath.lastIndexOf("\\"));
+  if (lastSeparatorIndex < 0) return null;
+  if (lastSeparatorIndex === 0) return normalizedPath.slice(0, 1);
+
+  const prefixWithSeparator = normalizedPath.slice(0, lastSeparatorIndex + 1);
+  if (/^[a-z]:[\\/]$/iu.test(prefixWithSeparator)) return prefixWithSeparator;
+
+  return normalizedPath.slice(0, lastSeparatorIndex);
+}
+
 export function isMarkdownPath(path: string) {
   return /\.(md|markdown|txt)$/i.test(fileNameFromPath(path));
 }


### PR DESCRIPTION
## Summary
- Fix untitled native saves so saved content remains visible after returning from the OS save dialog.
- Recreate the editor when an untitled document receives a saved file path.
- Use the active file tree folder for toolbar create actions and native save dialog defaults.

## Why
Issue #238 reports saved files showing blank in Markra even though the file on disk has content. The related untitled-file flow could also drift away from the folder selected in the file tree when creating folders or opening the OS save panel.

## Validation
- `pnpm --filter @markra/app test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed
- `pnpm --filter @markra/shared test` passed
- `pnpm --filter @markra/desktop exec vitest run src/runtime/tauri/file.test.ts` passed

Closes #238