### PR TITLE
feat(desktop): route OS-opened Markdown files to tabs

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -57,6 +57,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +280,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -335,6 +479,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -721,6 +874,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +925,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -892,6 +1093,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1271,6 +1485,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1905,6 +2125,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-os",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
@@ -2335,6 +2556,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2619,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2520,6 +2757,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2810,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3415,6 +3677,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3894,6 +4166,21 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -4463,6 +4750,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5558,6 +5856,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5654,3 +6013,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.2",
+]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -39,4 +39,5 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = ["std"
 objc2-foundation = { version = "0.3.0", default-features = false, features = ["std", "NSArray", "NSString", "NSURL"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = "2.4.2"
 tauri-plugin-window-state = "2.4.1"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -58,6 +58,13 @@ use windows::{
     spawn_blank_editor_window, spawn_settings_window,
 };
 
+fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default()
@@ -67,6 +74,12 @@ pub fn run() {
         .manage(NativeApplicationMenuState::default())
         .manage(NativeMenuTargetState::default())
         .manage(EditorWindowRestoreState::default());
+
+    #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+        queue_opened_markdown_paths(app, opened_markdown_paths_from_args(args));
+        focus_main_window(app);
+    }));
 
     #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
     let builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
@@ -232,6 +245,28 @@ mod tests {
         assert!(
             lib_source.contains("tauri_plugin_window_state::Builder::default().build()"),
             "Tauri builder should register the window state restore plugin"
+        );
+    }
+
+    #[test]
+    fn desktop_registers_single_instance_plugin_before_other_plugins() {
+        let manifest = include_str!("../Cargo.toml");
+        assert!(
+            manifest.contains("tauri-plugin-single-instance"),
+            "desktop manifest should include the single instance plugin"
+        );
+
+        let lib_source = include_str!("lib.rs");
+        let single_instance_index = lib_source
+            .find("tauri_plugin_single_instance::init")
+            .expect("Tauri builder should register the single instance plugin");
+        let store_plugin_index = lib_source
+            .find("tauri_plugin_store::Builder")
+            .expect("Tauri builder should register the store plugin");
+
+        assert!(
+            single_instance_index < store_plugin_index,
+            "single instance plugin should be registered before other plugins"
         );
     }
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3868,6 +3868,126 @@ describe("Markra workspace", () => {
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(mockDroppedPath);
   });
 
+  it("opens an OS-opened markdown file in a new tab when document tabs are enabled", async () => {
+    let onOpenedPaths: ((paths: string[]) => unknown) | null = null;
+    mockOpenMarkdownFile({
+      content: "# Native file\n\nAlready open.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListenNativeOpenedMarkdownPaths.mockImplementation(async (listener) => {
+      onOpenedPaths = listener;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === mockNativePath) {
+        return {
+          content: "# Native file\n\nAlready open.",
+          name: "native.md",
+          path: mockNativePath
+        };
+      }
+
+      return {
+        content: "# Runtime file\n\nOpened while Markra was already running.",
+        name: "dropped.md",
+        path: mockDroppedPath
+      };
+    });
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    expect(await screen.findByRole("heading", { name: "Native file" })).toBeInTheDocument();
+    await waitFor(() => expect(onOpenedPaths).not.toBeNull());
+
+    await act(async () => {
+      await onOpenedPaths?.([mockDroppedPath]);
+    });
+
+    expect(await screen.findByRole("heading", { name: "Runtime file" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /native\.md/ })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("tab", { name: /dropped\.md/ })).toHaveAttribute("aria-selected", "true");
+    expect(mockedOpenNativeMarkdownFileInNewWindow).not.toHaveBeenCalled();
+  });
+
+  it("opens an OS-opened markdown file from a child folder in the current workspace as a new tab", async () => {
+    const childFolderPath = "/mock-files/docs/dropped.md";
+    let onOpenedPaths: ((paths: string[]) => unknown) | null = null;
+    mockOpenMarkdownFile({
+      content: "# Native file\n\nAlready open.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListenNativeOpenedMarkdownPaths.mockImplementation(async (listener) => {
+      onOpenedPaths = listener;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === mockNativePath) {
+        return {
+          content: "# Native file\n\nAlready open.",
+          name: "native.md",
+          path: mockNativePath
+        };
+      }
+
+      return {
+        content: "# Child file\n\nOpened from a nested workspace folder.",
+        name: "dropped.md",
+        path: childFolderPath
+      };
+    });
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    expect(await screen.findByRole("heading", { name: "Native file" })).toBeInTheDocument();
+    await waitFor(() => expect(onOpenedPaths).not.toBeNull());
+
+    await act(async () => {
+      await onOpenedPaths?.([childFolderPath]);
+    });
+
+    expect(await screen.findByRole("heading", { name: "Child file" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /native\.md/ })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("tab", { name: /dropped\.md/ })).toHaveAttribute("aria-selected", "true");
+    expect(mockedOpenNativeMarkdownFileInNewWindow).not.toHaveBeenCalled();
+  });
+
+  it("opens an OS-opened markdown file from another folder in a new window", async () => {
+    const otherFolderPath = "/other-vault/dropped.md";
+    let onOpenedPaths: ((paths: string[]) => unknown) | null = null;
+    mockOpenMarkdownFile({
+      content: "# Native file\n\nAlready open.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListenNativeOpenedMarkdownPaths.mockImplementation(async (listener) => {
+      onOpenedPaths = listener;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Native file\n\nAlready open.",
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    expect(await screen.findByRole("heading", { name: "Native file" })).toBeInTheDocument();
+    await waitFor(() => expect(onOpenedPaths).not.toBeNull());
+
+    await act(async () => {
+      await onOpenedPaths?.([otherFolderPath]);
+    });
+
+    await waitFor(() => expect(mockedOpenNativeMarkdownFileInNewWindow).toHaveBeenCalledWith(otherFolderPath));
+    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalledWith(otherFolderPath);
+    expect(screen.queryByRole("tab", { name: /dropped\.md/ })).not.toBeInTheDocument();
+  });
+
   it("opens a markdown folder when a native folder window opens with an initial path", async () => {
     window.history.pushState({}, "", "/?folder=%2Fmock-files%2Fvault");
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -469,7 +469,8 @@ function WorkspaceApp() {
     onTreeRootFromFilePath: setRootFromMarkdownFilePath,
     onWorkspaceSessionChange: setAiAgentSessionId,
     preferencesReady: !editorPreferences.loading,
-    restoreWorkspaceOnStartup: editorPreferences.preferences.restoreWorkspaceOnStartup
+    restoreWorkspaceOnStartup: editorPreferences.preferences.restoreWorkspaceOnStartup,
+    workspaceSourcePath: fileTreeSourcePath
   });
   const {
     clearRecentMarkdownFiles,

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -40,7 +40,7 @@ import {
 } from "../lib/performance-marks";
 import { replaceMovedPath } from "../lib/path-move";
 import { setNativeWindowTitle } from "../lib/tauri";
-import { debug, pathNameFromPath, type DocumentState } from "@markra/shared";
+import { debug, isMarkdownPath, parentPathFromPath, pathNameFromPath, type DocumentState } from "@markra/shared";
 import {
   activeFilePathFromTabs,
   activeFilePathFromWindowRestore,
@@ -144,6 +144,7 @@ type UseMarkdownDocumentOptions = {
   onWorkspaceSessionChange?: (sessionId: string) => unknown;
   preferencesReady?: boolean;
   restoreWorkspaceOnStartup?: boolean;
+  workspaceSourcePath?: string | null;
 };
 
 type ClearOpenDocumentOptions = {
@@ -162,6 +163,38 @@ function resolveEditorReady(editorReady: boolean | (() => boolean)) {
   return typeof editorReady === "function" ? editorReady() : editorReady;
 }
 
+function normalizeComparablePath(path: string | null | undefined) {
+  const trimmedPath = path?.trim();
+  if (!trimmedPath) return null;
+
+  const normalizedPath = trimmedPath.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  return normalizedPath || (trimmedPath.startsWith("/") ? "/" : null);
+}
+
+function isPathWithinRoot(path: string, rootPath: string | null) {
+  const normalizedPath = normalizeComparablePath(path);
+  const normalizedRootPath = normalizeComparablePath(rootPath);
+  if (!normalizedPath || !normalizedRootPath) return false;
+  if (normalizedPath === normalizedRootPath) return true;
+
+  const rootWithSeparator = normalizedRootPath.endsWith("/")
+    ? normalizedRootPath
+    : `${normalizedRootPath}/`;
+  return normalizedPath.startsWith(rootWithSeparator);
+}
+
+function workspaceRootForSource(sourcePath: string | null | undefined, currentFilePath: string | null) {
+  const normalizedSourcePath = normalizeComparablePath(sourcePath);
+  if (normalizedSourcePath) {
+    return isMarkdownPath(normalizedSourcePath)
+      ? parentPathFromPath(normalizedSourcePath)
+      : normalizedSourcePath;
+  }
+
+  const normalizedCurrentFilePath = normalizeComparablePath(currentFilePath);
+  return normalizedCurrentFilePath ? parentPathFromPath(normalizedCurrentFilePath) : null;
+}
+
 export function useMarkdownDocument({
   beforeNativeAppExit,
   confirmDiscardUnsavedChanges,
@@ -175,7 +208,8 @@ export function useMarkdownDocument({
   onTreeRootFromFilePath,
   onWorkspaceSessionChange,
   preferencesReady = true,
-  restoreWorkspaceOnStartup = true
+  restoreWorkspaceOnStartup = true,
+  workspaceSourcePath
 }: UseMarkdownDocumentOptions) {
   const [document, setDocument] = useState<DocumentState>(() => createInitialDocumentState());
   const [tabs, setTabs] = useState<MarkdownDocumentTab[]>(() => [createDocumentTab(createInitialDocumentState(), "untitled:0")]);
@@ -1257,13 +1291,20 @@ export function useMarkdownDocument({
     return true;
   }, [confirmDiscardUnsavedChanges, hasDiscardableTabChanges, registerWindowRestoreState, setActiveTabState, syncActiveDocumentFromEditor]);
 
+  const isCurrentDocumentEmptyUntitled = useCallback(() => {
+    const current = documentRef.current;
+    return !current.open || (current.path === null && currentMarkdown().trim() === "");
+  }, [currentMarkdown]);
+
+  const isFileInCurrentWorkspace = useCallback((path: string) => {
+    const workspaceRootPath = workspaceRootForSource(workspaceSourcePath, documentRef.current.path);
+    return isPathWithinRoot(path, workspaceRootPath);
+  }, [workspaceSourcePath]);
+
   const handleDroppedMarkdownPath = useCallback(
     async (target: NativeMarkdownDroppedTarget) => {
-      const current = documentRef.current;
-      const isEmptyUntitledDocument = !current.open || (current.path === null && currentMarkdown().trim() === "");
-
       if (target.kind === "folder") {
-        if (!isEmptyUntitledDocument) {
+        if (!isCurrentDocumentEmptyUntitled()) {
           await openNativeMarkdownFolderInNewWindow(target.path);
           return;
         }
@@ -1274,14 +1315,14 @@ export function useMarkdownDocument({
         return;
       }
 
-      if (isEmptyUntitledDocument) {
+      if (isCurrentDocumentEmptyUntitled()) {
         await loadNativeMarkdownPath(target.path);
         return;
       }
 
       await openNativeMarkdownFileInNewWindow(target.path);
     },
-    [clearOpenDocument, currentMarkdown, loadNativeMarkdownPath, onTreeRootFromFolderPath, resolveWorkspaceSessionId]
+    [clearOpenDocument, isCurrentDocumentEmptyUntitled, loadNativeMarkdownPath, onTreeRootFromFolderPath, resolveWorkspaceSessionId]
   );
 
   const handleNativeOpenedMarkdownPaths = useCallback(async (paths: string[]) => {
@@ -1292,7 +1333,15 @@ export function useMarkdownDocument({
     for (const path of paths) {
       try {
         const target = await resolveNativeMarkdownPath(path);
-        await handleDroppedMarkdownPath(target);
+
+        if (target.kind === "folder") {
+          await handleDroppedMarkdownPath(target);
+        } else if (isCurrentDocumentEmptyUntitled() || (documentTabsEnabled && isFileInCurrentWorkspace(target.path))) {
+          await loadNativeMarkdownPath(target.path);
+        } else {
+          await openNativeMarkdownFileInNewWindow(target.path);
+        }
+
         openedPath = true;
       } catch {
         // Unsupported or moved OS-opened paths should not block other files.
@@ -1301,7 +1350,7 @@ export function useMarkdownDocument({
 
     if (openedPath) openedFromNativeRef.current = true;
     return openedPath;
-  }, [handleDroppedMarkdownPath]);
+  }, [documentTabsEnabled, handleDroppedMarkdownPath, isCurrentDocumentEmptyUntitled, isFileInCurrentWorkspace, loadNativeMarkdownPath]);
 
   useEffect(() => {
     const title = document.open && document.dirty ? `${document.name} *` : document.name;


### PR DESCRIPTION
## Summary
- Add Tauri single-instance handling so OS-opened Markdown paths are forwarded to the running Markra instance instead of launching a separate process.
- Reuse the existing opened Markdown path queue and focus the main window when a second launch is intercepted.
- Open OS-opened files in the current window as tabs only when they belong to the current workspace, including child folders; keep different workspaces in new windows.
- Add regression coverage for same-folder tabs, child-folder tabs, different-folder new windows, and native plugin registration.

## Why
Issue #282 reports that setting Markra as the default Markdown app opens each file in a new window. The desired behavior is tab reuse, but Markra still needs to preserve workspace boundaries so unrelated folders do not mix in one window.

## Validation
- `cargo test desktop_registers_single_instance_plugin_before_other_plugins --manifest-path apps/desktop/src-tauri/Cargo.toml` passed
- `cargo test collects_supported_markdown_paths --manifest-path apps/desktop/src-tauri/Cargo.toml` passed
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "opens an OS-opened markdown file in a new tab"` passed
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "opens an OS-opened markdown file from a child folder"` passed
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "opens an OS-opened markdown file from another folder"` passed
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "loads a markdown file when the operating system opens Markra with a file path"` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed

## Risk
- Adds `tauri-plugin-single-instance`, which brings transitive native IPC dependencies into `Cargo.lock`.
- Not run: Windows manual double-click QA for `.md` default-app association.

Closes #282
