### PR TITLE
feat(app): support md5 image naming token

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,6 +43,7 @@
     "@markra/ui": "workspace:*",
     "@milkdown/kit": "^7.20.0",
     "@milkdown/react": "^7.20.0",
+    "@noble/hashes": "^2.2.0",
     "@tanstack/react-virtual": "3.14.2",
     "codemirror": "6.0.2",
     "katex": "0.16.45",

--- a/packages/app/src/lib/image-upload.test.ts
+++ b/packages/app/src/lib/image-upload.test.ts
@@ -2,27 +2,35 @@ import { defaultEditorPreferences } from "./settings/app-settings";
 import { createImageUploadFileName, saveEditorImage } from "./image-upload";
 
 describe("save editor image", () => {
-  it("creates safe image file names from the configured pattern", () => {
+  it("creates safe image file names from the configured pattern", async () => {
     const image = new File([new Uint8Array([1, 2, 3])], "My Diagram!.png", { type: "image/png" });
 
-    expect(createImageUploadFileName(image, "{name}-{timestamp}-{random}", {
+    expect(await createImageUploadFileName(image, "{name}-{timestamp}-{random}", {
       random: () => "abc123",
       timestamp: () => "1700000000000"
     })).toBe("My-Diagram-1700000000000-abc123.png");
   });
 
-  it("keeps dots that are part of the configured file naming pattern", () => {
+  it("uses the image content md5 in configured file naming patterns", async () => {
+    const image = new File([new Uint8Array([1, 2, 3])], "Diagram.png", { type: "image/png" });
+
+    expect(await createImageUploadFileName(image, "{name}-{md5}", {
+      timestamp: () => "1700000000000"
+    })).toBe("Diagram-5289df737df57326fcdd22597afb1fac.png");
+  });
+
+  it("keeps dots that are part of the configured file naming pattern", async () => {
     const image = new File([new Uint8Array([1, 2, 3])], "My Diagram.png", { type: "image/png" });
 
-    expect(createImageUploadFileName(image, "{name}.{timestamp}", {
+    expect(await createImageUploadFileName(image, "{name}.{timestamp}", {
       timestamp: () => "1700000000000"
     })).toBe("My-Diagram.1700000000000.png");
   });
 
-  it("keeps SVG image extensions when creating upload file names", () => {
+  it("keeps SVG image extensions when creating upload file names", async () => {
     const image = new File([new Uint8Array([1, 2, 3])], "Logo.svg", { type: "image/svg+xml" });
 
-    expect(createImageUploadFileName(image, "{name}-{timestamp}", {
+    expect(await createImageUploadFileName(image, "{name}-{timestamp}", {
       timestamp: () => "1700000000000"
     })).toBe("Logo-1700000000000.svg");
   });
@@ -128,6 +136,7 @@ describe("save editor image", () => {
           ...defaultEditorPreferences,
           imageUpload: {
             ...defaultEditorPreferences.imageUpload,
+            fileNamePattern: "{name}-{md5}",
             provider: "picgo",
             picgo
           }
@@ -146,7 +155,7 @@ describe("save editor image", () => {
     });
 
     expect(uploadPicGoImage).toHaveBeenCalledWith({
-      fileName: expect.stringMatching(/^pasted-image-\d+\.png$/u),
+      fileName: "Diagram-5289df737df57326fcdd22597afb1fac.png",
       image,
       settings: picgo
     });

--- a/packages/app/src/lib/image-upload.ts
+++ b/packages/app/src/lib/image-upload.ts
@@ -1,3 +1,6 @@
+import { md5 } from "@noble/hashes/legacy.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+
 import type {
   EditorPreferences,
   PicGoImageUploadSettings,
@@ -65,7 +68,7 @@ const imageMimeExtensions: Record<string, string> = {
   "image/webp": "webp"
 };
 
-export function createImageUploadFileName(
+export async function createImageUploadFileName(
   image: File,
   pattern: string,
   options: ImageUploadFileNameOptions = {}
@@ -74,10 +77,12 @@ export function createImageUploadFileName(
   const name = sanitizeFileNamePart(image.name.replace(/\.[^.]*$/u, "")) || "image";
   const timestamp = options.timestamp?.() ?? String(Date.now());
   const random = options.random?.() ?? defaultRandomToken();
+  const md5 = pattern.includes("{md5}") ? await fileMd5Hex(image) : "";
   const renderedPattern = (pattern.trim() || "pasted-image-{timestamp}")
     .replace(/\{name\}/gu, name)
     .replace(/\{timestamp\}/gu, timestamp)
-    .replace(/\{random\}/gu, random);
+    .replace(/\{random\}/gu, random)
+    .replace(/\{md5\}/gu, md5);
   const baseName = sanitizeFileNamePart(stripKnownImageExtension(renderedPattern)) || `pasted-image-${timestamp}`;
 
   return `${baseName}.${extension}`;
@@ -111,7 +116,6 @@ export async function saveEditorImage({
   uploadS3Image = uploadNativeS3Image,
   uploadWebDavImage = uploadNativeWebDavImage
 }: SaveEditorImageInput): Promise<SaveEditorImageResult> {
-  const fileName = createImageUploadFileName(image, preferences.imageUpload.fileNamePattern);
   const provider = preferences.imageUpload.provider === "s3" && !s3ImageUploadEnabled
     ? "local"
     : preferences.imageUpload.provider;
@@ -126,7 +130,11 @@ export async function saveEditorImage({
     }
 
     return {
-      image: await uploadPicGoImage({ fileName, image, settings }),
+      image: await uploadPicGoImage({
+        fileName: await createImageUploadFileName(image, preferences.imageUpload.fileNamePattern),
+        image,
+        settings
+      }),
       refreshTree: false,
       status: "saved"
     };
@@ -142,7 +150,11 @@ export async function saveEditorImage({
     }
 
     return {
-      image: await uploadS3Image({ fileName, image, settings }),
+      image: await uploadS3Image({
+        fileName: await createImageUploadFileName(image, preferences.imageUpload.fileNamePattern),
+        image,
+        settings
+      }),
       refreshTree: false,
       status: "saved"
     };
@@ -158,7 +170,11 @@ export async function saveEditorImage({
     }
 
     return {
-      image: await uploadWebDavImage({ fileName, image, settings }),
+      image: await uploadWebDavImage({
+        fileName: await createImageUploadFileName(image, preferences.imageUpload.fileNamePattern),
+        image,
+        settings
+      }),
       refreshTree: false,
       status: "saved"
     };
@@ -174,7 +190,7 @@ export async function saveEditorImage({
   return {
     image: await saveLocalImage({
       documentPath,
-      fileName,
+      fileName: await createImageUploadFileName(image, preferences.imageUpload.fileNamePattern),
       folder: preferences.clipboardImageFolder,
       image
     }),
@@ -209,6 +225,10 @@ function sanitizeFileNamePart(value: string) {
 
 function stripKnownImageExtension(value: string) {
   return value.replace(/\.(?:avif|bmp|gif|jpe?g|png|webp)$/iu, "");
+}
+
+async function fileMd5Hex(file: File) {
+  return bytesToHex(md5(new Uint8Array(await file.arrayBuffer())));
 }
 
 function defaultRandomToken() {

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "PicGo/PicList-Einstellungen anzeigen",
   "settings.editor.imageUploadProvider.showS3Settings": "S3-kompatible Einstellungen anzeigen",
   "settings.editor.imageUploadFileNamePattern": "Dateibenennungsregel",
-  "settings.editor.imageUploadFileNamePatternDescription": "Unterstützt {name}, {timestamp} und {random}. Keine Pfadtrenner verwenden.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Unterstützt {name}, {timestamp}, {random} und {md5}. Keine Pfadtrenner verwenden.",
   "settings.editor.webDavServerUrl": "WebDAV-Server-URL",
   "settings.editor.webDavServerUrlDescription": "Basis-URL des WebDAV-Ordners, der Bild-Uploads annimmt.",
   "settings.editor.webDavUsername": "WebDAV-Benutzername",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -102,7 +102,7 @@ const messages: BaseLocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "Show PicGo/PicList settings",
   "settings.editor.imageUploadProvider.showS3Settings": "Show S3-compatible settings",
   "settings.editor.imageUploadFileNamePattern": "File naming pattern",
-  "settings.editor.imageUploadFileNamePatternDescription": "Tokens: {name}, {timestamp}, {random}. The image extension is added automatically.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Tokens: {name}, {timestamp}, {random}, {md5}. The image extension is added automatically.",
   "settings.editor.clipboardImageFolder": "Clipboard image folder",
   "settings.editor.clipboardImageFolderDescription": "Save pasted images in this folder beside the current Markdown file.",
   "settings.editor.webDavServerUrl": "WebDAV server URL",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "Mostrar configuración de PicGo/PicList",
   "settings.editor.imageUploadProvider.showS3Settings": "Mostrar configuración compatible con S3",
   "settings.editor.imageUploadFileNamePattern": "Regla de nombres de archivo",
-  "settings.editor.imageUploadFileNamePatternDescription": "Admite {name}, {timestamp} y {random}. No incluyas separadores de ruta.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Admite {name}, {timestamp}, {random} y {md5}. No incluyas separadores de ruta.",
   "settings.editor.webDavServerUrl": "URL del servidor WebDAV",
   "settings.editor.webDavServerUrlDescription": "URL base de la carpeta WebDAV que recibe las imágenes.",
   "settings.editor.webDavUsername": "Usuario WebDAV",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "Afficher les réglages PicGo/PicList",
   "settings.editor.imageUploadProvider.showS3Settings": "Afficher les réglages compatibles S3",
   "settings.editor.imageUploadFileNamePattern": "Règle de nommage des fichiers",
-  "settings.editor.imageUploadFileNamePatternDescription": "Prend en charge {name}, {timestamp} et {random}. N’incluez pas de séparateurs de chemin.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Prend en charge {name}, {timestamp}, {random} et {md5}. N’incluez pas de séparateurs de chemin.",
   "settings.editor.webDavServerUrl": "URL du serveur WebDAV",
   "settings.editor.webDavServerUrlDescription": "URL de base du dossier WebDAV recevant les images.",
   "settings.editor.webDavUsername": "Nom d’utilisateur WebDAV",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "Mostra impostazioni PicGo/PicList",
   "settings.editor.imageUploadProvider.showS3Settings": "Mostra impostazioni compatibili S3",
   "settings.editor.imageUploadFileNamePattern": "Regola nome file",
-  "settings.editor.imageUploadFileNamePatternDescription": "Supporta {name}, {timestamp} e {random}. Non includere separatori di percorso.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Supporta {name}, {timestamp}, {random} e {md5}. Non includere separatori di percorso.",
   "settings.editor.webDavServerUrl": "URL server WebDAV",
   "settings.editor.webDavServerUrlDescription": "URL base della cartella WebDAV che riceve le immagini.",
   "settings.editor.webDavUsername": "Nome utente WebDAV",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "PicGo/PicList 設定を表示",
   "settings.editor.imageUploadProvider.showS3Settings": "S3 互換設定を表示",
   "settings.editor.imageUploadFileNamePattern": "ファイル命名規則",
-  "settings.editor.imageUploadFileNamePatternDescription": "{name}、{timestamp}、{random} を使用できます。パス区切り文字は含めないでください。",
+  "settings.editor.imageUploadFileNamePatternDescription": "{name}、{timestamp}、{random}、{md5} を使用できます。パス区切り文字は含めないでください。",
   "settings.editor.webDavServerUrl": "WebDAV サーバー URL",
   "settings.editor.webDavServerUrlDescription": "画像アップロードを受け取る WebDAV フォルダーのベース URL です。",
   "settings.editor.webDavUsername": "WebDAV ユーザー名",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "PicGo/PicList 설정 보기",
   "settings.editor.imageUploadProvider.showS3Settings": "S3 호환 설정 보기",
   "settings.editor.imageUploadFileNamePattern": "파일 이름 규칙",
-  "settings.editor.imageUploadFileNamePatternDescription": "{name}, {timestamp}, {random}을 지원합니다. 경로 구분자는 포함하지 마세요.",
+  "settings.editor.imageUploadFileNamePatternDescription": "{name}, {timestamp}, {random}, {md5}을 지원합니다. 경로 구분자는 포함하지 마세요.",
   "settings.editor.webDavServerUrl": "WebDAV 서버 URL",
   "settings.editor.webDavServerUrlDescription": "이미지 업로드를 받을 WebDAV 폴더의 기본 URL입니다.",
   "settings.editor.webDavUsername": "WebDAV 사용자 이름",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "Mostrar configurações PicGo/PicList",
   "settings.editor.imageUploadProvider.showS3Settings": "Mostrar configurações compatíveis com S3",
   "settings.editor.imageUploadFileNamePattern": "Regra de nome de arquivo",
-  "settings.editor.imageUploadFileNamePatternDescription": "Aceita {name}, {timestamp} e {random}. Não inclua separadores de caminho.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Aceita {name}, {timestamp}, {random} e {md5}. Não inclua separadores de caminho.",
   "settings.editor.webDavServerUrl": "URL do servidor WebDAV",
   "settings.editor.webDavServerUrlDescription": "URL base da pasta WebDAV que recebe imagens.",
   "settings.editor.webDavUsername": "Usuário WebDAV",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "Показать настройки PicGo/PicList",
   "settings.editor.imageUploadProvider.showS3Settings": "Показать S3-совместимые настройки",
   "settings.editor.imageUploadFileNamePattern": "Правило именования файлов",
-  "settings.editor.imageUploadFileNamePatternDescription": "Поддерживает {name}, {timestamp} и {random}. Не используйте разделители путей.",
+  "settings.editor.imageUploadFileNamePatternDescription": "Поддерживает {name}, {timestamp}, {random} и {md5}. Не используйте разделители путей.",
   "settings.editor.webDavServerUrl": "URL сервера WebDAV",
   "settings.editor.webDavServerUrlDescription": "Базовый URL папки WebDAV, принимающей изображения.",
   "settings.editor.webDavUsername": "Имя пользователя WebDAV",

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -102,7 +102,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "显示 PicGo/PicList 配置",
   "settings.editor.imageUploadProvider.showS3Settings": "显示 S3 兼容配置",
   "settings.editor.imageUploadFileNamePattern": "文件命名规则",
-  "settings.editor.imageUploadFileNamePatternDescription": "支持 {name}、{timestamp}、{random}，图片扩展名会自动追加。",
+  "settings.editor.imageUploadFileNamePatternDescription": "支持 {name}、{timestamp}、{random}、{md5}，图片扩展名会自动追加。",
   "settings.editor.clipboardImageFolder": "剪贴板图片文件夹",
   "settings.editor.clipboardImageFolderDescription": "粘贴图片时保存到当前 Markdown 文件旁边的这个文件夹。",
   "settings.editor.webDavServerUrl": "WebDAV 服务器 URL",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -442,7 +442,7 @@ const messages: LocaleMessages = {
   "settings.editor.imageUploadProvider.showPicGoSettings": "顯示 PicGo/PicList 設定",
   "settings.editor.imageUploadProvider.showS3Settings": "顯示 S3 相容設定",
   "settings.editor.imageUploadFileNamePattern": "檔案命名規則",
-  "settings.editor.imageUploadFileNamePatternDescription": "支援 {name}、{timestamp}、{random}。請勿包含路徑分隔符。",
+  "settings.editor.imageUploadFileNamePatternDescription": "支援 {name}、{timestamp}、{random}、{md5}。請勿包含路徑分隔符。",
   "settings.editor.webDavServerUrl": "WebDAV 伺服器 URL",
   "settings.editor.webDavServerUrlDescription": "接收圖片上傳的 WebDAV 資料夾基礎 URL。",
   "settings.editor.webDavUsername": "WebDAV 使用者名稱",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 6.0.1(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -86,7 +86,7 @@ importers:
         version: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -126,7 +126,7 @@ importers:
         version: 6.0.1(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -138,7 +138,7 @@ importers:
         version: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/ai:
     dependencies:
@@ -205,13 +205,13 @@ importers:
         version: 5.0.6
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/app:
     dependencies:
@@ -263,6 +263,9 @@ importers:
       '@milkdown/react':
         specifier: ^7.20.0
         version: 7.20.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@tanstack/react-virtual':
         specifier: 3.14.2
         version: 3.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -320,7 +323,7 @@ importers:
         version: 6.0.1(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -332,7 +335,7 @@ importers:
         version: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/editor:
     dependencies:
@@ -372,7 +375,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/markdown:
     dependencies:
@@ -388,13 +391,13 @@ importers:
         version: 24.10.0
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/providers:
     dependencies:
@@ -410,7 +413,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/scripts:
     dependencies:
@@ -422,7 +425,7 @@ importers:
         version: 6.0.1(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -431,7 +434,7 @@ importers:
         version: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 24.10.0
@@ -447,13 +450,13 @@ importers:
         version: 24.10.0
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
   packages/ui:
     devDependencies:
@@ -474,7 +477,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -486,7 +489,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
 
 packages:
 
@@ -1105,6 +1108,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -3874,7 +3881,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4317,6 +4326,8 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodable/entities@2.1.0': {}
 
@@ -5215,10 +5226,10 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -5381,9 +5392,9 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -5438,17 +5449,17 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@29.1.1:
+  jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
       parse5: 8.0.1
@@ -5459,7 +5470,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -6508,7 +6519,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.9.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
@@ -6533,7 +6544,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.10.0
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -6559,9 +6570,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Add `{md5}` support to the editor image upload file naming pattern.
- Compute the token from image content with `@noble/hashes` so it works in the frontend runtime.
- Update settings helper text across locales and cover the PicGo upload path with tests.

## Why
- PicGo/PicList users requested `{md5}` naming support for uploaded images.

## Validation
- `pnpm --filter @markra/app test -- src/lib/image-upload.test.ts` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/shared build` passed

## Risk
- Low. Existing naming tokens are preserved; `{md5}` only adds async content hashing when the token is present.

Closes #236