### PR TITLE
fix(app): commit file tree rename on outside click

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1201,6 +1201,38 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(renameFile).not.toHaveBeenCalled();
   });
 
+  it("commits and closes the rename input when clicking outside the sidebar", async () => {
+    const renameFile = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onRenameFile={renameFile}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Untitled.md" }));
+    const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls[0]?.[0];
+    act(() => {
+      contextHandlers?.renameFile?.(markdownFiles[0]);
+    });
+
+    const renameInput = screen.getByRole("textbox", { name: "Rename file" });
+    fireEvent.change(renameInput, { target: { value: "Renamed.md" } });
+    fireEvent.pointerDown(document.body);
+
+    expect(renameFile).toHaveBeenCalledWith(markdownFiles[0], "Renamed.md");
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: "Rename file" })).not.toBeInTheDocument();
+    });
+  });
+
   it("opens the blank file tree area context menu and creates folders", () => {
     const createFile = vi.fn();
     const createFolder = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -229,6 +229,7 @@ export function MarkdownFileTreeDrawer({
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameFileName, setRenameFileName] = useState("");
   const renamingPathRef = useRef<string | null>(null);
+  const renamingFileRef = useRef<NativeMarkdownFolderFile | null>(null);
   const [dragOverTargetPath, setDragOverTargetPath] = useState<string | null>(null);
   const [activeDragFile, setActiveDragFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [collapsedOutlineKeys, setCollapsedOutlineKeys] = useState<Set<string>>(() => new Set());
@@ -523,6 +524,7 @@ export function MarkdownFileTreeDrawer({
     setCreatingFolder(false);
     setNewFolderName("");
     setRenamingPath(null);
+    renamingFileRef.current = null;
     setRenameFileName("");
     setCreatingParentPath(normalizeTreeCreateParentPath(parentPath));
     setCreatingTemplate(template);
@@ -540,6 +542,7 @@ export function MarkdownFileTreeDrawer({
     setCreatingTemplate(null);
     setCreatingTemplateStartedAt(null);
     setRenamingPath(null);
+    renamingFileRef.current = null;
     setRenameFileName("");
     setCreatingParentPath(normalizeTreeCreateParentPath(parentPath));
     setCreatingFolder(true);
@@ -613,6 +616,7 @@ export function MarkdownFileTreeDrawer({
     setNewFolderName("");
     setCreatingParentPath(null);
     setCreateMenuOpen(false);
+    renamingFileRef.current = file;
     setRenamingPath(file.path);
     setRenameFileName(file.name);
   };
@@ -620,6 +624,7 @@ export function MarkdownFileTreeDrawer({
   const commitRenameFile = (file: NativeMarkdownFolderFile) => {
     const normalizedName = renameFileName.trim();
     if (!normalizedName || normalizedName === file.name) {
+      renamingFileRef.current = null;
       setRenamingPath(null);
       setRenameFileName("");
       return;
@@ -630,6 +635,7 @@ export function MarkdownFileTreeDrawer({
       .then(() => {
         if (renamingPathRef.current !== file.path) return;
 
+        renamingFileRef.current = null;
         setRenamingPath(null);
         setRenameFileName("");
       });
@@ -644,6 +650,7 @@ export function MarkdownFileTreeDrawer({
     setNewFolderName("");
     setCreatingParentPath(null);
     setCreateMenuOpen(false);
+    renamingFileRef.current = null;
     setRenamingPath(null);
     setRenameFileName("");
   };
@@ -654,6 +661,29 @@ export function MarkdownFileTreeDrawer({
 
     cancelFileTreeInputs();
   };
+
+  useEffect(() => {
+    if (!renamingPath) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+
+      const fileTreeRoot = fileTreeBodyRef.current?.closest(".markdown-file-tree");
+      if (fileTreeRoot?.contains(target)) return;
+
+      const renamingFile = renamingFileRef.current;
+      if (!renamingFile) return;
+
+      commitRenameFile(renamingFile);
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [renamingPath, commitRenameFile]);
 
   const creatingAtParentPath = (parentPath: string | null | undefined, depth = 0) => {
     return creatingAtFileTreeParentPath(parentPath, depth, creatingParentPath);


### PR DESCRIPTION
## Summary
- Track the active file tree rename target so an outside click can commit it.
- Commit and close the rename input when the user clicks outside the sidebar.
- Preserve the existing file tree blank-area behavior that cancels rename without calling the rename handler.

## Why
- The previous cleanup only handled clicks inside the file tree scroll area, so clicking the editor or other sidebar-external blank space left rename mode active.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownFileTreeDrawer.test.tsx -t "commits and closes the rename input when clicking outside the sidebar"` passed; Vitest reported 1160 tests passed for `@markra/app`.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Risk
- Low. The change is limited to file tree rename mode and keeps existing in-sidebar blank-area cancel behavior.

## Related Issues
- Closes #275
