### PR TITLE
feat(editor): add clear formatting toolbar action

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -494,6 +494,7 @@ function WorkspaceApp() {
   }, [editorPreferences.preferences.markdownTemplates]);
 
   const editor = useEditorController();
+  const clearEditorSelectionFormatting = editor.clearSelectionFormatting;
   const findEditorSearchMatches = editor.findSearchMatches;
   const getEditorCurrentMarkdown = editor.getCurrentMarkdown;
   const handleMilkdownEditorReady = editor.handleEditorReady;
@@ -2594,6 +2595,14 @@ function WorkspaceApp() {
       return;
     }
 
+    if (action === "clearFormatting") {
+      if (!clearEditorSelectionFormatting()) return;
+
+      syncVisualMarkdownAfterEditorCommand();
+      syncAiSelectionToolbarFormattingState();
+      return;
+    }
+
     const normalizedShortcuts = normalizeMarkdownShortcuts(editorPreferences.preferences.markdownShortcuts);
     const shortcut = markdownShortcutToKeyboardEventInit(normalizedShortcuts[action]);
     if (!shortcut) return;
@@ -2604,6 +2613,7 @@ function WorkspaceApp() {
     });
     syncAiSelectionToolbarFormattingState();
   }, [
+    clearEditorSelectionFormatting,
     editorPreferences.preferences.markdownShortcuts,
     handleRunEditorShortcut,
     readOnlyMode,

--- a/packages/app/src/components/AiSelectionToolbar.test.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.test.tsx
@@ -61,6 +61,7 @@ describe("AiSelectionToolbar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Strikethrough" }));
     fireEvent.click(screen.getByRole("button", { name: "Inline Code" }));
     fireEvent.click(screen.getByRole("button", { name: "Highlight" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear Formatting" }));
     fireEvent.click(screen.getByRole("button", { name: "Quote" }));
     fireEvent.click(screen.getByRole("button", { name: "Bullet List" }));
     fireEvent.click(screen.getByRole("button", { name: "Ordered List" }));
@@ -73,6 +74,7 @@ describe("AiSelectionToolbar", () => {
       "strikethrough",
       "inlineCode",
       "highlight",
+      "clearFormatting",
       "quote",
       "bulletList",
       "orderedList"

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Code2,
   Copy,
+  Eraser,
   FileText,
   Heading,
   Heading1,
@@ -129,6 +130,11 @@ const basicSelectionActions: BasicSelectionAction[] = [
     action: "highlight",
     icon: Highlighter,
     labelKey: "menu.highlight"
+  },
+  {
+    action: "clearFormatting",
+    icon: Eraser,
+    labelKey: "menu.clearFormatting"
   },
   {
     action: "quote",

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -23,6 +23,7 @@ import {
 import type { MarkdownOutlineItem } from "@markra/markdown";
 import { debug, type SearchRange } from "@markra/shared";
 import {
+  clearSelectionFormattingInView,
   readSelectionFormattingActionsFromView,
   readSelectionFormattingStateFromView,
   setSelectionHeadingLevelInView,
@@ -456,6 +457,17 @@ export function useEditorController() {
     }
   }, []);
 
+  const clearSelectionFormatting = useCallback(() => {
+    try {
+      const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
+      if (!view) return false;
+
+      return clearSelectionFormattingInView(view);
+    } catch {
+      return false;
+    }
+  }, []);
+
   const getHeadingAnchors = useCallback((): AiHeadingAnchor[] => {
     try {
       const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
@@ -849,6 +861,7 @@ export function useEditorController() {
     applyAiResult,
     clearAiPreview,
     clearAiSelection,
+    clearSelectionFormatting,
     confirmAiResultApplied,
     findSearchMatches,
     getDocumentEndPosition,

--- a/packages/app/src/lib/selection-formatting.test.tsx
+++ b/packages/app/src/lib/selection-formatting.test.tsx
@@ -15,6 +15,7 @@ import { TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { MarkdownPaper } from "../components/MarkdownPaper";
 import {
+  clearSelectionFormattingInView,
   readSelectionFormattingActionsFromView,
   readSelectionFormattingStateFromView,
   setSelectionHeadingLevelInView,
@@ -174,5 +175,25 @@ describe("selection formatting", () => {
     expect(toggleSelectionHighlightInView(view)).toBe(true);
     expect(view.state.doc.textContent).toBe("Highlight this text");
     expect(readSelectionFormattingActionsFromView(view)).not.toContain("highlight");
+  });
+
+  it("clears mixed inline formatting from the selected text", async () => {
+    const { view } = await renderEditor(
+      "**Bold** *italic* ~~strike~~ `code` [link](https://example.test) ==highlight=="
+    );
+    const from = findTextPosition(view, "Bold");
+    const to = findTextPosition(view, "highlight") + "highlight".length;
+
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+
+    expect(readSelectionFormattingActionsFromView(view)).toEqual(
+      expect.arrayContaining(["bold", "italic", "strikethrough", "inlineCode", "link"])
+    );
+    expect(view.state.doc.textContent).toContain("==highlight==");
+
+    expect(clearSelectionFormattingInView(view)).toBe(true);
+
+    expect(view.state.doc.textContent).toBe("Bold italic strike code link highlight");
+    expect(readSelectionFormattingActionsFromView(view)).toEqual([]);
   });
 });

--- a/packages/app/src/lib/selection-formatting.ts
+++ b/packages/app/src/lib/selection-formatting.ts
@@ -20,6 +20,7 @@ export const selectionFormattingToolbarActions = [
   "strikethrough",
   "inlineCode",
   "highlight",
+  "clearFormatting",
   "heading1",
   "quote",
   "bulletList",
@@ -61,6 +62,11 @@ type ActiveHighlightRange = HighlightRange & {
   absoluteContentTo: number;
 };
 
+type DeletionRange = {
+  from: number;
+  to: number;
+};
+
 function getHighlightRanges(text: string) {
   const ranges: HighlightRange[] = [];
   const pattern = /==[^=\n][^\n]*?==/g;
@@ -84,6 +90,10 @@ function getHighlightRanges(text: string) {
   }
 
   return ranges;
+}
+
+function rangesOverlap(firstFrom: number, firstTo: number, secondFrom: number, secondTo: number) {
+  return firstFrom < secondTo && secondFrom < firstTo;
 }
 
 function positionHasAncestor(
@@ -148,6 +158,45 @@ function findActiveHighlightRange(state: EditorState): ActiveHighlightRange | nu
     absoluteContentFrom: blockStart + range.contentFrom,
     absoluteContentTo: blockStart + range.contentTo
   };
+}
+
+function highlightMarkerDeletionRangesForSelection(state: EditorState) {
+  const { selection } = state;
+  const ranges: DeletionRange[] = [];
+
+  if (!(selection instanceof TextSelection) || selection.empty) return ranges;
+
+  state.doc.nodesBetween(selection.from, selection.to, (node, position) => {
+    if (!node.isTextblock) return true;
+
+    const blockStart = position + 1;
+    const selectedFrom = Math.max(selection.from, blockStart) - blockStart;
+    const selectedTo = Math.min(selection.to, blockStart + node.textContent.length) - blockStart;
+    if (selectedFrom >= selectedTo) return false;
+
+    for (const range of getHighlightRanges(node.textContent)) {
+      const selectionTouchesHighlight =
+        rangesOverlap(range.contentFrom, range.contentTo, selectedFrom, selectedTo) ||
+        rangesOverlap(range.from, range.to, selectedFrom, selectedTo);
+
+      if (!selectionTouchesHighlight) continue;
+
+      ranges.push(
+        {
+          from: blockStart + range.contentTo,
+          to: blockStart + range.to
+        },
+        {
+          from: blockStart + range.from,
+          to: blockStart + range.contentFrom
+        }
+      );
+    }
+
+    return false;
+  });
+
+  return ranges;
 }
 
 function normalizeHeadingLevel(value: unknown) {
@@ -271,6 +320,35 @@ export function toggleSelectionHighlightInView(view: EditorView) {
   view.dispatch(
     transaction
       .setSelection(TextSelection.create(transaction.doc, nextFrom, nextTo))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
+export function clearSelectionFormattingInView(view: EditorView) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || selection.empty) return false;
+
+  const transaction = view.state.tr;
+  for (const markType of Object.values(view.state.schema.marks)) {
+    transaction.removeMark(selection.from, selection.to, markType);
+  }
+
+  const markerDeletionRanges = highlightMarkerDeletionRangesForSelection(view.state)
+    .sort((first, second) => second.from - first.from);
+  for (const range of markerDeletionRanges) {
+    transaction.delete(range.from, range.to);
+  }
+
+  if (!transaction.docChanged) return false;
+
+  const nextFrom = Math.max(0, Math.min(transaction.mapping.map(selection.from, -1), transaction.doc.content.size));
+  const nextTo = Math.max(0, Math.min(transaction.mapping.map(selection.to, 1), transaction.doc.content.size));
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, Math.min(nextFrom, nextTo), Math.max(nextFrom, nextTo)))
       .scrollIntoView()
   );
   view.focus();

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Durchgestrichen",
   "menu.inlineCode": "Inline-Code",
   "menu.highlight": "Hervorheben",
+  "menu.clearFormatting": "Formatierung entfernen",
   "menu.paragraph": "Absatz",
   "menu.headingLevel": "Überschriftenebene",
   "menu.heading1": "Überschrift 1",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -676,6 +676,7 @@ const messages: BaseLocaleMessages = {
   "menu.strikethrough": "Strikethrough",
   "menu.inlineCode": "Inline Code",
   "menu.highlight": "Highlight",
+  "menu.clearFormatting": "Clear Formatting",
   "menu.paragraph": "Paragraph",
   "menu.headingLevel": "Heading Level",
   "menu.heading1": "Heading 1",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Tachado",
   "menu.inlineCode": "Código en línea",
   "menu.highlight": "Resaltar",
+  "menu.clearFormatting": "Borrar formato",
   "menu.paragraph": "Párrafo",
   "menu.headingLevel": "Nivel de encabezado",
   "menu.heading1": "Encabezado 1",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Barré",
   "menu.inlineCode": "Code en ligne",
   "menu.highlight": "Surligner",
+  "menu.clearFormatting": "Effacer la mise en forme",
   "menu.paragraph": "Paragraphe",
   "menu.headingLevel": "Niveau de titre",
   "menu.heading1": "Titre 1",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Barrato",
   "menu.inlineCode": "Codice inline",
   "menu.highlight": "Evidenzia",
+  "menu.clearFormatting": "Cancella formattazione",
   "menu.paragraph": "Paragrafo",
   "menu.headingLevel": "Livello titolo",
   "menu.heading1": "Titolo 1",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "取り消し線",
   "menu.inlineCode": "インラインコード",
   "menu.highlight": "ハイライト",
+  "menu.clearFormatting": "書式をクリア",
   "menu.paragraph": "段落",
   "menu.headingLevel": "見出しレベル",
   "menu.heading1": "見出し 1",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "취소선",
   "menu.inlineCode": "인라인 코드",
   "menu.highlight": "하이라이트",
+  "menu.clearFormatting": "서식 지우기",
   "menu.paragraph": "단락",
   "menu.headingLevel": "제목 수준",
   "menu.heading1": "제목 1",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Tachado",
   "menu.inlineCode": "Código embutido",
   "menu.highlight": "Destacar",
+  "menu.clearFormatting": "Limpar formatação",
   "menu.paragraph": "Parágrafo",
   "menu.headingLevel": "Nível do título",
   "menu.heading1": "Título 1",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "Зачёркнутый",
   "menu.inlineCode": "Встроенный код",
   "menu.highlight": "Выделить",
+  "menu.clearFormatting": "Очистить форматирование",
   "menu.paragraph": "Абзац",
   "menu.headingLevel": "Уровень заголовка",
   "menu.heading1": "Заголовок 1",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -687,6 +687,7 @@ export type I18nKey =
   | "menu.strikethrough"
   | "menu.inlineCode"
   | "menu.highlight"
+  | "menu.clearFormatting"
   | "menu.paragraph"
   | "menu.headingLevel"
   | "menu.heading1"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "删除线",
   "menu.inlineCode": "行内代码",
   "menu.highlight": "高亮",
+  "menu.clearFormatting": "清除格式",
   "menu.paragraph": "段落",
   "menu.headingLevel": "标题级别",
   "menu.heading1": "标题 1",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -676,6 +676,7 @@ const messages: LocaleMessages = {
   "menu.strikethrough": "刪除線",
   "menu.inlineCode": "行內程式碼",
   "menu.highlight": "高亮",
+  "menu.clearFormatting": "清除格式",
   "menu.paragraph": "段落",
   "menu.headingLevel": "標題層級",
   "menu.heading1": "標題 1",


### PR DESCRIPTION
## Summary
- Add a clear-formatting action to the selection toolbar with an eraser icon.
- Clear inline marks from the current text selection, including bold, italic, strikethrough, inline code, and links.
- Strip Markra highlight markers from selected highlighted text while preserving the plain text.
- Add localized labels for the new toolbar action.

## Why
Users sometimes need to remove mixed inline formatting from a selected passage in one step instead of toggling each format manually.

## Validation
- `pnpm --filter @markra/app exec vitest run src/lib/selection-formatting.test.tsx src/components/AiSelectionToolbar.test.tsx` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/shared build` passed
- `pnpm --filter @markra/shared test` passed
- `git diff --check` passed

## Related Issues
Closes #250
