### PR TITLE
fix(desktop): reduce Windows title repaint on save

### DIFF
--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -619,6 +619,18 @@ mod tests {
     }
 
     #[test]
+    fn windows_main_window_config_uses_stable_app_title() {
+        let config: serde_json::Value =
+            serde_json::from_str(include_str!("../tauri.windows.conf.json"))
+                .expect("windows Tauri config should be valid JSON");
+        let title = config
+            .pointer("/app/windows/0/title")
+            .and_then(serde_json::Value::as_str);
+
+        assert_eq!(title, Some("Markra"));
+    }
+
+    #[test]
     fn linux_main_window_config_disables_transparency() {
         let config_path =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.linux.conf.json");

--- a/apps/desktop/src-tauri/tauri.windows.conf.json
+++ b/apps/desktop/src-tauri/tauri.windows.conf.json
@@ -3,7 +3,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "",
+        "title": "Markra",
         "width": 1360,
         "height": 800,
         "minWidth": 960,

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { platform } from "@tauri-apps/plugin-os";
 import { exit } from "@tauri-apps/plugin-process";
 import {
   closeNativeWindow,
@@ -11,6 +12,7 @@ import {
   listNativeEditorWindowRestoreStates,
   minimizeNativeWindow,
   openSettingsWindow,
+  setNativeWindowTitle,
   setNativeEditorWindowRestoreState,
   toggleNativeWindowFullscreen,
   toggleNativeWindowMaximized
@@ -28,6 +30,10 @@ vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: vi.fn()
 }));
 
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: vi.fn()
+}));
+
 vi.mock("@tauri-apps/plugin-process", () => ({
   exit: vi.fn()
 }));
@@ -35,6 +41,7 @@ vi.mock("@tauri-apps/plugin-process", () => ({
 const mockedGetCurrentWindow = vi.mocked(getCurrentWindow);
 const mockedInvoke = vi.mocked(invoke);
 const mockedListen = vi.mocked(listen);
+const mockedPlatform = vi.mocked(platform);
 const mockedExit = vi.mocked(exit);
 
 describe("native window actions", () => {
@@ -46,6 +53,7 @@ describe("native window actions", () => {
     mockedGetCurrentWindow.mockReset();
     mockedInvoke.mockReset();
     mockedListen.mockReset();
+    mockedPlatform.mockReturnValue("macos");
     mockedExit.mockReset();
   });
 
@@ -132,6 +140,32 @@ describe("native window actions", () => {
 
     expect(isFullscreen).toHaveBeenCalledTimes(1);
     expect(setFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  it("updates the native window title outside Windows", async () => {
+    const setTitle = vi.fn().mockResolvedValue(undefined);
+    mockedPlatform.mockReturnValue("linux");
+    mockedGetCurrentWindow.mockReturnValue({ setTitle } as unknown as ReturnType<typeof getCurrentWindow>);
+
+    await setNativeWindowTitle("Guide.md *");
+
+    expect(document.title).toBe("Guide.md *");
+    expect(setTitle).toHaveBeenCalledWith("Guide.md *");
+  });
+
+  it("keeps Windows native title on file names without syncing dirty markers", async () => {
+    const setTitle = vi.fn().mockResolvedValue(undefined);
+    mockedPlatform.mockReturnValue("windows");
+    mockedGetCurrentWindow.mockReturnValue({ setTitle } as unknown as ReturnType<typeof getCurrentWindow>);
+
+    await setNativeWindowTitle("Guide.md");
+    await setNativeWindowTitle("Guide.md *");
+    await setNativeWindowTitle("Notes.md *");
+
+    expect(document.title).toBe("Notes.md *");
+    expect(setTitle).toHaveBeenCalledTimes(2);
+    expect(setTitle).toHaveBeenNthCalledWith(1, "Guide.md");
+    expect(setTitle).toHaveBeenNthCalledWith(2, "Notes.md");
   });
 
   it("skips native calls outside Tauri", async () => {

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { platform } from "@tauri-apps/plugin-os";
 import { exit } from "@tauri-apps/plugin-process";
 
 export type NativeSettingsWindowTarget = "exportPandocPath";
@@ -24,9 +25,26 @@ type NativeSettingsWindowTargetPayload = {
 
 const nativeSettingsWindowTargetEvent = "markra://settings-window-target";
 const nativeAppExitRequestedEvent = "markra://app-exit-requested";
+let lastNativeWindowTitle: { platform: string | null; title: string } | null = null;
 
 function isNativeSettingsWindowTarget(value: unknown): value is NativeSettingsWindowTarget {
   return value === "exportPandocPath";
+}
+
+function currentDesktopPlatform() {
+  try {
+    return platform();
+  } catch {
+    return null;
+  }
+}
+
+function nativeWindowTitleForPlatform(title: string, desktopPlatform: string | null) {
+  if (desktopPlatform === "windows" && title.endsWith(" *")) {
+    return title.slice(0, -2);
+  }
+
+  return title;
 }
 
 export function openSettingsWindow(target?: NativeSettingsWindowTarget) {
@@ -73,8 +91,22 @@ export async function setNativeWindowTitle(title: string) {
     return;
   }
 
+  const desktopPlatform = currentDesktopPlatform();
+  const nativeTitle = nativeWindowTitleForPlatform(title, desktopPlatform);
+
+  if (
+    lastNativeWindowTitle?.platform === desktopPlatform &&
+    lastNativeWindowTitle.title === nativeTitle
+  ) {
+    return;
+  }
+
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
-  await getCurrentWindow().setTitle(title);
+  await getCurrentWindow().setTitle(nativeTitle);
+  lastNativeWindowTitle = {
+    platform: desktopPlatform,
+    title: nativeTitle
+  };
 }
 
 async function getCurrentNativeWindow() {


### PR DESCRIPTION
## Summary
- Keep the Windows native title on the current file name instead of syncing every dirty-marker change.
- Continue updating `document.title` with the dirty marker so in-app/browser title state is unchanged.
- Use a stable Windows initial title and cover the behavior with frontend and Tauri config tests.

## Why
Issue #257 reports a full-window/editor repaint on Windows when switching files or saving. The reporter's recording points at content repaint rather than a macOS-reproducible resize. The likely low-risk trigger is frequent native `setTitle` calls when the title flips between `File.md` and `File.md *` on edit/save.

## Beta Build
- Pre-release: https://github.com/murongg/markra/releases/tag/v0.11.3-beta.1
- Windows installer: https://github.com/murongg/markra/releases/download/v0.11.3-beta.1/Markra_0.11.3-beta.1_windows_x64_setup.exe
- Windows portable zip: https://github.com/murongg/markra/releases/download/v0.11.3-beta.1/Markra_0.11.3-beta.1_windows_x64_portable.zip

## Validation
- `pnpm install --frozen-lockfile` completed in the clean PR worktree
- `pnpm --filter @markra/desktop test -- src/runtime/tauri/window.test.ts` passed: 1 file, 14 tests
- `cargo test main_window_config --lib` passed: 4 tests
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification
- Release workflow for `v0.11.3-beta.1` passed: https://github.com/murongg/markra/actions/runs/27499524766

## Risk
- Windows native title no longer shows the unsaved `*` marker, but still updates when the active file name changes.
- Non-Windows platforms keep the existing native title behavior.

## Related Issues
Refs #257
