### PR TITLE
fix(outline): render formatted heading titles

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3740,6 +3740,62 @@ describe("Markra workspace", () => {
     );
   });
 
+  it("scrolls to a formatted outline heading using its readable title", async () => {
+    mockOpenMarkdownFile({
+      content: "# Native file\n\nParagraph\n\n## **Synthetic** heading\n\nTarget body",
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    const formattedHeading = await screen.findByRole("heading", { name: "Synthetic heading" });
+
+    const writingSurface = screen.getByLabelText("Writing surface");
+    const scrollTo = vi.fn();
+    Object.defineProperty(writingSurface, "scrollTop", {
+      configurable: true,
+      value: 120
+    });
+    Object.defineProperty(writingSurface, "scrollTo", {
+      configurable: true,
+      value: scrollTo
+    });
+    vi.spyOn(writingSurface, "getBoundingClientRect").mockReturnValue({
+      bottom: 710,
+      height: 700,
+      left: 0,
+      right: 900,
+      top: 10,
+      width: 900,
+      x: 0,
+      y: 10,
+      toJSON: () => ({})
+    });
+    vi.spyOn(formattedHeading, "getBoundingClientRect").mockReturnValue({
+      bottom: 350,
+      height: 40,
+      left: 160,
+      right: 760,
+      top: 310,
+      width: 600,
+      x: 160,
+      y: 310,
+      toJSON: () => ({})
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle file list" }));
+    fireEvent.click(screen.getByRole("button", { name: "Synthetic heading" }));
+
+    await waitFor(() =>
+      expect(scrollTo).toHaveBeenCalledWith({
+        behavior: "auto",
+        top: 356
+      })
+    );
+  });
+
   it("keeps outline heading navigation stable across repeated heading clicks", async () => {
     mockOpenMarkdownFile({
       content: "# A\n\nA body\n\n# B\n\nB body",

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MarkdownFileTreeDrawer } from "./MarkdownFileTreeDrawer";
+import { getMarkdownOutline } from "@markra/markdown";
 import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
 
 vi.mock("../lib/tauri", () => ({
@@ -1981,6 +1982,119 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.getByText("Details")).toBeInTheDocument();
     expect(screen.getByText("Obsidian Vault")).toBeInTheDocument();
     expect(selectOutlineItem).toHaveBeenCalledWith({ level: 2, title: "Details" }, 1);
+  });
+
+  it("renders inline markdown formatting in outline titles", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          {
+            level: 1,
+            title: "Bold italic deleted",
+            titleMarkdown: "**Bold** _italic_ ~~deleted~~"
+          }
+        ]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const outlineButton = screen.getByRole("button", { name: "Bold italic deleted" });
+    const boldTitle = within(outlineButton).getByText("Bold");
+    const italicTitle = within(outlineButton).getByText("italic");
+    const deletedTitle = within(outlineButton).getByText("deleted");
+
+    expect(boldTitle.tagName).toBe("STRONG");
+    expect(boldTitle).toHaveClass("font-[760]");
+    expect(italicTitle.tagName).toBe("EM");
+    expect(italicTitle).toHaveClass("italic");
+    expect(italicTitle.getAttribute("style")).toContain("font-style: italic");
+    expect(italicTitle.getAttribute("style")).toContain("font-synthesis: style");
+    expect(deletedTitle.tagName).toBe("DEL");
+  });
+
+  it("renders Markra highlight and inline math in outline titles", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          {
+            level: 1,
+            title: "Marked formula x^2",
+            titleMarkdown: "==Marked== formula $x^2$"
+          }
+        ]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const outlineButton = screen.getByRole("button", { name: "Marked formula x^2" });
+    const highlightedTitle = within(outlineButton).getByText("Marked");
+    const mathTitle = within(outlineButton).getByText("x^2");
+
+    expect(highlightedTitle.tagName).toBe("MARK");
+    expect(highlightedTitle).toHaveClass("bg-(--accent-soft)");
+    expect(mathTitle).toHaveClass("markra-outline-title-math");
+  });
+
+  it("keeps links and images as plain outline title text", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          {
+            level: 1,
+            title: "Linked Alt text",
+            titleMarkdown: "[Linked](https://example.test) ![Alt text](asset.png)"
+          }
+        ]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const outlineButton = screen.getByRole("button", { name: "Linked Alt text" });
+
+    expect(outlineButton).toHaveTextContent("Linked Alt text");
+    expect(outlineButton.querySelector("a")).not.toBeInTheDocument();
+    expect(outlineButton.querySelector("img")).not.toBeInTheDocument();
+    expect(outlineButton.querySelector(".underline")).not.toBeInTheDocument();
+  });
+
+  it("renders combined bold and italic outline titles from markdown content", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={getMarkdownOutline("## ***Synthetic***")}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const outlineButton = screen.getByRole("button", { name: "Synthetic" });
+    const strongTitle = outlineButton.querySelector("strong");
+    const italicTitle = outlineButton.querySelector("em");
+
+    expect(strongTitle).toHaveTextContent("Synthetic");
+    expect(strongTitle).toHaveClass("font-[760]");
+    expect(italicTitle).toHaveTextContent("Synthetic");
+    expect(italicTitle).toHaveClass("italic");
+    expect(italicTitle?.getAttribute("style")).toContain("font-style: italic");
+    expect(italicTitle?.getAttribute("style")).toContain("font-synthesis: style");
   });
 
   it("collapses nested outline headings without affecting later siblings", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -42,9 +42,12 @@ import {
   TableOfContents,
   X
 } from "lucide-react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 import { clampNumber, t, type AppLanguage } from "@markra/shared";
 import { IconButton } from "@markra/ui";
-import type { MarkdownOutlineItem } from "@markra/markdown";
+import { markraHighlightRemarkPlugin, type MarkdownOutlineItem } from "@markra/markdown";
 import type { NativeMarkdownFolderFile } from "../lib/tauri";
 import { normalizeMovedPath, sameNativePath } from "../lib/path-move";
 import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
@@ -154,9 +157,54 @@ const fileTreeDropListTargetClassName = "rounded-sm bg-(--bg-active)";
 const sidebarPanelTabBaseClassName = "relative -mb-px h-10 cursor-pointer border-0 border-b border-transparent bg-transparent px-2 text-[13px] leading-none font-[560] transition-colors duration-150 ease-out focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)";
 const sidebarPanelTabActiveClassName = "border-(--text-secondary) text-(--text-heading)";
 const sidebarPanelTabInactiveClassName = "text-(--text-secondary) hover:text-(--text-heading)";
+const outlineTitleMarkdownPlugins = [remarkGfm, remarkMath, markraHighlightRemarkPlugin];
+const outlineTitleMarkdownComponents = {
+  a: ({ children }) => <>{children}</>,
+  code: ({ children, className }) => {
+    const isMath = typeof className === "string" && className.split(/\s+/u).includes("math-inline");
+    if (isMath) {
+      return <span className="markra-outline-title-math font-mono text-[0.92em] text-(--text-heading)">{children}</span>;
+    }
+
+    return (
+      <code className="rounded-sm bg-(--bg-active) px-0.75 py-0.25 font-mono text-[0.92em] text-(--text-heading)">
+        {children}
+      </code>
+    );
+  },
+  del: ({ children }) => <del className="line-through decoration-(--text-tertiary) decoration-1">{children}</del>,
+  em: ({ children }) => (
+    <em className="italic text-(--text-primary)" style={{ fontStyle: "italic", fontSynthesis: "style" }}>
+      {children}
+    </em>
+  ),
+  img: ({ alt }) => <>{alt}</>,
+  mark: ({ children }) => (
+    <mark className="rounded-sm bg-(--accent-soft) px-0.5 text-(--text-heading)">
+      {children}
+    </mark>
+  ),
+  p: ({ children }) => <>{children}</>,
+  strong: ({ children }) => <strong className="font-[760] text-(--text-heading)">{children}</strong>
+} satisfies Components;
 
 function sidebarPanelTabClassName(selected: boolean) {
   return `${sidebarPanelTabBaseClassName} ${selected ? sidebarPanelTabActiveClassName : sidebarPanelTabInactiveClassName}`;
+}
+
+function OutlineTitle({ item }: { item: MarkdownOutlineItem }) {
+  if (!item.titleMarkdown || item.titleMarkdown === item.title) return item.title;
+
+  return (
+    <ReactMarkdown
+      allowedElements={["a", "br", "code", "del", "em", "img", "mark", "p", "strong"]}
+      components={outlineTitleMarkdownComponents}
+      remarkPlugins={outlineTitleMarkdownPlugins}
+      unwrapDisallowed
+    >
+      {item.titleMarkdown}
+    </ReactMarkdown>
+  );
 }
 
 export function MarkdownFileTreeDrawer({
@@ -1318,7 +1366,7 @@ export function MarkdownFileTreeDrawer({
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => onSelectOutlineItem(item, index)}
                 >
-                  {item.title}
+                  <OutlineTitle item={item} />
                 </button>
               </div>
             </li>

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -53,6 +53,7 @@ async function renderEditor(
     onSaveClipboardImage?: (image: File) => Promise<{ alt: string; src: string } | null>;
     onSaveRemoteClipboardImage?: (image: RemoteClipboardImage) => Promise<{ alt: string; src: string } | null>;
     openExternalUrl?: (url: string) => unknown;
+    bottomOverlayInset?: number;
     onTextSelectionChange?: (selection: AiSelectionContext | null) => unknown;
     readOnly?: boolean;
     resolveImageSrc?: (src: string) => string;
@@ -72,6 +73,7 @@ async function renderEditor(
     <MarkdownPaper
       documentPath={options.documentPath}
       editorTheme={options.editorTheme}
+      bottomOverlayInset={options.bottomOverlayInset}
       initialContent={initialContent}
       onEditorReady={(instance) => {
         editor = instance;
@@ -781,6 +783,20 @@ describe("MarkdownPaper editing", () => {
 
     expect(container.querySelector(".paper-scroll")).toHaveClass("overscroll-none");
     expect(container.querySelector(".paper-scroll")).toHaveClass("h-full", "min-h-0", "overflow-auto");
+  });
+
+  it("keeps enough bottom space for outline jumps near the end of a document", async () => {
+    const { container } = await renderEditor("# Synthetic heading");
+    const paper = container.querySelector(".markdown-paper");
+
+    expect(paper?.getAttribute("style")).toContain("padding-bottom: calc(100vh - 4rem)");
+  });
+
+  it("adds bottom overlays to the outline jump reserve", async () => {
+    const { container } = await renderEditor("# Synthetic heading", { bottomOverlayInset: 96 });
+    const paper = container.querySelector(".markdown-paper");
+
+    expect(paper?.getAttribute("style")).toContain("padding-bottom: calc(96px + calc(100vh - 4rem))");
   });
 
   it("marks the editor paper with the default resolved app theme", async () => {

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -45,6 +45,14 @@ type MarkdownPaperProps = {
   wrapCodeBlocks?: boolean;
 };
 
+const editorBottomScrollReserve = "calc(100vh - 4rem)";
+
+function editorBottomPadding(bottomOverlayInset: number) {
+  if (bottomOverlayInset <= 0) return editorBottomScrollReserve;
+
+  return `calc(${editorBottomScrollReserve} + ${bottomOverlayInset}px)`;
+}
+
 export function MarkdownPaper({
   autoFocus = false,
   bottomOverlayInset = 0,
@@ -84,7 +92,7 @@ export function MarkdownPaper({
     fontSize: `${bodyFontSize}px`,
     lineHeight,
     maxWidth: `${resolvedContentWidth}px`,
-    ...(bottomOverlayInset > 0 ? { paddingBottom: `${bottomOverlayInset}px` } : {})
+    paddingBottom: editorBottomPadding(bottomOverlayInset)
   } satisfies CSSProperties;
   const topInsetClassName = topInset === "tabs" ? "pt-24 max-[900px]:pt-20" : "pt-14 max-[900px]:pt-10";
   const editorInstanceKey = `${documentKey ?? "untitled"}:${documentPath ?? "unsaved"}:${revision}`;

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -18,7 +18,12 @@
   },
   "dependencies": {
     "@markra/shared": "workspace:*",
-    "@tauri-apps/api": "2.11.0"
+    "@tauri-apps/api": "2.11.0",
+    "mdast-util-to-string": "4.0.0",
+    "remark-gfm": "4.0.1",
+    "remark-math": "6.0.0",
+    "remark-parse": "11.0.0",
+    "unified": "11.0.5"
   },
   "devDependencies": {
     "@types/node": "24.10.0",

--- a/packages/markdown/src/markdown.test.ts
+++ b/packages/markdown/src/markdown.test.ts
@@ -17,4 +17,26 @@ describe("markdown helpers", () => {
       { level: 2, title: "Next" }
     ]);
   });
+
+  it("extracts readable titles from formatted markdown headings", () => {
+    expect(
+      getMarkdownOutline(
+        [
+          "# **Synthetic** heading",
+          "## _Linked_ [label](https://example.test)",
+          "### `Code` and ~~old text~~"
+        ].join("\n\n")
+      )
+    ).toEqual([
+      { level: 1, title: "Synthetic heading", titleMarkdown: "**Synthetic** heading" },
+      { level: 2, title: "Linked label", titleMarkdown: "_Linked_ [label](https://example.test)" },
+      { level: 3, title: "Code and old text", titleMarkdown: "`Code` and ~~old text~~" }
+    ]);
+  });
+
+  it("extracts readable titles from Markra highlight and math headings", () => {
+    expect(getMarkdownOutline("# ==Marked== formula $x^2$")).toEqual([
+      { level: 1, title: "Marked formula x^2", titleMarkdown: "==Marked== formula $x^2$" }
+    ]);
+  });
 });

--- a/packages/markdown/src/markdown.ts
+++ b/packages/markdown/src/markdown.ts
@@ -1,5 +1,20 @@
+import { toString } from "mdast-util-to-string";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
 const countableWordUnits =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]|(?:(?![\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])[\p{L}\p{N}_'-])+/gu;
+const markraHighlightPattern = /(?<!=)==[^=\n][^\n]*?==(?!=)/gu;
+const inlineMarkdownParser = unified().use(remarkParse).use(remarkGfm).use(remarkMath).use(markraHighlightRemarkPlugin);
+
+type MarkdownNode = {
+  children?: MarkdownNode[];
+  data?: Record<string, unknown>;
+  type: string;
+  value?: string;
+};
 
 export function getWordCount(text: string) {
   const words = text.trim().match(countableWordUnits);
@@ -9,7 +24,61 @@ export function getWordCount(text: string) {
 export type MarkdownOutlineItem = {
   level: number;
   title: string;
+  titleMarkdown?: string;
 };
+
+function splitMarkraHighlightText(value: string): MarkdownNode[] {
+  const nodes: MarkdownNode[] = [];
+  let cursor = 0;
+
+  markraHighlightPattern.lastIndex = 0;
+  for (const match of value.matchAll(markraHighlightPattern)) {
+    const matchIndex = match.index ?? 0;
+    const source = match[0];
+    const content = source.slice(2, -2);
+
+    if (matchIndex > cursor) nodes.push({ type: "text", value: value.slice(cursor, matchIndex) });
+    nodes.push({
+      children: [{ type: "text", value: content }],
+      data: { hName: "mark" },
+      type: "markraHighlight"
+    });
+    cursor = matchIndex + source.length;
+  }
+
+  if (cursor < value.length) nodes.push({ type: "text", value: value.slice(cursor) });
+
+  return nodes;
+}
+
+function transformMarkraHighlight(node: MarkdownNode) {
+  if (!Array.isArray(node.children)) return;
+
+  for (let index = node.children.length - 1; index >= 0; index -= 1) {
+    const child = node.children[index];
+    if (!child) continue;
+
+    if (child.type === "text" && typeof child.value === "string" && child.value.includes("==")) {
+      const replacement = splitMarkraHighlightText(child.value);
+      if (replacement.length > 1 || replacement[0]?.type !== "text" || replacement[0].value !== child.value) {
+        node.children.splice(index, 1, ...replacement);
+      }
+      continue;
+    }
+
+    transformMarkraHighlight(child);
+  }
+}
+
+export function markraHighlightRemarkPlugin() {
+  return (tree: MarkdownNode) => {
+    transformMarkraHighlight(tree);
+  };
+}
+
+function readableMarkdownHeadingTitle(title: string) {
+  return toString(inlineMarkdownParser.runSync(inlineMarkdownParser.parse(title))).trim();
+}
 
 export function getMarkdownOutline(text: string): MarkdownOutlineItem[] {
   const outline: MarkdownOutlineItem[] = [];
@@ -26,9 +95,13 @@ export function getMarkdownOutline(text: string): MarkdownOutlineItem[] {
     const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
     if (!match) return;
 
+    const titleMarkdown = match[2].trim();
+    const title = readableMarkdownHeadingTitle(titleMarkdown);
+
     outline.push({
       level: match[1].length,
-      title: match[2].trim()
+      title,
+      ...(titleMarkdown === title ? {} : { titleMarkdown })
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,21 @@ importers:
       '@tauri-apps/api':
         specifier: 2.11.0
         version: 2.11.0
+      mdast-util-to-string:
+        specifier: 4.0.0
+        version: 4.0.0
+      remark-gfm:
+        specifier: 4.0.1
+        version: 4.0.1
+      remark-math:
+        specifier: 6.0.0
+        version: 6.0.0
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
     devDependencies:
       '@types/node':
         specifier: 24.10.0


### PR DESCRIPTION
## Summary
- parse formatted Markdown headings into readable outline titles for navigation and optional Markdown titles for display
- render supported inline heading formats in the left outline: bold, italic, bold+italic, strikethrough, inline code, highlight, and inline math
- keep links and images as plain outline text and add bottom scroll reserve for near-end heading jumps

## Why
- Closes #285
- Formatted headings were shown incorrectly in the outline and could fail to navigate because display text and editor text did not match

## Validation
- `pnpm --filter @markra/markdown test -- src/markdown.test.ts` passed
- `pnpm --filter @markra/markdown build` passed
- `pnpm --filter @markra/app test -- src/components/MarkdownFileTreeDrawer.test.tsx -t "links and images"` passed
- `pnpm --filter @markra/app test -- src/components/MarkdownFileTreeDrawer.test.tsx -t "outline titles"` passed
- `pnpm --filter @markra/app test -- src/App.test.tsx -t "formatted outline heading"` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed

## Risk
- Raw HTML remains intentionally unrendered in outline titles
- Links and images display as plain text only in the outline