### PR TITLE
feat(editor): add code block line wrapping setting

### DIFF
--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -146,6 +146,7 @@ describe("Markra AI workspace", () => {
       splitVisualPanePercent: 50,
       showWordCount: true,
       suggestAiPanelForComplexInlinePrompts: true,
+      wrapCodeBlocks: true,
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
@@ -226,6 +227,7 @@ describe("Markra AI workspace", () => {
       splitVisualPanePercent: 50,
       showWordCount: true,
       suggestAiPanelForComplexInlinePrompts: false,
+      wrapCodeBlocks: true,
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -160,7 +160,8 @@ function createStoredEditorPreferences(
       { id: "theme", visible: true }
     ],
     showWordCount: true,
-    ...overrides
+    ...overrides,
+    wrapCodeBlocks: overrides.wrapCodeBlocks ?? true
   };
 }
 
@@ -473,7 +474,8 @@ describe("Markra workspace", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
     renderApp();
 
@@ -519,7 +521,8 @@ describe("Markra workspace", () => {
           { id: "aiAgent", visible: true },
           { id: "theme", visible: true }
         ],
-        showWordCount: true
+        showWordCount: true,
+        wrapCodeBlocks: true
       })
     );
     await waitFor(() =>
@@ -553,7 +556,8 @@ describe("Markra workspace", () => {
           { id: "aiAgent", visible: true },
           { id: "theme", visible: true }
         ],
-        showWordCount: true
+        showWordCount: true,
+        wrapCodeBlocks: true
       })
     );
   });
@@ -1103,7 +1107,8 @@ describe("Markra workspace", () => {
         { id: "save" as const, visible: true },
         { id: "theme" as const, visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     };
     mockedGetStoredEditorPreferences.mockResolvedValue(initialPreferences);
     window.history.pushState({}, "", "/?settings=1");
@@ -1214,7 +1219,8 @@ describe("Markra workspace", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
     window.history.pushState({}, "", "/?settings=1");
 
@@ -3266,7 +3272,8 @@ describe("Markra workspace", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
     mockedOpenNativeMarkdownPath.mockResolvedValue({
       kind: "folder",
@@ -3400,7 +3407,8 @@ describe("Markra workspace", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
     mockOpenMarkdownFile({
       content: "Original synthetic text",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3605,6 +3605,7 @@ function WorkspaceApp() {
                             scrollRef={visualScrollRef}
                             topInset="titlebar"
                             workspaceFiles={fileTreeFiles}
+                            wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
                           />
                         )}
                       </div>
@@ -3706,6 +3707,7 @@ function WorkspaceApp() {
                         scrollRef={visualScrollRef}
                         topInset="titlebar"
                         workspaceFiles={fileTreeFiles}
+                        wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
                       />
                     )
                   )}
@@ -3758,6 +3760,7 @@ function WorkspaceApp() {
                         onContentWidthChange={handleEditorContentWidthChange}
                         onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                         onFocus={handleSideDocumentPaneFocus}
+                        wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
                       />
                     </>
                   ) : null}

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -64,6 +64,7 @@ async function renderEditor(
       path: string;
       relativePath: string;
     }>;
+    wrapCodeBlocks?: boolean;
   } = {}
 ) {
   let editor: Editor | null = null;
@@ -86,6 +87,7 @@ async function renderEditor(
       resolveImageSrc={options.resolveImageSrc}
       revision={0}
       workspaceFiles={options.workspaceFiles}
+      wrapCodeBlocks={options.wrapCodeBlocks}
     />
   );
 
@@ -721,6 +723,12 @@ afterAll(async () => {
 });
 
 describe("MarkdownPaper editing", () => {
+  it("marks whether code blocks should wrap long lines", async () => {
+    const { container } = await renderEditor("```ts\nconst syntheticValue = 'mock';\n```", { wrapCodeBlocks: false });
+
+    expect(container.querySelector(".markdown-paper")).toHaveAttribute("data-code-block-wrap", "false");
+  });
+
   it("renders exact visual search highlights without width normalization", async () => {
     const { container, view } = await renderEditor("alpha, beta，gamma, delta");
 

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -42,6 +42,7 @@ type MarkdownPaperProps = {
   scrollRef?: Ref<HTMLElement>;
   topInset?: "tabs" | "titlebar";
   workspaceFiles?: MarkdownPaperSurfaceProps["workspaceFiles"];
+  wrapCodeBlocks?: boolean;
 };
 
 export function MarkdownPaper({
@@ -75,7 +76,8 @@ export function MarkdownPaper({
   revision,
   scrollRef,
   topInset = "titlebar",
-  workspaceFiles
+  workspaceFiles,
+  wrapCodeBlocks = true
 }: MarkdownPaperProps) {
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const paperStyle = {
@@ -101,6 +103,7 @@ export function MarkdownPaper({
         aria-label={t(language, "app.markdownEditor")}
         data-editor-engine="milkdown"
         data-editor-theme={editorTheme}
+        data-code-block-wrap={wrapCodeBlocks ? "true" : "false"}
       >
         <EditorWidthResizer
           language={language}

--- a/packages/app/src/components/SettingsSections.test.tsx
+++ b/packages/app/src/components/SettingsSections.test.tsx
@@ -315,6 +315,32 @@ describe("EditorSettings", () => {
     });
   });
 
+  it("toggles code block line wrapping from the editor settings", () => {
+    const onUpdatePreferences = vi.fn();
+
+    render(
+      <EditorSettings
+        preferences={{
+          ...defaultEditorPreferences,
+          wrapCodeBlocks: true
+        }}
+        translate={translate}
+        onUpdatePreferences={onUpdatePreferences}
+      />
+    );
+
+    const wrapSwitch = screen.getByRole("switch", { name: "Wrap code block lines" });
+
+    expect(wrapSwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(wrapSwitch);
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      wrapCodeBlocks: false
+    });
+  });
+
   it("switches the sidebar layout from the editor settings", () => {
     const onUpdatePreferences = vi.fn();
 

--- a/packages/app/src/components/SettingsSections.tsx
+++ b/packages/app/src/components/SettingsSections.tsx
@@ -2813,6 +2813,22 @@ export function EditorSettings({
             />
           }
         />
+        <SettingsRow
+          title={translate("settings.editor.wrapCodeBlocks")}
+          description={translate("settings.editor.wrapCodeBlocksDescription")}
+          action={
+            <SettingsSwitch
+              checked={preferences.wrapCodeBlocks}
+              label={translate("settings.editor.wrapCodeBlocks")}
+              onChange={() =>
+                onUpdatePreferences({
+                  ...preferences,
+                  wrapCodeBlocks: !preferences.wrapCodeBlocks
+                })
+              }
+            />
+          }
+        />
       </SettingsSection>
       <SettingsSection label={translate("settings.sections.extendedSyntax")}>
         <SettingsRow

--- a/packages/app/src/components/SideDocumentPane.tsx
+++ b/packages/app/src/components/SideDocumentPane.tsx
@@ -27,6 +27,7 @@ type SideDocumentPaneProps = {
   revision: number;
   sizeBytes?: number;
   workspaceFiles?: MarkdownDocumentLinkFile[];
+  wrapCodeBlocks?: boolean;
   onChange: (content: string) => unknown;
   onContentWidthChange?: (width: number) => unknown;
   onContentWidthResizeEnd?: () => unknown;
@@ -56,6 +57,7 @@ export function SideDocumentPane({
   revision,
   sizeBytes,
   workspaceFiles,
+  wrapCodeBlocks = true,
   onChange,
   onContentWidthChange,
   onContentWidthResizeEnd,
@@ -111,6 +113,7 @@ export function SideDocumentPane({
           revision={revision}
           topInset="titlebar"
           workspaceFiles={workspaceFiles}
+          wrapCodeBlocks={wrapCodeBlocks}
         />
       )}
     </section>

--- a/packages/app/src/hooks/useEditorPreferences.test.tsx
+++ b/packages/app/src/hooks/useEditorPreferences.test.tsx
@@ -77,7 +77,8 @@ vi.mock("../lib/settings/app-settings", () => ({
     showAiSelectionToolbarOnSelection: false,
     showDocumentTabs: true,
     splitVisualPanePercent: 50,
-    showWordCount: true
+    showWordCount: true,
+    wrapCodeBlocks: true
   },
   getStoredEditorPreferences: vi.fn()
 }));
@@ -174,7 +175,8 @@ describe("useEditorPreferences", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
     mockedListenAppEditorPreferencesChanged.mockImplementation(async (listener) => {
       onPreferencesChanged = listener;
@@ -264,7 +266,8 @@ describe("useEditorPreferences", () => {
           { id: "sourceMode", visible: true },
           { id: "aiAgent", visible: true }
         ],
-        showWordCount: false
+        showWordCount: false,
+        wrapCodeBlocks: false
       });
     });
 

--- a/packages/app/src/lib/settings/app-settings.test.ts
+++ b/packages/app/src/lib/settings/app-settings.test.ts
@@ -245,7 +245,8 @@ describe("app settings", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
 
     expect(store.get).toHaveBeenCalledWith("editorPreferences");
@@ -614,7 +615,8 @@ describe("app settings", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: false
+      showWordCount: false,
+      wrapCodeBlocks: true
     });
   });
 
@@ -642,6 +644,12 @@ describe("app settings", () => {
     expect(normalizeEditorPreferences({}).autoUpdateEnabled).toBe(true);
     expect(normalizeEditorPreferences({ autoUpdateEnabled: false }).autoUpdateEnabled).toBe(false);
     expect(normalizeEditorPreferences({ autoUpdateEnabled: "no" }).autoUpdateEnabled).toBe(true);
+  });
+
+  it("normalizes the code block line wrapping preference", () => {
+    expect(normalizeEditorPreferences({}).wrapCodeBlocks).toBe(true);
+    expect(normalizeEditorPreferences({ wrapCodeBlocks: false }).wrapCodeBlocks).toBe(false);
+    expect(normalizeEditorPreferences({ wrapCodeBlocks: "no" }).wrapCodeBlocks).toBe(true);
   });
 
   it("migrates the old AI selection display mode into independent switches", () => {
@@ -991,7 +999,8 @@ describe("app settings", () => {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
   });
 
@@ -1060,7 +1069,8 @@ describe("app settings", () => {
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ],
-      showWordCount: false
+      showWordCount: false,
+      wrapCodeBlocks: false
     });
 
     expect(store.set).toHaveBeenCalledWith("editorPreferences", {
@@ -1127,7 +1137,8 @@ describe("app settings", () => {
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ],
-      showWordCount: false
+      showWordCount: false,
+      wrapCodeBlocks: false
     });
     expect(store.save).toHaveBeenCalledTimes(1);
   });

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -145,6 +145,7 @@ export type EditorPreferences = {
   splitVisualPanePercent: number;
   titlebarActions: TitlebarActionPreference[];
   showWordCount: boolean;
+  wrapCodeBlocks: boolean;
 };
 export type ExportSettings = {
   pandocArgs: string;
@@ -313,7 +314,8 @@ export const defaultEditorPreferences: EditorPreferences = {
   showDocumentTabs: true,
   splitVisualPanePercent: defaultSplitVisualPanePercent,
   titlebarActions: [...defaultTitlebarActions],
-  showWordCount: true
+  showWordCount: true,
+  wrapCodeBlocks: true
 };
 
 export const defaultExportSettings: ExportSettings = {
@@ -980,7 +982,9 @@ export function normalizeEditorPreferences(value: unknown): EditorPreferences {
     splitVisualPanePercent: normalizeSplitVisualPanePercent(preferences.splitVisualPanePercent),
     titlebarActions: normalizeTitlebarActions(preferences.titlebarActions),
     showWordCount:
-      typeof preferences.showWordCount === "boolean" ? preferences.showWordCount : defaultEditorPreferences.showWordCount
+      typeof preferences.showWordCount === "boolean" ? preferences.showWordCount : defaultEditorPreferences.showWordCount,
+    wrapCodeBlocks:
+      typeof preferences.wrapCodeBlocks === "boolean" ? preferences.wrapCodeBlocks : defaultEditorPreferences.wrapCodeBlocks
   };
 }
 

--- a/packages/app/src/lib/settings/settings-events.test.ts
+++ b/packages/app/src/lib/settings/settings-events.test.ts
@@ -180,7 +180,8 @@ describe("settings events", () => {
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ],
-      showWordCount: false
+      showWordCount: false,
+      wrapCodeBlocks: false
     };
 
     await notifyAppEditorPreferencesChanged(preferences);

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -3029,6 +3029,15 @@
     white-space: pre-wrap;
   }
 
+  .markdown-paper[data-code-block-wrap="false"] .markra-code-block pre {
+    overflow-x: auto;
+  }
+
+  .markdown-paper[data-code-block-wrap="false"] .markra-code-block code {
+    overflow-wrap: normal;
+    white-space: pre;
+  }
+
   .markdown-paper .hljs-keyword,
   .markdown-paper .hljs-selector-tag,
   .markdown-paper .hljs-literal {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -318,14 +318,32 @@ describe("editor stylesheet", () => {
     expect(languageSelectStyles).toContain("border border-(--border-default)");
   });
 
-  it("wraps code block lines instead of forcing horizontal scrolling", () => {
+  it("wraps code block lines by default", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const codeStart = styles.indexOf(".markdown-paper .markra-code-block code {");
-    const codeEnd = styles.indexOf(".markdown-paper .hljs-keyword");
+    const codeEnd = styles.indexOf(".markdown-paper[data-code-block-wrap=\"false\"] .markra-code-block pre");
     const codeStyles = styles.slice(codeStart, codeEnd);
 
     expect(codeStyles).toContain("white-space: pre-wrap");
     expect(codeStyles).toContain("overflow-wrap: anywhere");
+  });
+
+  it("allows code block wrapping to be disabled", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const preStart = styles.indexOf(".markdown-paper[data-code-block-wrap=\"false\"] .markra-code-block pre");
+    const preEnd = styles.indexOf(".markdown-paper[data-code-block-wrap=\"false\"] .markra-code-block code");
+    const preStyles = styles.slice(preStart, preEnd);
+    const codeStart = styles.indexOf(".markdown-paper[data-code-block-wrap=\"false\"] .markra-code-block code");
+    const codeEnd = styles.indexOf(".markdown-paper .hljs-keyword");
+    const codeStyles = styles.slice(codeStart, codeEnd);
+
+    expect(preStart).toBeGreaterThanOrEqual(0);
+    expect(preEnd).toBeGreaterThan(preStart);
+    expect(preStyles).toContain("overflow-x: auto");
+    expect(codeStart).toBeGreaterThanOrEqual(0);
+    expect(codeEnd).toBeGreaterThan(codeStart);
+    expect(codeStyles).toContain("white-space: pre");
+    expect(codeStyles).toContain("overflow-wrap: normal");
   });
 
   it("folds Mermaid code source while showing the rendered preview", () => {

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -273,7 +273,8 @@ vi.mock("../lib/settings/app-settings", () => ({
       { id: "save", visible: true },
       { id: "theme", visible: true }
     ],
-    showWordCount: true
+    showWordCount: true,
+    wrapCodeBlocks: true
   },
   appThemeOptions: [
     "system",
@@ -444,7 +445,8 @@ vi.mock("../lib/settings/app-settings", () => ({
       { id: "theme", visible: true }
     ],
     showWordCount: true,
-    ...preferences
+    ...preferences,
+    wrapCodeBlocks: preferences?.wrapCodeBlocks ?? true
   })),
   normalizeTitlebarActions: vi.fn((actions) => Array.isArray(actions) ? actions : [
     { id: "aiAgent", visible: true },
@@ -1046,7 +1048,8 @@ export function installAppTestHarness() {
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
-      showWordCount: true
+      showWordCount: true,
+      wrapCodeBlocks: true
     });
     mockedGetStoredExportSettings.mockResolvedValue({
       pandocArgs: "",

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Tabs",
   "settings.editor.showWordCount": "Wortzahl anzeigen",
   "settings.editor.showWordCountDescription": "Zeigt die Wortzahl des Dokuments in der Statuszeile des Editors.",
+  "settings.editor.wrapCodeBlocks": "Codeblock-Zeilen umbrechen",
+  "settings.editor.wrapCodeBlocksDescription": "Bricht lange Zeilen in Codeblöcken um, statt horizontales Scrollen zu erzwingen.",
   "settings.editor.highlightSyntax": "Hervorhebungs-Syntax",
   "settings.editor.highlightSyntaxDescription": "Stellt ==text== im visuellen Editor als hervorgehobenen Text dar.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -190,6 +190,8 @@ const messages: BaseLocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Tabs",
   "settings.editor.showWordCount": "Show word count",
   "settings.editor.showWordCountDescription": "Show document word count in the editor status line.",
+  "settings.editor.wrapCodeBlocks": "Wrap code block lines",
+  "settings.editor.wrapCodeBlocksDescription": "Wrap long lines inside code blocks instead of requiring horizontal scrolling.",
   "settings.editor.highlightSyntax": "Highlight syntax",
   "settings.editor.highlightSyntaxDescription": "Render ==text== as highlighted text in the visual editor.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Pestañas",
   "settings.editor.showWordCount": "Mostrar recuento de palabras",
   "settings.editor.showWordCountDescription": "Muestra el recuento de palabras en la línea de estado del editor.",
+  "settings.editor.wrapCodeBlocks": "Ajustar líneas de bloques de código",
+  "settings.editor.wrapCodeBlocksDescription": "Ajusta las líneas largas dentro de bloques de código en vez de requerir desplazamiento horizontal.",
   "settings.editor.highlightSyntax": "Sintaxis de resaltado",
   "settings.editor.highlightSyntaxDescription": "Muestra ==text== como texto resaltado en el editor visual.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Onglets",
   "settings.editor.showWordCount": "Afficher le nombre de mots",
   "settings.editor.showWordCountDescription": "Affiche le nombre de mots dans la ligne d’état de l’éditeur.",
+  "settings.editor.wrapCodeBlocks": "Renvoyer les lignes des blocs de code",
+  "settings.editor.wrapCodeBlocksDescription": "Renvoie les longues lignes dans les blocs de code au lieu d’imposer un défilement horizontal.",
   "settings.editor.highlightSyntax": "Syntaxe de surlignage",
   "settings.editor.highlightSyntaxDescription": "Affiche ==text== comme texte surligné dans l’éditeur visuel.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Schede",
   "settings.editor.showWordCount": "Mostra conteggio parole",
   "settings.editor.showWordCountDescription": "Mostra il conteggio parole nella riga di stato dell’editor.",
+  "settings.editor.wrapCodeBlocks": "Manda a capo le righe dei blocchi di codice",
+  "settings.editor.wrapCodeBlocksDescription": "Manda a capo le righe lunghe nei blocchi di codice invece di richiedere lo scorrimento orizzontale.",
   "settings.editor.highlightSyntax": "Sintassi evidenziata",
   "settings.editor.highlightSyntaxDescription": "Mostra ==text== come testo evidenziato nell’editor visuale.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "タブ",
   "settings.editor.showWordCount": "単語数を表示",
   "settings.editor.showWordCountDescription": "エディターのステータス行にドキュメントの単語数を表示します。",
+  "settings.editor.wrapCodeBlocks": "コードブロックの行を折り返す",
+  "settings.editor.wrapCodeBlocksDescription": "横スクロールではなく、コードブロック内の長い行を折り返します。",
   "settings.editor.highlightSyntax": "ハイライト構文",
   "settings.editor.highlightSyntaxDescription": "ビジュアルエディターで ==text== をハイライト表示します。",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "탭",
   "settings.editor.showWordCount": "단어 수 표시",
   "settings.editor.showWordCountDescription": "편집기 상태 줄에 문서 단어 수를 표시합니다.",
+  "settings.editor.wrapCodeBlocks": "코드 블록 줄 바꿈",
+  "settings.editor.wrapCodeBlocksDescription": "가로 스크롤 대신 코드 블록의 긴 줄을 줄 바꿈합니다.",
   "settings.editor.highlightSyntax": "하이라이트 구문",
   "settings.editor.highlightSyntaxDescription": "비주얼 편집기에서 ==text== 를 하이라이트 텍스트로 표시합니다.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Abas",
   "settings.editor.showWordCount": "Mostrar contagem de palavras",
   "settings.editor.showWordCountDescription": "Mostra a contagem de palavras na linha de status do editor.",
+  "settings.editor.wrapCodeBlocks": "Quebrar linhas em blocos de código",
+  "settings.editor.wrapCodeBlocksDescription": "Quebra linhas longas dentro de blocos de código em vez de exigir rolagem horizontal.",
   "settings.editor.highlightSyntax": "Sintaxe de destaque",
   "settings.editor.highlightSyntaxDescription": "Renderiza ==text== como texto destacado no editor visual.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "Вкладки",
   "settings.editor.showWordCount": "Показывать число слов",
   "settings.editor.showWordCountDescription": "Показывает число слов документа в строке состояния редактора.",
+  "settings.editor.wrapCodeBlocks": "Переносить строки в блоках кода",
+  "settings.editor.wrapCodeBlocksDescription": "Переносит длинные строки в блоках кода вместо горизонтальной прокрутки.",
   "settings.editor.highlightSyntax": "Синтаксис выделения",
   "settings.editor.highlightSyntaxDescription": "Показывает ==text== как выделенный текст в визуальном редакторе.",
   "settings.editor.githubAlerts": "GitHub-style warning boxes",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -214,6 +214,8 @@ export type I18nKey =
   | "settings.editor.sidebarLayoutMode.tabs"
   | "settings.editor.showWordCount"
   | "settings.editor.showWordCountDescription"
+  | "settings.editor.wrapCodeBlocks"
+  | "settings.editor.wrapCodeBlocksDescription"
   | "settings.editor.highlightSyntax"
   | "settings.editor.highlightSyntaxDescription"
   | "settings.editor.githubAlerts"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -190,6 +190,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "页签",
   "settings.editor.showWordCount": "显示字数统计",
   "settings.editor.showWordCountDescription": "在编辑器状态栏显示当前文档字数。",
+  "settings.editor.wrapCodeBlocks": "代码块自动换行",
+  "settings.editor.wrapCodeBlocksDescription": "在代码块中折行显示长行，而不是依赖横向滚动。",
   "settings.editor.highlightSyntax": "语法高亮",
   "settings.editor.highlightSyntaxDescription": "在可视编辑器中把 ==text== 显示为高亮文本。",
   "settings.editor.githubAlerts": "GitHub 风格警告框",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -530,6 +530,8 @@ const messages: LocaleMessages = {
   "settings.editor.sidebarLayoutMode.tabs": "標籤頁",
   "settings.editor.showWordCount": "顯示字數統計",
   "settings.editor.showWordCountDescription": "在編輯器狀態列顯示目前文件字數。",
+  "settings.editor.wrapCodeBlocks": "程式碼區塊自動換行",
+  "settings.editor.wrapCodeBlocksDescription": "在程式碼區塊中折行顯示長行，而不是依賴水平捲動。",
   "settings.editor.highlightSyntax": "語法高亮",
   "settings.editor.highlightSyntaxDescription": "在視覺編輯器中把 ==text== 顯示為高亮文字。",
   "settings.editor.githubAlerts": "GitHub 風格警告框",


### PR DESCRIPTION
## Summary
- Add a persisted editor preference for wrapping long code block lines.
- Add an Editor settings switch to turn code block wrapping on or off.
- Apply the preference to both the main visual editor and side-by-side visual editor.
- Localize the new setting label and description across supported languages.

## Why
Users who write or review long code lines need the choice between wrapped code blocks for readability and horizontal scrolling for preserving line layout.

## Validation
- `pnpm --filter @markra/app test` passed: 57 files, 1096 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/shared test` passed: 6 files, 34 tests.
- `pnpm --filter @markra/shared build` passed.

Note: app tests still emit existing jsdom `Window.scrollBy()` not implemented warnings, with all tests passing.

## Risk
- Low. Default behavior remains wrapping enabled for existing users, and disabling the setting only changes code block CSS in the visual editor.

Closes #242