### PR TITLE
fix(editor): stabilize source mode scroll and rules

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -4275,6 +4275,39 @@ describe("Markra workspace", () => {
     expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to split mode" }));
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+
+    const splitScrollElements = Array.from(
+      container.querySelectorAll<HTMLElement>(".editor-split-surface .paper-scroll")
+    );
+    const sourceScroll = sourceEditor.closest<HTMLElement>(".paper-scroll");
+    const visualScroll = splitScrollElements.find((element) => element !== sourceScroll) ?? null;
+    expect(sourceScroll).toBeInTheDocument();
+    expect(visualScroll).toBeInTheDocument();
+
+    mockScrollMetrics(sourceScroll!, {
+      clientHeight: 200,
+      scrollHeight: 1000,
+      scrollTop: 200
+    });
+    mockScrollMetrics(visualScroll!, {
+      clientHeight: 300,
+      scrollHeight: 700,
+      scrollTop: 0
+    });
+
+    fireEvent.scroll(sourceScroll!);
+
+    expect(visualScroll!.scrollTop).toBe(100);
+  });
+
+  it("recalibrates split pane scrolling after target layout changes", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to split mode" }));
+    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toBeInTheDocument();
 
     const [visualScroll, sourceScroll] = Array.from(
       container.querySelectorAll<HTMLElement>(".editor-split-surface .paper-scroll")
@@ -4294,8 +4327,21 @@ describe("Markra workspace", () => {
     });
 
     fireEvent.scroll(sourceScroll!);
-
     expect(visualScroll!.scrollTop).toBe(100);
+
+    mockScrollMetrics(visualScroll!, {
+      clientHeight: 300,
+      scrollHeight: 900,
+      scrollTop: visualScroll!.scrollTop
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+
+    expect(visualScroll!.scrollTop).toBe(150);
   });
 
   it("keeps scroll progress when an opened file switches from visual to source mode", async () => {
@@ -4321,10 +4367,14 @@ describe("Markra workspace", () => {
     });
     fireEvent.scroll(visualScroll);
 
-    let restoreFrame: FrameRequestCallback | null = null;
+    const restoreFrames: FrameRequestCallback[] = [];
+    const flushRestoreFrames = () => {
+      const frames = restoreFrames.splice(0);
+      frames.forEach((frame) => frame(0));
+    };
     const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      restoreFrame = callback;
-      return 1;
+      restoreFrames.push(callback);
+      return restoreFrames.length;
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
@@ -4336,7 +4386,7 @@ describe("Markra workspace", () => {
     });
 
     act(() => {
-      restoreFrame?.(0);
+      flushRestoreFrames();
     });
 
     expect(sourceScroll.scrollTop).toBe(500);
@@ -4351,7 +4401,7 @@ describe("Markra workspace", () => {
     });
 
     act(() => {
-      restoreFrame?.(0);
+      flushRestoreFrames();
     });
 
     expect(restoredVisualScroll.scrollTop).toBe(400);

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -464,6 +464,7 @@ function WorkspaceApp() {
   const splitSurfaceRef = useRef<HTMLDivElement | null>(null);
   const sideDocumentSurfaceRef = useRef<HTMLDivElement | null>(null);
   const splitScrollSyncTargetRef = useRef<EditorSurface | null>(null);
+  const splitScrollSyncFrameRef = useRef<number | null>(null);
   const splitPaneResizeCleanupRef = useRef<(() => unknown) | null>(null);
   const sideDocumentPaneResizeCleanupRef = useRef<(() => unknown) | null>(null);
   const exportContextRef = useRef({
@@ -1716,6 +1717,10 @@ function WorkspaceApp() {
       splitPaneResizeCleanupRef.current = null;
       sideDocumentPaneResizeCleanupRef.current?.();
       sideDocumentPaneResizeCleanupRef.current = null;
+      if (splitScrollSyncFrameRef.current !== null) {
+        window.cancelAnimationFrame(splitScrollSyncFrameRef.current);
+        splitScrollSyncFrameRef.current = null;
+      }
     };
   }, []);
 
@@ -2542,37 +2547,58 @@ function WorkspaceApp() {
     if (splitMode) setActiveEditorSurface("source");
     handleMarkdownChange(content, options);
   }, [handleMarkdownChange, readOnlyMode, splitMode]);
-  const syncSplitPaneScroll = useCallback((sourceSurface: EditorSurface, event: ReactUIEvent<HTMLElement>) => {
-    if (!splitMode) return;
+  const syncSplitPaneScrollPosition = useCallback((sourceSurface: EditorSurface, sourceElement: HTMLElement) => {
+    if (!splitMode) return false;
 
     if (splitScrollSyncTargetRef.current === sourceSurface) {
       splitScrollSyncTargetRef.current = null;
-      return;
+      return false;
     }
 
-    const sourceElement = event.currentTarget;
     const targetSurface: EditorSurface = sourceSurface === "source" ? "visual" : "source";
     const targetElement = targetSurface === "visual" ? visualScrollRef.current : sourceScrollRef.current;
-    if (!targetElement) return;
+    if (!targetElement) return false;
 
     const sourceMaxScrollTop = Math.max(0, sourceElement.scrollHeight - sourceElement.clientHeight);
     const targetMaxScrollTop = Math.max(0, targetElement.scrollHeight - targetElement.clientHeight);
-    if (targetMaxScrollTop <= 0) return;
+    if (targetMaxScrollTop <= 0) return true;
 
     const nextScrollTop =
       sourceMaxScrollTop <= 0
         ? 0
         : Math.round((sourceElement.scrollTop / sourceMaxScrollTop) * targetMaxScrollTop);
-    if (Math.abs(targetElement.scrollTop - nextScrollTop) < 1) return;
+    if (Math.abs(targetElement.scrollTop - nextScrollTop) >= 1) {
+      splitScrollSyncTargetRef.current = targetSurface;
+      targetElement.scrollTop = nextScrollTop;
+      window.setTimeout(() => {
+        if (splitScrollSyncTargetRef.current === targetSurface) {
+          splitScrollSyncTargetRef.current = null;
+        }
+      }, 0);
+    }
 
-    splitScrollSyncTargetRef.current = targetSurface;
-    targetElement.scrollTop = nextScrollTop;
-    window.setTimeout(() => {
-      if (splitScrollSyncTargetRef.current === targetSurface) {
-        splitScrollSyncTargetRef.current = null;
-      }
-    }, 0);
+    return true;
   }, [splitMode]);
+  const scheduleSplitPaneScrollResync = useCallback((sourceSurface: EditorSurface, sourceElement: HTMLElement) => {
+    if (!splitMode) return;
+
+    if (splitScrollSyncFrameRef.current !== null) {
+      window.cancelAnimationFrame(splitScrollSyncFrameRef.current);
+    }
+
+    splitScrollSyncFrameRef.current = window.requestAnimationFrame(() => {
+      splitScrollSyncFrameRef.current = null;
+      if (!sourceElement.isConnected) return;
+
+      syncSplitPaneScrollPosition(sourceSurface, sourceElement);
+    });
+  }, [splitMode, syncSplitPaneScrollPosition]);
+  const syncSplitPaneScroll = useCallback((sourceSurface: EditorSurface, event: ReactUIEvent<HTMLElement>) => {
+    const sourceElement = event.currentTarget;
+    if (!syncSplitPaneScrollPosition(sourceSurface, sourceElement)) return;
+
+    scheduleSplitPaneScrollResync(sourceSurface, sourceElement);
+  }, [scheduleSplitPaneScrollResync, syncSplitPaneScrollPosition]);
   const handleSourcePaneScroll = useCallback((event: ReactUIEvent<HTMLElement>) => {
     saveDocumentTabViewState(activeTabId, { sourceScrollTop: event.currentTarget.scrollTop });
     syncSplitPaneScroll("source", event);

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2677,8 +2677,23 @@ describe("MarkdownPaper editing", () => {
     });
 
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-    expect(serializeMarkdown(view.state.doc)).toBe("First\n\nSecond\n\n---\n");
+    expect(serializeMarkdown(view.state.doc)).toBe("First\n\nSecond\n\n***\n");
     restoreLayout();
+  });
+
+  it("serializes horizontal rules without creating a setext-heading trap in source mode", async () => {
+    const { editor, view } = await renderEditor("First\n\n---\n\nSecond");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const parseMarkdown = editor.action((ctx) => ctx.get(parserCtx));
+    const markdown = serializeMarkdown(view.state.doc);
+
+    expect(markdown).toBe("First\n\n***\n\nSecond\n");
+
+    const editedMarkdown = markdown.replace("\n\n***", "\nInserted\n***");
+    const editedDocument = parseMarkdown(editedMarkdown);
+    expect(editedDocument.child(0).type.name).toBe("paragraph");
+    expect(editedDocument.child(0).textContent).toContain("Inserted");
+    expect(editedDocument.child(1).type.name).toBe("hr");
   });
 
   it("reorders blocks below a table drop target", async () => {

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -286,7 +286,7 @@ function markraMarkdownStyleRemark(this: { data: () => RemarkProcessorData }) {
   const data = this.data();
   data.settings = {
     ...data.settings,
-    rule: "-",
+    rule: "*",
     ruleRepetition: 3,
     ruleSpaces: false
   };


### PR DESCRIPTION
## Summary
- Recalibrate split-pane source/visual scroll sync on the next animation frame after user scrolling.
- Serialize horizontal rules as `***` so source-mode edits above a rule do not turn into Setext headings.
- Add regression coverage for split scroll recalibration and horizontal rule serialization.

## Why
Issue #264 reported split-mode source/visual scroll drift and confusion around editing near horizontal rules in source mode. The `---` rule marker is valid Markdown, but when text is inserted directly above it Markdown parses the text as a Setext heading.

## Validation
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx` passed: 145 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 362 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.

Closes #264