### PR TITLE
fix(app): keep collapsed file tree root on restore

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1454,6 +1454,7 @@ describe("useMarkdownDocument", () => {
         "/mock-files/deleted-notes",
         "notes",
         "session-missing-folder",
+        true,
         true
       )
     );
@@ -1573,10 +1574,55 @@ describe("useMarkdownDocument", () => {
     });
     expect(result.current.tabs.map((tab) => tab.path)).toEqual([guidePath, notesPath]);
     expect(result.current.activeTabId).toBe(`file:${notesPath}`);
-    expect(onTreeRootFromFolderPath).toHaveBeenCalledWith("/mock-files/vault", "vault", "session-tabs", false);
+    expect(onTreeRootFromFolderPath).toHaveBeenCalledWith("/mock-files/vault", "vault", "session-tabs", false, true);
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(notesPath);
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("keeps the saved folder root when restoring tabs with the file tree collapsed", async () => {
+    const guidePath = "/mock-files/vault/docs/guide.md";
+    const onTreeRootFromFilePath = vi.fn();
+    const onTreeRootFromFolderPath = vi.fn(async () => ({ name: "vault", path: "/mock-files/vault" }));
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-collapsed-tree",
+      filePath: guidePath,
+      fileTreeOpen: false,
+      folderName: "vault",
+      folderPath: "/mock-files/vault",
+      openFilePaths: [guidePath]
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide",
+      name: "guide.md",
+      path: guidePath
+    });
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath,
+        onTreeRootFromFolderPath,
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.document.name).toBe("guide.md"));
+
+    expect(onTreeRootFromFolderPath).toHaveBeenCalledWith(
+      "/mock-files/vault",
+      "vault",
+      "session-collapsed-tree",
+      false,
+      false
+    );
+    expect(onTreeRootFromFilePath).not.toHaveBeenCalled();
+    expect(mockedSaveStoredWorkspaceState).not.toHaveBeenCalledWith(expect.objectContaining({
+      folderName: null,
+      folderPath: null
+    }));
   });
 
   it("restores dirty draft tabs from the last workspace", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -294,7 +294,13 @@ type UseMarkdownDocumentOptions = {
   getCurrentMarkdown: (fallbackContent: string) => string;
   isCurrentMarkdownEquivalent?: (markdown: string) => boolean | undefined;
   onMarkdownTreeChange?: (path: string) => unknown | Promise<unknown>;
-  onTreeRootFromFolderPath: (path: string, name: string, sessionId?: string | null, clearFilePath?: boolean) => unknown | Promise<unknown>;
+  onTreeRootFromFolderPath: (
+    path: string,
+    name: string,
+    sessionId?: string | null,
+    clearFilePath?: boolean,
+    openTree?: boolean
+  ) => unknown | Promise<unknown>;
   onTreeRootFromFilePath: (path: string) => unknown;
   onWorkspaceSessionChange?: (sessionId: string) => unknown;
   preferencesReady?: boolean;
@@ -1660,12 +1666,13 @@ export function useMarkdownDocument({
 
           assignWorkspaceSessionId(sessionId);
 
-          if (workspace.folderPath && workspace.fileTreeOpen) {
+          if (workspace.folderPath) {
             const folderResult = await onTreeRootFromFolderPath(
               workspace.folderPath,
               workspace.folderName ?? workspace.folderPath,
               sessionId,
-              restoreFilePaths.length === 0
+              restoreFilePaths.length === 0,
+              workspace.fileTreeOpen
             );
             if (!active) return;
 

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -81,6 +81,12 @@ function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) 
       </button>
       <button
         type="button"
+        onClick={() => tree.openFolderPath("/vault", "vault", "session-restored", false, false)}
+      >
+        Restore collapsed folder
+      </button>
+      <button
+        type="button"
         onClick={() => tree.removeRecentFolder?.({ name: "notes", path: "/recent/notes" })}
       >
         Remove recent folder
@@ -305,6 +311,26 @@ describe("useMarkdownFileTree", () => {
     expect(mockedSaveStoredRecentMarkdownFolder).toHaveBeenCalledWith({
       name: "notes",
       path: "/recent/notes"
+    });
+  });
+
+  it("restores a markdown folder root without reopening a collapsed tree", async () => {
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
+    ]);
+
+    render(<FileTreeProbe currentPath="/vault/docs/guide.md" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore collapsed folder" }));
+
+    expect(await screen.findByText("docs/guide.md")).toBeInTheDocument();
+    expect(screen.getByTestId("root-name")).toHaveTextContent("vault");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      aiAgentSessionId: "session-restored",
+      fileTreeOpen: false,
+      folderName: "vault",
+      folderPath: "/vault"
     });
   });
 

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -112,7 +112,8 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     path: string,
     name = pathNameFromPath(path),
     preferredSessionId?: string | null,
-    clearFilePath = true
+    clearFilePath = true,
+    openTree = true
   ) => {
     const folderName = name || pathNameFromPath(path);
     const sessionId = preferredSessionId?.trim() ? preferredSessionId : createAiAgentSessionId();
@@ -135,7 +136,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
 
     setSourcePath(path);
     setRootName(folderName);
-    setOpen(true);
+    setOpen(openTree);
     loadedSourcePathRef.current = path;
     setFiles(nextFiles);
     rememberFolder({ name: folderName, path });
@@ -144,7 +145,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     persistWorkspaceState({
       aiAgentSessionId: sessionId,
       ...(clearFilePath ? { filePath: null, openFilePaths: [] } : {}),
-      fileTreeOpen: true,
+      fileTreeOpen: openTree,
       folderName,
       folderPath: path
     });


### PR DESCRIPTION
## Summary
- Restore the saved folder root during workspace startup even when the file tree was collapsed at shutdown.
- Let folder-root restoration preserve the collapsed/open UI state instead of always reopening the tree.
- Add regression coverage for collapsed file-tree startup restore.

## Why
- Previously Markra only restored the saved folder root when `fileTreeOpen` was true. If the app exited with the tree collapsed, restoring the active file could retarget the tree root to the file's containing folder.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx src/hooks/useMarkdownFileTree.test.tsx` passed, 49 tests.
- `pnpm --filter @markra/app test` passed, 57 files and 1101 tests.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Risk
- Low. The change is scoped to startup workspace restoration and file tree open-state preservation.

Closes #247