### PR TITLE
fix(editor): stabilize quote and callout list editing

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5388,6 +5388,23 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("nests only the current list item when Tab is pressed before following siblings", async () => {
+    const { editor, view } = await renderEditor(["- A", "- B", "- C", "- D"].join("\n"));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "C"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toEqual([
+      "- A",
+      "- B",
+      "  - C",
+      "- D"
+    ]);
+    await settleMarkdownListener();
+  });
+
   it("lifts only the current list item with Shift+Tab", async () => {
     const source = ["- Parent", "  - First child", "  - Second child", "- After"].join("\n");
     const { container, editor, view } = await renderEditor(source);
@@ -5399,21 +5416,47 @@ describe("MarkdownPaper editing", () => {
 
     const topLevelItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li"));
     const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li > ul > li"));
-    expect(topLevelItems).toHaveLength(4);
+    expect(topLevelItems).toHaveLength(3);
     expect(topLevelItems[0]).toHaveTextContent("Parent");
     expect(topLevelItems[1]).toHaveTextContent("First child");
-    expect(topLevelItems[2]).toHaveTextContent("Second child");
-    expect(topLevelItems[3]).toHaveTextContent("After");
-    expect(nestedItems).toHaveLength(0);
+    expect(topLevelItems[2]).toHaveTextContent("After");
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Second child");
 
     const markdown = serializeMarkdown(view.state.doc);
     expect(markdown.split("\n").filter((line) => line.length > 0)).toEqual([
       "- Parent",
       "- First child",
-      "- Second child",
+      "  - Second child",
       "- After"
     ]);
-    expect(markdown).not.toContain("- First child\n  - Second child");
+  });
+
+  it("lifts list items without reducing following sibling indentation", async () => {
+    const source = [
+      "- Parent",
+      "  - First child",
+      "  - Second child",
+      "    - Nested detail",
+      "  - Third child",
+      "- After"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second child"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toEqual([
+      "- Parent",
+      "  - First child",
+      "- Second child",
+      "  - Nested detail",
+      "  - Third child",
+      "- After"
+    ]);
+    await settleMarkdownListener();
   });
 
   it("lifts only the active list continuation line with Shift+Tab", async () => {
@@ -5552,7 +5595,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("exits quote formatting when pressing Enter at the quote end", async () => {
+  it("continues quote formatting at the quote end and exits from a blank quote line", async () => {
     const { container, editor, view } = await renderEditor("> Quote");
     moveCursor(view, findTextPosition(view, "Quote", "Quote".length));
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
@@ -5560,9 +5603,33 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".ProseMirror blockquote")).toHaveTextContent("Quote");
     expect(pressEnter(view)).toBe(true);
 
-    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
     typeText(view, "Next");
-    expect(serializeMarkdown(view.state.doc)).toBe("> Quote\n\nNext\n");
+    expect(serializeMarkdown(view.state.doc)).toContain("> Quote\n>\n> Next");
+
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(pressEnter(view)).toBe(true);
+    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
+    typeText(view, "After");
+    expect(serializeMarkdown(view.state.doc)).toBe("> Quote\n>\n> Next\n\nAfter\n");
+    await settleMarkdownListener();
+  });
+
+  it("moves to a new quote line after one Enter from typed quote content", async () => {
+    const { editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "> ");
+    typeText(view, "First line");
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(pressEnter(view)).toBe(true);
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+    typeText(view, "Second line");
+    expect(serializeMarkdown(view.state.doc)).toContain("> First line\n>\n> Second line");
     await settleMarkdownListener();
   });
 
@@ -5629,6 +5696,89 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("nests only the current quote list item when Tab is pressed before following siblings", async () => {
+    const { editor, view } = await renderEditor(["> - A", "> - B", "> - C", "> - D"].join("\n"));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "C"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toEqual([
+      "> - A",
+      "> - B",
+      ">   - C",
+      "> - D"
+    ]);
+    await settleMarkdownListener();
+  });
+
+  it("keeps following quote list siblings outside when nesting an item with children", async () => {
+    const source = ["> - A", "> - B", "> - C", ">   - C child", "> - D"].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "C"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toEqual([
+      "> - A",
+      "> - B",
+      ">   - C",
+      ">     - C child",
+      "> - D"
+    ]);
+    await settleMarkdownListener();
+  });
+
+  it("keeps following quote list siblings outside when nesting after an item with children", async () => {
+    const source = ["> - A", "> - B", ">   - B child", "> - C", "> - D"].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "C"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toEqual([
+      "> - A",
+      "> - B",
+      ">   - B child",
+      ">   - C",
+      "> - D"
+    ]);
+    await settleMarkdownListener();
+  });
+
+  it("lifts quote list items without reducing following sibling indentation", async () => {
+    const source = [
+      "> - Parent",
+      ">   - First child",
+      ">   - Second child",
+      ">     - Nested detail",
+      ">   - Third child",
+      "> - After"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second child"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    const lines = serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0);
+    expect(lines).toEqual([
+      "> - Parent",
+      ">   - First child",
+      "> - Second child",
+      ">   - Nested detail",
+      ">   - Third child",
+      "> - After"
+    ]);
+    await settleMarkdownListener();
+  });
+
   it("removes emptied quote list items without recreating the bullet", async () => {
     const source = ["> - Parent", ">   - First child", ">   - Empty child", ">   - Last child"].join("\n");
     const { container, editor, view } = await renderEditor(source);
@@ -5656,7 +5806,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("exits quote formatting before following prose when pressing Enter at the quote end", async () => {
+  it("keeps quote formatting before following prose when pressing Enter at the quote end", async () => {
     const { editor, view } = await renderEditor(["> Quote", "", "After"].join("\n"));
     moveCursor(view, findTextPosition(view, "Quote", "Quote".length));
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
@@ -5664,12 +5814,12 @@ describe("MarkdownPaper editing", () => {
     expect(pressEnter(view)).toBe(true);
     typeText(view, "Next");
 
-    expect(selectionHasAncestor(view, "blockquote")).toBe(false);
-    expect(serializeMarkdown(view.state.doc)).toBe("> Quote\n\nNext\n\nAfter\n");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(serializeMarkdown(view.state.doc)).toBe("> Quote\n>\n> Next\n\nAfter\n");
     await settleMarkdownListener();
   });
 
-  it("finalizes live markdown inside quote formatting before exiting on the next Enter", async () => {
+  it("finalizes live markdown inside quote formatting and continues on one Enter", async () => {
     const { container, editor, view } = await renderEditor("> ");
     moveCursor(view, findFirstTextBlockCursor(view));
     typeText(view, "**Quote**");
@@ -5680,11 +5830,15 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".ProseMirror blockquote strong")).toHaveTextContent("Quote");
     expect(selectionHasAncestor(view, "blockquote")).toBe(true);
 
-    expect(pressEnter(view)).toBe(true);
+    expect(view.state.selection.$from.parent.textContent).toBe("");
     typeText(view, "Next");
 
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(serializeMarkdown(view.state.doc)).toBe("> **Quote**\n>\n> Next\n");
+
+    expect(pressEnter(view)).toBe(true);
+    expect(pressEnter(view)).toBe(true);
     expect(selectionHasAncestor(view, "blockquote")).toBe(false);
-    expect(serializeMarkdown(view.state.doc)).toBe("> **Quote**\n\nNext\n");
     await settleMarkdownListener();
   });
 
@@ -6798,6 +6952,25 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("> - First\n> - Second");
   });
 
+  it("nests only the current callout list item when Tab is pressed before following siblings", async () => {
+    const source = ["> [!NOTE]", ">", "> - A", "> - B", "> - C", "> - D"].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "C"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    expect(serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0)).toEqual([
+      "> [!NOTE]",
+      ">",
+      "> - A",
+      "> - B",
+      ">   - C",
+      "> - D"
+    ]);
+  });
+
   it("lifts only the current callout list item with Shift+Tab", async () => {
     const source = [
       "> [!NOTE]",
@@ -6820,16 +6993,46 @@ describe("MarkdownPaper editing", () => {
     const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(
       ".ProseMirror blockquote.markra-callout > ul > li > ul > li"
     ));
-    expect(topLevelItems).toHaveLength(4);
+    expect(topLevelItems).toHaveLength(3);
     expect(topLevelItems[0]).toHaveTextContent("Parent");
     expect(topLevelItems[1]).toHaveTextContent("First child");
-    expect(topLevelItems[2]).toHaveTextContent("Second child");
-    expect(topLevelItems[3]).toHaveTextContent("After");
-    expect(nestedItems).toHaveLength(0);
+    expect(topLevelItems[2]).toHaveTextContent("After");
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Second child");
 
     const markdown = serializeMarkdown(view.state.doc);
-    expect(markdown).toContain("> - Parent\n> - First child\n> - Second child\n> - After");
-    expect(markdown).not.toContain("> - First child\n>   - Second child");
+    expect(markdown).toContain("> - Parent\n> - First child\n>   - Second child\n> - After");
+  });
+
+  it("lifts callout list items without reducing following sibling indentation", async () => {
+    const source = [
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - First child",
+      ">   - Second child",
+      ">     - Nested detail",
+      ">   - Third child",
+      "> - After"
+    ].join("\n");
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Second child"));
+
+    expect(pressShortcut(view, "Tab", { shiftKey: true })).toBe(true);
+
+    const lines = serializeMarkdown(view.state.doc).split("\n").filter((line) => line.length > 0);
+    expect(lines).toEqual([
+      "> [!NOTE]",
+      ">",
+      "> - Parent",
+      ">   - First child",
+      "> - Second child",
+      ">   - Nested detail",
+      ">   - Third child",
+      "> - After"
+    ]);
   });
 
   it("lifts only the active callout continuation paragraph with Shift+Tab", async () => {
@@ -7884,6 +8087,44 @@ describe("MarkdownPaper editing", () => {
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n>\n> Second line");
+    await settleMarkdownListener();
+  });
+
+  it("moves to a new callout body line after one Enter from typed callout content", async () => {
+    const { editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "> [!WARNING]");
+    typeText(view, "First line");
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(pressEnter(view)).toBe(true);
+
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+    typeText(view, "Second line");
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> First line\n>\n> Second line");
+    await settleMarkdownListener();
+  });
+
+  it("finalizes live markdown inside callout body content and continues on one Enter", async () => {
+    const { container, editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "> [!WARNING]");
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout")).toBeInTheDocument();
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+    typeText(view, "**First line**");
+
+    expectLiveMark(container, "strong", "First line");
+    expect(pressEnter(view)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror blockquote.markra-callout strong")).toHaveTextContent("First line");
+    expect(selectionHasAncestor(view, "blockquote")).toBe(true);
+    expect(view.state.selection.$from.parent.textContent).toBe("");
+
+    typeText(view, "Second line");
+    expect(serializeMarkdown(view.state.doc)).toContain("> [!WARNING]\n>\n> **First line**\n>\n> Second line");
     await settleMarkdownListener();
   });
 

--- a/packages/editor/src/callout.ts
+++ b/packages/editor/src/callout.ts
@@ -15,6 +15,7 @@ import {
   type MarkdownCalloutType,
   type ParsedMarkdownCalloutMarker
 } from "@markra/shared";
+import { finalizeActiveLiveMarkdown, markraLiveMarkdownSpecs } from "./input-rules.ts";
 import { removeEmptyListItem } from "./list-editing.ts";
 
 type CalloutBlock = {
@@ -733,6 +734,7 @@ export const markraCalloutPlugin = $prose((ctx) => {
   const paragraph = paragraphSchema.type(ctx);
   const blockquote = blockquoteSchema.type(ctx);
   const listItem = listItemSchema.type(ctx);
+  const liveMarkdownSpecs = markraLiveMarkdownSpecs(ctx);
   let deleteHoldStartedInsideNonEmptyCallout = false;
 
   return new Plugin({
@@ -787,6 +789,9 @@ export const markraCalloutPlugin = $prose((ctx) => {
           if (selectionIsAtSlashCommandEnd(view.state)) return false;
 
           const callout = findCalloutAtSelection(view);
+          if (callout) {
+            finalizeActiveLiveMarkdown(view, liveMarkdownSpecs);
+          }
 
           const handled = callout
             ? handleCalloutEnter(view, callout, paragraph, listItem)

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -11,7 +11,7 @@ import {
   strongSchema
 } from "@milkdown/kit/preset/commonmark";
 import { strikethroughSchema } from "@milkdown/kit/preset/gfm";
-import { exitCode, lift, setBlockType, toggleMark, wrapIn } from "@milkdown/kit/prose/commands";
+import { exitCode, lift, setBlockType, splitBlock, toggleMark, wrapIn } from "@milkdown/kit/prose/commands";
 import { redo, undo } from "@milkdown/kit/prose/history";
 import { Fragment, type Node as ProseNode, type NodeType, type ResolvedPos } from "@milkdown/kit/prose/model";
 import type { Command, Selection } from "@milkdown/kit/prose/state";
@@ -113,62 +113,6 @@ function listItemContext(selection: Selection, listItem: NodeType): ListItemCont
     parentListDepth: fromDepth - 1,
     to
   };
-}
-
-function listItemHasChildList(item: ProseNode) {
-  for (let index = 0; index < item.childCount; index += 1) {
-    if (nodeIsList(item.child(index))) return true;
-  }
-
-  return false;
-}
-
-function listItemIsNested(context: ListItemContext, listItem: NodeType, selection: Selection) {
-  return context.parentListDepth > 0 && selection.$from.node(context.parentListDepth - 1).type === listItem;
-}
-
-function liftCreatesChildListFromFollowingSiblings(selection: Selection, listItem: NodeType) {
-  const context = listItemContext(selection, listItem);
-  if (!context) return false;
-  if (!listItemIsNested(context, listItem, selection)) return false;
-  if (listItemHasChildList(context.item)) return false;
-
-  return context.itemIndex < context.parentList.childCount - 1;
-}
-
-function splitCurrentListItemChildLists(view: EditorView, listItem: NodeType) {
-  const { selection } = view.state;
-  const context = listItemContext(selection, listItem);
-  if (!context) return false;
-
-  const retainedChildren: ProseNode[] = [];
-  const promotedItems: ProseNode[] = [];
-  context.item.forEach((child) => {
-    if (nodeIsList(child)) {
-      child.forEach((item) => promotedItems.push(item));
-      return;
-    }
-
-    retainedChildren.push(child);
-  });
-  if (promotedItems.length === 0 || retainedChildren.length === 0) return false;
-
-  const retainedItem = context.item.type.create(
-    context.item.attrs,
-    Fragment.fromArray(retainedChildren),
-    context.item.marks
-  );
-  const replacement = Fragment.fromArray([retainedItem, ...promotedItems]);
-  const transaction = view.state.tr.replaceWith(context.from, context.to, replacement);
-  const selectionPosition = Math.min(selection.from, transaction.doc.content.size);
-  view.dispatch(
-    transaction
-      .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1))
-      .scrollIntoView()
-  );
-  view.focus();
-
-  return true;
 }
 
 function continuationBlockContext(selection: Selection, listItem: NodeType) {
@@ -336,17 +280,7 @@ function liftCurrentListItem(listItem: NodeType): Command {
       return handled || true;
     }
 
-    const shouldSplitLiftedChildren = liftCreatesChildListFromFollowingSiblings(state.selection, listItem);
-
-    if (!shouldSplitLiftedChildren || !dispatch || !view) {
-      return liftListItem(listItem)(state, dispatch, view);
-    }
-
-    const handled = liftListItem(listItem)(state, dispatch, view);
-    if (!handled) return false;
-
-    splitCurrentListItemChildLists(view, listItem);
-    return true;
+    return liftListItem(listItem)(state, dispatch, view);
   };
 }
 
@@ -389,38 +323,6 @@ function continueListItem(view: EditorView, listItem: NodeType, tightAncestorNam
   if (handled && tightAncestorName) tightenListSpreadInSelectionAncestor(view, tightAncestorName);
 
   return handled;
-}
-
-function blockquoteExitDepth(selection: Selection, blockquote: NodeType) {
-  if (!(selection instanceof TextSelection) || !selection.empty) return null;
-  if (!selection.$from.parent.isTextblock) return null;
-  if (selection.$from.parentOffset !== selection.$from.parent.content.size) return null;
-
-  const blockquoteDepth = ancestorDepthOfNodeType(selection.$from, blockquote);
-  if (blockquoteDepth === null) return null;
-  if (selection.$from.after(selection.$from.depth) !== selection.$from.end(blockquoteDepth)) return null;
-
-  return blockquoteDepth;
-}
-
-function exitBlockquoteAtEnd(view: EditorView, blockquote: NodeType, paragraph: NodeType) {
-  const blockquoteDepth = blockquoteExitDepth(view.state.selection, blockquote);
-  if (blockquoteDepth === null) return false;
-
-  if (selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
-    return runCommand(view, lift);
-  }
-
-  const insertAt = view.state.selection.$from.after(blockquoteDepth);
-  const transaction = view.state.tr.insert(insertAt, paragraph.create());
-  view.dispatch(
-    transaction
-      .setSelection(TextSelection.create(transaction.doc, insertAt + 1))
-      .scrollIntoView()
-  );
-  view.focus();
-
-  return true;
 }
 
 function emptyTopLevelParagraphAfterTable(view: EditorView, paragraph: NodeType) {
@@ -562,9 +464,7 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
         if (event.key === "Enter" && !hasModifier && selectionIsInsideNodeType(view.state.selection, blockquote)) {
           const finalizedLiveMarkdown = finalizeActiveLiveMarkdown(view, liveMarkdownSpecs);
           if (finalizedLiveMarkdown) {
-            event.preventDefault();
             view.focus();
-            return true;
           }
 
           if (selectionIsInsideNodeType(view.state.selection, listItem)) {
@@ -575,15 +475,19 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
             return true;
           }
 
-          const handled = exitBlockquoteAtEnd(view, blockquote, paragraph);
-          if (handled) {
+          if (selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
+            const handled = runCommand(view, lift);
+            if (!handled) return false;
+
             event.preventDefault();
             return true;
           }
 
-          if (selectionIsEmptyBlockquote(view.state.selection, blockquote)) {
+          if (finalizedLiveMarkdown) {
+            const handled = runCommand(view, splitBlock);
+            if (!handled) return false;
+
             event.preventDefault();
-            view.focus();
             return true;
           }
         } else if (


### PR DESCRIPTION
## Summary
- Align ordinary blockquote Enter behavior with callouts: non-empty lines continue inside the quote, while blank quote lines exit.
- Stabilize list editing in blockquotes and callouts, including Enter, Tab, Shift+Tab, empty list deletion, and sibling indentation preservation.
- Finalize live markdown and continue the Enter action in the same keystroke for quote/callout content.

## Why
- Follow-up feedback on #224 reported ordinary blockquote list regressions and callout/quote Enter/list indentation behavior that differed from Typora-style expectations.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed (344 tests)
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "quote formatting|quote list|callout body|callout list|callouts on Enter|callout.*Enter|live markdown inside|typed quote content|typed callout content|Shift\\+Tab|Tab like ordinary|list continuation|without reducing|nests only the current"` passed (59 tests)
- `pnpm --filter @markra/editor test` passed (3 tests)
- `pnpm -r --if-present test` passed
- `pnpm -r --if-present build` passed
- `git diff --check HEAD` passed

## Risk
- The changed surface is editor keyboard handling inside lists, blockquotes, and callouts; the main residual risk is platform-specific desktop key/caret behavior not captured by jsdom.

## Related Issues
- Refs #224