### PR TITLE
fix(editor): indent adjacent mixed-marker list items

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1679,7 +1679,10 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
 
-    const sourceEditor = await screen.findByLabelText("Markdown editor");
+    const sourceEditor = (await screen.findByTestId("markdown-source-editor")).closest<HTMLElement>(
+      '[data-editor-engine="source"]'
+    );
+    expect(sourceEditor).toBeInTheDocument();
     expect(sourceEditor).toHaveAttribute("data-editor-engine", "source");
     expect(sourceEditor).toHaveStyle({
       maxWidth: "980px"
@@ -3974,9 +3977,73 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
 
-    expect(await screen.findByText("Source edit")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Source edit" })).toBeInTheDocument();
     expect(screen.getByText("Updated from source mode.")).toBeInTheDocument();
     expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
+  });
+
+  it("keeps visual undo history after switching to source mode and back", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalledTimes(1));
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls[0]?.[0] as NativeMenuHandlers;
+
+    act(() => {
+      menuHandlers.insertTable?.();
+    });
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText("Unsaved changes")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+    await waitFor(() => expect(readMarkdownSource(sourceEditor)).toContain("| - | - |"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+
+    act(() => {
+      menuHandlers.editUndo?.();
+    });
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).not.toBeInTheDocument());
+
+    act(() => {
+      menuHandlers.editRedo?.();
+    });
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+  });
+
+  it("keeps source edits undoable after switching back to visual mode", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalledTimes(1));
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls[0]?.[0] as NativeMenuHandlers;
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    replaceMarkdownSource(
+      await screen.findByRole("textbox", { name: "Markdown source" }),
+      "# Source history\n\nShared undo."
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to visual mode" }));
+    expect(await screen.findByRole("heading", { name: "Source history" })).toBeInTheDocument();
+    expect(screen.getByText("Shared undo.")).toBeInTheDocument();
+
+    act(() => {
+      menuHandlers.editUndo?.();
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("heading", { name: "Source history" })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole("heading", { name: "Welcome to Markra" })).toBeInTheDocument();
+
+    act(() => {
+      menuHandlers.editRedo?.();
+    });
+    expect(await screen.findByRole("heading", { name: "Source history" })).toBeInTheDocument();
+    expect(screen.getByText("Shared undo.")).toBeInTheDocument();
   });
 
   it("keeps callout body line breaks when switching from source to visual mode", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -155,6 +155,40 @@ function replaceMarkdownSource(sourceEditor: HTMLElement, value: string) {
   });
 }
 
+function queryVisibleMilkdownEditor(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-editor-engine="milkdown"]')).find(
+    (element) => !element.closest("[hidden]")
+  ) ?? null;
+}
+
+function getVisibleMilkdownEditor(container: HTMLElement) {
+  const editor = queryVisibleMilkdownEditor(container);
+  if (!editor) {
+    throw new Error("Expected a visible Milkdown editor.");
+  }
+
+  return editor;
+}
+
+function getVisibleWritingSurface(container: HTMLElement) {
+  const surface = Array.from(container.querySelectorAll<HTMLElement>('[aria-label="Writing surface"]')).find(
+    (element) => !element.closest("[hidden]")
+  );
+  if (!surface) {
+    throw new Error("Expected a visible writing surface.");
+  }
+
+  return surface;
+}
+
+function queryVisibleMilkdownTable(container: HTMLElement) {
+  return getVisibleMilkdownEditor(container).querySelector("table");
+}
+
+async function expectVisibleMilkdownText(container: HTMLElement, text: string) {
+  await waitFor(() => expect(within(getVisibleMilkdownEditor(container)).getByText(text)).toBeInTheDocument());
+}
+
 function createStoredEditorPreferences(
   overrides: Partial<Parameters<typeof mockedSaveStoredEditorPreferences>[0]> = {}
 ): Parameters<typeof mockedSaveStoredEditorPreferences>[0] {
@@ -2148,7 +2182,7 @@ describe("Markra workspace", () => {
       path: guidePath
     });
 
-    renderApp();
+    const { container } = renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true });
     expect(await screen.findByText("Native file")).toBeInTheDocument();
@@ -2163,25 +2197,25 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("tab", { name: /native\.md/ })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("tab", { name: /pasted-image\.png/ })).toHaveAttribute("aria-selected", "true");
     expect(screen.queryByRole("heading", { name: "pasted-image.png" })).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Markdown editor")).not.toBeInTheDocument();
+    expect(queryVisibleMilkdownEditor(container)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Markdown" })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("tab", { name: /native\.md/ }));
 
     expect(await screen.findByText("Native file")).toBeInTheDocument();
-    expect(screen.getByLabelText("Markdown editor")).toBeInTheDocument();
+    expect(getVisibleMilkdownEditor(container)).toBeInTheDocument();
     expect(screen.queryByRole("img", { name: "pasted-image.png" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: /pasted-image\.png/ }));
 
     expect(await screen.findByRole("img", { name: "pasted-image.png" })).toBeInTheDocument();
-    expect(screen.queryByLabelText("Markdown editor")).not.toBeInTheDocument();
+    expect(queryVisibleMilkdownEditor(container)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "docs" }));
     fireEvent.click(await screen.findByRole("button", { name: "docs/guide.md" }));
 
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
-    expect(screen.getByLabelText("Markdown editor")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Guide");
+    expect(getVisibleMilkdownEditor(container)).toBeInTheDocument();
     expect(screen.queryByRole("img", { name: "pasted-image.png" })).not.toBeInTheDocument();
   });
 
@@ -2243,17 +2277,17 @@ describe("Markra workspace", () => {
       };
     });
 
-    renderApp();
+    const { container } = renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true });
     expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("button", { name: "docs" }));
     fireEvent.click(await screen.findByRole("button", { name: "docs/guide.md" }));
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Guide");
 
     fireEvent.click(await screen.findByRole("button", { name: "docs/notes.md" }));
-    expect(await screen.findByText("Notes")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Notes");
 
     expect(mockedConfirmNativeUnsavedMarkdownDocumentDiscard).not.toHaveBeenCalled();
   });
@@ -2309,8 +2343,79 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: /guide\.md/ }));
 
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Guide");
     expect(screen.getByRole("tab", { name: /guide\.md/ })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps visual undo history after switching document tabs", async () => {
+    const guidePath = "/mock-files/vault/docs/guide.md";
+    const notesPath = "/mock-files/vault/docs/notes.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "guide.md", path: guidePath, relativePath: "docs/guide.md" },
+      { name: "notes.md", path: notesPath, relativePath: "docs/notes.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === guidePath) {
+        return {
+          content: "# Guide",
+          name: "guide.md",
+          path: guidePath
+        };
+      }
+
+      return {
+        content: "# Notes",
+        name: "notes.md",
+        path: notesPath
+      };
+    });
+
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "docs/guide.md" }));
+    await expectVisibleMilkdownText(container, "Guide");
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs/notes.md" }));
+    await expectVisibleMilkdownText(container, "Notes");
+
+    fireEvent.click(screen.getByRole("tab", { name: /guide\.md/ }));
+    await expectVisibleMilkdownText(container, "Guide");
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalled());
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls.at(-1)?.[0] as NativeMenuHandlers;
+
+    act(() => {
+      menuHandlers.insertTable?.();
+    });
+    await waitFor(() => expect(queryVisibleMilkdownTable(container)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByLabelText("Unsaved changes")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("tab", { name: /notes\.md/ }));
+    await expectVisibleMilkdownText(container, "Notes");
+
+    fireEvent.click(screen.getByRole("tab", { name: /guide\.md/ }));
+    await expectVisibleMilkdownText(container, "Guide");
+    await waitFor(() => expect(queryVisibleMilkdownTable(container)).toBeInTheDocument());
+
+    act(() => {
+      menuHandlers.editUndo?.();
+    });
+    await waitFor(() => expect(queryVisibleMilkdownTable(container)).not.toBeInTheDocument());
+
+    act(() => {
+      menuHandlers.editRedo?.();
+    });
+    await waitFor(() => expect(queryVisibleMilkdownTable(container)).toBeInTheDocument());
   });
 
   it("opens a document tab to a side editor, toggles both panes to source mode, and closes the side tab from the titlebar", async () => {
@@ -2359,16 +2464,16 @@ describe("Markra workspace", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "docs" }));
     fireEvent.click(await screen.findByRole("button", { name: "docs/guide.md" }));
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Guide");
 
     fireEvent.click(await screen.findByRole("button", { name: "docs/notes.md" }));
-    expect(await screen.findByText("Notes")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Notes");
 
     fireEvent.click(await screen.findByRole("button", { name: "docs/third.md" }));
-    expect(await screen.findByText("Third")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Third");
 
     fireEvent.click(screen.getByRole("tab", { name: /guide\.md/ }));
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Guide");
 
     fireEvent.contextMenu(screen.getByRole("tab", { name: /notes\.md/ }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
@@ -2422,7 +2527,7 @@ describe("Markra workspace", () => {
     );
 
     const sideSource = await within(replacedSidePane).findByRole("textbox", { name: "Markdown source" });
-    expect(readMarkdownSource(sideSource)).toBe("# Third\n\nIndependent");
+    expect(readMarkdownSource(sideSource).trimEnd()).toBe("# Third\n\nIndependent");
 
     replaceMarkdownSource(sideSource, "# Third\n\nIndependent update");
     expect(screen.getByRole("tab", { name: /guide\.md/ })).toHaveAttribute("aria-selected", "true");
@@ -2655,16 +2760,16 @@ describe("Markra workspace", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "docs" }));
     fireEvent.click(await screen.findByRole("button", { name: "docs/1.md" }));
-    expect(await screen.findByText("First")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "First");
 
     fireEvent.click(await screen.findByRole("button", { name: "docs/2.md" }));
-    expect(await screen.findByText("Second")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Second");
 
     fireEvent.click(await screen.findByRole("button", { name: "docs/3.md" }));
-    expect(await screen.findByText("Third")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Third");
 
     fireEvent.click(screen.getByRole("tab", { name: /1\.md/ }));
-    expect(await screen.findByText("First")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "First");
 
     fireEvent.contextMenu(screen.getByRole("tab", { name: /2\.md/ }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
@@ -2692,7 +2797,7 @@ describe("Markra workspace", () => {
     expect(mockedConfirmNativeUnsavedMarkdownDocumentDiscard).not.toHaveBeenCalled();
 
     fireEvent.click(within(inactiveGroup).getByRole("tab", { name: /2\.md/ }));
-    expect(await screen.findByText("First")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "First");
     await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).toBeInTheDocument());
     fireEvent.contextMenu(screen.getByRole("tab", { name: /2\.md/ }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
@@ -3005,18 +3110,18 @@ describe("Markra workspace", () => {
       };
     });
 
-    renderApp();
+    const { container } = renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true });
     expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("button", { name: "docs" }));
     fireEvent.click(await screen.findByRole("button", { name: "docs/guide.md" }));
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Guide");
     await waitFor(() => expect(screen.getByRole("tab", { name: /guide\.md/ })).toHaveAttribute("aria-selected", "true"));
     await settleEditorUpdates();
 
-    const guideScroll = screen.getByLabelText("Writing surface");
+    const guideScroll = getVisibleWritingSurface(container);
     mockScrollMetrics(guideScroll, {
       clientHeight: 300,
       scrollHeight: 1200,
@@ -3025,11 +3130,11 @@ describe("Markra workspace", () => {
     fireEvent.scroll(guideScroll);
 
     fireEvent.click(await screen.findByRole("button", { name: "docs/notes.md" }));
-    expect(await screen.findByText("Notes")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Notes");
     await waitFor(() => expect(screen.getByRole("tab", { name: /notes\.md/ })).toHaveAttribute("aria-selected", "true"));
     await settleEditorUpdates();
 
-    const notesScroll = screen.getByLabelText("Writing surface");
+    const notesScroll = getVisibleWritingSurface(container);
     mockScrollMetrics(notesScroll, {
       clientHeight: 300,
       scrollHeight: 1200,
@@ -3039,8 +3144,8 @@ describe("Markra workspace", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: /guide\.md/ }));
 
-    expect(await screen.findByText("Guide")).toBeInTheDocument();
-    await waitFor(() => expect(screen.getByLabelText("Writing surface").scrollTop).toBe(240));
+    await expectVisibleMilkdownText(container, "Guide");
+    await waitFor(() => expect(getVisibleWritingSurface(container).scrollTop).toBe(240));
   });
 
   it("renames an opened markdown file from a titlebar tab double click", async () => {
@@ -3353,10 +3458,10 @@ describe("Markra workspace", () => {
       path: mockUntitledPath
     });
 
-    renderApp();
+    const { container } = renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true });
-    expect(await screen.findByText("Native file")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Native file");
     expect(screen.getByRole("button", { name: "Toggle file list" })).toHaveAttribute("aria-pressed", "false");
     expect(screen.queryByRole("button", { name: "New file" })).not.toBeInTheDocument();
 
@@ -3366,7 +3471,7 @@ describe("Markra workspace", () => {
     expect(mockedSaveNativeMarkdownFile).not.toHaveBeenCalled();
     expect(screen.getByRole("tab", { name: /Untitled\.md/ })).toBeInTheDocument();
     expect(screen.getByLabelText("Unsaved changes")).toBeInTheDocument();
-    expect(screen.queryByText("Native file")).not.toBeInTheDocument();
+    expect(within(getVisibleMilkdownEditor(container)).queryByText("Native file")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
 
@@ -4249,6 +4354,7 @@ describe("Markra workspace", () => {
     const { container } = renderApp();
 
     expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    await settleEditorUpdates();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to split mode" }));
 
@@ -4372,15 +4478,28 @@ describe("Markra workspace", () => {
     const { container } = renderApp();
 
     expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    await settleEditorUpdates();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to split mode" }));
-    expect(await screen.findByRole("textbox", { name: "Markdown source" })).toBeInTheDocument();
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
 
-    const [visualScroll, sourceScroll] = Array.from(
+    const splitScrollElements = Array.from(
       container.querySelectorAll<HTMLElement>(".editor-split-surface .paper-scroll")
     );
+    const sourceScroll = sourceEditor.closest<HTMLElement>(".paper-scroll");
+    const visualScroll = splitScrollElements.find((element) => element !== sourceScroll && !element.closest("[hidden]")) ?? null;
     expect(sourceScroll).toBeInTheDocument();
     expect(visualScroll).toBeInTheDocument();
+
+    const resyncFrames: FrameRequestCallback[] = [];
+    const flushResyncFrames = () => {
+      const frames = resyncFrames.splice(0);
+      frames.forEach((frame) => frame(0));
+    };
+    const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      resyncFrames.push(callback);
+      return resyncFrames.length;
+    });
 
     mockScrollMetrics(sourceScroll!, {
       clientHeight: 200,
@@ -4402,13 +4521,12 @@ describe("Markra workspace", () => {
       scrollTop: visualScroll!.scrollTop
     });
 
-    await act(async () => {
-      await new Promise<void>((resolve) => {
-        window.requestAnimationFrame(() => resolve());
-      });
+    act(() => {
+      flushResyncFrames();
     });
 
     expect(visualScroll!.scrollTop).toBe(150);
+    requestAnimationFrameSpy.mockRestore();
   });
 
   it("keeps scroll progress when an opened file switches from visual to source mode", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -447,6 +447,7 @@ function WorkspaceApp() {
   const pendingEditorContentWidthPxRef = useRef<number | null>(null);
   const pendingSplitVisualPanePercentRef = useRef(defaultSplitVisualPanePercent);
   const pendingSideDocumentMainPanePercentRef = useRef(defaultSideDocumentMainPanePercent);
+  const sourceToVisualHistoryRef = useRef(false);
   const sourceToVisualSyncingRef = useRef(false);
   const lastDocumentSearchRevealRevisionRef = useRef(0);
   const documentRevisionRef = useRef(0);
@@ -2544,9 +2545,15 @@ function WorkspaceApp() {
   const handleSourceMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (readOnlyMode) return;
 
+    if (
+      content !== document.content &&
+      (options?.documentRevision === undefined || options.documentRevision === document.revision)
+    ) {
+      sourceToVisualHistoryRef.current = true;
+    }
     if (splitMode) setActiveEditorSurface("source");
     handleMarkdownChange(content, options);
-  }, [handleMarkdownChange, readOnlyMode, splitMode]);
+  }, [document.content, document.revision, handleMarkdownChange, readOnlyMode, splitMode]);
   const syncSplitPaneScrollPosition = useCallback((sourceSurface: EditorSurface, sourceElement: HTMLElement) => {
     if (!splitMode) return false;
 
@@ -2640,10 +2647,11 @@ function WorkspaceApp() {
     syncVisualMarkdownAfterEditorCommand();
   }, [insertEditorMarkdownTable, readOnlyMode, syncVisualMarkdownAfterEditorCommand]);
   const handleRunEditorShortcut = useCallback((...args: Parameters<typeof runEditorShortcut>) => {
-    if (readOnlyMode) return;
+    if (readOnlyMode) return false;
 
-    runEditorShortcut(...args);
+    const handled = runEditorShortcut(...args);
     syncVisualMarkdownAfterEditorCommand();
+    return handled;
   }, [readOnlyMode, runEditorShortcut, syncVisualMarkdownAfterEditorCommand]);
   const handleAiSelectionToolbarFormattingAction = useCallback((action: SelectionFormattingToolbarAction) => {
     if (readOnlyMode) return;
@@ -3101,16 +3109,25 @@ function WorkspaceApp() {
     visualEditorReadySequence
   ]);
   useEffect(() => {
-    if (!splitMode || activeEditorSurface !== "source") return;
+    if (!sourceSurfaceActive || largeMarkdownVisualBlocked) {
+      sourceToVisualHistoryRef.current = false;
+      return;
+    }
 
     sourceToVisualSyncingRef.current = true;
-    replaceEditorMarkdown(document.content);
-    sourceToVisualSyncingRef.current = false;
+    try {
+      const synced = replaceEditorMarkdown(document.content, {
+        addToHistory: sourceToVisualHistoryRef.current
+      });
+      if (synced) sourceToVisualHistoryRef.current = false;
+    } finally {
+      sourceToVisualSyncingRef.current = false;
+    }
   }, [
-    activeEditorSurface,
     document.content,
+    largeMarkdownVisualBlocked,
     replaceEditorMarkdown,
-    splitMode,
+    sourceSurfaceActive,
     visualEditorReadySequence
   ]);
   const aiAgentContext = useMemo(() => ({
@@ -3711,7 +3728,17 @@ function WorkspaceApp() {
                           })}
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+                          onRedo={
+                            largeMarkdownVisualBlocked
+                              ? undefined
+                              : () => handleRunEditorShortcut("z", { shiftKey: true }, { focusEditor: false })
+                          }
                           onScroll={handleSourcePaneScroll}
+                          onUndo={
+                            largeMarkdownVisualBlocked
+                              ? undefined
+                              : () => handleRunEditorShortcut("z", {}, { focusEditor: false })
+                          }
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}
                           searchMatches={visibleSourceDocumentSearchMatches}
@@ -3720,69 +3747,90 @@ function WorkspaceApp() {
                         />
                       </div>
                     </div>
-                  ) : sourceMode ? (
-                    <LazyMarkdownSourceEditor
-                      autoFocus
-                      bodyFontSize={editorPreferences.preferences.bodyFontSize}
-                      content={document.content}
-                      contentWidth={activeEditorContentWidth}
-                      contentWidthPx={activeEditorContentWidthPx}
-                      extendedSyntax={editorPreferences.preferences.extendedSyntax}
-                      language={appLanguage.language}
-                      lineHeight={editorPreferences.preferences.lineHeight}
-                      onChange={(content) => handleSourceMarkdownChange(content, {
-                        documentRevision: document.revision
-                      })}
-                      onContentWidthChange={handleEditorContentWidthChange}
-                      onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                      onScroll={handleSourcePaneScroll}
-                      readOnly={readOnlyMode}
-                      searchActiveIndex={normalizedDocumentSearchActiveIndex}
-                      searchMatches={visibleSourceDocumentSearchMatches}
-                      scrollRef={sourceScrollRef}
-                      topInset="titlebar"
-                    />
                   ) : (
-                    largeMarkdownVisualBlocked ? (
-                      <LargeMarkdownNotice
-                        language={appLanguage.language}
-                        onOpenSourceMode={handleEditorModeToggle}
-                      />
-                    ) : (
-                      <MarkdownPaper
-                        autoFocus={shouldFocusEditorOnReady(document.content)}
-                        bottomOverlayInset={aiCommandVisible ? aiCommandOverlayInset : 0}
-                        bodyFontSize={editorPreferences.preferences.bodyFontSize}
-                        contentWidth={activeEditorContentWidth}
-                        contentWidthPx={activeEditorContentWidthPx}
-                        documentKey={activeTabId}
-                        documentPath={document.path}
-                        editorTheme={appTheme.editorTheme}
-                        extendedSyntax={editorPreferences.preferences.extendedSyntax}
-                        initialContent={document.content}
-                        language={appLanguage.language}
-                        lineHeight={editorPreferences.preferences.lineHeight}
-                        markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
-                        onEditorReady={handleVisualEditorReady}
-                        onMarkdownChange={(content) => handleVisualMarkdownChange(content, {
-                          documentRevision: document.revision
-                        })}
-                        onContentWidthChange={handleEditorContentWidthChange}
-                        onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                        onSaveClipboardImage={handleSaveClipboardImage}
-                        onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
-                        openExternalUrl={handleOpenEditorLink}
-                        readOnly={readOnlyMode}
-                        onTextSelectionChange={handleTextSelectionChange}
-                        resolveImageSrc={resolveImageSrc}
-                        revision={document.revision}
-                        onScroll={handleVisualPaneScroll}
-                        scrollRef={visualScrollRef}
-                        topInset="titlebar"
-                        workspaceFiles={fileTreeFiles}
-                        wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
-                      />
-                    )
+                    <div className="relative h-full min-h-0">
+                      {largeMarkdownVisualBlocked ? (
+                        sourceMode ? null : (
+                          <LargeMarkdownNotice
+                            language={appLanguage.language}
+                            onOpenSourceMode={handleEditorModeToggle}
+                          />
+                        )
+                      ) : (
+                        <div
+                          aria-hidden={sourceMode ? "true" : undefined}
+                          className="h-full min-h-0"
+                          hidden={sourceMode}
+                        >
+                          <MarkdownPaper
+                            autoFocus={!sourceMode && shouldFocusEditorOnReady(document.content)}
+                            bottomOverlayInset={!sourceMode && aiCommandVisible ? aiCommandOverlayInset : 0}
+                            bodyFontSize={editorPreferences.preferences.bodyFontSize}
+                            contentWidth={activeEditorContentWidth}
+                            contentWidthPx={activeEditorContentWidthPx}
+                            documentKey={activeTabId}
+                            documentPath={document.path}
+                            editorTheme={appTheme.editorTheme}
+                            extendedSyntax={editorPreferences.preferences.extendedSyntax}
+                            initialContent={document.content}
+                            language={appLanguage.language}
+                            lineHeight={editorPreferences.preferences.lineHeight}
+                            markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
+                            onEditorReady={handleVisualEditorReady}
+                            onMarkdownChange={(content) => handleVisualMarkdownChange(content, {
+                              documentRevision: document.revision
+                            })}
+                            onContentWidthChange={handleEditorContentWidthChange}
+                            onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+                            onSaveClipboardImage={handleSaveClipboardImage}
+                            onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
+                            openExternalUrl={handleOpenEditorLink}
+                            readOnly={readOnlyMode}
+                            onTextSelectionChange={handleTextSelectionChange}
+                            resolveImageSrc={resolveImageSrc}
+                            revision={document.revision}
+                            onScroll={handleVisualPaneScroll}
+                            scrollRef={visualScrollRef}
+                            topInset="titlebar"
+                            workspaceFiles={fileTreeFiles}
+                            wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
+                          />
+                        </div>
+                      )}
+                      {sourceMode ? (
+                        <LazyMarkdownSourceEditor
+                          autoFocus
+                          bodyFontSize={editorPreferences.preferences.bodyFontSize}
+                          content={document.content}
+                          contentWidth={activeEditorContentWidth}
+                          contentWidthPx={activeEditorContentWidthPx}
+                          extendedSyntax={editorPreferences.preferences.extendedSyntax}
+                          language={appLanguage.language}
+                          lineHeight={editorPreferences.preferences.lineHeight}
+                          onChange={(content) => handleSourceMarkdownChange(content, {
+                            documentRevision: document.revision
+                          })}
+                          onContentWidthChange={handleEditorContentWidthChange}
+                          onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+                          onRedo={
+                            largeMarkdownVisualBlocked
+                              ? undefined
+                              : () => handleRunEditorShortcut("z", { shiftKey: true }, { focusEditor: false })
+                          }
+                          onScroll={handleSourcePaneScroll}
+                          onUndo={
+                            largeMarkdownVisualBlocked
+                              ? undefined
+                              : () => handleRunEditorShortcut("z", {}, { focusEditor: false })
+                          }
+                          readOnly={readOnlyMode}
+                          searchActiveIndex={normalizedDocumentSearchActiveIndex}
+                          searchMatches={visibleSourceDocumentSearchMatches}
+                          scrollRef={sourceScrollRef}
+                          topInset="titlebar"
+                        />
+                      ) : null}
+                    </div>
                   )}
                   <QuietStatus
                     backupLabel={backupStatusLabel}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -56,6 +56,7 @@ import { shouldFocusEditorOnReady, useEditorController } from "./hooks/useEditor
 import { useMarkdownDocument } from "./hooks/useMarkdownDocument";
 import { useMarkdownFileTree } from "./hooks/useMarkdownFileTree";
 import { useSelectionToolbarAnchorRefresh } from "./hooks/useSelectionToolbarAnchorRefresh";
+import { useSharedEditorHistory } from "./hooks/useSharedEditorHistory";
 import { useSideBySideTabs } from "./hooks/useSideBySideTabs";
 import { useAutoUpdater } from "./hooks/useAutoUpdater";
 import { useBackupSettings } from "./hooks/useBackupSettings";
@@ -447,8 +448,6 @@ function WorkspaceApp() {
   const pendingEditorContentWidthPxRef = useRef<number | null>(null);
   const pendingSplitVisualPanePercentRef = useRef(defaultSplitVisualPanePercent);
   const pendingSideDocumentMainPanePercentRef = useRef(defaultSideDocumentMainPanePercent);
-  const sourceToVisualHistoryRef = useRef(false);
-  const sourceToVisualSyncingRef = useRef(false);
   const lastDocumentSearchRevealRevisionRef = useRef(0);
   const documentRevisionRef = useRef(0);
   const visualEditorReadyRevisionRef = useRef<number | null>(null);
@@ -877,6 +876,17 @@ function WorkspaceApp() {
       : null;
   const visibleSourceDocumentSearchMatches =
     documentSearchOpen && documentSearchSurface === "source" ? sourceDocumentSearchMatches : [];
+  const {
+    isApplyingSourceToVisualSync,
+    markSourceEditForHistory
+  } = useSharedEditorHistory({
+    documentContent: document.content,
+    documentRevision: document.revision,
+    largeMarkdownVisualBlocked,
+    replaceEditorMarkdown,
+    sourceSurfaceActive,
+    visualEditorReadySequence
+  });
   const activeAiAgentSessionId = workspaceSessionId ?? aiAgentSessionId;
   const aiResult = aiResults.at(-1) ?? null;
   const activeEditorContentWidth = editorContentWidth;
@@ -2536,24 +2546,19 @@ function WorkspaceApp() {
     setDocumentOperationTarget("side");
   }, []);
   const handleVisualMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
-    if (sourceToVisualSyncingRef.current) return;
+    if (isApplyingSourceToVisualSync()) return;
     if (readOnlyMode) return;
 
     if (splitMode) setActiveEditorSurface("visual");
     handleMarkdownChange(content, options);
-  }, [handleMarkdownChange, readOnlyMode, splitMode]);
+  }, [handleMarkdownChange, isApplyingSourceToVisualSync, readOnlyMode, splitMode]);
   const handleSourceMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (readOnlyMode) return;
 
-    if (
-      content !== document.content &&
-      (options?.documentRevision === undefined || options.documentRevision === document.revision)
-    ) {
-      sourceToVisualHistoryRef.current = true;
-    }
+    markSourceEditForHistory(content, options);
     if (splitMode) setActiveEditorSurface("source");
     handleMarkdownChange(content, options);
-  }, [document.content, document.revision, handleMarkdownChange, readOnlyMode, splitMode]);
+  }, [handleMarkdownChange, markSourceEditForHistory, readOnlyMode, splitMode]);
   const syncSplitPaneScrollPosition = useCallback((sourceSurface: EditorSurface, sourceElement: HTMLElement) => {
     if (!splitMode) return false;
 
@@ -2653,6 +2658,14 @@ function WorkspaceApp() {
     syncVisualMarkdownAfterEditorCommand();
     return handled;
   }, [readOnlyMode, runEditorShortcut, syncVisualMarkdownAfterEditorCommand]);
+  const sourceEditorHistoryHandlers = useMemo(() => {
+    if (largeMarkdownVisualBlocked) return {};
+
+    return {
+      onRedo: () => handleRunEditorShortcut("z", { shiftKey: true }, { focusEditor: false }),
+      onUndo: () => handleRunEditorShortcut("z", {}, { focusEditor: false })
+    };
+  }, [handleRunEditorShortcut, largeMarkdownVisualBlocked]);
   const handleAiSelectionToolbarFormattingAction = useCallback((action: SelectionFormattingToolbarAction) => {
     if (readOnlyMode) return;
 
@@ -3106,28 +3119,6 @@ function WorkspaceApp() {
     editorMode,
     hasOpenDocument,
     saveDocumentTabViewState,
-    visualEditorReadySequence
-  ]);
-  useEffect(() => {
-    if (!sourceSurfaceActive || largeMarkdownVisualBlocked) {
-      sourceToVisualHistoryRef.current = false;
-      return;
-    }
-
-    sourceToVisualSyncingRef.current = true;
-    try {
-      const synced = replaceEditorMarkdown(document.content, {
-        addToHistory: sourceToVisualHistoryRef.current
-      });
-      if (synced) sourceToVisualHistoryRef.current = false;
-    } finally {
-      sourceToVisualSyncingRef.current = false;
-    }
-  }, [
-    document.content,
-    largeMarkdownVisualBlocked,
-    replaceEditorMarkdown,
-    sourceSurfaceActive,
     visualEditorReadySequence
   ]);
   const aiAgentContext = useMemo(() => ({
@@ -3728,17 +3719,8 @@ function WorkspaceApp() {
                           })}
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                          onRedo={
-                            largeMarkdownVisualBlocked
-                              ? undefined
-                              : () => handleRunEditorShortcut("z", { shiftKey: true }, { focusEditor: false })
-                          }
+                          {...sourceEditorHistoryHandlers}
                           onScroll={handleSourcePaneScroll}
-                          onUndo={
-                            largeMarkdownVisualBlocked
-                              ? undefined
-                              : () => handleRunEditorShortcut("z", {}, { focusEditor: false })
-                          }
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}
                           searchMatches={visibleSourceDocumentSearchMatches}
@@ -3812,17 +3794,8 @@ function WorkspaceApp() {
                           })}
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                          onRedo={
-                            largeMarkdownVisualBlocked
-                              ? undefined
-                              : () => handleRunEditorShortcut("z", { shiftKey: true }, { focusEditor: false })
-                          }
+                          {...sourceEditorHistoryHandlers}
                           onScroll={handleSourcePaneScroll}
-                          onUndo={
-                            largeMarkdownVisualBlocked
-                              ? undefined
-                              : () => handleRunEditorShortcut("z", {}, { focusEditor: false })
-                          }
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}
                           searchMatches={visibleSourceDocumentSearchMatches}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3558,7 +3558,7 @@ function WorkspaceApp() {
             style={{ gridTemplateColumns: `minmax(0,1fr) ${aiAgentInset}` }}
           >
             <div
-              className={`editor-content-slot relative h-full min-h-0 overflow-hidden transition-[box-shadow] duration-150 ease-out ${
+              className={`editor-content-slot relative h-full min-h-0 overflow-hidden transition-shadow duration-150 ease-out ${
                 editorTabDropTargetActive ? "ring-2 ring-(--accent)/30 ring-inset" : ""
               }`}
               data-document-search-open={documentSearchOpen && documentSearchAvailable ? "true" : undefined}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -69,6 +69,7 @@ import {
   useNativeMenuHandlers,
   useNativeMenus
 } from "./hooks/useNativeBindings";
+import type { Editor as MilkdownEditor } from "@milkdown/kit/core";
 import {
   aiTranslationLanguageName,
   clampNumber,
@@ -459,6 +460,7 @@ function WorkspaceApp() {
   const largeMarkdownVisualBlockedRef = useRef(false);
   const sourceScrollRef = useRef<HTMLElement | null>(null);
   const visualScrollRef = useRef<HTMLElement | null>(null);
+  const mainVisualEditorsRef = useRef(new Map<string, MilkdownEditor>());
   const documentTabViewStatesRef = useRef(new Map<string, DocumentTabViewState>());
   const pendingEditorModeScrollRef = useRef<PendingEditorModeScroll | null>(null);
   const splitSurfaceRef = useRef<HTMLDivElement | null>(null);
@@ -777,6 +779,32 @@ function WorkspaceApp() {
     path: document.path,
     sizeBytes: document.sizeBytes ?? null
   };
+  const handleMainVisualEditorReady = useCallback((
+    tabId: string,
+    readyEditor: MilkdownEditor | null,
+    options?: Parameters<typeof handleMilkdownEditorReady>[1]
+  ) => {
+    if (readyEditor) {
+      mainVisualEditorsRef.current.set(tabId, readyEditor);
+    } else {
+      mainVisualEditorsRef.current.delete(tabId);
+    }
+
+    if (tabId === activeTabId) {
+      handleVisualEditorReady(readyEditor, options);
+    }
+  }, [activeTabId, handleVisualEditorReady]);
+  useEffect(() => {
+    if (!activeTabId) {
+      handleVisualEditorReady(null);
+      return;
+    }
+
+    const activeEditor = mainVisualEditorsRef.current.get(activeTabId);
+    if (!activeEditor) return;
+
+    handleVisualEditorReady(activeEditor, { autoFocus: false });
+  }, [activeTabId, handleVisualEditorReady]);
   const workspaceKey = document.path ?? fileTree.sourcePath ?? null;
   backupSourcePathRef.current = fileTreeSourcePath ?? document.path;
   syncSourcePathRef.current = fileTreeSourcePath ?? document.path;
@@ -907,7 +935,6 @@ function WorkspaceApp() {
     "--side-document-main-pane": `${resolvedSideDocumentMainPanePercent}fr`,
     "--side-document-secondary-pane": `${100 - resolvedSideDocumentMainPanePercent}fr`
   } as CSSProperties), [resolvedSideDocumentMainPanePercent]);
-  const resolveImageSrc = useMemo(() => createMarkdownImageSrcResolver(document.path), [document.path]);
   const resolveExportImageSrc = useMemo(
     () => createMarkdownImageSrcResolver(document.path, { convertFileSrc: localFileUrlFromPath }),
     [document.path]
@@ -3469,6 +3496,90 @@ function WorkspaceApp() {
       : editorPreferences.preferences.titlebarActions.filter((action) => action.id !== "aiAgent"),
     [aiFeatureEnabled, editorPreferences.preferences.titlebarActions]
   );
+  const mainVisualEditorTabs = documentTabs.filter((tab) => tab.open);
+  const mainVisualEditors = (
+    <>
+      {mainVisualEditorTabs.map((tab) => {
+        const tabActive = tab.id === activeTabId;
+        const tabVisualBlocked = shouldBlockLargeMarkdownVisual(tab.content, {
+          sizeBytes: tab.sizeBytes
+        });
+        if (tabVisualBlocked) {
+          if (!tabActive || sourceMode) return null;
+
+          return (
+            <LargeMarkdownNotice
+              key={`${tab.id}:large-visual-notice`}
+              language={appLanguage.language}
+              onOpenSourceMode={handleEditorModeToggle}
+            />
+          );
+        }
+
+        const visualHidden = !tabActive || sourceMode;
+
+        return (
+          <div
+            key={tab.id}
+            aria-hidden={visualHidden ? "true" : undefined}
+            className="h-full min-h-0"
+            hidden={visualHidden}
+          >
+            <MarkdownPaper
+              autoFocus={
+                tabActive &&
+                !sourceMode &&
+                (splitMode ? activeEditorSurface === "visual" : shouldFocusEditorOnReady(tab.content))
+              }
+              bottomOverlayInset={
+                tabActive &&
+                !sourceMode &&
+                aiCommandVisible &&
+                (!splitMode || activeEditorSurface === "visual")
+                  ? aiCommandOverlayInset
+                  : 0
+              }
+              bodyFontSize={editorPreferences.preferences.bodyFontSize}
+              contentWidth={activeEditorContentWidth}
+              contentWidthPx={activeEditorContentWidthPx}
+              documentKey={tab.id}
+              documentPath={tab.path}
+              editorTheme={appTheme.editorTheme}
+              extendedSyntax={editorPreferences.preferences.extendedSyntax}
+              initialContent={tab.content}
+              language={appLanguage.language}
+              lineHeight={editorPreferences.preferences.lineHeight}
+              markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
+              onEditorReady={(readyEditor, options) => handleMainVisualEditorReady(tab.id, readyEditor, options)}
+              onMarkdownChange={(content) => {
+                const options = { documentRevision: tab.revision };
+                if (tabActive) {
+                  handleVisualMarkdownChange(content, options);
+                  return;
+                }
+
+                handleMarkdownTabChange(tab.id, content, options);
+              }}
+              onContentWidthChange={handleEditorContentWidthChange}
+              onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+              onSaveClipboardImage={handleSaveClipboardImage}
+              onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
+              openExternalUrl={handleOpenEditorLink}
+              readOnly={readOnlyMode}
+              onTextSelectionChange={tabActive ? handleTextSelectionChange : undefined}
+              resolveImageSrc={createMarkdownImageSrcResolver(tab.path)}
+              revision={tab.revision}
+              onScroll={tabActive ? handleVisualPaneScroll : undefined}
+              scrollRef={tabActive ? visualScrollRef : undefined}
+              topInset="titlebar"
+              workspaceFiles={fileTreeFiles}
+              wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
+            />
+          </div>
+        );
+      })}
+    </>
+  );
 
   return (
     <>
@@ -3649,46 +3760,7 @@ function WorkspaceApp() {
                       style={splitSurfaceStyle}
                     >
                       <div className="min-h-0 overflow-hidden" onFocusCapture={handleVisualPaneFocus}>
-                        {largeMarkdownVisualBlocked ? (
-                          <LargeMarkdownNotice
-                            language={appLanguage.language}
-                            onOpenSourceMode={handleEditorModeToggle}
-                          />
-                        ) : (
-                          <MarkdownPaper
-                            autoFocus={activeEditorSurface === "visual"}
-                            bottomOverlayInset={aiCommandVisible && activeEditorSurface === "visual" ? aiCommandOverlayInset : 0}
-                            bodyFontSize={editorPreferences.preferences.bodyFontSize}
-                            contentWidth={activeEditorContentWidth}
-                            contentWidthPx={activeEditorContentWidthPx}
-                            documentKey={activeTabId}
-                            documentPath={document.path}
-                            editorTheme={appTheme.editorTheme}
-                            extendedSyntax={editorPreferences.preferences.extendedSyntax}
-                            initialContent={document.content}
-                            language={appLanguage.language}
-                            lineHeight={editorPreferences.preferences.lineHeight}
-                            markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
-                            onEditorReady={handleVisualEditorReady}
-                            onMarkdownChange={(content) => handleVisualMarkdownChange(content, {
-                              documentRevision: document.revision
-                            })}
-                            onContentWidthChange={handleEditorContentWidthChange}
-                            onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                            onSaveClipboardImage={handleSaveClipboardImage}
-                            onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
-                            openExternalUrl={handleOpenEditorLink}
-                            readOnly={readOnlyMode}
-                            onTextSelectionChange={handleTextSelectionChange}
-                            resolveImageSrc={resolveImageSrc}
-                            revision={document.revision}
-                            onScroll={handleVisualPaneScroll}
-                            scrollRef={visualScrollRef}
-                            topInset="titlebar"
-                            workspaceFiles={fileTreeFiles}
-                            wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
-                          />
-                        )}
+                        {mainVisualEditors}
                       </div>
                       <div
                         className="group/split-resizer relative z-20 hidden cursor-col-resize touch-none outline-none min-[900px]:block"
@@ -3731,54 +3803,7 @@ function WorkspaceApp() {
                     </div>
                   ) : (
                     <div className="relative h-full min-h-0">
-                      {largeMarkdownVisualBlocked ? (
-                        sourceMode ? null : (
-                          <LargeMarkdownNotice
-                            language={appLanguage.language}
-                            onOpenSourceMode={handleEditorModeToggle}
-                          />
-                        )
-                      ) : (
-                        <div
-                          aria-hidden={sourceMode ? "true" : undefined}
-                          className="h-full min-h-0"
-                          hidden={sourceMode}
-                        >
-                          <MarkdownPaper
-                            autoFocus={!sourceMode && shouldFocusEditorOnReady(document.content)}
-                            bottomOverlayInset={!sourceMode && aiCommandVisible ? aiCommandOverlayInset : 0}
-                            bodyFontSize={editorPreferences.preferences.bodyFontSize}
-                            contentWidth={activeEditorContentWidth}
-                            contentWidthPx={activeEditorContentWidthPx}
-                            documentKey={activeTabId}
-                            documentPath={document.path}
-                            editorTheme={appTheme.editorTheme}
-                            extendedSyntax={editorPreferences.preferences.extendedSyntax}
-                            initialContent={document.content}
-                            language={appLanguage.language}
-                            lineHeight={editorPreferences.preferences.lineHeight}
-                            markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
-                            onEditorReady={handleVisualEditorReady}
-                            onMarkdownChange={(content) => handleVisualMarkdownChange(content, {
-                              documentRevision: document.revision
-                            })}
-                            onContentWidthChange={handleEditorContentWidthChange}
-                            onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                            onSaveClipboardImage={handleSaveClipboardImage}
-                            onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
-                            openExternalUrl={handleOpenEditorLink}
-                            readOnly={readOnlyMode}
-                            onTextSelectionChange={handleTextSelectionChange}
-                            resolveImageSrc={resolveImageSrc}
-                            revision={document.revision}
-                            onScroll={handleVisualPaneScroll}
-                            scrollRef={visualScrollRef}
-                            topInset="titlebar"
-                            workspaceFiles={fileTreeFiles}
-                            wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
-                          />
-                        </div>
-                      )}
+                      {mainVisualEditors}
                       {sourceMode ? (
                         <LazyMarkdownSourceEditor
                           autoFocus

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5494,6 +5494,23 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("nests the first item of an adjacent mixed-marker bullet list with Tab", async () => {
+    const { container, editor, view } = await renderEditor(["- Parent", "", "* Child"].join("\n"));
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Child"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    const topLevelItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li"));
+    const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > ul > li > ul > li"));
+    expect(topLevelItems).toHaveLength(1);
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Child");
+    expect(serializeMarkdown(view.state.doc)).toContain("  - Child");
+    await settleMarkdownListener();
+  });
+
   it("nests only the current list item when Tab is pressed before following siblings", async () => {
     const { editor, view } = await renderEditor(["- A", "- B", "- C", "- D"].join("\n"));
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
@@ -7119,6 +7136,28 @@ describe("MarkdownPaper editing", () => {
     expect(nestedItems).toHaveLength(0);
     expect(topLevelItems[1]).toHaveTextContent("Second");
     expect(serializeMarkdown(view.state.doc)).toContain("> - First\n> - Second");
+  });
+
+  it("nests the first item of an adjacent mixed-marker callout bullet list with Tab", async () => {
+    const source = ["> [!NOTE]", ">", "> - Parent", ">", "> * Child"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Child"));
+
+    expect(pressShortcut(view, "Tab")).toBe(true);
+
+    const topLevelItems = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror blockquote.markra-callout > ul > li")
+    );
+    const nestedItems = Array.from(container.querySelectorAll<HTMLElement>(
+      ".ProseMirror blockquote.markra-callout > ul > li > ul > li"
+    ));
+    expect(topLevelItems).toHaveLength(1);
+    expect(nestedItems).toHaveLength(1);
+    expect(nestedItems[0]).toHaveTextContent("Child");
+    expect(serializeMarkdown(view.state.doc)).toContain(">   - Child");
+    await settleMarkdownListener();
   });
 
   it("nests only the current callout list item when Tab is pressed before following siblings", async () => {

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -89,21 +89,26 @@ function markdownShortcutSignature(shortcuts: MarkdownShortcutMap | undefined) {
 function MilkdownInstanceBridge({ autoFocus, onEditorReady }: Pick<MarkdownPaperSurfaceProps, "autoFocus" | "onEditorReady">) {
   const [loading, getEditor] = useInstance();
   const autoFocusRef = useRef(autoFocus);
+  const onEditorReadyRef = useRef(onEditorReady);
 
   useEffect(() => {
     autoFocusRef.current = autoFocus;
   }, [autoFocus]);
 
   useEffect(() => {
+    onEditorReadyRef.current = onEditorReady;
+  }, [onEditorReady]);
+
+  useEffect(() => {
     if (loading) return;
 
     const editor = getEditor();
-    onEditorReady(editor, { autoFocus: autoFocusRef.current });
+    onEditorReadyRef.current(editor, { autoFocus: autoFocusRef.current });
 
     return () => {
-      onEditorReady(null);
+      onEditorReadyRef.current(null);
     };
-  }, [getEditor, loading, onEditorReady]);
+  }, [getEditor, loading]);
 
   return null;
 }
@@ -160,6 +165,7 @@ function MilkdownEditorSurface({
   const onSaveRemoteClipboardImageRef = useRef(onSaveRemoteClipboardImage);
   const onTextSelectionChangeRef = useRef(onTextSelectionChange);
   const readOnlyRef = useRef(readOnly);
+  const resolveImageSrcRef = useRef(resolveImageSrc);
   const workspaceFilesRef = useRef(workspaceFiles ?? []);
   const externalLinkOpeningEnabled = Boolean(openExternalUrl);
   const markdownDocumentLabel = t(language, "app.markdownDocument");
@@ -242,8 +248,16 @@ function MilkdownEditorSurface({
   }, [readOnly]);
 
   useEffect(() => {
+    resolveImageSrcRef.current = resolveImageSrc;
+  }, [resolveImageSrc]);
+
+  useEffect(() => {
     workspaceFilesRef.current = workspaceFiles ?? [];
   }, [workspaceFiles]);
+
+  const resolveCurrentImageSrc = useCallback((src: string) => {
+    return resolveImageSrcRef.current?.(src) ?? src;
+  }, []);
 
   const createEditor = useCallback(
     (root: HTMLElement) => {
@@ -331,13 +345,13 @@ function MilkdownEditorSurface({
         )
         .use(markraTableControlsPlugin(tableControlLabels))
         .use(markraTrailingParagraphPlugin)
-        .use(markraLinkImageLivePlugin(resolveImageSrc))
+        .use(markraLinkImageLivePlugin(resolveCurrentImageSrc))
         .use(markraHeadingLevelPlugin)
         .use(
           markraRawHtmlPlugin({
             htmlSourceApplyLabel: t(language, "editor.htmlSourceApply"),
             htmlSourceLabel: t(language, "editor.htmlSource"),
-            resolveImageSrc
+            resolveImageSrc: resolveCurrentImageSrc
           })
         )
         .use(markraLiveMarkdownPlugin({ highlight: highlightSyntaxEnabled, initialMarkdown: initialContentRef.current }));
@@ -370,7 +384,7 @@ function MilkdownEditorSurface({
       language,
       markdownDocumentLabel,
       normalizedMarkdownShortcuts,
-      resolveImageSrc,
+      resolveCurrentImageSrc,
       slashCommandLabels
     ]
   );

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { redo, undo } from "@codemirror/commands";
 import { EditorView } from "@codemirror/view";
 import { MarkdownSourceEditor } from "./MarkdownSourceEditor";
@@ -110,6 +110,26 @@ describe("MarkdownSourceEditor", () => {
     });
     expect(view.state.doc.toString()).toBe("# Changed");
     expect(handleChange).toHaveBeenLastCalledWith("# Changed");
+  });
+
+  it("routes undo and redo shortcuts to shared history handlers when provided", () => {
+    const handleRedo = vi.fn();
+    const handleUndo = vi.fn();
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="# Shared history"
+        onChange={() => {}}
+        onRedo={handleRedo}
+        onUndo={handleUndo}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    fireEvent.keyDown(view.contentDOM, { ctrlKey: true, key: "z" });
+    expect(handleUndo).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(view.contentDOM, { ctrlKey: true, key: "y" });
+    expect(handleRedo).toHaveBeenCalledTimes(1);
   });
 
   it("highlights GitHub-style alert markers in CodeMirror source mode", async () => {

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, type CSSProperties, type Ref, type UIEvent } from "react";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-import { Annotation, Compartment, EditorSelection, EditorState, Transaction, type Extension, type Range } from "@codemirror/state";
-import { Decoration, EditorView } from "@codemirror/view";
+import { Annotation, Compartment, EditorSelection, EditorState, Prec, Transaction, type Extension, type Range } from "@codemirror/state";
+import { Decoration, EditorView, keymap } from "@codemirror/view";
 import { minimalSetup } from "codemirror";
 import { parseMarkdownCalloutMarker, t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
@@ -29,6 +29,8 @@ export type MarkdownSourceEditorProps = {
   onContentWidthResizeEnd?: () => unknown;
   onContentWidthResizeStart?: () => unknown;
   onScroll?: (event: UIEvent<HTMLElement>) => unknown;
+  onRedo?: () => unknown;
+  onUndo?: () => unknown;
   readOnly?: boolean;
   searchActiveIndex?: number;
   searchMatches?: SearchRange[];
@@ -51,6 +53,39 @@ function markdownSourceContentAttributes(label: string, readOnly: boolean): Exte
     role: "textbox",
     spellcheck: "false"
   });
+}
+
+function markdownSourceSharedHistoryExtension(
+  onUndoRef: { current?: () => unknown },
+  onRedoRef: { current?: () => unknown }
+): Extension {
+  const runRedo = () => {
+    if (!onRedoRef.current) return false;
+
+    onRedoRef.current();
+    return true;
+  };
+
+  return Prec.highest(keymap.of([
+    {
+      key: "Mod-z",
+      run() {
+        if (!onUndoRef.current) return false;
+
+        onUndoRef.current();
+        return true;
+      }
+    },
+    {
+      key: "Ctrl-Shift-z",
+      run: runRedo
+    },
+    {
+      key: "Mod-y",
+      mac: "Mod-Shift-z",
+      run: runRedo
+    }
+  ]));
 }
 
 function clampSearchRange(match: SearchRange, documentLength: number) {
@@ -266,6 +301,8 @@ export function MarkdownSourceEditor({
   onContentWidthResizeEnd,
   onContentWidthResizeStart,
   onScroll,
+  onRedo,
+  onUndo,
   readOnly = false,
   searchActiveIndex = -1,
   searchMatches = [],
@@ -275,6 +312,8 @@ export function MarkdownSourceEditor({
   const editorContainerRef = useRef<HTMLDivElement | null>(null);
   const initialContentRef = useRef(content);
   const onChangeRef = useRef(onChange);
+  const onRedoRef = useRef(onRedo);
+  const onUndoRef = useRef(onUndo);
   const viewRef = useRef<EditorView | null>(null);
   const contentAttributesCompartmentRef = useRef(new Compartment());
   const editableCompartmentRef = useRef(new Compartment());
@@ -299,9 +338,18 @@ export function MarkdownSourceEditor({
     onChangeRef.current = onChange;
   }, [onChange]);
 
+  useEffect(() => {
+    onRedoRef.current = onRedo;
+  }, [onRedo]);
+
+  useEffect(() => {
+    onUndoRef.current = onUndo;
+  }, [onUndo]);
+
   const extensions = useMemo(
     () => [
       minimalSetup,
+      markdownSourceSharedHistoryExtension(onUndoRef, onRedoRef),
       markdown({
         base: markdownLanguage,
         codeLanguages: []

--- a/packages/app/src/components/SettingsSections.tsx
+++ b/packages/app/src/components/SettingsSections.tsx
@@ -632,7 +632,7 @@ function SettingsCallout({
         <Icon size={14} />
       </span>
       <div className="min-w-0">
-        <p className="m-0 text-[12px] leading-5 font-[700] tracking-normal text-(--text-heading)">{title}</p>
+        <p className="m-0 text-[12px] leading-5 font-bold tracking-normal text-(--text-heading)">{title}</p>
         <p className="m-0 max-w-[72ch] text-[12px] leading-4.5 font-[450] text-(--text-secondary)">{description}</p>
       </div>
     </div>

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -387,7 +387,7 @@ export function useEditorController() {
     }
   }, []);
 
-  const replaceMarkdown = useCallback((markdown: string) => {
+  const replaceMarkdown = useCallback((markdown: string, options: { addToHistory?: boolean } = {}) => {
     try {
       const editor = editorRef.current;
       if (!editor) {
@@ -417,8 +417,11 @@ export function useEditorController() {
         const parsedDocument = parseMarkdown(markdown);
         const selectionPosition = Math.min(view.state.selection.from, parsedDocument.content.size);
         const tr = view.state.tr
-          .replace(0, view.state.doc.content.size, new Slice(parsedDocument.content, 0, 0))
-          .setMeta("addToHistory", false);
+          .replace(0, view.state.doc.content.size, new Slice(parsedDocument.content, 0, 0));
+
+        if (!options.addToHistory) {
+          tr.setMeta("addToHistory", false);
+        }
 
         tr.setSelection(TextSelection.near(tr.doc.resolve(selectionPosition))).scrollIntoView();
         view.dispatch(tr);
@@ -605,9 +608,13 @@ export function useEditorController() {
   }, []);
 
   const runEditorShortcut = useCallback(
-    (key: string, modifiers: Pick<KeyboardEventInit, "altKey" | "shiftKey"> = {}) => {
+    (
+      key: string,
+      modifiers: Pick<KeyboardEventInit, "altKey" | "shiftKey"> = {},
+      options: { focusEditor?: boolean } = {}
+    ) => {
       const editor = editorRef.current;
-      if (!editor) return;
+      if (!editor) return false;
 
       const view = editor.action((ctx) => ctx.get(editorViewCtx));
       const event = new KeyboardEvent("keydown", {
@@ -619,9 +626,11 @@ export function useEditorController() {
       });
       const handled = view.someProp("handleKeyDown", (handler) => handler(view, event));
 
-      if (handled) {
+      if (handled && options.focusEditor !== false) {
         view.focus();
       }
+
+      return Boolean(handled);
     },
     []
   );

--- a/packages/app/src/hooks/useSharedEditorHistory.ts
+++ b/packages/app/src/hooks/useSharedEditorHistory.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef } from "react";
+
+type MarkdownChangeOptions = {
+  documentRevision?: number;
+};
+
+type ReplaceEditorMarkdown = (markdown: string, options?: { addToHistory?: boolean }) => boolean;
+
+type SharedEditorHistoryOptions = {
+  documentContent: string;
+  documentRevision: number;
+  largeMarkdownVisualBlocked: boolean;
+  replaceEditorMarkdown: ReplaceEditorMarkdown;
+  sourceSurfaceActive: boolean;
+  visualEditorReadySequence: number;
+};
+
+export function useSharedEditorHistory({
+  documentContent,
+  documentRevision,
+  largeMarkdownVisualBlocked,
+  replaceEditorMarkdown,
+  sourceSurfaceActive,
+  visualEditorReadySequence
+}: SharedEditorHistoryOptions) {
+  const pendingSourceHistoryRef = useRef(false);
+  const syncingSourceToVisualRef = useRef(false);
+
+  const isApplyingSourceToVisualSync = useCallback(() => syncingSourceToVisualRef.current, []);
+  const markSourceEditForHistory = useCallback((content: string, options?: MarkdownChangeOptions) => {
+    if (
+      content !== documentContent &&
+      (options?.documentRevision === undefined || options.documentRevision === documentRevision)
+    ) {
+      pendingSourceHistoryRef.current = true;
+    }
+  }, [documentContent, documentRevision]);
+
+  useEffect(() => {
+    if (!sourceSurfaceActive || largeMarkdownVisualBlocked) {
+      pendingSourceHistoryRef.current = false;
+      return;
+    }
+
+    syncingSourceToVisualRef.current = true;
+    try {
+      const synced = replaceEditorMarkdown(documentContent, {
+        addToHistory: pendingSourceHistoryRef.current
+      });
+      if (synced) pendingSourceHistoryRef.current = false;
+    } finally {
+      syncingSourceToVisualRef.current = false;
+    }
+  }, [
+    documentContent,
+    largeMarkdownVisualBlocked,
+    replaceEditorMarkdown,
+    sourceSurfaceActive,
+    visualEditorReadySequence
+  ]);
+
+  return {
+    isApplyingSourceToVisualSync,
+    markSourceEditForHistory
+  };
+}

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -284,6 +284,155 @@ function liftCurrentListItem(listItem: NodeType): Command {
   };
 }
 
+function nodeChildren(node: ProseNode) {
+  const children: ProseNode[] = [];
+  node.forEach((child) => children.push(child));
+  return children;
+}
+
+function appendItemToNestedList(
+  listItemNode: ProseNode,
+  listType: NodeType,
+  item: ProseNode
+) {
+  const children = nodeChildren(listItemNode);
+  const lastChild = children.at(-1);
+
+  if (lastChild?.type === listType) {
+    children[children.length - 1] = lastChild.type.create(
+      lastChild.attrs,
+      lastChild.content.append(Fragment.from(item)),
+      lastChild.marks
+    );
+  } else {
+    children.push(listType.create(null, Fragment.from(item)));
+  }
+
+  return listItemNode.type.create(listItemNode.attrs, Fragment.fromArray(children), listItemNode.marks);
+}
+
+function orderedListAttrsAfterRemovingFirstItem(list: ProseNode) {
+  if (list.type.name !== "ordered_list") return list.attrs;
+
+  const order = typeof list.attrs.order === "number" ? list.attrs.order : 1;
+  return {
+    ...list.attrs,
+    order: order + 1
+  };
+}
+
+function listWithoutChild(list: ProseNode, childIndex: number) {
+  const children = nodeChildren(list).filter((_child, index) => index !== childIndex);
+  if (children.length === 0) return null;
+
+  const attrs = childIndex === 0
+    ? orderedListAttrsAfterRemovingFirstItem(list)
+    : list.attrs;
+  return list.type.create(attrs, Fragment.fromArray(children), list.marks);
+}
+
+function adjacentPreviousListContext(selection: Selection, context: ListItemContext) {
+  const grandparentDepth = context.parentListDepth - 1;
+  if (grandparentDepth < 0) return null;
+
+  const currentListIndex = selection.$from.index(grandparentDepth);
+  if (currentListIndex <= 0) return null;
+
+  const grandparent = selection.$from.node(grandparentDepth);
+  const previousList = grandparent.child(currentListIndex - 1);
+  if (previousList.type !== context.parentList.type || previousList.childCount === 0) return null;
+
+  const currentListFrom = selection.$from.before(context.parentListDepth);
+  return {
+    currentListFrom,
+    currentListIndex,
+    grandparent,
+    previousList,
+    previousListFrom: currentListFrom - previousList.nodeSize
+  };
+}
+
+function nestedItemPosition(previousListFrom: number, previousList: ProseNode, listType: NodeType) {
+  const previousItem = previousList.lastChild;
+  if (!previousItem) return null;
+
+  const previousItemOffset = previousList.content.size - previousItem.nodeSize;
+  const previousItemFrom = previousListFrom + 1 + previousItemOffset;
+  const existingNestedList = previousItem.lastChild?.type === listType ? previousItem.lastChild : null;
+  if (!existingNestedList) return previousItemFrom + 2 + previousItem.content.size;
+
+  const nestedListOffset = previousItem.content.size - existingNestedList.nodeSize;
+  const nestedListFrom = previousItemFrom + 1 + nestedListOffset;
+  return nestedListFrom + 1 + existingNestedList.content.size;
+}
+
+function sinkFirstItemIntoAdjacentPreviousList(listItem: NodeType): Command {
+  return (state, dispatch) => {
+    const context = listItemContext(state.selection, listItem);
+    if (!context || context.itemIndex !== 0) return false;
+
+    const adjacentContext = adjacentPreviousListContext(state.selection, context);
+    if (!adjacentContext) return false;
+
+    const previousItems = nodeChildren(adjacentContext.previousList);
+    const previousItem = previousItems.at(-1);
+    if (!previousItem) return false;
+
+    const nestedItemFrom = nestedItemPosition(
+      adjacentContext.previousListFrom,
+      adjacentContext.previousList,
+      context.parentList.type
+    );
+    if (nestedItemFrom === null) return false;
+
+    previousItems[previousItems.length - 1] = appendItemToNestedList(
+      previousItem,
+      context.parentList.type,
+      context.item
+    );
+    const updatedPreviousList = adjacentContext.previousList.type.create(
+      adjacentContext.previousList.attrs,
+      Fragment.fromArray(previousItems),
+      adjacentContext.previousList.marks
+    );
+    const updatedCurrentList = listWithoutChild(context.parentList, context.itemIndex);
+    const replacementNodes = updatedCurrentList
+      ? [updatedPreviousList, updatedCurrentList]
+      : [updatedPreviousList];
+    const replacement = Fragment.fromArray(replacementNodes);
+
+    if (!adjacentContext.grandparent.canReplace(
+      adjacentContext.currentListIndex - 1,
+      adjacentContext.currentListIndex + 1,
+      replacement
+    )) return false;
+
+    if (dispatch) {
+      const selectionOffset = state.selection.from - context.from;
+      const transaction = state.tr.replaceWith(
+        adjacentContext.previousListFrom,
+        adjacentContext.currentListFrom + context.parentList.nodeSize,
+        replacement
+      );
+      const selectionPosition = Math.min(nestedItemFrom + selectionOffset, transaction.doc.content.size);
+
+      dispatch(
+        transaction
+          .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1))
+          .scrollIntoView()
+      );
+    }
+
+    return true;
+  };
+}
+
+function sinkCurrentListItem(listItem: NodeType): Command {
+  return (state, dispatch, view) =>
+    sinkListItem(listItem)(state, dispatch, view) ||
+    sinkFirstItemIntoAdjacentPreviousList(listItem)(state, dispatch, view);
+}
+
 function toggleBlockquote(blockquote: ReturnType<typeof blockquoteSchema.type>): Command {
   return (state, dispatch, view) => {
     if (selectionIsInsideNodeType(state.selection, blockquote)) {
@@ -528,7 +677,7 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
           if (selectionIsInsideNodeType(view.state.selection, listItem)) {
             const handled = runCommand(
               view,
-              event.shiftKey ? liftCurrentListItem(listItem) : sinkListItem(listItem)
+              event.shiftKey ? liftCurrentListItem(listItem) : sinkCurrentListItem(listItem)
             );
             if (handled && selectionIsInsideNodeType(view.state.selection, blockquote)) {
               tightenListSpreadInSelectionAncestor(view, "blockquote");


### PR DESCRIPTION
## Summary
- Add a Tab fallback for adjacent same-type lists that parse as separate lists because their bullet markers differ.
- Cover ordinary and GitHub alert list indentation cases.
- Keep the separate existing app style cleanup as its own commit by replacing equivalent arbitrary Tailwind utilities with named utilities.

## Why
- Closes #261.
- `sinkListItem` cannot indent the first item of a separate adjacent list, so Tab was handled without changing the document.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "adjacent mixed-marker"` passed: 2 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 364 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `git diff --check -- packages/editor/src/shortcuts.ts packages/app/src/components/MarkdownPaper.test.tsx` passed.
- `git diff --check -- packages/app/src/App.tsx packages/app/src/components/SettingsSections.tsx` passed.

## Risk
- Low; fallback only runs after the normal list sink command fails and only for adjacent lists of the same list node type.
- The style cleanup swaps equivalent Tailwind utility names only.