### PR TITLE
fix(sync): default remote folder to markra

### DIFF
--- a/packages/app/src/components/settings/SyncSettings.test.tsx
+++ b/packages/app/src/components/settings/SyncSettings.test.tsx
@@ -34,6 +34,10 @@ describe("SyncSettings", () => {
     expect(screen.queryByRole("textbox", { name: "WebDAV URL" })).not.toBeInTheDocument();
     expect(screen.queryByRole("textbox", { name: "Username" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Password")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Remote folder" })).toHaveAttribute(
+      "placeholder",
+      "e.g. markra"
+    );
 
     fireEvent.click(screen.getByRole("switch", { name: "Enable sync" }));
     expect(onUpdateSettings).toHaveBeenCalledWith({
@@ -79,6 +83,7 @@ describe("SyncSettings", () => {
       />
     );
 
+    expect(screen.getByRole("textbox", { name: "Remote folder" })).toHaveValue("markra");
     expect(screen.getByRole("button", { name: "Sync now" })).toBeDisabled();
   });
 });

--- a/packages/app/src/components/settings/SyncSettings.tsx
+++ b/packages/app/src/components/settings/SyncSettings.tsx
@@ -81,7 +81,7 @@ export function SyncSettings({
           <SettingsTextInput
             label={translate("settings.sync.remotePath")}
             value={settings.remotePath}
-            placeholder="markra"
+            placeholder={translate("settings.sync.remotePathPlaceholder")}
             widthClassName="w-56"
             onChange={(remotePath) =>
               onUpdateSettings({

--- a/packages/app/src/lib/settings/sync-settings.test.ts
+++ b/packages/app/src/lib/settings/sync-settings.test.ts
@@ -17,9 +17,28 @@ describe("sync settings", () => {
   it("loads remote sync settings disabled by default", async () => {
     store.get.mockResolvedValue(undefined);
 
-    await expect(getStoredSyncSettings()).resolves.toEqual(defaultSyncSettings);
+    await expect(getStoredSyncSettings()).resolves.toEqual({
+      ...defaultSyncSettings,
+      remotePath: "markra"
+    });
 
     expect(store.get).toHaveBeenCalledWith("syncSettings");
+  });
+
+  it("defaults the remote sync folder to markra", () => {
+    expect(normalizeSyncSettings({})).toEqual({
+      ...defaultSyncSettings,
+      remotePath: "markra"
+    });
+  });
+
+  it("keeps an explicitly cleared remote sync folder empty while editing", () => {
+    expect(normalizeSyncSettings({
+      remotePath: " "
+    })).toEqual({
+      ...defaultSyncSettings,
+      remotePath: ""
+    });
   });
 
   it("normalizes and persists WebDAV sync settings", async () => {

--- a/packages/app/src/lib/settings/sync-settings.ts
+++ b/packages/app/src/lib/settings/sync-settings.ts
@@ -18,13 +18,15 @@ export type SyncSettings = {
   remotePath: string;
 };
 
+const defaultSyncRemotePath = "markra";
+
 export const defaultSyncSettings: SyncSettings = {
   autoSyncOnSave: false,
   enabled: false,
   intervalMinutes: 0,
   lastSyncAt: null,
   provider: "webdav",
-  remotePath: ""
+  remotePath: defaultSyncRemotePath
 };
 
 const syncIntervalMinutesMin = 0;
@@ -58,9 +60,12 @@ export function normalizeSyncSettings(value: unknown): SyncSettings {
       : Math.round(intervalMinutes),
     lastSyncAt: lastSyncAt === null ? null : Math.round(lastSyncAt),
     provider: settings.provider === "webdav" ? "webdav" : defaultSyncSettings.provider,
-    remotePath:
-      normalizeNullableString(settings.remotePath)?.trim()
-      ?? normalizeNullableString(legacyWebDav.remotePath)?.trim()
-      ?? defaultSyncSettings.remotePath
+    remotePath: normalizeSyncRemotePath(settings.remotePath, legacyWebDav.remotePath)
   };
+}
+
+function normalizeSyncRemotePath(remotePath: unknown, legacyRemotePath: unknown) {
+  if (typeof remotePath === "string") return remotePath.trim();
+
+  return normalizeNullableString(legacyRemotePath)?.trim() ?? defaultSyncSettings.remotePath;
 }

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -212,7 +212,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     intervalMinutes: 0,
     lastSyncAt: null,
     provider: "webdav",
-    remotePath: ""
+    remotePath: "markra"
   },
   defaultSplitVisualPanePercent: 50,
   splitVisualPanePercentMin: 25,
@@ -1149,7 +1149,7 @@ export function installAppTestHarness() {
       intervalMinutes: 0,
       lastSyncAt: null,
       provider: "webdav",
-      remotePath: ""
+      remotePath: "markra"
     });
     mockedGetStoredCustomThemeCss.mockResolvedValue(":root[data-theme=\"custom\"] { --bg-primary: #fdf6e3; }");
     mockedGetStoredTheme.mockResolvedValue("light");

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -171,6 +171,7 @@ const messages: BaseLocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV URL",
   "settings.sync.webdavUrlDescription": "Base WebDAV collection URL from your provider.",
   "settings.sync.remotePath": "Remote folder",
+  "settings.sync.remotePathPlaceholder": "e.g. markra",
   "settings.sync.remotePathDescription": "Remote notes folder. Sync uploads and downloads changes, preserving conflicts as copies.",
   "settings.sync.username": "Username",
   "settings.sync.usernameDescription": "WebDAV username stored locally in Markra settings.",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -195,6 +195,7 @@ export type I18nKey =
   | "settings.sync.webdavUrl"
   | "settings.sync.webdavUrlDescription"
   | "settings.sync.remotePath"
+  | "settings.sync.remotePathPlaceholder"
   | "settings.sync.remotePathDescription"
   | "settings.sync.username"
   | "settings.sync.usernameDescription"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -171,6 +171,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV 地址",
   "settings.sync.webdavUrlDescription": "服务商提供的 WebDAV 基础目录地址。",
   "settings.sync.remotePath": "远端文件夹",
+  "settings.sync.remotePathPlaceholder": "例如：markra",
   "settings.sync.remotePathDescription": "远端笔记文件夹。同步会上传和下载变更，冲突会保留为副本。",
   "settings.sync.username": "用户名",
   "settings.sync.usernameDescription": "WebDAV 用户名会保存在本机 Markra 设置中。",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -509,6 +509,7 @@ const messages: LocaleMessages = {
   "settings.sync.webdavUrl": "WebDAV 位址",
   "settings.sync.webdavUrlDescription": "服務提供者給的 WebDAV 基礎目錄位址。",
   "settings.sync.remotePath": "遠端資料夾",
+  "settings.sync.remotePathPlaceholder": "例如：markra",
   "settings.sync.remotePathDescription": "遠端筆記資料夾。同步會上傳和下載變更，衝突會保留為副本。",
   "settings.sync.username": "使用者名稱",
   "settings.sync.usernameDescription": "WebDAV 使用者名稱會儲存在本機 Markra 設定中。",


### PR DESCRIPTION
## Summary
- Default the WebDAV sync remote folder to `markra` so the field contains a real value on first use.
- Keep an explicit example placeholder for cases where the field is cleared.
- Preserve the ability to temporarily clear the field while editing, and cover the behavior in settings tests.

## Why
The previous `markra` placeholder looked like a saved value, which confused users into thinking sync was configured when the remote folder was still empty.

## Validation
- `pnpm --dir packages/app exec vitest run src/lib/settings/sync-settings.test.ts src/components/settings/SyncSettings.test.tsx --reporter verbose` passed, 2 files and 7 tests.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/app test` passed, 77 files and 1159 tests.
- `git diff --check` passed.

## Risk
- Existing users with an explicitly empty saved remote folder keep that empty value; only missing sync settings default to `markra`.

Closes #235
