### PR TITLE
fix(editor): create trailing paragraphs after body and math

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -525,16 +525,31 @@ function mockBlockDragLayout(view: EditorView, blocks: HTMLElement[], positions:
   };
 }
 
+function isEditorTopLevelBlockElement(child: Element): child is HTMLElement {
+  return child instanceof HTMLElement && !child.classList.contains("markra-trailing-paragraph");
+}
+
+function editorTopLevelBlockElementsFromSurface(surface: HTMLElement) {
+  return Array.from(surface.children).filter(isEditorTopLevelBlockElement);
+}
+
+function editorTopLevelBlockElements(container: HTMLElement) {
+  const surface = container.querySelector<HTMLElement>(".ProseMirror");
+  if (!surface) throw new Error("Could not find editor surface.");
+
+  return editorTopLevelBlockElementsFromSurface(surface);
+}
+
 function mockTopLevelBlockDragLayout(view: EditorView, container: HTMLElement) {
   return mockBlockDragLayout(
     view,
-    Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > *")),
+    editorTopLevelBlockElements(container),
     topLevelBlockPositions(view)
   );
 }
 
 function mockThinHorizontalRuleBlockDragLayout(view: EditorView, container: HTMLElement) {
-  const blocks = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror > *"));
+  const blocks = editorTopLevelBlockElements(container);
   const positions = topLevelBlockPositions(view);
   const blockRects = [
     {
@@ -626,7 +641,7 @@ function mockTopLevelBlockDragLayoutByCurrentDomOrder(view: EditorView, containe
   const surface = container.querySelector<HTMLElement>(".ProseMirror");
   if (!surface) throw new Error("Could not find editor surface.");
 
-  const blocks = Array.from(surface.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
+  const blocks = editorTopLevelBlockElements(container);
   const positions = topLevelBlockPositions(view);
   const originalPosAtCoords = view.posAtCoords.bind(view);
 
@@ -646,7 +661,9 @@ function mockTopLevelBlockDragLayoutByCurrentDomOrder(view: EditorView, containe
   };
 
   for (const block of blocks) {
-    block.getBoundingClientRect = vi.fn(() => rectForIndex(Array.from(surface.children).indexOf(block)));
+    block.getBoundingClientRect = vi.fn(() =>
+      rectForIndex(editorTopLevelBlockElementsFromSurface(surface).indexOf(block))
+    );
   }
 
   view.dom.getBoundingClientRect = vi.fn(() => ({
@@ -6927,6 +6944,96 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.doc.child(view.state.doc.childCount - 1).type.name).toBe("paragraph");
     expect(view.state.doc.child(view.state.doc.childCount - 1).textContent).toBe("After terminal block");
     expect(serializeMarkdown(view.state.doc)).toContain("After terminal block");
+  });
+
+  it("creates a trailing paragraph after clicking past a terminal body paragraph", async () => {
+    const { container, editor, view } = await renderEditor("Synthetic body");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    let trailingAffordance: HTMLElement | null = null;
+
+    await waitFor(() => {
+      trailingAffordance = container.querySelector(".ProseMirror .markra-trailing-paragraph");
+      expect(trailingAffordance).toBeInTheDocument();
+    });
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).type.name).toBe("paragraph");
+    expect(view.state.doc.child(0).textContent).toBe("Synthetic body");
+
+    fireEvent.mouseDown(trailingAffordance!);
+
+    await waitFor(() => expect(view.state.doc.childCount).toBe(2));
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+
+    typeText(view, "Next body");
+
+    expect(view.state.doc.child(1).textContent).toBe("Next body");
+    expect(serializeMarkdown(view.state.doc)).toContain("Next body");
+  });
+
+  it("creates a trailing paragraph after clicking paper blank space below a terminal body paragraph", async () => {
+    const { editor, view } = await renderEditor("Synthetic body");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    fireEvent.mouseDown(screen.getByLabelText("Markdown editor"), { button: 0 });
+
+    await waitFor(() => expect(view.state.doc.childCount).toBe(2));
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+
+    typeText(view, "Next body");
+
+    expect(view.state.doc.child(1).textContent).toBe("Next body");
+    expect(serializeMarkdown(view.state.doc)).toContain("Next body");
+  });
+
+  it("creates a trailing paragraph after clicking past terminal display math", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    let trailingAffordance: HTMLElement | null = null;
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
+      trailingAffordance = container.querySelector(".ProseMirror .markra-trailing-paragraph");
+      expect(trailingAffordance).toBeInTheDocument();
+    });
+
+    fireEvent.mouseDown(trailingAffordance!);
+
+    await waitFor(() => expect(view.state.doc.childCount).toBe(2));
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+
+    typeText(view, "After formula");
+
+    expect(view.state.doc.child(1).textContent).toBe("After formula");
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+    expect(serializeMarkdown(view.state.doc)).toContain("After formula");
+  });
+
+  it("creates a trailing paragraph after clicking paper blank space below terminal display math", async () => {
+    const source = String.raw`$$ E = mc^2 $$`;
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-math-render-display")).toBeInTheDocument();
+      expect(container.querySelector(".ProseMirror .markra-trailing-paragraph")).toBeInTheDocument();
+    });
+
+    fireEvent.mouseDown(screen.getByLabelText("Markdown editor"), { button: 0 });
+
+    await waitFor(() => expect(view.state.doc.childCount).toBe(2));
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+
+    typeText(view, "After formula");
+
+    expect(view.state.doc.child(1).textContent).toBe("After formula");
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+    expect(serializeMarkdown(view.state.doc)).toContain("After formula");
   });
 
   it.each([

--- a/packages/editor/src/trailing-paragraph.ts
+++ b/packages/editor/src/trailing-paragraph.ts
@@ -20,7 +20,9 @@ const terminalAffordanceAtomNodeNames = new Set([
 function needsTrailingParagraphAffordance(doc: ProseNode, paragraph: NodeType) {
   const lastNode = doc.lastChild;
   if (!lastNode) return false;
-  if (lastNode.type === paragraph) return false;
+  if (lastNode.type === paragraph) {
+    return lastNode.content.size > 0 && doc.canReplaceWith(doc.childCount, doc.childCount, paragraph);
+  }
   if (lastNode.isTextblock && !terminalAffordanceTextblockNodeNames.has(lastNode.type.name)) return false;
   if (lastNode.isAtom && !terminalAffordanceAtomNodeNames.has(lastNode.type.name)) return false;
 
@@ -29,6 +31,15 @@ function needsTrailingParagraphAffordance(doc: ProseNode, paragraph: NodeType) {
 
 function isPlainLeftMouseDown(event: MouseEvent) {
   return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
+}
+
+function eventTargetElement(target: EventTarget | null) {
+  return target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+}
+
+function hasNonCollapsedNativeSelection(document: Document) {
+  const selection = document.getSelection();
+  return Boolean(selection && !selection.isCollapsed);
 }
 
 function insertTrailingParagraph(view: EditorView, paragraph: NodeType) {
@@ -71,6 +82,30 @@ function createTrailingParagraphWidget(view: EditorView, paragraph: NodeType) {
 export function createTrailingParagraphPlugin(paragraph: NodeType) {
   return new Plugin({
     key: trailingParagraphKey,
+    view(view) {
+      const paper = view.dom.closest<HTMLElement>(".markdown-paper");
+      if (!paper) return {};
+
+      const handlePaperMouseDown = (event: MouseEvent) => {
+        if (!isPlainLeftMouseDown(event)) return;
+
+        const target = eventTargetElement(event.target);
+        if (target !== paper) return;
+        if (hasNonCollapsedNativeSelection(paper.ownerDocument)) return;
+        if (!insertTrailingParagraph(view, paragraph)) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+      };
+
+      paper.addEventListener("mousedown", handlePaperMouseDown);
+
+      return {
+        destroy() {
+          paper.removeEventListener("mousedown", handlePaperMouseDown);
+        }
+      };
+    },
     props: {
       handleDOMEvents: {
         mousedown(view, event) {


### PR DESCRIPTION
## Summary
- Allow non-empty terminal body paragraphs to expose the trailing paragraph affordance.
- Let clicks on the editor paper blank area insert the same trailing paragraph when appropriate.
- Cover terminal display math and body paragraph cases, while preserving drag/text-selection behavior.

## Why
Issue #283 reported that users could not create a new line after the final body paragraph. The previous terminal-block affordance only worked when clicking the inserted widget directly, so clicks on the surrounding paper blank area still missed the action. Display math is represented as a decorated paragraph, so it needed coverage through the same path.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 368 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low. The new paper-blank handler only runs for plain left-clicks directly on the markdown paper and skips existing native text selections.

## Related Issues
Closes #283