### PR TITLE
fix(editor): sync link and format toolbar state

### DIFF
--- a/apps/desktop/src-tauri/src/external_urls.rs
+++ b/apps/desktop/src-tauri/src/external_urls.rs
@@ -1,5 +1,15 @@
 use std::process::Command;
 
+#[cfg(any(target_os = "windows", test))]
+fn windows_create_no_window_flag() -> u32 {
+    0x08000000
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_open_command_creation_flags() -> u32 {
+    windows_create_no_window_flag()
+}
+
 fn validate_external_url(url: &str) -> Result<String, String> {
     let parsed = reqwest::Url::parse(url.trim()).map_err(|_| "Invalid external URL".to_string())?;
 
@@ -20,8 +30,11 @@ fn open_system_url(url: &str) -> Result<(), String> {
 
 #[cfg(target_os = "windows")]
 fn open_system_url(url: &str) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+
     Command::new("cmd")
         .args(["/C", "start", "", url])
+        .creation_flags(windows_open_command_creation_flags())
         .spawn()
         .map(|_| ())
         .map_err(|error| format!("Failed to open external URL: {error}"))
@@ -44,7 +57,9 @@ pub(crate) fn open_external_url(url: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_external_url;
+    use super::{
+        validate_external_url, windows_create_no_window_flag, windows_open_command_creation_flags,
+    };
 
     #[test]
     fn accepts_browser_and_mail_urls() {
@@ -62,5 +77,13 @@ mod tests {
     fn rejects_non_external_url_schemes() {
         assert!(validate_external_url("javascript:alert(1)").is_err());
         assert!(validate_external_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn windows_open_command_uses_no_window_creation_flag() {
+        assert_eq!(
+            windows_open_command_creation_flags() & windows_create_no_window_flag(),
+            windows_create_no_window_flag()
+        );
     }
 }

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -86,6 +86,7 @@ import {
   mockedWriteNativeMarkdownTemplateFile,
   renderApp
 } from "./test/app-harness";
+import { runEditorLinkCommand } from "./App";
 import type { NativeMenuHandlers } from "./test/app-harness";
 import { configureAppRuntime, createDefaultAppRuntime, resetAppRuntimeForTests } from "./runtime";
 
@@ -245,6 +246,23 @@ function mockTitlebarActionRects(actionIds: string[]) {
 describe("Markra workspace", () => {
   afterEach(() => {
     resetAppRuntimeForTests();
+  });
+
+  it("syncs selection toolbar formatting after running the editor link command", () => {
+    const insertMarkdownLink = vi.fn();
+    const syncAiSelectionToolbarFormattingState = vi.fn();
+    const syncVisualMarkdownAfterEditorCommand = vi.fn();
+
+    expect(runEditorLinkCommand({
+      insertMarkdownLink,
+      readOnlyMode: false,
+      syncAiSelectionToolbarFormattingState,
+      syncVisualMarkdownAfterEditorCommand
+    })).toBe(true);
+
+    expect(insertMarkdownLink).toHaveBeenCalledTimes(1);
+    expect(syncVisualMarkdownAfterEditorCommand).toHaveBeenCalledTimes(1);
+    expect(syncAiSelectionToolbarFormattingState).toHaveBeenCalledTimes(1);
   });
 
   it("renders a Typora-like minimal writing surface", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -263,6 +263,27 @@ function useSettingsWindowRoute() {
 
 const pandocInstallUrl = "https://pandoc.org/installing.html";
 
+type EditorLinkCommandOptions = {
+  insertMarkdownLink: () => unknown;
+  readOnlyMode: boolean;
+  syncAiSelectionToolbarFormattingState: () => unknown;
+  syncVisualMarkdownAfterEditorCommand: () => unknown;
+};
+
+export function runEditorLinkCommand({
+  insertMarkdownLink,
+  readOnlyMode,
+  syncAiSelectionToolbarFormattingState,
+  syncVisualMarkdownAfterEditorCommand
+}: EditorLinkCommandOptions) {
+  if (readOnlyMode) return false;
+
+  insertMarkdownLink();
+  syncVisualMarkdownAfterEditorCommand();
+  syncAiSelectionToolbarFormattingState();
+  return true;
+}
+
 function isPandocSetupError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error ?? "");
 
@@ -498,6 +519,7 @@ function WorkspaceApp() {
   const findEditorSearchMatches = editor.findSearchMatches;
   const getEditorCurrentMarkdown = editor.getCurrentMarkdown;
   const handleMilkdownEditorReady = editor.handleEditorReady;
+  const insertEditorMarkdownLink = editor.insertMarkdownLink;
   const insertEditorMarkdownSnippet = editor.insertMarkdownSnippet;
   const insertEditorMarkdownTable = editor.insertMarkdownTable;
   const isEditorCurrentMarkdownEquivalent = editor.isCurrentMarkdownEquivalent;
@@ -2572,6 +2594,19 @@ function WorkspaceApp() {
     insertEditorMarkdownSnippet(...args);
     syncVisualMarkdownAfterEditorCommand();
   }, [insertEditorMarkdownSnippet, readOnlyMode, syncVisualMarkdownAfterEditorCommand]);
+  const handleInsertMarkdownLink = useCallback(() => {
+    runEditorLinkCommand({
+      insertMarkdownLink: insertEditorMarkdownLink,
+      readOnlyMode,
+      syncAiSelectionToolbarFormattingState,
+      syncVisualMarkdownAfterEditorCommand
+    });
+  }, [
+    insertEditorMarkdownLink,
+    readOnlyMode,
+    syncAiSelectionToolbarFormattingState,
+    syncVisualMarkdownAfterEditorCommand
+  ]);
   const handleInsertMarkdownTable = useCallback(() => {
     if (readOnlyMode) return;
 
@@ -2637,8 +2672,8 @@ function WorkspaceApp() {
     if (readOnlyMode) return;
 
     setAiSelectionToolbarAnchor(null);
-    handleInsertMarkdownSnippet("[", "](https://)", "text");
-  }, [handleInsertMarkdownSnippet, readOnlyMode]);
+    handleInsertMarkdownLink();
+  }, [handleInsertMarkdownLink, readOnlyMode]);
   const handleAiSelectionToolbarCopySelection = useCallback(() => {
     const selectedText = activeAiSelection?.source === "selection" ? activeAiSelection.text : "";
     if (!selectedText.trim() || !navigator.clipboard) return;
@@ -3082,6 +3117,7 @@ function WorkspaceApp() {
     exportHtml: exportFeatureEnabled ? exportHtmlDocument : undefined,
     exportLatex: exportFeatureEnabled && pandocFeatureEnabled ? exportLatexDocument : undefined,
     exportPdf: exportFeatureEnabled ? exportPdfDocument : undefined,
+    insertMarkdownLink: handleInsertMarkdownLink,
     insertMarkdownSnippet: handleInsertMarkdownSnippet,
     insertMarkdownTable: handleInsertMarkdownTable,
     language: appLanguage.language,

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -354,6 +354,21 @@ function pasteHtml(view: EditorView, html: string, slice: Slice) {
   return view.someProp("handlePaste", (handler) => handler(view, event, slice));
 }
 
+function pasteText(view: EditorView, text: string) {
+  const event = new Event("paste", {
+    bubbles: true,
+    cancelable: true
+  }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [],
+      getData: (type: string) => type === "text/plain" ? text : ""
+    }
+  });
+
+  return view.someProp("handlePaste", (handler) => handler(view, event, view.state.selection.content()));
+}
+
 function dropImage(view: EditorView, image: File) {
   const event = new Event("drop", {
     bubbles: true,
@@ -4358,6 +4373,31 @@ describe("MarkdownPaper editing", () => {
     });
   });
 
+  it.each([
+    ["bold", "b", { metaKey: true }, "strong"],
+    ["italic", "i", { metaKey: true }, "em"],
+    ["strikethrough", "x", { metaKey: true, shiftKey: true }, "del"],
+    ["inline code", "e", { metaKey: true }, "code"]
+  ] as const)("notifies when the %s shortcut changes the current text selection", async (_label, key, modifiers, selector) => {
+    const onTextSelectionChange = vi.fn();
+    const { container, view } = await renderEditor("Format me", { onTextSelectionChange });
+    const from = findTextPosition(view, "Format me");
+    const to = from + "Format me".length;
+
+    selectText(view, from, to);
+    onTextSelectionChange.mockClear();
+
+    expect(pressShortcut(view, key, modifiers)).toBe(true);
+
+    expect(container.querySelector(`.ProseMirror ${selector}`)).toHaveTextContent("Format me");
+    expect(onTextSelectionChange).toHaveBeenCalledWith({
+      from,
+      source: "selection",
+      text: "Format me",
+      to
+    });
+  });
+
   it("waits until pointer text selection settles before notifying selected text", async () => {
     const onTextSelectionChange = vi.fn();
     const selectedDomSelection = {
@@ -7739,6 +7779,21 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector('.ProseMirror a[href="https://example.com"]')).not.toBeInTheDocument();
     expect(container.querySelectorAll(".ProseMirror .markra-live-link-source.markra-md-delimiter")).toHaveLength(2);
     expect(container.querySelector(".ProseMirror")?.textContent).toBe("[Markra](https://example.com)");
+    await settleMarkdownListener();
+  });
+
+  it("turns pasted standalone URLs into finalized links", async () => {
+    const { container, editor, view } = await renderEditor();
+
+    expect(pasteText(view, "https://example.test/articles/about")).toBe(true);
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      '.ProseMirror a[href="https://example.test/articles/about"]'
+    );
+    expect(link).toHaveTextContent("https://example.test/articles/about");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("<https://example.test/articles/about>");
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -344,7 +344,10 @@ export function markraTextSelectionObserverPlugin(
   return $prose(() => {
     let lastSignature = "";
 
-    const notifySelectionChange = (view: EditorView, options: { requireFocusForEmptySelection: boolean }) => {
+    const notifySelectionChange = (
+      view: EditorView,
+      options: { force?: boolean; requireFocusForEmptySelection: boolean }
+    ) => {
       if (editorViewIsComposing(view)) return;
 
       const { selection } = view.state;
@@ -363,7 +366,7 @@ export function markraTextSelectionObserverPlugin(
         const blockContext = readAiSelectionContextFromView(view);
         if (blockContext.text.trim()) {
           const signature = `${blockContext.source ?? "block"}:${blockContext.from}:${blockContext.to}:${blockContext.text}`;
-          if (signature === lastSignature) return;
+          if (!options.force && signature === lastSignature) return;
 
           lastSignature = signature;
           onTextSelectionChange(blockContext);
@@ -388,7 +391,7 @@ export function markraTextSelectionObserverPlugin(
       }
 
       const signature = `${selection.from}:${selection.to}:${text}`;
-      if (signature === lastSignature) return;
+      if (!options.force && signature === lastSignature) return;
 
       lastSignature = signature;
       onTextSelectionChange({
@@ -467,9 +470,14 @@ export function markraTextSelectionObserverPlugin(
           },
           update(view, previousState) {
             const { selection } = view.state;
-            if (selection.eq(previousState.selection)) return;
+            const selectionChanged = !selection.eq(previousState.selection);
+            const selectionTextMayNeedRefresh = !selectionChanged && !selection.empty && !view.state.doc.eq(previousState.doc);
+            if (!selectionChanged && !selectionTextMayNeedRefresh) return;
             if (pointerSelectionPending) return;
-            notifySelectionChange(view, { requireFocusForEmptySelection: true });
+            notifySelectionChange(view, {
+              force: selectionTextMayNeedRefresh,
+              requireFocusForEmptySelection: true
+            });
           }
         };
       }

--- a/packages/app/src/hooks/useEditorController.test.ts
+++ b/packages/app/src/hooks/useEditorController.test.ts
@@ -1,4 +1,5 @@
 import {
+  markdownLinkInsertionForSelection,
   scrollElementToContainerTop,
   scrollElementsAboveContainerBottomInset,
   selectionAnchorFromEditorView
@@ -125,6 +126,35 @@ describe("editor controller scrolling", () => {
 
     expect(scrollElementsAboveContainerBottomInset([target], container, 200, 24)).toBe(false);
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("editor controller link insertion", () => {
+  it("uses a selected URL as both the link label and href", () => {
+    expect(markdownLinkInsertionForSelection("https://example.test/articles/about")).toEqual({
+      href: "https://example.test/articles/about",
+      kind: "link",
+      label: "https://example.test/articles/about",
+      selectionFromOffset: 0,
+      selectionToOffset: "https://example.test/articles/about".length
+    });
+  });
+
+  it("keeps non-URL selections as an editable markdown link snippet", () => {
+    expect(markdownLinkInsertionForSelection("Synthetic label")).toEqual({
+      insertedText: "[Synthetic label](https://)",
+      kind: "snippet",
+      selectionFromOffset: 1,
+      selectionToOffset: "[Synthetic label".length
+    });
+  });
+
+  it("places the cursor after the placeholder label for empty link snippets", () => {
+    expect(markdownLinkInsertionForSelection("")).toEqual({
+      cursorOffset: "[text".length,
+      insertedText: "[text](https://)",
+      kind: "snippet"
+    });
   });
 });
 

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -21,12 +21,13 @@ import {
   type AiEditorPreviewLabels
 } from "@markra/editor";
 import type { MarkdownOutlineItem } from "@markra/markdown";
-import { debug, type SearchRange } from "@markra/shared";
+import { debug, normalizedExternalAutolinkUrl, type SearchRange } from "@markra/shared";
 import {
   clearSelectionFormattingInView,
   readSelectionFormattingActionsFromView,
   readSelectionFormattingStateFromView,
   setSelectionHeadingLevelInView,
+  toggleSelectionLinkInView,
   toggleSelectionHighlightInView,
   type SelectionHeadingLevel,
   type SelectionFormattingState
@@ -43,6 +44,29 @@ const defaultMarkdownTable = [
   "|  |  |"
 ].join("\n");
 const aiSelectionHoldSelector = ".markra-ai-selection-hold";
+
+type MarkdownLinkInsertion =
+  | {
+      href: string;
+      kind: "link";
+      label: string;
+      selectionFromOffset: number;
+      selectionToOffset: number;
+    }
+  | {
+      cursorOffset: number;
+      insertedText: string;
+      kind: "snippet";
+      selectionFromOffset?: undefined;
+      selectionToOffset?: undefined;
+    }
+  | {
+      cursorOffset?: undefined;
+      insertedText: string;
+      kind: "snippet";
+      selectionFromOffset: number;
+      selectionToOffset: number;
+    };
 
 function comparableSerializedMarkdown(markdown: string) {
   return markdown
@@ -114,6 +138,36 @@ function aiCommandSelectionScrollBehavior(): ScrollBehavior {
   if (typeof window.matchMedia !== "function") return "smooth";
 
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+}
+
+export function markdownLinkInsertionForSelection(selectedText: string): MarkdownLinkInsertion {
+  const href = normalizedExternalAutolinkUrl(selectedText);
+  if (href) {
+    return {
+      href,
+      kind: "link",
+      label: selectedText.trim(),
+      selectionFromOffset: 0,
+      selectionToOffset: selectedText.trim().length
+    };
+  }
+
+  const content = selectedText || "text";
+  const insertedText = `[${content}](https://)`;
+  if (selectedText) {
+    return {
+      insertedText,
+      kind: "snippet",
+      selectionFromOffset: 1,
+      selectionToOffset: 1 + content.length
+    };
+  }
+
+  return {
+    cursorOffset: `[${content}`.length,
+    insertedText,
+    kind: "snippet"
+  };
 }
 
 export function readAiSelectionContextFromView(view: EditorView): AiSelectionContext {
@@ -665,6 +719,49 @@ export function useEditorController() {
     view.focus();
   }, []);
 
+  const insertMarkdownLink = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (toggleSelectionLinkInView(view)) return;
+
+      const { from, to } = view.state.selection;
+      const selectedText = view.state.doc.textBetween(from, to, " ");
+      const insertion = markdownLinkInsertionForSelection(selectedText);
+
+      if (insertion.kind === "link") {
+        const link = linkSchema.type(ctx);
+        const linkedText = view.state.schema.text(insertion.label, [
+          link.create({ href: insertion.href })
+        ]);
+        const tr = view.state.tr.replaceWith(from, to, linkedText);
+        tr.setSelection(
+          TextSelection.create(
+            tr.doc,
+            from + insertion.selectionFromOffset,
+            from + insertion.selectionToOffset
+          )
+        ).scrollIntoView();
+
+        view.dispatch(tr);
+        view.focus();
+        return;
+      }
+
+      const tr = view.state.tr.insertText(insertion.insertedText, from, to);
+      const selection =
+        insertion.selectionFromOffset === undefined
+          ? TextSelection.create(tr.doc, from + insertion.cursorOffset)
+          : TextSelection.create(tr.doc, from + insertion.selectionFromOffset, from + insertion.selectionToOffset);
+      tr.setSelection(selection).scrollIntoView();
+
+      view.dispatch(tr);
+      view.focus();
+    });
+  }, []);
+
   const insertMarkdownTable = useCallback(() => {
     const editor = editorRef.current;
     if (!editor) return;
@@ -876,6 +973,7 @@ export function useEditorController() {
     getTableAnchors,
     handleEditorReady,
     holdAiSelection,
+    insertMarkdownLink,
     insertMarkdownSnippet,
     insertMarkdownTable,
     listAiPreviews,

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -4,6 +4,7 @@ import { useApplicationShortcuts, useNativeMenuHandlers } from "./useNativeBindi
 
 describe("useNativeMenuHandlers", () => {
   const baseOptions = {
+    insertMarkdownLink: vi.fn(),
     insertMarkdownSnippet: vi.fn(),
     insertMarkdownTable: vi.fn(),
     openDocument: vi.fn(),
@@ -14,10 +15,12 @@ describe("useNativeMenuHandlers", () => {
   };
 
   it("routes the insert table menu command to the editor table insertion", () => {
+    const insertMarkdownLink = vi.fn();
     const insertMarkdownSnippet = vi.fn();
     const insertMarkdownTable = vi.fn();
     const { result } = renderHook(() =>
       useNativeMenuHandlers({
+        insertMarkdownLink,
         insertMarkdownSnippet,
         insertMarkdownTable,
         openDocument: vi.fn(),
@@ -31,6 +34,24 @@ describe("useNativeMenuHandlers", () => {
     result.current.insertTable?.();
 
     expect(insertMarkdownTable).toHaveBeenCalledTimes(1);
+    expect(insertMarkdownLink).not.toHaveBeenCalled();
+    expect(insertMarkdownSnippet).not.toHaveBeenCalled();
+  });
+
+  it("routes the insert link menu command to the editor link insertion", () => {
+    const insertMarkdownLink = vi.fn();
+    const insertMarkdownSnippet = vi.fn();
+    const { result } = renderHook(() =>
+      useNativeMenuHandlers({
+        ...baseOptions,
+        insertMarkdownLink,
+        insertMarkdownSnippet
+      })
+    );
+
+    result.current.insertLink?.();
+
+    expect(insertMarkdownLink).toHaveBeenCalledTimes(1);
     expect(insertMarkdownSnippet).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -33,6 +33,7 @@ type NativeMenuHandlerOptions = {
   exportHtml?: () => unknown | Promise<unknown>;
   exportLatex?: () => unknown | Promise<unknown>;
   exportPdf?: () => unknown | Promise<unknown>;
+  insertMarkdownLink: () => unknown;
   insertMarkdownSnippet: (open: string, close: string, placeholder: string) => unknown;
   insertMarkdownTable: () => unknown;
   language?: AppLanguage;
@@ -86,6 +87,7 @@ export function useNativeMenuHandlers({
   exportHtml,
   exportLatex,
   exportPdf,
+  insertMarkdownLink,
   insertMarkdownSnippet,
   insertMarkdownTable,
   language = "en",
@@ -118,6 +120,7 @@ export function useNativeMenuHandlers({
     exportLatex,
     exportPdf,
     closeDocument,
+    insertMarkdownLink,
     insertMarkdownSnippet,
     insertMarkdownTable,
     language,
@@ -146,6 +149,7 @@ export function useNativeMenuHandlers({
     exportLatex,
     exportPdf,
     closeDocument,
+    insertMarkdownLink,
     insertMarkdownSnippet,
     insertMarkdownTable,
     language,
@@ -187,7 +191,7 @@ export function useNativeMenuHandlers({
         formatOrderedList: () => runMarkdownShortcut("orderedList"),
         formatQuote: () => runMarkdownShortcut("quote"),
         formatCodeBlock: () => runMarkdownShortcut("codeBlock"),
-        insertLink: () => latestOptionsRef.current.insertMarkdownSnippet("[", "](https://)", "text"),
+        insertLink: () => latestOptionsRef.current.insertMarkdownLink(),
         insertImage: () => latestOptionsRef.current.insertMarkdownSnippet("![", "](https://)", "alt"),
         insertTable: () => latestOptionsRef.current.insertMarkdownTable(),
         toggleAllFolds: () => runMarkdownShortcut("toggleAllFolds")

--- a/packages/app/src/lib/selection-formatting.test.tsx
+++ b/packages/app/src/lib/selection-formatting.test.tsx
@@ -19,6 +19,7 @@ import {
   readSelectionFormattingActionsFromView,
   readSelectionFormattingStateFromView,
   setSelectionHeadingLevelInView,
+  toggleSelectionLinkInView,
   toggleSelectionHighlightInView,
   type SelectionFormattingAction
 } from "./selection-formatting";
@@ -175,6 +176,19 @@ describe("selection formatting", () => {
     expect(toggleSelectionHighlightInView(view)).toBe(true);
     expect(view.state.doc.textContent).toBe("Highlight this text");
     expect(readSelectionFormattingActionsFromView(view)).not.toContain("highlight");
+  });
+
+  it("removes link formatting from selected linked text", async () => {
+    const { view } = await renderEditor("[Synthetic link](https://example.test/articles/about)");
+
+    selectText(view, "Synthetic link");
+
+    expect(readSelectionFormattingActionsFromView(view)).toContain("link");
+
+    expect(toggleSelectionLinkInView(view)).toBe(true);
+
+    expect(view.state.doc.textContent).toBe("Synthetic link");
+    expect(readSelectionFormattingActionsFromView(view)).not.toContain("link");
   });
 
   it("clears mixed inline formatting from the selected text", async () => {

--- a/packages/app/src/lib/selection-formatting.ts
+++ b/packages/app/src/lib/selection-formatting.ts
@@ -326,6 +326,25 @@ export function toggleSelectionHighlightInView(view: EditorView) {
   return true;
 }
 
+export function toggleSelectionLinkInView(view: EditorView) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || selection.empty) return false;
+
+  const link = view.state.schema.marks.link;
+  if (!link || !view.state.doc.rangeHasMark(selection.from, selection.to, link)) return false;
+
+  const transaction = view.state.tr.removeMark(selection.from, selection.to, link);
+  if (!transaction.docChanged) return false;
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, selection.from, selection.to))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
 export function clearSelectionFormattingInView(view: EditorView) {
   const { selection } = view.state;
   if (!(selection instanceof TextSelection) || selection.empty) return false;

--- a/packages/editor/src/link-image/plugin.ts
+++ b/packages/editor/src/link-image/plugin.ts
@@ -1,6 +1,7 @@
 import { imageSchema, linkSchema } from "@milkdown/kit/preset/commonmark";
 import { Plugin, PluginKey, type EditorState } from "@milkdown/kit/prose/state";
 import { $prose } from "@milkdown/kit/utils";
+import { normalizedExternalAutolinkUrl } from "@markra/shared";
 import { buildLiveLinkImageDecorations } from "./decorations.ts";
 import { replaceRawMarkdownTarget } from "./finalize.ts";
 import { createFinalizedImageNodeView } from "./images.ts";
@@ -43,6 +44,11 @@ function activeLiveMarkdownRange(state: EditorState) {
   const liveState = linkImageLiveKey.getState(state);
 
   return sameRange(liveState?.suppressedRange ?? null, range) ? null : range;
+}
+
+function pastedExternalUrl(event: ClipboardEvent) {
+  const text = event.clipboardData?.getData("text/plain") ?? "";
+  return normalizedExternalAutolinkUrl(text);
 }
 
 export function markraLinkImageLivePlugin(resolveImageSrc?: ResolveMarkdownImageSrc) {
@@ -135,6 +141,23 @@ export function markraLinkImageLivePlugin(resolveImageSrc?: ResolveMarkdownImage
             event.preventDefault();
             return true;
           }
+        },
+        handlePaste: (view, event) => {
+          const { $from, $to } = view.state.selection;
+          if ($from.parent.type.spec.code || !$from.parent.inlineContent || !$from.sameParent($to)) return false;
+
+          const href = pastedExternalUrl(event);
+          if (!href) return false;
+
+          const { from, to } = view.state.selection;
+          const selectedText = view.state.selection.empty ? "" : view.state.doc.textBetween(from, to, " ");
+          const pastedText = event.clipboardData?.getData("text/plain") ?? "";
+          const label = selectedText.trim() || pastedText.trim() || href;
+          const linkedText = view.state.schema.text(label, [link.create({ href })]);
+          const tr = view.state.tr.replaceWith(from, to, linkedText).scrollIntoView();
+
+          view.dispatch(tr);
+          return true;
         },
         handleKeyDown: (view, event) => {
           const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   isRecord,
   joinApiUrl,
   normalizeNullableString,
+  normalizedExternalAutolinkUrl,
   parentPathFromPath,
   pathNameFromPath,
   stableTextKey
@@ -94,5 +95,19 @@ describe("utilities", () => {
 
   it("appends query paths directly to host-only URLs", () => {
     expect(joinApiUrl("https://api.example.com", "?api-version=1")).toBe("https://api.example.com?api-version=1");
+  });
+
+  it("normalizes explicit external URLs for autolinking", () => {
+    expect(normalizedExternalAutolinkUrl(" https://example.test/articles/about ")).toBe(
+      "https://example.test/articles/about"
+    );
+    expect(normalizedExternalAutolinkUrl("mailto:hello@example.test")).toBe("mailto:hello@example.test");
+  });
+
+  it("rejects text that should not be autolinked", () => {
+    expect(normalizedExternalAutolinkUrl("example.test/articles/about")).toBeNull();
+    expect(normalizedExternalAutolinkUrl("https://example.test first")).toBeNull();
+    expect(normalizedExternalAutolinkUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizedExternalAutolinkUrl("file:///mock-files/secret.md")).toBeNull();
   });
 });

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -4,3 +4,19 @@ export function joinApiUrl(baseUrl: string, path: string) {
 
   return `${baseUrl.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
 }
+
+export function normalizedExternalAutolinkUrl(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed || /\s/u.test(trimmed)) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:" || parsed.protocol === "mailto:") {
+      return parsed.toString();
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Fix `Cmd+K` / toolbar / native menu link handling for selected text.
- Apply selected standalone external URLs as finalized links instead of placeholder snippets.
- Allow selected links to be toggled back to plain text while preserving the selection.
- Keep the floating toolbar formatting state in sync after link commands and same-selection inline formatting shortcuts.
- Autolink pasted standalone external URLs.
- Suppress the Windows console flash when opening external links.

## Root Cause
- Link insertion used snippet replacement instead of mark-aware link toggling, so unlinking and selected-URL behavior were inconsistent.
- The selection observer deduplicated only by selection range/text, so mark changes from shortcuts like `Cmd+B` did not refresh toolbar active state when the selection stayed in place.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed, 353 tests.
- `pnpm --filter @markra/app exec vitest run src/hooks/useEditorController.test.ts src/hooks/useNativeBindings.test.tsx src/lib/selection-formatting.test.tsx` passed, 49 tests.
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "syncs selection toolbar formatting after running the editor link command"` passed, 1 test.
- `pnpm --filter @markra/shared test -- src/index.test.ts` passed, 36 tests.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml external_urls` passed, 3 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/shared build` passed.
- `git diff --check` passed.

## Risk
- Moderate editor-surface risk because this touches link formatting, paste handling, and selection notifications; covered by focused regression tests.

Closes #259