### PR TITLE
feat(app): use CodeMirror for markdown source mode

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,7 +27,9 @@
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
   "dependencies": {
+    "@codemirror/commands": "6.10.3",
     "@codemirror/lang-json": "6.0.2",
+    "@codemirror/lang-markdown": "6.5.0",
     "@codemirror/lint": "6.9.5",
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.41.1",

--- a/packages/app/src/App.document-history.test.tsx
+++ b/packages/app/src/App.document-history.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { EditorView } from "@codemirror/view";
 import {
   installAppTestHarness,
   mockNativePath,
@@ -27,6 +28,23 @@ vi.mock("./hooks/useEditorController", async (importOriginal) => {
 });
 
 installAppTestHarness();
+
+function replaceMarkdownSource(sourceEditor: HTMLElement, value: string) {
+  const view = EditorView.findFromDOM(sourceEditor);
+  if (!view) {
+    throw new Error("Expected the markdown source editor to use CodeMirror.");
+  }
+
+  act(() => {
+    view.dispatch({
+      changes: {
+        from: 0,
+        insert: value,
+        to: view.state.doc.length
+      }
+    });
+  });
+}
 
 describe("Markra document history restore", () => {
   beforeEach(() => {
@@ -287,11 +305,7 @@ describe("Markra document history restore", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
-    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
-      target: {
-        value: "# Updated\n\nSynthetic body."
-      }
-    });
+    replaceMarkdownSource(await screen.findByRole("textbox", { name: "Markdown source" }), "# Updated\n\nSynthetic body.");
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
 
     await waitFor(() => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2394,12 +2394,12 @@ describe("Markra workspace", () => {
     expect(sourceModeButton).toBeEnabled();
     fireEvent.click(sourceModeButton);
 
-    const sourceEditors = screen.getAllByRole("textbox", { name: "Markdown source" });
+    const sourceEditors = await screen.findAllByRole("textbox", { name: "Markdown source" });
     expect(sourceEditors.map((editor) => readMarkdownSource(editor).trimEnd())).toEqual(
       expect.arrayContaining(["# Guide\n\nReference", "# Third\n\nIndependent"])
     );
 
-    const sideSource = within(replacedSidePane).getByRole("textbox", { name: "Markdown source" });
+    const sideSource = await within(replacedSidePane).findByRole("textbox", { name: "Markdown source" });
     expect(readMarkdownSource(sideSource)).toBe("# Third\n\nIndependent");
 
     replaceMarkdownSource(sideSource, "# Third\n\nIndependent update");
@@ -2739,8 +2739,8 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
     const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
-    const sideSource = within(sidePane).getByRole("textbox", { name: "Markdown source" });
-    const mainSource = screen.getAllByRole("textbox", { name: "Markdown source" }).find((editor) =>
+    const sideSource = await within(sidePane).findByRole("textbox", { name: "Markdown source" });
+    const mainSource = (await screen.findAllByRole("textbox", { name: "Markdown source" })).find((editor) =>
       !sidePane.contains(editor)
     ) as HTMLElement;
 
@@ -2868,7 +2868,7 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
     const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
-    const sideSource = within(sidePane).getByRole("textbox", { name: "Markdown source" });
+    const sideSource = await within(sidePane).findByRole("textbox", { name: "Markdown source" });
 
     fireEvent.focus(sideSource);
     replaceMarkdownSource(sideSource, "# Second\n\nFocused side draft");
@@ -2941,7 +2941,7 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
     const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
-    fireEvent.focus(within(sidePane).getByRole("textbox", { name: "Markdown source" }));
+    fireEvent.focus(await within(sidePane).findByRole("textbox", { name: "Markdown source" }));
 
     fireEvent.keyDown(window, { key: "w", metaKey: true });
 
@@ -4207,7 +4207,7 @@ describe("Markra workspace", () => {
 
     const [visualPane, , sourcePane] = Array.from(splitSurface!.children) as HTMLElement[];
     expect(within(visualPane!).getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
-    expect(within(sourcePane!).getByRole("textbox", { name: "Markdown source" })).toBeInTheDocument();
+    expect(await within(sourcePane!).findByRole("textbox", { name: "Markdown source" })).toBeInTheDocument();
   });
 
   it("resizes split panes from the center divider and persists the ratio", async () => {
@@ -4309,7 +4309,7 @@ describe("Markra workspace", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
-    const sourceScroll = screen.getByLabelText("Markdown source").closest(".paper-scroll")!;
+    const sourceScroll = (await screen.findByLabelText("Markdown source")).closest(".paper-scroll")!;
     mockScrollMetrics(sourceScroll, {
       clientHeight: 200,
       scrollHeight: 1200,

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1661,8 +1661,9 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
-    expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "source");
-    expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+    const sourceEditor = await screen.findByLabelText("Markdown editor");
+    expect(sourceEditor).toHaveAttribute("data-editor-engine", "source");
+    expect(sourceEditor).toHaveStyle({
       maxWidth: "980px"
     });
     expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "980");

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { EditorView } from "@codemirror/view";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import desktopPackage from "../package.json";
 import { defaultAiQuickActionPrompts } from "./lib/ai-actions";
@@ -124,6 +125,33 @@ function mockElementFromPoint(element: Element) {
   });
 
   return mock;
+}
+
+function getMarkdownSourceView(sourceEditor: HTMLElement) {
+  const view = EditorView.findFromDOM(sourceEditor);
+  if (!view) {
+    throw new Error("Expected the markdown source editor to use CodeMirror.");
+  }
+
+  return view;
+}
+
+function readMarkdownSource(sourceEditor: HTMLElement) {
+  return getMarkdownSourceView(sourceEditor).state.doc.toString();
+}
+
+function replaceMarkdownSource(sourceEditor: HTMLElement, value: string) {
+  const view = getMarkdownSourceView(sourceEditor);
+
+  act(() => {
+    view.dispatch({
+      changes: {
+        from: 0,
+        insert: value,
+        to: view.state.doc.length
+      }
+    });
+  });
 }
 
 function createStoredEditorPreferences(
@@ -2367,18 +2395,14 @@ describe("Markra workspace", () => {
     fireEvent.click(sourceModeButton);
 
     const sourceEditors = screen.getAllByRole("textbox", { name: "Markdown source" });
-    expect(sourceEditors.map((editor) => (editor as HTMLTextAreaElement).value.trimEnd())).toEqual(
+    expect(sourceEditors.map((editor) => readMarkdownSource(editor).trimEnd())).toEqual(
       expect.arrayContaining(["# Guide\n\nReference", "# Third\n\nIndependent"])
     );
 
     const sideSource = within(replacedSidePane).getByRole("textbox", { name: "Markdown source" });
-    expect(sideSource).toHaveValue("# Third\n\nIndependent");
+    expect(readMarkdownSource(sideSource)).toBe("# Third\n\nIndependent");
 
-    fireEvent.change(sideSource, {
-      target: {
-        value: "# Third\n\nIndependent update"
-      }
-    });
+    replaceMarkdownSource(sideSource, "# Third\n\nIndependent update");
     expect(screen.getByRole("tab", { name: /guide\.md/ })).toHaveAttribute("aria-selected", "true");
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
@@ -2718,14 +2742,10 @@ describe("Markra workspace", () => {
     const sideSource = within(sidePane).getByRole("textbox", { name: "Markdown source" });
     const mainSource = screen.getAllByRole("textbox", { name: "Markdown source" }).find((editor) =>
       !sidePane.contains(editor)
-    ) as HTMLTextAreaElement;
+    ) as HTMLElement;
 
     fireEvent.focus(sideSource);
-    fireEvent.change(sideSource, {
-      target: {
-        value: "# Second\n\nFocused side edit"
-      }
-    });
+    replaceMarkdownSource(sideSource, "# Second\n\nFocused side edit");
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
 
     await waitFor(() =>
@@ -2739,11 +2759,7 @@ describe("Markra workspace", () => {
     );
 
     fireEvent.focus(sideSource);
-    fireEvent.change(sideSource, {
-      target: {
-        value: "# Second\n\nFocused side save as"
-      }
-    });
+    replaceMarkdownSource(sideSource, "# Second\n\nFocused side save as");
     fireEvent.keyDown(window, { key: "s", metaKey: true, shiftKey: true });
 
     await waitFor(() =>
@@ -2765,11 +2781,7 @@ describe("Markra workspace", () => {
     );
 
     fireEvent.focus(mainSource);
-    fireEvent.change(mainSource, {
-      target: {
-        value: "# First\n\nFocused main edit"
-      }
-    });
+    replaceMarkdownSource(mainSource, "# First\n\nFocused main edit");
     fireEvent.keyDown(window, { key: "s", metaKey: true, shiftKey: true });
 
     await waitFor(() =>
@@ -2859,11 +2871,7 @@ describe("Markra workspace", () => {
     const sideSource = within(sidePane).getByRole("textbox", { name: "Markdown source" });
 
     fireEvent.focus(sideSource);
-    fireEvent.change(sideSource, {
-      target: {
-        value: "# Second\n\nFocused side draft"
-      }
-    });
+    replaceMarkdownSource(sideSource, "# Second\n\nFocused side draft");
 
     fireEvent.click(screen.getByRole("tab", { name: /3\.md/ }));
     await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).not.toBeInTheDocument());
@@ -3938,14 +3946,10 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
-    expect((sourceEditor as HTMLTextAreaElement).value).toContain("# Welcome to Markra");
+    expect(readMarkdownSource(sourceEditor)).toContain("# Welcome to Markra");
     expect(screen.queryByRole("heading", { name: "Welcome to Markra" })).not.toBeInTheDocument();
 
-    fireEvent.change(sourceEditor, {
-      target: {
-        value: "# Source edit\n\nUpdated from source mode."
-      }
-    });
+    replaceMarkdownSource(sourceEditor, "# Source edit\n\nUpdated from source mode.");
 
     expect(screen.getByLabelText("Unsaved changes")).toBeInTheDocument();
 
@@ -3964,11 +3968,7 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
-    fireEvent.change(sourceEditor, {
-      target: {
-        value: "> [!WARNING]\n>\n> First line\n> Second line"
-      }
-    });
+    replaceMarkdownSource(sourceEditor, "> [!WARNING]\n>\n> First line\n> Second line");
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
 
@@ -3993,11 +3993,7 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     const source = "> [!WARNING]\n>\n>";
-    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
-      target: {
-        value: source
-      }
-    });
+    replaceMarkdownSource(await screen.findByRole("textbox", { name: "Markdown source" }), source);
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
 
@@ -4008,7 +4004,7 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(source);
+      expect(readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }))).toBe(source);
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
@@ -4026,11 +4022,7 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     const source = "> [!WARNING]\n>\n> Synthetic details\n>\n>";
-    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
-      target: {
-        value: source
-      }
-    });
+    replaceMarkdownSource(await screen.findByRole("textbox", { name: "Markdown source" }), source);
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
 
@@ -4041,7 +4033,7 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(source);
+      expect(readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }))).toBe(source);
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
@@ -4120,13 +4112,9 @@ describe("Markra workspace", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open in source mode" }));
 
     const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
-    expect(sourceEditor).toHaveValue(largeContent);
+    expect(readMarkdownSource(sourceEditor)).toBe(largeContent);
 
-    fireEvent.change(sourceEditor, {
-      target: {
-        value: `${largeContent}\n\nEdited in source mode.`
-      }
-    });
+    replaceMarkdownSource(sourceEditor, `${largeContent}\n\nEdited in source mode.`);
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
 
@@ -4162,11 +4150,11 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
     const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
-    expect(sourceEditor).toHaveValue(restoredContent);
+    expect(readMarkdownSource(sourceEditor)).toBe(restoredContent);
 
     await settleEditorUpdates();
 
-    expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(restoredContent);
+    expect(readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }))).toBe(restoredContent);
     expect(screen.getByRole("button", { name: "Switch to visual mode" })).toBeInTheDocument();
     expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
   });
@@ -4183,11 +4171,7 @@ describe("Markra workspace", () => {
     expect(visualEditor).toBeInTheDocument();
     expect(container.querySelector(".editor-split-surface")).toBeInTheDocument();
 
-    fireEvent.change(sourceEditor, {
-      target: {
-        value: "# Split source edit\n\nUpdated from the source pane."
-      }
-    });
+    replaceMarkdownSource(sourceEditor, "# Split source edit\n\nUpdated from the source pane.");
 
     await waitFor(() => {
       const currentVisualEditor = container.querySelector('[data-editor-engine="milkdown"]') as HTMLElement | null;
@@ -4204,10 +4188,10 @@ describe("Markra workspace", () => {
     });
 
     await waitFor(() => {
-      const currentSourceEditor = screen.getByRole("textbox", { name: "Markdown source" }) as HTMLTextAreaElement;
-      expect(currentSourceEditor.value).toMatch(/\|\s+\|\s+\|\n\|\s+-+\s+\|\s+-+\s+\|\n\|\s+\|\s+\|/u);
-      expect(currentSourceEditor.value).not.toContain("Column 1");
-      expect(currentSourceEditor.value).not.toContain("Column 2");
+      const currentSource = readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }));
+      expect(currentSource).toMatch(/\|\s+\|\s+\|\n\|\s+-+\s+\|\s+-+\s+\|\n\|\s+\|\s+\|/u);
+      expect(currentSource).not.toContain("Column 1");
+      expect(currentSource).not.toContain("Column 2");
     });
   });
 
@@ -4363,7 +4347,7 @@ describe("Markra workspace", () => {
     fireEvent.keyDown(window, { key: "s", altKey: true, metaKey: true });
 
     const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
-    expect((sourceEditor as HTMLTextAreaElement).value).toContain("# Welcome to Markra");
+    expect(readMarkdownSource(sourceEditor)).toContain("# Welcome to Markra");
 
     fireEvent.keyDown(window, { key: "s", altKey: true, metaKey: true });
 
@@ -4749,7 +4733,7 @@ describe("Markra workspace", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Replace" }));
 
-    expect((sourceEditor as HTMLTextAreaElement).value).toContain("# Hello to Markra");
+    expect(readMarkdownSource(sourceEditor)).toContain("# Hello to Markra");
   });
 
   it("toggles read-only mode from the keyboard shortcut and marks the status area", async () => {
@@ -4775,7 +4759,7 @@ describe("Markra workspace", () => {
     fireEvent.keyDown(window, { key: "s", altKey: true, metaKey: true });
     fireEvent.keyDown(window, { key: "l", altKey: true, metaKey: true });
 
-    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveAttribute("readonly");
+    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveAttribute("aria-readonly", "true");
     expect(screen.queryByLabelText("Unsaved changes")).not.toBeInTheDocument();
   });
 
@@ -4818,7 +4802,7 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
-    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveValue(originalContent);
+    expect(readMarkdownSource(await screen.findByRole("textbox", { name: "Markdown source" }))).toBe(originalContent);
     expect(screen.queryByLabelText("Unsaved changes")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
@@ -4849,7 +4833,7 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
-    expect((await screen.findByRole("textbox", { name: "Markdown source" }) as HTMLTextAreaElement).value.trim()).toBe(
+    expect(readMarkdownSource(await screen.findByRole("textbox", { name: "Markdown source" })).trim()).toBe(
       "### C\n\nSummary content."
     );
     expect(screen.queryByLabelText("Unsaved changes")).not.toBeInTheDocument();
@@ -4872,11 +4856,10 @@ describe("Markra workspace", () => {
     expect(await screen.findByText("Native file")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
-    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
-      target: {
-        value: "# Source save\n\nSaved from source mode."
-      }
-    });
+    replaceMarkdownSource(
+      await screen.findByRole("textbox", { name: "Markdown source" }),
+      "# Source save\n\nSaved from source mode."
+    );
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
 
     await waitFor(() =>
@@ -4935,11 +4918,10 @@ describe("Markra workspace", () => {
     expect(await screen.findByText("Native file")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
-    fireEvent.change(await screen.findByRole("textbox", { name: "Markdown source" }), {
-      target: {
-        value: "# Source save\n\nSynced after save."
-      }
-    });
+    replaceMarkdownSource(
+      await screen.findByRole("textbox", { name: "Markdown source" }),
+      "# Source save\n\nSynced after save."
+    );
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
 
     await waitFor(() => expect(mockedSaveNativeMarkdownFile).toHaveBeenCalled());

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,7 +27,7 @@ import {
 } from "./components/MarkdownExportDocument";
 import { MarkdownFileTreeDrawer } from "./components/MarkdownFileTreeDrawer";
 import { MarkdownPaper } from "./components/MarkdownPaper";
-import { MarkdownSourceEditor } from "./components/MarkdownSourceEditor";
+import { LazyMarkdownSourceEditor } from "./components/LazyMarkdownSourceEditor";
 import {
   MarkdownTabsBar,
   markdownTabDragDataType,
@@ -3634,7 +3634,7 @@ function WorkspaceApp() {
                         <span className="pointer-events-none absolute inset-y-5 left-1/2 w-px -translate-x-1/2 bg-(--border-default) transition-colors duration-150 ease-out group-hover/split-resizer:bg-(--accent) group-focus/split-resizer:bg-(--accent)" />
                       </div>
                       <div className="min-h-0 overflow-hidden" onFocusCapture={handleSourcePaneFocus}>
-                        <MarkdownSourceEditor
+                        <LazyMarkdownSourceEditor
                           autoFocus={activeEditorSurface === "source"}
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
@@ -3658,7 +3658,7 @@ function WorkspaceApp() {
                       </div>
                     </div>
                   ) : sourceMode ? (
-                    <MarkdownSourceEditor
+                    <LazyMarkdownSourceEditor
                       autoFocus
                       bodyFontSize={editorPreferences.preferences.bodyFontSize}
                       content={document.content}

--- a/packages/app/src/components/LazyMarkdownSourceEditor.tsx
+++ b/packages/app/src/components/LazyMarkdownSourceEditor.tsx
@@ -1,0 +1,60 @@
+import { lazy, Suspense, type CSSProperties } from "react";
+import {
+  editorContentWidthPixels,
+  type EditorContentWidth
+} from "../lib/editor-width";
+import type { MarkdownSourceEditorProps } from "./MarkdownSourceEditor";
+
+const MarkdownSourceEditor = lazy(async () => {
+  const module = await import("./MarkdownSourceEditor");
+
+  return { default: module.MarkdownSourceEditor };
+});
+
+function markdownSourceTopInsetClassName(topInset: MarkdownSourceEditorProps["topInset"]) {
+  if (topInset === "tabs") return "pt-24 max-[900px]:pt-20";
+  if (topInset === "titlebar") return "pt-14 max-[900px]:pt-10";
+
+  return "pt-6 max-[900px]:pt-5";
+}
+
+function markdownSourceContentWidth(contentWidth: EditorContentWidth | undefined, contentWidthPx: number | null | undefined) {
+  return contentWidthPx ?? editorContentWidthPixels[contentWidth ?? "default"];
+}
+
+function MarkdownSourceEditorFallback({
+  bodyFontSize = 16,
+  contentWidth,
+  contentWidthPx,
+  lineHeight = 1.65,
+  scrollRef,
+  topInset = "titlebar"
+}: MarkdownSourceEditorProps) {
+  const paperStyle = {
+    fontSize: `${bodyFontSize}px`,
+    lineHeight,
+    maxWidth: `${markdownSourceContentWidth(contentWidth, contentWidthPx)}px`
+  } satisfies CSSProperties;
+
+  return (
+    <section
+      aria-hidden="true"
+      className="paper-scroll h-full min-h-0 overflow-auto overscroll-none bg-transparent"
+      ref={scrollRef}
+    >
+      <article
+        className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${markdownSourceTopInsetClassName(topInset)} text-[16px] leading-[1.65] text-(--text-primary) max-[900px]:px-5.25`}
+        data-editor-engine="source-loading"
+        style={paperStyle}
+      />
+    </section>
+  );
+}
+
+export function LazyMarkdownSourceEditor(props: MarkdownSourceEditorProps) {
+  return (
+    <Suspense fallback={<MarkdownSourceEditorFallback {...props} />}>
+      <MarkdownSourceEditor {...props} />
+    </Suspense>
+  );
+}

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -1,8 +1,34 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { redo, undo } from "@codemirror/commands";
+import { EditorView } from "@codemirror/view";
 import { MarkdownSourceEditor } from "./MarkdownSourceEditor";
 
+function getMarkdownSourceView(container: HTMLElement) {
+  const shell = container.querySelector<HTMLElement>('[data-testid="markdown-source-editor"]');
+  expect(shell).toBeInTheDocument();
+
+  const view = EditorView.findFromDOM(shell!);
+  if (!view) {
+    throw new Error("Expected the markdown source editor to use CodeMirror.");
+  }
+
+  return view;
+}
+
+function replaceCodeMirrorDoc(view: EditorView, value: string) {
+  act(() => {
+    view.dispatch({
+      changes: {
+        from: 0,
+        insert: value,
+        to: view.state.doc.length
+      }
+    });
+  });
+}
+
 describe("MarkdownSourceEditor", () => {
-  it("renders editable markdown with source highlighting", () => {
+  it("renders editable markdown with CodeMirror source highlighting", () => {
     const content = [
       "# Title",
       "",
@@ -19,43 +45,62 @@ describe("MarkdownSourceEditor", () => {
         onChange={handleChange}
       />
     );
+    const view = getMarkdownSourceView(container);
+    const sourceEditor = screen.getByRole("textbox", { name: "Markdown source" });
 
-    expect(screen.getByRole("textbox", { name: "Markdown source" })).toHaveValue(content);
-    expect(container.querySelector(".markdown-source-highlight")).toHaveTextContent("const answer = 42;");
-    expect(container.querySelector(".markdown-source-token-heading-marker")).toHaveTextContent("#");
-    expect(container.querySelector(".markdown-source-token-code-fence")).toHaveTextContent("```");
-    expect(container.querySelector(".markdown-source-token-code")).toHaveTextContent("const answer = 42;");
-    expect(container.querySelector(".markdown-source-token-list-marker")).toHaveTextContent("-");
+    expect(sourceEditor.tagName).not.toBe("TEXTAREA");
+    expect(view.state.doc.toString()).toBe(content);
+    expect(container.querySelector(".cm-editor")).toBeInTheDocument();
+    expect(container.querySelector(".cm-content")).toHaveTextContent("const answer = 42;");
 
-    fireEvent.change(screen.getByRole("textbox", { name: "Markdown source" }), {
-      target: {
-        value: "# Changed"
-      }
-    });
+    replaceCodeMirrorDoc(view, "# Changed");
 
     expect(handleChange).toHaveBeenCalledWith("# Changed");
   });
 
-  it("highlights GitHub-style alert markers in source mode", () => {
-    const content = "> [!TIP]\n> Keep notes portable.";
-
+  it("keeps source edits undoable and redoable", () => {
+    const handleChange = vi.fn();
     const { container } = render(
       <MarkdownSourceEditor
-        content={content}
+        content=""
+        onChange={handleChange}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    replaceCodeMirrorDoc(view, "# Changed");
+    expect(view.state.doc.toString()).toBe("# Changed");
+
+    act(() => {
+      expect(undo(view)).toBe(true);
+    });
+    expect(view.state.doc.toString()).toBe("");
+
+    act(() => {
+      expect(redo(view)).toBe(true);
+    });
+    expect(view.state.doc.toString()).toBe("# Changed");
+    expect(handleChange).toHaveBeenLastCalledWith("# Changed");
+  });
+
+  it("highlights GitHub-style alert markers in CodeMirror source mode", async () => {
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="> [!TIP]\n> Keep notes portable."
         onChange={() => {}}
       />
     );
 
-    expect(container.querySelector(".markdown-source-token-callout")).toHaveTextContent("[!TIP]");
-    expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
+    await waitFor(() => {
+      expect(container.querySelector(".markdown-source-token-callout")).toHaveTextContent("[!TIP]");
+      expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
+    });
   });
 
   it("leaves GitHub-style alert markers plain when the extension is disabled", () => {
-    const content = "> [!TIP]\n> Keep notes portable.";
-
     const { container } = render(
       <MarkdownSourceEditor
-        content={content}
+        content="> [!TIP]\n> Keep notes portable."
         extendedSyntax={{
           githubAlerts: false,
           highlight: true
@@ -68,7 +113,7 @@ describe("MarkdownSourceEditor", () => {
     expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
   });
 
-  it("renders exact search highlights in source mode", () => {
+  it("selects exact search matches in source mode", async () => {
     const { container } = render(
       <MarkdownSourceEditor
         content="alpha, beta，gamma"
@@ -77,9 +122,11 @@ describe("MarkdownSourceEditor", () => {
         onChange={() => {}}
       />
     );
+    const view = getMarkdownSourceView(container);
 
-    expect(container.querySelector(".markra-source-search-match")).toHaveTextContent(",");
-    expect(container.querySelector(".markra-source-search-match-current")).toHaveTextContent(",");
-    expect(container.querySelector(".markra-source-search-match")).not.toHaveTextContent("，");
+    await waitFor(() => {
+      expect(view.state.selection.main.from).toBe(5);
+      expect(view.state.selection.main.to).toBe(6);
+    });
   });
 });

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -58,6 +58,35 @@ describe("MarkdownSourceEditor", () => {
     expect(handleChange).toHaveBeenCalledWith("# Changed");
   });
 
+  it("applies visible Markra token classes to common Markdown syntax", async () => {
+    const content = [
+      "# Title",
+      "",
+      "```ts",
+      "const answer = 42;",
+      "```",
+      "- Item",
+      "Text with `code`, [link](https://example.test), and **strong text**."
+    ].join("\n");
+
+    const { container } = render(
+      <MarkdownSourceEditor
+        content={content}
+        onChange={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".markdown-source-token-heading")).toHaveTextContent("Title");
+      expect(container.querySelector(".markdown-source-token-code-fence")).toHaveTextContent("```");
+      expect(container.querySelector(".markdown-source-token-code")).toHaveTextContent("const answer = 42;");
+      expect(container.querySelector(".markdown-source-token-list-marker")).toHaveTextContent("-");
+      expect(container.querySelector(".markdown-source-token-inline-code")).toHaveTextContent("code");
+      expect(container.querySelector(".markdown-source-token-link")).toHaveTextContent("link");
+      expect(container.querySelector(".markdown-source-token-emphasis")).toHaveTextContent("strong text");
+    });
+  });
+
   it("keeps source edits undoable and redoable", () => {
     const handleChange = vi.fn();
     const { container } = render(

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -13,7 +13,7 @@ import {
 import type { ExtendedSyntaxPreferences } from "../lib/settings/app-settings";
 import { EditorWidthResizer } from "./EditorWidthResizer";
 
-type MarkdownSourceEditorProps = {
+export type MarkdownSourceEditorProps = {
   autoFocus?: boolean;
   bodyFontSize?: number;
   content: string;
@@ -303,7 +303,8 @@ export function MarkdownSourceEditor({
     () => [
       minimalSetup,
       markdown({
-        base: markdownLanguage
+        base: markdownLanguage,
+        codeLanguages: []
       }),
       EditorView.lineWrapping,
       contentAttributesCompartmentRef.current.of(markdownSourceContentAttributes(sourceLabel, readOnly)),

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -38,6 +38,10 @@ type MarkdownSourceEditorProps = {
 
 const externalSourceUpdate = Annotation.define<boolean>();
 
+type FenceState = {
+  marker: "`" | "~" | null;
+};
+
 function markdownSourceContentAttributes(label: string, readOnly: boolean): Extension {
   return EditorView.contentAttributes.of({
     "aria-label": label,
@@ -73,41 +77,131 @@ function markdownSourceSearchExtension(matches: SearchRange[] = [], activeIndex 
   });
 }
 
-function markdownSourceExtendedSyntaxExtension(githubAlertsEnabled: boolean): Extension {
+function addMarkdownSourceDecoration(
+  decorations: Range<Decoration>[],
+  from: number,
+  to: number,
+  className: string
+) {
+  if (to <= from) return;
+
+  decorations.push(Decoration.mark({ class: className }).range(from, to));
+}
+
+function markdownInlineTokenClassName(token: string) {
+  if (token.startsWith("`")) return "markdown-source-token-inline-code";
+  if (token.startsWith("!") || token.startsWith("[")) return "markdown-source-token-link";
+
+  return "markdown-source-token-emphasis";
+}
+
+function addMarkdownInlineSourceDecorations(decorations: Range<Decoration>[], text: string, from: number) {
+  const tokenPattern = /(!?\[[^\]]+\]\([^)]+\)|`[^`]+`|\*\*[^*]+?\*\*|__[^_]+?__|\*[^*\s][^*]*\*|_[^_\s][^_]*_)/gu;
+
+  for (const match of text.matchAll(tokenPattern)) {
+    const token = match[0];
+    const index = match.index ?? 0;
+    addMarkdownSourceDecoration(
+      decorations,
+      from + index,
+      from + index + token.length,
+      markdownInlineTokenClassName(token)
+    );
+  }
+}
+
+function markdownSourceSyntaxExtension(githubAlertsEnabled: boolean): Extension {
   return EditorView.decorations.compute(["doc"], (state) => {
     const decorations: Range<Decoration>[] = [];
+    const fenceState: FenceState = { marker: null };
 
     for (let lineNumber = 1; lineNumber <= state.doc.lines; lineNumber += 1) {
       const line = state.doc.line(lineNumber);
-      const blockquoteMatch = /^(\s*>+)(\s.*)?$/u.exec(line.text);
-      if (!blockquoteMatch) continue;
-
-      const quoteMarker = blockquoteMatch[1] ?? "";
-      if (quoteMarker) {
-        decorations.push(
-          Decoration.mark({
-            class: "markdown-source-token-quote-marker"
-          }).range(line.from, line.from + quoteMarker.length)
-        );
+      const fenceMatch = /^(\s*)(`{3,}|~{3,})(.*)$/u.exec(line.text);
+      if (fenceMatch && (!fenceState.marker || fenceMatch[2]!.startsWith(fenceState.marker))) {
+        const [, indent = "", fence = "", info = ""] = fenceMatch;
+        const fenceFrom = line.from + indent.length;
+        addMarkdownSourceDecoration(decorations, line.from, fenceFrom, "markdown-source-token-muted");
+        addMarkdownSourceDecoration(decorations, fenceFrom, fenceFrom + fence.length, "markdown-source-token-code-fence");
+        addMarkdownSourceDecoration(decorations, fenceFrom + fence.length, line.to, "markdown-source-token-code-info");
+        fenceState.marker = fenceState.marker ? null : fence[0] === "~" ? "~" : "`";
+        continue;
       }
 
-      if (!githubAlertsEnabled) continue;
+      if (fenceState.marker) {
+        addMarkdownSourceDecoration(decorations, line.from, line.to, "markdown-source-token-code");
+        continue;
+      }
 
-      const calloutContent = blockquoteMatch[2] ?? "";
-      const calloutPrefixMatch = /^(\s*)(.*)$/u.exec(calloutContent);
-      const calloutMarker = parseMarkdownCalloutMarker(calloutPrefixMatch?.[2] ?? "");
-      if (!calloutMarker || !calloutPrefixMatch) continue;
+      const headingMatch = /^(#{1,6})(\s.*)?$/u.exec(line.text);
+      if (headingMatch) {
+        const marker = headingMatch[1] ?? "";
+        addMarkdownSourceDecoration(decorations, line.from, line.from + marker.length, "markdown-source-token-heading-marker");
+        addMarkdownSourceDecoration(decorations, line.from + marker.length, line.to, "markdown-source-token-heading");
+        continue;
+      }
 
-      const [, prefix = "", content = ""] = calloutPrefixMatch;
-      const markerIndex = content.indexOf(calloutMarker.source);
-      if (markerIndex < 0) continue;
+      const blockquoteMatch = /^(\s*>+)(\s.*)?$/u.exec(line.text);
+      if (blockquoteMatch) {
+        const quoteMarker = blockquoteMatch[1] ?? "";
+        const quoteTo = line.from + quoteMarker.length;
+        addMarkdownSourceDecoration(decorations, line.from, quoteTo, "markdown-source-token-quote-marker");
 
-      const markerFrom = line.from + quoteMarker.length + prefix.length + markerIndex;
-      decorations.push(
-        Decoration.mark({
-          class: "markdown-source-token-callout"
-        }).range(markerFrom, markerFrom + calloutMarker.source.length)
-      );
+        const calloutContent = blockquoteMatch[2] ?? "";
+        const calloutStart = quoteTo;
+        const calloutPrefixMatch = /^(\s*)(.*)$/u.exec(calloutContent);
+        const calloutMarker = githubAlertsEnabled ? parseMarkdownCalloutMarker(calloutPrefixMatch?.[2] ?? "") : null;
+        if (calloutMarker && calloutPrefixMatch) {
+          const [, prefix = "", content = ""] = calloutPrefixMatch;
+          const contentStart = calloutStart + prefix.length;
+          const markerIndex = content.indexOf(calloutMarker.source);
+          if (markerIndex < 0) {
+            addMarkdownInlineSourceDecorations(decorations, calloutContent, calloutStart);
+            continue;
+          }
+
+          const markerFrom = contentStart + markerIndex;
+          if (markerIndex > 0) addMarkdownInlineSourceDecorations(decorations, content.slice(0, markerIndex), contentStart);
+          addMarkdownSourceDecoration(
+            decorations,
+            markerFrom,
+            markerFrom + calloutMarker.source.length,
+            "markdown-source-token-callout"
+          );
+          addMarkdownInlineSourceDecorations(
+            decorations,
+            content.slice(markerIndex + calloutMarker.source.length),
+            markerFrom + calloutMarker.source.length
+          );
+        } else {
+          addMarkdownInlineSourceDecorations(decorations, calloutContent, calloutStart);
+        }
+
+        continue;
+      }
+
+      const listMatch = /^(\s*)([-*+]|\d+[.)])(\s+.*)?$/u.exec(line.text);
+      if (listMatch) {
+        const indent = listMatch[1] ?? "";
+        const marker = listMatch[2] ?? "";
+        const markerFrom = line.from + indent.length;
+        const markerTo = markerFrom + marker.length;
+        addMarkdownSourceDecoration(decorations, line.from, markerFrom, "markdown-source-token-muted");
+        addMarkdownSourceDecoration(decorations, markerFrom, markerTo, "markdown-source-token-list-marker");
+        addMarkdownInlineSourceDecorations(decorations, listMatch[3] ?? "", markerTo);
+        continue;
+      }
+
+      const ruleMatch = /^(\s*)([-*_])(?:\s*\2){2,}\s*$/u.exec(line.text);
+      if (ruleMatch) {
+        const indent = ruleMatch[1] ?? "";
+        const ruleFrom = line.from + indent.length;
+        addMarkdownSourceDecoration(decorations, line.from, ruleFrom, "markdown-source-token-muted");
+        addMarkdownSourceDecoration(decorations, ruleFrom, line.to, "markdown-source-token-rule");
+        continue;
+      }
+
+      addMarkdownInlineSourceDecorations(decorations, line.text, line.from);
     }
 
     return Decoration.set(decorations, true);
@@ -215,7 +309,7 @@ export function MarkdownSourceEditor({
       contentAttributesCompartmentRef.current.of(markdownSourceContentAttributes(sourceLabel, readOnly)),
       editableCompartmentRef.current.of(EditorView.editable.of(!readOnly)),
       searchCompartmentRef.current.of(markdownSourceSearchExtension(searchMatches, searchActiveIndex)),
-      syntaxCompartmentRef.current.of(markdownSourceExtendedSyntaxExtension(githubAlertsEnabled)),
+      syntaxCompartmentRef.current.of(markdownSourceSyntaxExtension(githubAlertsEnabled)),
       EditorView.updateListener.of((update) => {
         if (!update.docChanged) return;
         if (update.transactions.some((transaction) => transaction.annotation(externalSourceUpdate))) return;
@@ -306,7 +400,7 @@ export function MarkdownSourceEditor({
     if (!view) return;
 
     view.dispatch({
-      effects: syntaxCompartmentRef.current.reconfigure(markdownSourceExtendedSyntaxExtension(githubAlertsEnabled))
+      effects: syntaxCompartmentRef.current.reconfigure(markdownSourceSyntaxExtension(githubAlertsEnabled))
     });
   }, [githubAlertsEnabled]);
 

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -1,13 +1,8 @@
-import {
-  Fragment,
-  useEffect,
-  useRef,
-  type CSSProperties,
-  type ChangeEvent,
-  type ReactNode,
-  type Ref,
-  type UIEvent
-} from "react";
+import { useEffect, useMemo, useRef, type CSSProperties, type Ref, type UIEvent } from "react";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { Annotation, Compartment, EditorSelection, EditorState, Transaction, type Extension, type Range } from "@codemirror/state";
+import { Decoration, EditorView } from "@codemirror/view";
+import { minimalSetup } from "codemirror";
 import { parseMarkdownCalloutMarker, t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
   editorContentWidthPixels,
@@ -41,186 +36,124 @@ type MarkdownSourceEditorProps = {
   topInset?: "none" | "tabs" | "titlebar";
 };
 
-type FenceState = {
-  marker: "`" | "~" | null;
-};
+const externalSourceUpdate = Annotation.define<boolean>();
 
-type MarkdownSourceHighlightOptions = {
-  githubAlerts: boolean;
-};
-
-function renderMarkdownSourceHighlight(content: string, options: MarkdownSourceHighlightOptions) {
-  const lines = content.split("\n");
-  const fenceState: FenceState = { marker: null };
-
-  return lines.map((line, index) => (
-    <Fragment key={`line-${index}`}>
-      {renderMarkdownSourceLine(line, index, fenceState, options)}
-      {index < lines.length - 1 ? "\n" : null}
-    </Fragment>
-  ));
+function markdownSourceContentAttributes(label: string, readOnly: boolean): Extension {
+  return EditorView.contentAttributes.of({
+    "aria-label": label,
+    "aria-multiline": "true",
+    "aria-readonly": readOnly ? "true" : "false",
+    "data-language": "markdown",
+    role: "textbox",
+    spellcheck: "false"
+  });
 }
 
-function renderMarkdownSourceLine(
-  line: string,
-  lineIndex: number,
-  fenceState: FenceState,
-  options: MarkdownSourceHighlightOptions
-): ReactNode {
-  const fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})(.*)$/u);
-  if (fenceMatch && (!fenceState.marker || fenceMatch[2]!.startsWith(fenceState.marker))) {
-    const [, indent = "", fence = "", info = ""] = fenceMatch;
-    fenceState.marker = fenceState.marker ? null : fence[0] === "~" ? "~" : "`";
+function clampSearchRange(match: SearchRange, documentLength: number) {
+  const from = Math.max(0, Math.min(documentLength, match.from));
+  const to = Math.max(from, Math.min(documentLength, match.to));
 
-    return (
-      <>
-        {indent ? <span className="markdown-source-token-muted">{indent}</span> : null}
-        <span className="markdown-source-token-code-fence">{fence}</span>
-        {info ? <span className="markdown-source-token-code-info">{info}</span> : null}
-      </>
-    );
-  }
+  return { from, to };
+}
 
-  if (fenceState.marker) {
-    return <span className="markdown-source-token-code">{line}</span>;
-  }
+function markdownSourceSearchExtension(matches: SearchRange[] = [], activeIndex = -1): Extension {
+  return EditorView.decorations.compute(["doc"], (state) => {
+    const decorations = matches.flatMap((match, index) => {
+      const { from, to } = clampSearchRange(match, state.doc.length);
+      if (to <= from) return [];
 
-  const headingMatch = line.match(/^(#{1,6})(\s.*)?$/u);
-  if (headingMatch) {
-    return (
-      <>
-        <span className="markdown-source-token-heading-marker">{headingMatch[1]}</span>
-        {headingMatch[2] ? <span className="markdown-source-token-heading">{headingMatch[2]}</span> : null}
-      </>
-    );
-  }
+      return Decoration.mark({
+        class: `markra-cm-source-search-match ${
+          index === activeIndex ? "markra-cm-source-search-match-current" : ""
+        }`
+      }).range(from, to);
+    });
 
-  const blockquoteMatch = line.match(/^(\s*>+)(\s.*)?$/u);
-  if (blockquoteMatch) {
-    const calloutContent = blockquoteMatch[2] ?? "";
-    const calloutPrefixMatch = /^(\s*)(.*)$/u.exec(calloutContent);
-    const calloutMarker = options.githubAlerts ? parseMarkdownCalloutMarker(calloutPrefixMatch?.[2] ?? "") : null;
-    if (calloutMarker && calloutPrefixMatch) {
+    return Decoration.set(decorations, true);
+  });
+}
+
+function markdownSourceExtendedSyntaxExtension(githubAlertsEnabled: boolean): Extension {
+  return EditorView.decorations.compute(["doc"], (state) => {
+    const decorations: Range<Decoration>[] = [];
+
+    for (let lineNumber = 1; lineNumber <= state.doc.lines; lineNumber += 1) {
+      const line = state.doc.line(lineNumber);
+      const blockquoteMatch = /^(\s*>+)(\s.*)?$/u.exec(line.text);
+      if (!blockquoteMatch) continue;
+
+      const quoteMarker = blockquoteMatch[1] ?? "";
+      if (quoteMarker) {
+        decorations.push(
+          Decoration.mark({
+            class: "markdown-source-token-quote-marker"
+          }).range(line.from, line.from + quoteMarker.length)
+        );
+      }
+
+      if (!githubAlertsEnabled) continue;
+
+      const calloutContent = blockquoteMatch[2] ?? "";
+      const calloutPrefixMatch = /^(\s*)(.*)$/u.exec(calloutContent);
+      const calloutMarker = parseMarkdownCalloutMarker(calloutPrefixMatch?.[2] ?? "");
+      if (!calloutMarker || !calloutPrefixMatch) continue;
+
       const [, prefix = "", content = ""] = calloutPrefixMatch;
       const markerIndex = content.indexOf(calloutMarker.source);
-      const afterMarker = content.slice(markerIndex + calloutMarker.source.length);
+      if (markerIndex < 0) continue;
 
-      return (
-        <>
-          <span className="markdown-source-token-quote-marker">{blockquoteMatch[1]}</span>
-          {prefix ? <span className="markdown-source-token-muted">{prefix}</span> : null}
-          {markerIndex > 0 ? renderInlineMarkdownSource(content.slice(0, markerIndex), lineIndex) : null}
-          <span className="markdown-source-token-callout">{calloutMarker.source}</span>
-          {afterMarker ? renderInlineMarkdownSource(afterMarker, lineIndex) : null}
-        </>
+      const markerFrom = line.from + quoteMarker.length + prefix.length + markerIndex;
+      decorations.push(
+        Decoration.mark({
+          class: "markdown-source-token-callout"
+        }).range(markerFrom, markerFrom + calloutMarker.source.length)
       );
     }
 
-    return (
-      <>
-        <span className="markdown-source-token-quote-marker">{blockquoteMatch[1]}</span>
-        {blockquoteMatch[2] ? renderInlineMarkdownSource(blockquoteMatch[2], lineIndex) : null}
-      </>
-    );
-  }
-
-  const listMatch = line.match(/^(\s*)([-*+]|\d+[.)])(\s+.*)?$/u);
-  if (listMatch) {
-    return (
-      <>
-        {listMatch[1] ? <span className="markdown-source-token-muted">{listMatch[1]}</span> : null}
-        <span className="markdown-source-token-list-marker">{listMatch[2]}</span>
-        {listMatch[3] ? renderInlineMarkdownSource(listMatch[3], lineIndex) : null}
-      </>
-    );
-  }
-
-  const ruleMatch = line.match(/^(\s*)([-*_])(?:\s*\2){2,}\s*$/u);
-  if (ruleMatch) {
-    return (
-      <>
-        {ruleMatch[1] ? <span className="markdown-source-token-muted">{ruleMatch[1]}</span> : null}
-        <span className="markdown-source-token-rule">{line.slice(ruleMatch[1]!.length)}</span>
-      </>
-    );
-  }
-
-  return renderInlineMarkdownSource(line, lineIndex);
-}
-
-function renderInlineMarkdownSource(text: string, lineIndex: number) {
-  const tokens: ReactNode[] = [];
-  const tokenPattern = /(!?\[[^\]]+\]\([^)]+\)|`[^`]+`|\*\*[^*]+?\*\*|__[^_]+?__|\*[^*\s][^*]*\*|_[^_\s][^_]*_)/gu;
-  let offset = 0;
-
-  for (const match of text.matchAll(tokenPattern)) {
-    const token = match[0];
-    const index = match.index ?? 0;
-    if (index > offset) tokens.push(text.slice(offset, index));
-
-    tokens.push(
-      <span
-        className={markdownInlineTokenClassName(token)}
-        key={`line-${lineIndex}-token-${index}`}
-      >
-        {token}
-      </span>
-    );
-    offset = index + token.length;
-  }
-
-  if (offset < text.length) tokens.push(text.slice(offset));
-
-  return tokens;
-}
-
-function markdownInlineTokenClassName(token: string) {
-  if (token.startsWith("`")) return "markdown-source-token-inline-code";
-  if (token.startsWith("!") || token.startsWith("[")) return "markdown-source-token-link";
-
-  return "markdown-source-token-emphasis";
-}
-
-function renderSourceSearchHighlights(content: string, matches: SearchRange[] = [], activeIndex = -1) {
-  if (matches.length === 0) return null;
-
-  const nodes: ReactNode[] = [];
-  let offset = 0;
-
-  matches.forEach((match, index) => {
-    const from = Math.max(0, Math.min(content.length, match.from));
-    const to = Math.max(from, Math.min(content.length, match.to));
-    if (to <= from) return;
-
-    if (from > offset) {
-      nodes.push(
-        <span className="markra-source-search-transparent" key={`text-${offset}`}>
-          {content.slice(offset, from)}
-        </span>
-      );
-    }
-
-    nodes.push(
-      <span
-        className={`markra-source-search-match ${index === activeIndex ? "markra-source-search-match-current" : ""}`}
-        data-markra-source-search-current={index === activeIndex ? "true" : undefined}
-        key={`match-${from}-${to}-${index}`}
-      >
-        {content.slice(from, to)}
-      </span>
-    );
-    offset = to;
+    return Decoration.set(decorations, true);
   });
+}
 
-  if (offset < content.length) {
-    nodes.push(
-      <span className="markra-source-search-transparent" key={`text-${offset}`}>
-        {content.slice(offset)}
-      </span>
-    );
-  }
-
-  return nodes;
+function markdownSourceTheme(): Extension {
+  return EditorView.theme({
+    "&": {
+      backgroundColor: "transparent",
+      color: "var(--text-primary)",
+      fontSize: "0.94em",
+      minHeight: "calc(100vh - 176px)"
+    },
+    "&.cm-editor": {
+      height: "auto"
+    },
+    "&.cm-focused": {
+      outline: "none"
+    },
+    ".cm-activeLine": {
+      backgroundColor: "transparent"
+    },
+    ".cm-content": {
+      caretColor: "var(--accent)",
+      minHeight: "calc(100vh - 176px)",
+      padding: "0",
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word"
+    },
+    ".cm-cursor": {
+      borderLeftColor: "var(--accent)"
+    },
+    ".cm-line": {
+      padding: "0"
+    },
+    ".cm-scroller": {
+      fontFamily:
+        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+      lineHeight: "inherit",
+      overflow: "visible"
+    },
+    ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+      backgroundColor: "color-mix(in srgb, var(--accent) 22%, transparent)"
+    }
+  });
 }
 
 export function MarkdownSourceEditor({
@@ -245,20 +178,22 @@ export function MarkdownSourceEditor({
   scrollRef,
   topInset = "titlebar"
 }: MarkdownSourceEditorProps) {
-  const sourceLayerRef = useRef<HTMLDivElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const editorContainerRef = useRef<HTMLDivElement | null>(null);
+  const initialContentRef = useRef(content);
+  const onChangeRef = useRef(onChange);
+  const viewRef = useRef<EditorView | null>(null);
+  const contentAttributesCompartmentRef = useRef(new Compartment());
+  const editableCompartmentRef = useRef(new Compartment());
+  const searchCompartmentRef = useRef(new Compartment());
+  const syntaxCompartmentRef = useRef(new Compartment());
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const githubAlertsEnabled = extendedSyntax?.githubAlerts ?? true;
+  const sourceLabel = t(language, "app.markdownSource");
   const paperStyle = {
     fontSize: `${bodyFontSize}px`,
     lineHeight,
     maxWidth: `${resolvedContentWidth}px`
   } satisfies CSSProperties;
-  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    if (readOnly) return;
-
-    onChange(event.currentTarget.value);
-  };
   const topInsetClassName =
     topInset === "tabs"
       ? "pt-24 max-[900px]:pt-20"
@@ -267,15 +202,119 @@ export function MarkdownSourceEditor({
         : "pt-6 max-[900px]:pt-5";
 
   useEffect(() => {
-    const activeMatch = searchMatches[searchActiveIndex];
-    if (!activeMatch) return;
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
-    textareaRef.current?.setSelectionRange(activeMatch.from, activeMatch.to);
-    const currentMatch = sourceLayerRef.current?.querySelector('[data-markra-source-search-current="true"]');
-    if (currentMatch instanceof HTMLElement && typeof currentMatch.scrollIntoView === "function") {
-      currentMatch.scrollIntoView({ block: "center", inline: "nearest" });
+  const extensions = useMemo(
+    () => [
+      minimalSetup,
+      markdown({
+        base: markdownLanguage
+      }),
+      EditorView.lineWrapping,
+      contentAttributesCompartmentRef.current.of(markdownSourceContentAttributes(sourceLabel, readOnly)),
+      editableCompartmentRef.current.of(EditorView.editable.of(!readOnly)),
+      searchCompartmentRef.current.of(markdownSourceSearchExtension(searchMatches, searchActiveIndex)),
+      syntaxCompartmentRef.current.of(markdownSourceExtendedSyntaxExtension(githubAlertsEnabled)),
+      EditorView.updateListener.of((update) => {
+        if (!update.docChanged) return;
+        if (update.transactions.some((transaction) => transaction.annotation(externalSourceUpdate))) return;
+
+        onChangeRef.current(update.state.doc.toString());
+      }),
+      markdownSourceTheme()
+    ],
+    [githubAlertsEnabled, sourceLabel]
+  );
+
+  useEffect(() => {
+    const container = editorContainerRef.current;
+
+    if (!container || viewRef.current) return;
+
+    const view = new EditorView({
+      parent: container,
+      state: EditorState.create({
+        doc: initialContentRef.current,
+        extensions
+      })
+    });
+
+    viewRef.current = view;
+    if (autoFocus) view.focus();
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  }, [autoFocus, extensions]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    view.dispatch({
+      effects: [
+        contentAttributesCompartmentRef.current.reconfigure(markdownSourceContentAttributes(sourceLabel, readOnly)),
+        editableCompartmentRef.current.reconfigure(EditorView.editable.of(!readOnly))
+      ]
+    });
+  }, [readOnly, sourceLabel]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const currentContent = view.state.doc.toString();
+    if (currentContent === content) return;
+
+    const cursor = Math.min(view.state.selection.main.head, content.length);
+    view.dispatch({
+      annotations: [externalSourceUpdate.of(true), Transaction.addToHistory.of(false)],
+      changes: {
+        from: 0,
+        insert: content,
+        to: view.state.doc.length
+      },
+      selection: EditorSelection.cursor(cursor)
+    });
+  }, [content]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const effects = searchCompartmentRef.current.reconfigure(
+      markdownSourceSearchExtension(searchMatches, searchActiveIndex)
+    );
+    const activeMatch = searchMatches[searchActiveIndex];
+    if (!activeMatch) {
+      view.dispatch({ effects });
+      return;
     }
+
+    const { from, to } = clampSearchRange(activeMatch, view.state.doc.length);
+    view.dispatch({
+      effects,
+      scrollIntoView: true,
+      selection: EditorSelection.range(from, to)
+    });
   }, [searchActiveIndex, searchMatches]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    view.dispatch({
+      effects: syntaxCompartmentRef.current.reconfigure(markdownSourceExtendedSyntaxExtension(githubAlertsEnabled))
+    });
+  }, [githubAlertsEnabled]);
+
+  useEffect(() => {
+    if (!autoFocus) return;
+
+    viewRef.current?.focus();
+  }, [autoFocus]);
 
   return (
     <section
@@ -299,32 +338,12 @@ export function MarkdownSourceEditor({
           onResizeEnd={onContentWidthResizeEnd}
           onResizeStart={onContentWidthResizeStart}
         />
-        <div className="markdown-source-layer relative min-h-[calc(100vh-176px)]" ref={sourceLayerRef}>
-          <pre
-            className="markdown-source-highlight pointer-events-none m-0 min-h-[calc(100vh-176px)] whitespace-pre-wrap wrap-break-word border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal"
-            aria-hidden="true"
-          >
-            <code>{renderMarkdownSourceHighlight(content, { githubAlerts: githubAlertsEnabled })}</code>
-          </pre>
-          {searchMatches.length > 0 ? (
-            <pre
-              className="markra-source-search-layer pointer-events-none absolute inset-0 m-0 min-h-[calc(100vh-176px)] whitespace-pre-wrap wrap-break-word border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal"
-              aria-hidden="true"
-            >
-              <code>{renderSourceSearchHighlights(content, searchMatches, searchActiveIndex)}</code>
-            </pre>
-          ) : null}
-          <textarea
-            className="markdown-source-input absolute inset-0 block h-full min-h-full w-full resize-none overflow-hidden border-0 bg-transparent p-0 font-mono text-[0.94em] leading-[inherit] tracking-normal text-transparent outline-none placeholder:text-(--text-secondary) focus:outline-none"
-            aria-label={t(language, "app.markdownSource")}
-            autoFocus={autoFocus}
-            readOnly={readOnly}
-            ref={textareaRef}
-            spellCheck={false}
-            value={content}
-            onChange={handleChange}
-          />
-        </div>
+        <div
+          className="markdown-source-editor min-h-[calc(100vh-176px)]"
+          data-language="markdown"
+          data-testid="markdown-source-editor"
+          ref={editorContainerRef}
+        />
       </article>
     </section>
   );

--- a/packages/app/src/components/SideDocumentPane.lazy.test.tsx
+++ b/packages/app/src/components/SideDocumentPane.lazy.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { SideDocumentPane } from "./SideDocumentPane";
+
+const sourceEditorModule = vi.hoisted(() => ({
+  loads: 0
+}));
+
+vi.mock("./LargeMarkdownNotice", () => ({
+  LargeMarkdownNotice: () => <div data-testid="large-markdown-notice" />
+}));
+
+vi.mock("./MarkdownPaper", () => ({
+  MarkdownPaper: () => <div data-testid="visual-editor" />
+}));
+
+vi.mock("./MarkdownSourceEditor", () => {
+  sourceEditorModule.loads += 1;
+
+  return {
+    MarkdownSourceEditor: ({ content }: { content: string }) => (
+      <div
+        aria-label="Markdown source"
+        role="textbox"
+      >
+        {content}
+      </div>
+    )
+  };
+});
+
+describe("SideDocumentPane source editor loading", () => {
+  it("loads the source editor module only when source mode is rendered", async () => {
+    const props = {
+      bodyFontSize: 16,
+      content: "# Source",
+      contentWidth: "default" as const,
+      contentWidthPx: null,
+      editorTheme: "light" as const,
+      lineHeight: 1.65,
+      mode: "visual" as const,
+      onChange: vi.fn(),
+      revision: 0
+    };
+    const { rerender } = render(<SideDocumentPane {...props} />);
+
+    expect(screen.getByTestId("visual-editor")).toBeInTheDocument();
+    expect(sourceEditorModule.loads).toBe(0);
+
+    rerender(<SideDocumentPane {...props} mode="source" />);
+
+    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveTextContent("# Source");
+    expect(sourceEditorModule.loads).toBe(1);
+  });
+});

--- a/packages/app/src/components/SideDocumentPane.tsx
+++ b/packages/app/src/components/SideDocumentPane.tsx
@@ -4,9 +4,9 @@ import type { EditorContentWidth } from "../lib/editor-width";
 import type { EditorTheme, ExtendedSyntaxPreferences } from "../lib/settings/app-settings";
 import type { MarkdownDocumentLinkFile } from "../lib/document-links";
 import { shouldBlockLargeMarkdownVisual } from "../lib/large-markdown";
+import { LazyMarkdownSourceEditor } from "./LazyMarkdownSourceEditor";
 import { LargeMarkdownNotice } from "./LargeMarkdownNotice";
 import { MarkdownPaper } from "./MarkdownPaper";
-import { MarkdownSourceEditor } from "./MarkdownSourceEditor";
 
 type SideDocumentPaneProps = {
   bodyFontSize: number;
@@ -73,7 +73,7 @@ export function SideDocumentPane({
       onFocusCapture={onFocus}
     >
       {mode === "source" ? (
-        <MarkdownSourceEditor
+        <LazyMarkdownSourceEditor
           bodyFontSize={bodyFontSize}
           content={content}
           contentWidth={contentWidth}

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -967,6 +967,7 @@
     color: transparent;
   }
 
+  .markra-cm-source-search-match,
   .markra-source-search-match,
   .markra-search-match {
     border-radius: 2px;
@@ -977,6 +978,7 @@
     color: transparent;
   }
 
+  .markra-cm-source-search-match-current,
   .markra-source-search-match-current,
   .markra-search-match-current {
     background: color-mix(in srgb, var(--accent) 30%, transparent);

--- a/packages/scripts/src/vite/index.ts
+++ b/packages/scripts/src/vite/index.ts
@@ -58,6 +58,7 @@ const milkdownDependencies = dependencyPattern([
 const tauriDependencies = dependencyPattern(["@tauri-apps"]);
 const iconDependencies = dependencyPattern(["lucide-react", "lucide-static"]);
 const piAgentDependencies = dependencyPattern(["@earendil-works/pi-agent-core", "@earendil-works/pi-ai", "typebox"]);
+const markdownSourceEditorDependencies = dependencyPattern(["@codemirror/lang-markdown", "@lezer/markdown"]);
 const codeEditorDependencies = dependencyPattern(["@codemirror", "codemirror"]);
 const dndDependencies = dependencyPattern(["@dnd-kit"]);
 const mathDependencies = dependencyPattern(["katex"]);
@@ -93,6 +94,7 @@ function vendorChunkName(id: string) {
   if (tauriDependencies.test(id)) return "tauri-vendor";
   if (iconDependencies.test(id)) return "icons-vendor";
   if (piAgentDependencies.test(id)) return "pi-agent-vendor";
+  if (markdownSourceEditorDependencies.test(id)) return "markdown-source-editor-vendor";
   if (codeEditorDependencies.test(id)) return "code-editor-vendor";
   if (dndDependencies.test(id)) return "dnd-vendor";
   if (mathDependencies.test(id)) return "math-vendor";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,9 +215,15 @@ importers:
 
   packages/app:
     dependencies:
+      '@codemirror/commands':
+        specifier: 6.10.3
+        version: 6.10.3
       '@codemirror/lang-json':
         specifier: 6.0.2
         version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: 6.5.0
+        version: 6.5.0
       '@codemirror/lint':
         specifier: 6.9.5
         version: 6.9.5


### PR DESCRIPTION
## Summary
- replace the custom markdown source textarea/highlight overlay with a CodeMirror 6 source editor
- keep Markra source-mode search selection, read-only state, width controls, and GitHub alert marker highlighting wired through CodeMirror extensions
- lazy-load the Markdown source editor UI and split markdown source parsing into a source-mode-only vendor chunk to reduce startup preload cost
- update source-mode app tests to read and edit CodeMirror documents through editor transactions

## Validation
- pnpm --dir packages/app exec vitest run src/components/MarkdownSourceEditor.test.tsx --reporter=default
- pnpm --dir packages/app exec vitest run src/App.test.tsx src/App.document-history.test.tsx --reporter=dot
- pnpm --filter @markra/app build
- pnpm --filter @markra/app typecheck:test
- pnpm --dir packages/app exec vitest run --reporter=dot
- pnpm --dir packages/app exec vitest run src/components/MarkdownSourceEditor.test.tsx src/components/SideDocumentPane.lazy.test.tsx --reporter=default
- pnpm --dir packages/app exec vitest run src/App.test.tsx --reporter=default -t "source"
- pnpm --filter @markra/app typecheck:test
- pnpm --filter @markra/desktop build
- git diff --check

## Bundle Notes
- The source editor is no longer imported by the visual editor path; a focused test verifies the side document pane does not load it until source mode renders.
- The desktop build now emits `MarkdownSourceEditor-*.js` and `markdown-source-editor-vendor-*.js` as dynamic chunks, and the built `index.html` preload list does not include those source-editor chunks.
- Current desktop build output: `MarkdownSourceEditor-Ci36A5qE.js` is 6.67 kB raw / 2.82 kB gzip, and `markdown-source-editor-vendor-D07SCx4i.js` is 43.61 kB raw / 15.06 kB gzip.

## Notes
- This PR tries CodeMirror in source mode against the cursor/undo-redo issues reported in the current source editor.
