### PR TITLE
fix(app): reuse Windows file tree tabs by path equivalence

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2002,6 +2002,53 @@ describe("Markra workspace", () => {
     expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith(mockFolderPath);
   });
 
+  it("keeps a newly created Windows tree file selected without opening duplicate tabs", async () => {
+    const rootPath = "C:\\mock-vault";
+    const treeFilePath = "C:\\mock-vault\\Created.md";
+    const createdFilePath = "\\\\?\\C:\\mock-vault\\Created.md";
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      path: rootPath,
+      name: "mock-vault"
+    });
+    mockedListNativeMarkdownFilesForPath
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { name: "Created.md", path: treeFilePath, relativePath: "Created.md" }
+      ]);
+    mockedCreateNativeMarkdownTreeFile.mockResolvedValue({
+      name: "Created.md",
+      path: createdFilePath,
+      relativePath: "Created.md"
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
+      content: "# Created\n\nSynthetic note.",
+      name: "Created.md",
+      path
+    }));
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true, shiftKey: true });
+    expect(await screen.findByRole("heading", { name: "mock-vault" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+    const fileNameInput = screen.getByRole("textbox", { name: "New file name" });
+    fireEvent.change(fileNameInput, { target: { value: "Created" } });
+    fireEvent.keyDown(fileNameInput, { key: "Enter" });
+
+    const createdTreeButton = await screen.findByRole("button", { name: "Created.md" });
+    expect(createdTreeButton).toHaveAttribute("aria-current", "page");
+    expect(screen.getAllByRole("tab", { name: /Created\.md/ })).toHaveLength(1);
+
+    fireEvent.click(createdTreeButton);
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("tab", { name: /Created\.md/ })).toHaveLength(1)
+    );
+    expect(screen.getByRole("tab", { name: /Created\.md/ })).toHaveAttribute("aria-selected", "true");
+  });
+
   it("deletes a sidebar folder from the context menu", async () => {
     const docsPath = `${mockFolderPath}/docs`;
     const docsFolder = { kind: "folder" as const, name: "docs", path: docsPath, relativePath: "docs" };

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -46,7 +46,7 @@ import { clampNumber, t, type AppLanguage } from "@markra/shared";
 import { IconButton } from "@markra/ui";
 import type { MarkdownOutlineItem } from "@markra/markdown";
 import type { NativeMarkdownFolderFile } from "../lib/tauri";
-import { normalizeMovedPath } from "../lib/path-move";
+import { normalizeMovedPath, sameNativePath } from "../lib/path-move";
 import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
 import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
 import type { RecentMarkdownFolder, SidebarLayoutMode } from "../lib/settings/app-settings";
@@ -1157,7 +1157,7 @@ export function MarkdownFileTreeDrawer({
   };
 
   const renderFileRowContent = (node: FileNode, depth: number, mode: FileTreeRowRenderMode) => {
-    const active = node.file.path === currentPath;
+    const active = sameNativePath(node.file.path, currentPath);
     const renaming = renamingPath === node.file.path;
     const asset = node.file.kind === "asset";
     const FileIcon = asset ? ImageIcon : FileText;

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -38,7 +38,7 @@ import {
   measureAppPerformance,
   measureAppPerformanceAsync
 } from "../lib/performance-marks";
-import { replaceMovedPath } from "../lib/path-move";
+import { normalizeComparablePath, replaceMovedPath, sameNativePath } from "../lib/path-move";
 import { setNativeWindowTitle } from "../lib/tauri";
 import { debug, isMarkdownPath, parentPathFromPath, pathNameFromPath, type DocumentState } from "@markra/shared";
 import {
@@ -161,14 +161,6 @@ function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState
 
 function resolveEditorReady(editorReady: boolean | (() => boolean)) {
   return typeof editorReady === "function" ? editorReady() : editorReady;
-}
-
-function normalizeComparablePath(path: string | null | undefined) {
-  const trimmedPath = path?.trim();
-  if (!trimmedPath) return null;
-
-  const normalizedPath = trimmedPath.replace(/\\/gu, "/").replace(/\/+$/u, "");
-  return normalizedPath || (trimmedPath.startsWith("/") ? "/" : null);
 }
 
 function isPathWithinRoot(path: string, rootPath: string | null) {
@@ -672,7 +664,7 @@ export function useMarkdownDocument({
         if (documentTabsEnabled) {
           syncActiveDocumentFromEditor();
           const currentTabs = tabsRef.current;
-          const existingTab = currentTabs.find((tab) => tab.path === file.path);
+          const existingTab = currentTabs.find((tab) => sameNativePath(tab.path, file.path));
           let nextTabs: MarkdownDocumentTab[];
           let nextActiveTabId: string;
 
@@ -905,7 +897,7 @@ export function useMarkdownDocument({
         syncActiveDocumentFromEditor();
 
         const currentTabs = tabsRef.current;
-        const existingTab = currentTabs.find((tab) => tab.path === nativeFile.path);
+        const existingTab = currentTabs.find((tab) => sameNativePath(tab.path, nativeFile.path));
         if (existingTab) return existingTab.id;
 
         const nextTab = createDocumentTab(nextDocument, fileTabId(nativeFile.path));

--- a/packages/app/src/lib/path-move.test.ts
+++ b/packages/app/src/lib/path-move.test.ts
@@ -1,0 +1,16 @@
+import { normalizeComparablePath, replaceMovedPath, sameNativePath } from "./path-move";
+
+describe("path move helpers", () => {
+  it("compares Windows verbatim paths with regular native paths", () => {
+    expect(normalizeComparablePath("\\\\?\\C:\\mock-vault\\Created.md")).toBe("c:/mock-vault/created.md");
+    expect(sameNativePath("\\\\?\\C:\\mock-vault\\Created.md", "c:/mock-vault/created.md")).toBe(true);
+  });
+
+  it("replaces moved paths when the current path uses a Windows verbatim prefix", () => {
+    expect(replaceMovedPath(
+      "\\\\?\\C:\\mock-vault\\docs\\note.md",
+      "C:\\mock-vault",
+      "D:\\archive"
+    )).toBe("D:\\archive\\docs\\note.md");
+  });
+});

--- a/packages/app/src/lib/path-move.ts
+++ b/packages/app/src/lib/path-move.ts
@@ -1,5 +1,42 @@
+function normalizePathSeparators(path: string) {
+  return path.replace(/\\/gu, "/");
+}
+
+function stripWindowsVerbatimPrefix(path: string) {
+  const normalizedPath = normalizePathSeparators(path);
+  if (/^\/\/\?\/UNC\//iu.test(normalizedPath)) {
+    return `//${normalizedPath.slice("//?/UNC/".length)}`;
+  }
+
+  return normalizedPath.replace(/^\/\/\?\//iu, "");
+}
+
 export function normalizeMovedPath(path: string) {
-  return path.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  return stripWindowsVerbatimPrefix(path).replace(/\/+$/u, "");
+}
+
+function isWindowsComparablePath(path: string) {
+  return /^[a-z]:($|\/)/iu.test(path) || path.startsWith("//");
+}
+
+export function normalizeComparablePath(path: string | null | undefined) {
+  const trimmedPath = path?.trim();
+  if (!trimmedPath) return null;
+
+  const normalizedPath = stripWindowsVerbatimPrefix(trimmedPath).replace(/\/+$/u, "");
+  const comparablePath = normalizedPath || (trimmedPath.startsWith("/") ? "/" : null);
+  if (!comparablePath) return null;
+
+  return isWindowsComparablePath(comparablePath)
+    ? comparablePath.toLowerCase()
+    : comparablePath;
+}
+
+export function sameNativePath(left: string | null | undefined, right: string | null | undefined) {
+  const normalizedLeft = normalizeComparablePath(left);
+  const normalizedRight = normalizeComparablePath(right);
+
+  return normalizedLeft !== null && normalizedRight !== null && normalizedLeft === normalizedRight;
 }
 
 function nativePathSeparator(path: string) {


### PR DESCRIPTION
## Summary
- Normalize native path comparisons for Windows verbatim paths, separators, and casing.
- Use path-equivalence checks for file-tree active state and tab reuse.
- Add regression coverage for newly created Windows tree files and path helper behavior.

## Why
- Creating tree files on Windows can return a `\\?\C:\...` path while the refreshed tree lists `C:\...`; strict equality left the tree row unselected and allowed duplicate tabs.

## Validation
- `pnpm --filter @markra/app test -- path-move.test.ts App.test.tsx -t "path move helpers|keeps a newly created Windows tree file selected without opening duplicate tabs"` passed, 1163 tests.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low; this only changes native path comparison for file matching and keeps persisted paths unchanged.

Closes #262