### PR TITLE
fix(editor): add trailing lines after terminal blocks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6840,6 +6840,36 @@ describe("MarkdownPaper editing", () => {
       label: "ordered list",
       source: "1. First\n2. Second",
       terminalType: "ordered_list"
+    },
+    {
+      label: "heading",
+      source: "## Terminal heading",
+      terminalType: "heading"
+    },
+    {
+      label: "code block",
+      source: ["```ts", "const value = 1;", "```"].join("\n"),
+      terminalType: "code_block"
+    },
+    {
+      label: "Mermaid code block",
+      source: ["```mermaid", "flowchart TD", "  A --> B", "```"].join("\n"),
+      terminalType: "code_block"
+    },
+    {
+      label: "horizontal rule",
+      source: "___",
+      terminalType: "hr"
+    },
+    {
+      label: "image",
+      source: "![Screenshot](assets/example-image.png)",
+      terminalType: "image"
+    },
+    {
+      label: "frontmatter",
+      source: ["---", "title: Synthetic draft", "---"].join("\n"),
+      terminalType: "frontmatter"
     }
   ])("creates a trailing paragraph after clicking past a terminal $label", async ({ source, terminalType }) => {
     const { container, editor, view } = await renderEditor(source);
@@ -6865,6 +6895,23 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.doc.child(view.state.doc.childCount - 1).type.name).toBe("paragraph");
     expect(view.state.doc.child(view.state.doc.childCount - 1).textContent).toBe("After terminal block");
     expect(serializeMarkdown(view.state.doc)).toContain("After terminal block");
+  });
+
+  it.each([
+    { label: "level 1 heading", source: "# Terminal heading" },
+    { label: "level 2 heading", source: "## Terminal heading" }
+  ])("creates a trailing paragraph after clicking editor blank space below a terminal $label", async ({ source }) => {
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    fireEvent.mouseDown(view.dom, { button: 0 });
+
+    await waitFor(() => expect(view.state.doc.child(view.state.doc.childCount - 1).type.name).toBe("paragraph"));
+    expect(view.state.doc.child(view.state.doc.childCount - 1).content.size).toBe(0);
+
+    typeText(view, "After heading");
+
+    expect(serializeMarkdown(view.state.doc)).toContain("After heading");
   });
 
   it("renders GitHub-style alert blockquotes as callouts while preserving Markdown source", async () => {

--- a/packages/editor/src/trailing-paragraph.ts
+++ b/packages/editor/src/trailing-paragraph.ts
@@ -6,19 +6,34 @@ import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
 const trailingParagraphKey = new PluginKey("markraTrailingParagraph");
+const terminalAffordanceTextblockNodeNames = new Set([
+  "code_block",
+  "frontmatter",
+  "heading"
+]);
+const terminalAffordanceAtomNodeNames = new Set([
+  "hr",
+  "html",
+  "image"
+]);
 
 function needsTrailingParagraphAffordance(doc: ProseNode, paragraph: NodeType) {
   const lastNode = doc.lastChild;
   if (!lastNode) return false;
   if (lastNode.type === paragraph) return false;
-  if (lastNode.isTextblock || lastNode.isAtom) return false;
+  if (lastNode.isTextblock && !terminalAffordanceTextblockNodeNames.has(lastNode.type.name)) return false;
+  if (lastNode.isAtom && !terminalAffordanceAtomNodeNames.has(lastNode.type.name)) return false;
 
   return doc.canReplaceWith(doc.childCount, doc.childCount, paragraph);
 }
 
+function isPlainLeftMouseDown(event: MouseEvent) {
+  return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
+}
+
 function insertTrailingParagraph(view: EditorView, paragraph: NodeType) {
-  if (!view.editable) return;
-  if (!needsTrailingParagraphAffordance(view.state.doc, paragraph)) return;
+  if (!view.editable) return false;
+  if (!needsTrailingParagraphAffordance(view.state.doc, paragraph)) return false;
 
   const insertAt = view.state.doc.content.size;
   const transaction = view.state.tr.insert(insertAt, paragraph.create());
@@ -28,6 +43,7 @@ function insertTrailingParagraph(view: EditorView, paragraph: NodeType) {
       .scrollIntoView()
   );
   view.focus();
+  return true;
 }
 
 function createTrailingParagraphWidget(view: EditorView, paragraph: NodeType) {
@@ -56,6 +72,16 @@ export function createTrailingParagraphPlugin(paragraph: NodeType) {
   return new Plugin({
     key: trailingParagraphKey,
     props: {
+      handleDOMEvents: {
+        mousedown(view, event) {
+          if (event.target !== view.dom || !isPlainLeftMouseDown(event)) return false;
+          if (!insertTrailingParagraph(view, paragraph)) return false;
+
+          event.preventDefault();
+          event.stopPropagation();
+          return true;
+        }
+      },
       decorations(state) {
         if (!needsTrailingParagraphAffordance(state.doc, paragraph)) return DecorationSet.empty;
 


### PR DESCRIPTION
## Summary
- Extend the terminal trailing paragraph affordance to headings, code/frontmatter text blocks, and terminal atom-like blocks such as horizontal rules and images.
- Handle plain blank-space clicks on the editor root after terminal headings, matching the real interaction path for H1/H2.
- Add regression coverage for terminal headings, code blocks, Mermaid code blocks, horizontal rules, images, frontmatter, and H1/H2 blank-space clicks.

## Why
- The previous terminal-block fix skipped every textblock and atom node, so a document ending in a heading never rendered the clickable tail line.
- Directly clicking the generated tail widget was not enough for real heading usage, because clicks in the heading margin/blank editor space target the editor root instead of the widget.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "editor blank space below a terminal"` passed: 2 tests passed.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "creates a trailing paragraph"` passed: 12 tests passed.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 361 tests passed.
- `pnpm --filter @markra/editor test` passed: 3 tests passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Related Issues
- Closes #265