### PR TITLE
fix(editor): preserve escaped markdown literals

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5266,6 +5266,17 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps escaped literal asterisks between inline code visible", async () => {
+    const source = "`n!`/`(n1!` \\* `n2!` \\* ... \\* `nk!`)";
+    const { container } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("n!/(n1! * n2! * ... * nk!)");
+    expect(container.querySelectorAll(".ProseMirror code")).toHaveLength(4);
+    expect(container.querySelector(".ProseMirror .markra-live-mark-emphasis")).not.toBeInTheDocument();
+    expectHiddenMarkdownDelimiters(container, 0);
+    await settleMarkdownListener();
+  });
+
   it("supports inline markdown formatting shortcuts", async () => {
     const strong = await renderEditor();
     typeText(strong.view, "bold");

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5277,6 +5277,46 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps escaped literal markdown delimiters visible as plain text", async () => {
+    const cases = [
+      { source: "\\*literal\\*", text: "*literal*", selector: ".markra-live-mark-emphasis" },
+      { source: "\\*\\*literal\\*\\*", text: "**literal**", selector: ".markra-live-mark-strong" },
+      {
+        source: "\\*\\*\\*literal\\*\\*\\*",
+        text: "***literal***",
+        selector: ".markra-live-mark-strong.markra-live-mark-emphasis"
+      },
+      { source: "\\_literal\\_", text: "_literal_", selector: ".markra-live-mark-emphasis" },
+      { source: "\\_\\_literal\\_\\_", text: "__literal__", selector: ".markra-live-mark-strong" },
+      { source: "\\~\\~literal\\~\\~", text: "~~literal~~", selector: ".markra-live-mark-strikethrough" },
+      { source: "\\=\\=literal\\=\\=", text: "==literal==", selector: ".markra-live-mark-highlight" },
+      { source: "\\`literal\\`", text: "`literal`", selector: ".markra-live-mark-inlineCode" }
+    ];
+
+    for (const { source, text, selector } of cases) {
+      const { container } = await renderEditor(source);
+
+      expect(container.querySelector(".ProseMirror")?.textContent).toBe(text);
+      expect(container.querySelector(`.ProseMirror ${selector}`)).not.toBeInTheDocument();
+      expectHiddenMarkdownDelimiters(container, 0);
+    }
+
+    await settleMarkdownListener();
+  });
+
+  it("keeps edited escaped literal markdown delimiters as plain text", async () => {
+    const { container, view } = await renderEditor("\\*literal\\*");
+
+    const from = findTextPosition(view, "literal");
+    selectText(view, from, from + "literal".length);
+    typeText(view, "edited");
+
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("*edited*");
+    expect(container.querySelector(".ProseMirror .markra-live-mark-emphasis")).not.toBeInTheDocument();
+    expectHiddenMarkdownDelimiters(container, 0);
+    await settleMarkdownListener();
+  });
+
   it("supports inline markdown formatting shortcuts", async () => {
     const strong = await renderEditor();
     typeText(strong.view, "bold");

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -340,7 +340,7 @@ function MilkdownEditorSurface({
             resolveImageSrc
           })
         )
-        .use(markraLiveMarkdownPlugin({ highlight: highlightSyntaxEnabled }));
+        .use(markraLiveMarkdownPlugin({ highlight: highlightSyntaxEnabled, initialMarkdown: initialContentRef.current }));
 
       if (externalLinkOpeningEnabled) {
         editor.use(

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -554,7 +554,7 @@ export function markraLiveMarkdownSpecs(ctx: Ctx, options: MarkraLiveMarkdownOpt
     },
     {
       markers: ["***"],
-      pattern: /\*\*\*[^\n]*?\*\*\*/g,
+      pattern: /(?<!\*)\*\*\*(?!\s)[^\n]*?(?<!\s)\*\*\*(?!\*)/g,
       marks: [
         {
           kind: "strong",
@@ -594,7 +594,7 @@ export function markraLiveMarkdownSpecs(ctx: Ctx, options: MarkraLiveMarkdownOpt
     },
     {
       markers: ["**"],
-      pattern: /\*\*[^\n]*?\*\*/g,
+      pattern: /(?<!\*)\*\*(?!\s)[^\n]*?(?<!\s)\*\*(?!\*)/g,
       marks: [
         {
           kind: "strong",
@@ -640,7 +640,7 @@ export function markraLiveMarkdownSpecs(ctx: Ctx, options: MarkraLiveMarkdownOpt
       : []),
     {
       markers: ["*"],
-      pattern: /(?<!\*)\*(?!\*)[^*\n]*?(?<!\*)\*(?!\*)/g,
+      pattern: /(?<!\*)\*(?![\s*])[^*\n]*?(?<![\s*])\*(?!\*)/g,
       marks: [
         {
           kind: "emphasis",

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -2,7 +2,7 @@ import type { Ctx } from "@milkdown/kit/ctx";
 import { emphasisSchema, inlineCodeSchema, strongSchema } from "@milkdown/kit/preset/commonmark";
 import { strikethroughSchema } from "@milkdown/kit/preset/gfm";
 import type { Mark, MarkType, Node as ProseNode } from "@milkdown/kit/prose/model";
-import { type EditorState, Plugin, PluginKey, TextSelection } from "@milkdown/kit/prose/state";
+import { type EditorState, Plugin, PluginKey, TextSelection, type Transaction } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
@@ -10,6 +10,7 @@ export type LiveMarkdownKind = "strong" | "emphasis" | "inlineCode" | "strikethr
 
 export type MarkraLiveMarkdownOptions = {
   highlight?: boolean;
+  initialMarkdown?: string;
 };
 
 export type LiveMarkdownSpec = {
@@ -53,6 +54,10 @@ type SuppressedLiveMarkdownRange = ActiveLiveMarkdownRange & {
   cursor: number;
 };
 
+type SuppressedLiteralMarkdownRange = ActiveLiveMarkdownRange & {
+  marker: string;
+};
+
 type ExitedFoldedMarkdownRange = FoldedMarkdownRange & {
   cursor: number;
 };
@@ -62,6 +67,7 @@ type LiveMarkdownPluginState = {
   activeFoldedRange: FoldedMarkdownRange | null;
   exitedFoldedRange: ExitedFoldedMarkdownRange | null;
   suppressedLiveRange: SuppressedLiveMarkdownRange | null;
+  suppressedLiteralRanges: SuppressedLiteralMarkdownRange[];
 };
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
@@ -110,6 +116,132 @@ function getLiveMarkdownRanges(text: string, specs: LiveMarkdownSpec[]) {
   }
 
   return ranges.sort((left, right) => left.from - right.from || right.to - left.to);
+}
+
+function escapedMarkerSource(marker: string) {
+  return Array.from(marker).map((character) => `\\${character}`).join("");
+}
+
+function unescapeMarkdownPunctuation(text: string) {
+  const escapable = new Set(Array.from(String.raw`!"#$%&'()*+,-./:;<=>?@[\]^_` + "`{|}~"));
+  let result = "";
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    const nextCharacter = text[index + 1];
+    if (character === "\\" && nextCharacter && escapable.has(nextCharacter)) {
+      result += nextCharacter;
+      index += 1;
+      continue;
+    }
+
+    result += character;
+  }
+
+  return result;
+}
+
+function escapedLiteralMarkdownTexts(markdown: string, specs: LiveMarkdownSpec[]) {
+  const literals: Array<{ marker: string; text: string }> = [];
+  const seen = new Set<string>();
+  const markers = [...new Set(specs.flatMap((spec) => spec.markers))].sort((left, right) => right.length - left.length);
+
+  for (const marker of markers) {
+    const escapedMarker = escapedMarkerSource(marker);
+    let searchFrom = 0;
+
+    while (searchFrom < markdown.length) {
+      const openingStart = markdown.indexOf(escapedMarker, searchFrom);
+      if (openingStart < 0) break;
+
+      const openingEnd = openingStart + escapedMarker.length;
+      const lineEnd = markdown.indexOf("\n", openingEnd);
+      const closingLimit = lineEnd < 0 ? markdown.length : lineEnd;
+      const closingStart = markdown.indexOf(escapedMarker, openingEnd);
+
+      if (closingStart < 0 || closingStart > closingLimit) {
+        searchFrom = openingEnd;
+        continue;
+      }
+
+      const content = unescapeMarkdownPunctuation(markdown.slice(openingEnd, closingStart));
+      if (content.length > 0) {
+        const text = `${marker}${content}${marker}`;
+        const key = `${marker}\n${text}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          literals.push({ marker, text });
+        }
+      }
+      searchFrom = closingStart + escapedMarker.length;
+    }
+  }
+
+  return literals;
+}
+
+function findSuppressedLiteralRanges(
+  doc: ProseNode,
+  specs: LiveMarkdownSpec[],
+  initialMarkdown: string | undefined
+) {
+  if (!initialMarkdown) return [];
+
+  const literals = escapedLiteralMarkdownTexts(initialMarkdown, specs);
+  if (literals.length === 0) return [];
+
+  const ranges: SuppressedLiteralMarkdownRange[] = [];
+
+  doc.descendants((node, position) => {
+    if (!node.isTextblock) return;
+
+    const blockStart = position + 1;
+    for (const literal of literals) {
+      let fromIndex = 0;
+      while (fromIndex < node.textContent.length) {
+        const index = node.textContent.indexOf(literal.text, fromIndex);
+        if (index < 0) break;
+
+        ranges.push({
+          from: blockStart + index,
+          to: blockStart + index + literal.text.length,
+          marker: literal.marker
+        });
+        fromIndex = index + literal.text.length;
+      }
+    }
+  });
+
+  return ranges.sort((left, right) => left.from - right.from || right.to - left.to);
+}
+
+function mapSuppressedLiteralRanges(
+  ranges: SuppressedLiteralMarkdownRange[],
+  tr: Transaction
+) {
+  if (!tr.docChanged || ranges.length === 0) return ranges;
+
+  return ranges.flatMap((range) => {
+    const from = tr.mapping.map(range.from, -1);
+    const to = tr.mapping.map(range.to, 1);
+
+    if (to <= from) return [];
+
+    const text = tr.doc.textBetween(from, to);
+    if (!text.startsWith(range.marker) || !text.endsWith(range.marker)) return [];
+    if (text.length <= range.marker.length * 2) return [];
+
+    return [{ ...range, from, to }];
+  });
+}
+
+function isSuppressedLiteralRange(
+  ranges: SuppressedLiteralMarkdownRange[],
+  from: number,
+  to: number,
+  marker: string
+) {
+  return ranges.some((range) => range.from === from && range.to === to && range.marker === marker);
 }
 
 function getMarkByType(marks: readonly Mark[], markType: MarkType) {
@@ -338,7 +470,8 @@ function buildLiveMarkdownDecorations(
   specs: LiveMarkdownSpec[],
   activeLiveRange: ActiveLiveMarkdownRange | null,
   activeFoldedRange: FoldedMarkdownRange | null,
-  exitedFoldedRange: ExitedFoldedMarkdownRange | null
+  exitedFoldedRange: ExitedFoldedMarkdownRange | null,
+  suppressedLiteralRanges: SuppressedLiteralMarkdownRange[]
 ) {
   const decorations: Decoration[] = [];
 
@@ -351,6 +484,10 @@ function buildLiveMarkdownDecorations(
     for (const range of ranges) {
       const from = blockStart + range.from;
       const to = blockStart + range.to;
+      if (isSuppressedLiteralRange(suppressedLiteralRanges, from, to, range.marker)) {
+        continue;
+      }
+
       const contentFrom = blockStart + range.contentFrom;
       const contentTo = blockStart + range.contentTo;
       const delimiterClass =
@@ -679,20 +816,23 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       return clearManagedStoredMarks(newState, managedMarkTypes);
     },
     state: {
-      init: (): LiveMarkdownPluginState => ({
+      init: (_config, state): LiveMarkdownPluginState => ({
         suppressActiveAt: null,
         activeFoldedRange: null,
         exitedFoldedRange: null,
-        suppressedLiveRange: null
+        suppressedLiveRange: null,
+        suppressedLiteralRanges: findSuppressedLiteralRanges(state.doc, specs, options.initialMarkdown)
       }),
       apply: (tr, value, _oldState, newState): LiveMarkdownPluginState => {
         const meta = tr.getMeta(liveMarkdownKey) as Partial<LiveMarkdownPluginState> | undefined;
+        const suppressedLiteralRanges = mapSuppressedLiteralRanges(value.suppressedLiteralRanges, tr);
         if (meta && "exitedFoldedRange" in meta) {
           return {
             suppressActiveAt: null,
             activeFoldedRange: meta.activeFoldedRange ?? null,
             exitedFoldedRange: meta.exitedFoldedRange ?? null,
-            suppressedLiveRange: null
+            suppressedLiveRange: null,
+            suppressedLiteralRanges
           };
         }
 
@@ -702,7 +842,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
             suppressActiveAt: null,
             activeFoldedRange: null,
             exitedFoldedRange: null,
-            suppressedLiveRange: meta.suppressedLiveRange
+            suppressedLiveRange: meta.suppressedLiveRange,
+            suppressedLiteralRanges
           };
         }
 
@@ -711,7 +852,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
             suppressActiveAt: meta.suppressActiveAt,
             activeFoldedRange: null,
             exitedFoldedRange: null,
-            suppressedLiveRange: null
+            suppressedLiveRange: null,
+            suppressedLiteralRanges
           };
         }
 
@@ -729,7 +871,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
             activeFoldedRange,
             exitedFoldedRange,
             suppressedLiveRange:
-              selection?.from === value.suppressedLiveRange?.cursor ? value.suppressedLiveRange : null
+              selection?.from === value.suppressedLiveRange?.cursor ? value.suppressedLiveRange : null,
+            suppressedLiteralRanges
           };
         }
 
@@ -738,11 +881,12 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
             suppressActiveAt: null,
             activeFoldedRange: null,
             exitedFoldedRange: null,
-            suppressedLiveRange: null
+            suppressedLiveRange: null,
+            suppressedLiteralRanges
           };
         }
 
-        return value;
+        return suppressedLiteralRanges === value.suppressedLiteralRanges ? value : { ...value, suppressedLiteralRanges };
       }
     },
     props: {
@@ -761,7 +905,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           specs,
           activeLiveRange,
           pluginState?.activeFoldedRange ?? null,
-          pluginState?.exitedFoldedRange ?? null
+          pluginState?.exitedFoldedRange ?? null,
+          pluginState?.suppressedLiteralRanges ?? []
         );
       },
       handleTextInput: (view, _from, _to, text) => insertTextAfterExitedFoldedMarkdown(view, text, managedMarkTypes),


### PR DESCRIPTION
## Summary
- Preserve escaped literal Markdown delimiters from the original source so live Markdown decorations do not hide them in the visual editor.
- Cover escaped `*`, `**`, `***`, `_`, `__`, `~~`, `==`, and inline-code backtick delimiter pairs.
- Keep those escaped literal ranges stable when their inner text is edited, as long as the literal delimiters remain.

## Why
Issue #254 showed that source text containing escaped Markdown delimiters could be parsed into plain text, then reinterpreted by the live Markdown decoration layer. The most visible case was escaped literal asterisks being hidden or styled as emphasis.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx --reporter=default -t "keeps edited escaped literal"` passed after first confirming the new regression test failed before the range-tracking fix.
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx --reporter=default -t "escaped literal"` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx --reporter=dot` passed, 347 tests.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Related Issues
Closes #254
