### PR TITLE
fix(editor): allow right arrow past inline code delimiters

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6173,6 +6173,22 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("lets the browser continue right-arrow movement after exiting inline code delimiters", async () => {
+    const source = "`n!`/`n₁!` \\* `n₂!` \\* … \\* `nₖ!`)";
+    const { container, view } = await renderEditor(source);
+    const firstCodeEnd = findTextPosition(view, "n!", "n!".length);
+
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe("n!/n₁! * n₂! * … * nₖ!)");
+    expect(container.querySelectorAll(".ProseMirror code")).toHaveLength(4);
+
+    moveCursor(view, firstCodeEnd);
+    expect(pressArrowRight(view)).toBe(true);
+    expect(view.state.selection.from).toBe(firstCodeEnd);
+    expect(pressArrowRight(view)).toBeUndefined();
+    expect(view.state.selection.from).toBe(firstCodeEnd);
+    await settleMarkdownListener();
+  });
+
   it("turns filled strong delimiters into bold text", async () => {
     const { container, view } = await renderEditor();
 
@@ -6436,7 +6452,7 @@ describe("MarkdownPaper editing", () => {
       exitedClosingDelimiterDecorations.some((decoration) => decoration.from === codeEnd && decoration.to === codeEnd)
     ).toBe(true);
     expect(container.querySelector(".ProseMirror code")?.textContent).toBe("sample");
-    expect(pressArrowRight(view)).toBe(true);
+    expect(pressArrowRight(view)).toBeUndefined();
     const stableExitedClosingDelimiterDecorations: Array<{ from: number; to: number }> = [];
     view.someProp("decorations", (decorations) => {
       const value = typeof decorations === "function" ? decorations(view.state) : decorations;

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -349,6 +349,9 @@ function moveCursorPastFoldedMarkdownDelimiter(
   const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
 
   if (direction === "right") {
+    const exitedRange = pluginState?.exitedFoldedRange ?? null;
+    if (exitedRange && selection.from === exitedRange.cursor) return false;
+
     const foldedRange =
       pluginState?.activeFoldedRange ?? getFoldedMarkdownRangeAtCursor(view.state.doc, selection.from, specs);
     if (!foldedRange || selection.from !== foldedRange.to) return false;


### PR DESCRIPTION
## Summary
- Let the editor hand right-arrow movement back to ProseMirror after the user exits a folded inline Markdown delimiter.
- Add regression coverage for inline code mixed with escaped literal asterisks.

## Why
- The first right-arrow at a finalized inline code edge reveals the virtual closing delimiter, but repeated right-arrow presses were still swallowed by the live Markdown plugin. That could leave the cursor stuck around inline code boundaries.

## Validation
- `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx -t "right-arrow movement after exiting inline code|keeps text typed after moving past the folded closing delimiter"` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed

## Risk
- Low. The behavior change is limited to right-arrow handling after exiting folded inline Markdown delimiters.

Closes #260