### PR TITLE
fix(editor): stabilize empty callout list deletion

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8061,12 +8061,6 @@ describe("MarkdownPaper editing", () => {
     expect(fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true })).toBe(false);
 
     expect(selectionHasAncestor(view, "blockquote")).toBe(true);
-    expect(selectionHasAncestor(view, "list_item")).toBe(false);
-
-    focusEditor(view);
-    expect(fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true })).toBe(false);
-
-    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
     expect(selectionHasAncestor(view, "list_item")).toBe(true);
 
     typeText(view, " continued");
@@ -8121,6 +8115,79 @@ describe("MarkdownPaper editing", () => {
     expect(markdown).not.toContain("Nested child");
     expect(markdown).not.toContain("> - Parent two\n>   -");
     await settleMarkdownListener();
+  });
+
+  it("does not recreate an empty nested callout list item on repeated Backspace", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - A item",
+      ">   - B item",
+      ">   - Empty item",
+      ">   - C item"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const emptyFrom = findTextPosition(view, "Empty item");
+
+    selectText(view, emptyFrom, emptyFrom + "Empty item".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    expect(pressBackspace(view)).toBe(true);
+
+    focusEditor(view);
+    fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
+
+    const emptyItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout li")
+    ).filter((item) => item.textContent?.trim().length === 0);
+    expect(emptyItems).toHaveLength(0);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).not.toContain(">   -\n");
+    expect(markdown).not.toContain(">   - \n");
+    expect(markdown).not.toContain("Empty item");
+  });
+
+  it("keeps child items nested when deleting an empty nested callout list parent", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - Previous child",
+      ">   - Empty parent",
+      ">     - Grandchild one",
+      ">     - Grandchild two",
+      ">   - After child"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const emptyFrom = findTextPosition(view, "Empty parent");
+
+    selectText(view, emptyFrom, emptyFrom + "Empty parent".length);
+    view.dispatch(view.state.tr.deleteSelection().scrollIntoView());
+
+    focusEditor(view);
+    expect(pressBackspace(view)).toBe(true);
+
+    const previousChild = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li > ul > li")
+    ).find((item) => item.textContent?.includes("Previous child"));
+    expect(previousChild).toBeDefined();
+
+    const nestedGrandchildren = Array.from(previousChild?.querySelectorAll<HTMLElement>("ul > li") ?? []);
+    expect(nestedGrandchildren).toHaveLength(2);
+    expect(nestedGrandchildren[0]).toHaveTextContent("Grandchild one");
+    expect(nestedGrandchildren[1]).toHaveTextContent("Grandchild two");
+    expect(view.state.selection.$from.parent.textContent).toBe("Previous child");
+    expect(view.state.selection.from).toBe(findTextPosition(view, "Previous child", "Previous child".length));
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+    expect(markdown).toContain(">   - Previous child\n>     - Grandchild one\n>     - Grandchild two");
+    expect(markdown).toContain(">   - After child");
+    expect(markdown).not.toContain("Empty parent");
   });
 
   it("removes the first emptied callout list item instead of leaving an empty bullet", async () => {
@@ -8182,6 +8249,8 @@ describe("MarkdownPaper editing", () => {
 
     expect(nestedItems).toHaveLength(1);
     expect(nestedItems[0]).toHaveTextContent("Second child");
+    expect(view.state.selection.$from.parent.textContent).toBe("Parent");
+    expect(view.state.selection.from).toBe(findTextPosition(view, "Parent", "Parent".length));
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const markdown = serializeMarkdown(view.state.doc);
@@ -8191,7 +8260,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("promotes child list items when deleting an emptied callout list parent", async () => {
+  it("keeps child list items nested when deleting an emptied callout list parent", async () => {
     const source = [
       "> [!NOTE]",
       ">",
@@ -8216,18 +8285,21 @@ describe("MarkdownPaper editing", () => {
       (child): child is HTMLLIElement => child instanceof HTMLLIElement
     );
 
-    expect(topLevelItems).toHaveLength(4);
+    expect(topLevelItems).toHaveLength(2);
     expect(topLevelItems[0]).toHaveTextContent("Keep");
-    expect(topLevelItems[1]).toHaveTextContent("Child one");
-    expect(topLevelItems[2]).toHaveTextContent("Child two");
-    expect(topLevelItems[3]).toHaveTextContent("After");
+    expect(topLevelItems[1]).toHaveTextContent("After");
     expect(topLevelItems.some((item) => item.textContent?.trim().length === 0)).toBe(false);
+
+    const nestedItems = Array.from(topLevelItems[0].querySelectorAll<HTMLElement>("ul > li"));
+    expect(nestedItems).toHaveLength(2);
+    expect(nestedItems[0]).toHaveTextContent("Child one");
+    expect(nestedItems[1]).toHaveTextContent("Child two");
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const markdown = serializeMarkdown(view.state.doc);
-    expect(markdown).toContain("> - Keep\n> - Child one\n> - Child two\n> - After");
+    expect(markdown).toContain("> - Keep\n>   - Child one\n>   - Child two\n> - After");
     expect(markdown).not.toContain("Parent");
-    expect(markdown).not.toContain("> -\n>   - Child one");
+    expect(markdown).not.toContain("> - Child one");
     await settleMarkdownListener();
   });
 
@@ -8251,7 +8323,7 @@ describe("MarkdownPaper editing", () => {
     focusEditor(view);
     fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true });
 
-    expect(serializeMarkdown(view.state.doc)).toContain("> - Keep\n> - Child one\n> - Child two\n> - After");
+    expect(serializeMarkdown(view.state.doc)).toContain("> - Keep\n>   - Child one\n>   - Child two\n> - After");
 
     expect(pressShortcut(view, "z", { metaKey: true })).toBe(true);
 
@@ -8264,8 +8336,8 @@ describe("MarkdownPaper editing", () => {
     expect(pressShortcut(view, "z", { metaKey: true, shiftKey: true })).toBe(true);
 
     const redoMarkdown = serializeMarkdown(view.state.doc);
-    expect(redoMarkdown).toContain("> - Keep\n> - Child one\n> - Child two\n> - After");
-    expect(redoMarkdown).not.toContain("> -\n>   - Child one");
+    expect(redoMarkdown).toContain("> - Keep\n>   - Child one\n>   - Child two\n> - After");
+    expect(redoMarkdown).not.toContain("> - Child one");
     await settleMarkdownListener();
   });
 

--- a/packages/editor/src/callout.ts
+++ b/packages/editor/src/callout.ts
@@ -293,6 +293,7 @@ function firstTextBlockStartPosition(node: ProseNode, nodeFrom: number) {
   let position: number | null = null;
 
   node.descendants((child, offset) => {
+    if (position !== null) return false;
     if (!child.isTextblock) return true;
 
     position = nodeFrom + offset + 2;
@@ -306,6 +307,7 @@ function firstTextBlockEndPosition(node: ProseNode, nodeFrom: number) {
   let position: number | null = null;
 
   node.descendants((child, offset) => {
+    if (position !== null) return false;
     if (!child.isTextblock) return true;
 
     position = nodeFrom + offset + 2 + child.content.size;
@@ -340,11 +342,63 @@ function childListItems(listItem: ProseNode) {
   return items;
 }
 
-function promoteEmptyListItemChildren(view: EditorView) {
-  const context = emptyListItemContext(view.state);
-  if (!context) return false;
-  if (!listItemHasOnlyEmptyTextBlocksAndLists(context.listItem)) return false;
+function childLists(listItem: ProseNode) {
+  const lists: ProseNode[] = [];
 
+  listItem.forEach((child) => {
+    if (isListNode(child)) lists.push(child);
+  });
+
+  return lists;
+}
+
+function appendChildListsToListItem(listItem: ProseNode, lists: ProseNode[]) {
+  const children: ProseNode[] = [];
+  listItem.forEach((child) => children.push(child));
+
+  for (const list of lists) {
+    const lastChild = children.at(-1);
+    if (lastChild && isListNode(lastChild) && lastChild.type === list.type) {
+      children[children.length - 1] = lastChild.type.create(
+        lastChild.attrs,
+        lastChild.content.append(list.content),
+        lastChild.marks
+      );
+      continue;
+    }
+
+    children.push(list);
+  }
+
+  return listItem.type.create(listItem.attrs, Fragment.fromArray(children), listItem.marks);
+}
+
+function moveEmptyListItemChildrenToPreviousSibling(view: EditorView, context: EmptyListItemContext) {
+  if (context.itemIndex <= 0) return false;
+
+  const lists = childLists(context.listItem);
+  if (lists.length === 0) return false;
+
+  const previousItem = context.parentList.child(context.itemIndex - 1);
+  const previousItemFrom = context.from - previousItem.nodeSize;
+  const updatedPreviousItem = appendChildListsToListItem(previousItem, lists);
+  const transaction = closeHistory(view.state.tr.replaceWith(previousItemFrom, context.to, updatedPreviousItem));
+  const selectionPosition = Math.min(
+    firstTextBlockEndPosition(updatedPreviousItem, previousItemFrom) ?? previousItemFrom + 1,
+    transaction.doc.content.size
+  );
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, selectionPosition))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
+function promoteEmptyListItemChildren(view: EditorView, context: EmptyListItemContext) {
   const promotedItems = childListItems(context.listItem);
   if (promotedItems.length === 0) return false;
 
@@ -361,23 +415,72 @@ function promoteEmptyListItemChildren(view: EditorView) {
   return true;
 }
 
-function removeFirstEmptyLeafListItem(view: EditorView) {
+function removeEmptyListItemWithChildren(view: EditorView, key: KeyboardEvent["key"]) {
+  const context = emptyListItemContext(view.state);
+  if (!context) return false;
+  if (!listItemHasOnlyEmptyTextBlocksAndLists(context.listItem)) return false;
+
+  return (
+    (key === "Backspace" && moveEmptyListItemChildrenToPreviousSibling(view, context)) ||
+    promoteEmptyListItemChildren(view, context)
+  );
+}
+
+function parentListItemEndPosition(context: EmptyListItemContext) {
+  const parentListItemDepth = context.parentListDepth - 1;
+  if (parentListItemDepth <= 0) return null;
+
+  const parentListItem = context.$from.node(parentListItemDepth);
+  if (parentListItem.type.name !== "list_item") return null;
+
+  const parentListItemFrom = context.$from.before(parentListItemDepth);
+  return firstTextBlockEndPosition(parentListItem, parentListItemFrom) ?? parentListItemFrom + 1;
+}
+
+function removeEmptyLeafListItem(view: EditorView, key: KeyboardEvent["key"]) {
   const context = emptyListItemContext(view.state);
   if (!context) return false;
   if (context.listItem.childCount !== 1) return false;
-  if (context.itemIndex !== 0 || context.parentList.childCount <= 1) return false;
+  if (context.parentList.childCount <= 1) return false;
 
-  const nextItem = context.parentList.child(context.itemIndex + 1);
-  const nextItemPosition = firstTextBlockStartPosition(nextItem, context.to) ?? context.to + 1;
+  if (key === "Backspace" && context.itemIndex === 0) {
+    const parentSelectionPosition = parentListItemEndPosition(context);
+    if (parentSelectionPosition !== null) {
+      const transaction = closeHistory(view.state.tr.delete(context.from, context.to));
+      const mappedSelectionPosition = Math.min(
+        Math.max(transaction.mapping.map(parentSelectionPosition, -1), 1),
+        transaction.doc.content.size
+      );
+
+      view.dispatch(
+        transaction
+          .setSelection(TextSelection.create(transaction.doc, mappedSelectionPosition))
+          .scrollIntoView()
+      );
+      view.focus();
+
+      return true;
+    }
+  }
+
+  const preferPrevious = key === "Backspace" && context.itemIndex > 0;
+  const siblingIndex = preferPrevious ? context.itemIndex - 1 : context.itemIndex + 1;
+  if (siblingIndex < 0 || siblingIndex >= context.parentList.childCount) return false;
+
+  const sibling = context.parentList.child(siblingIndex);
+  const siblingFrom = preferPrevious ? context.from - sibling.nodeSize : context.to;
+  const selectionPosition = preferPrevious
+    ? firstTextBlockEndPosition(sibling, siblingFrom) ?? context.from - 1
+    : firstTextBlockStartPosition(sibling, siblingFrom) ?? context.to + 1;
   const transaction = closeHistory(view.state.tr.delete(context.from, context.to));
   const mappedSelectionPosition = Math.min(
-    Math.max(transaction.mapping.map(nextItemPosition, -1), 1),
+    Math.max(transaction.mapping.map(selectionPosition, preferPrevious ? -1 : 1), 1),
     transaction.doc.content.size
   );
 
   view.dispatch(
     transaction
-      .setSelection(TextSelection.near(transaction.doc.resolve(mappedSelectionPosition), 1))
+      .setSelection(TextSelection.near(transaction.doc.resolve(mappedSelectionPosition), preferPrevious ? -1 : 1))
       .scrollIntoView()
   );
   view.focus();
@@ -426,10 +529,10 @@ function removeEmptyNestedCalloutListItem(view: EditorView) {
   return true;
 }
 
-function removeEmptyCalloutListItem(view: EditorView) {
+function removeEmptyCalloutListItem(view: EditorView, key: KeyboardEvent["key"]) {
   return (
-    promoteEmptyListItemChildren(view) ||
-    removeFirstEmptyLeafListItem(view) ||
+    removeEmptyListItemWithChildren(view, key) ||
+    removeEmptyLeafListItem(view, key) ||
     removeEmptyNestedCalloutListItem(view)
   );
 }
@@ -994,7 +1097,7 @@ export const markraCalloutPlugin = $prose((ctx) => {
         const callout = findCalloutAtSelection(view);
         if (!callout) return false;
         if (selectionIsInsideNodeName(view.state, "list_item")) {
-          const handled = removeEmptyCalloutListItem(view);
+          const handled = removeEmptyCalloutListItem(view, event.key);
           if (!handled) return false;
 
           event.preventDefault();


### PR DESCRIPTION
## Summary
- Handle empty callout list item deletion before ProseMirror splits the surrounding nested list
- Keep the cursor on the expected adjacent text after deleting empty callout list items
- Preserve child list nesting when deleting an emptied parent list item, and keep the cursor on the receiving sibling text instead of the moved child list
- Move the cursor back to the parent list item when Backspace deletes the first empty item in a nested list level
- Add regression coverage for repeated Backspace, first nested item deletion, nested parent deletion, undo/redo, and child-depth preservation

## Why
Issue #224 reported that in 0.9.4 deleting an empty nested list item inside a callout could make the item disappear, then reappear on the next Backspace. The first Backspace left a split nested-list structure with an empty paragraph between siblings, and the next Backspace joined it back into an empty list item.

Follow-up testing also showed several related list-edge cases: deleting an emptied parent item could promote its child list to the wrong level, the cursor could land at the end of the moved deepest child item, and deleting the first item of a nested level could move the cursor to the next child item instead of back to the parent line. This PR now handles those callout list cleanup cases explicitly.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "removes the first emptied nested callout list item"` passed
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "keeps child items nested when deleting an empty nested callout list parent"` passed
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "callout.*Backspace|empty.*callout list|emptied.*callout list|empty nested callout list|deleting an emptied list item|recreate an empty nested|child list items|keeps child items nested|first nested callout|first emptied nested callout"` passed
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 329 tests
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm -r --if-present test` passed
- `pnpm -r --if-present build` passed

Refs #224
