### PR TITLE
feat(app): improve editor source and outline behavior

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -4310,6 +4310,43 @@ describe("Markra workspace", () => {
     expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "milkdown");
   });
 
+  it("keeps raw source punctuation unchanged while editing in source mode", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+
+    replaceMarkdownSource(sourceEditor, "# Raw source\n\n**");
+    await settleEditorUpdates();
+
+    expect(readMarkdownSource(sourceEditor)).toBe("# Raw source\n\n**");
+  });
+
+  it("keeps source mode typing undoable and redoable before switching back to visual mode", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+    const originalSource = readMarkdownSource(sourceEditor);
+
+    replaceMarkdownSource(sourceEditor, "# Source draft\n\nUndo me.");
+    expect(readMarkdownSource(sourceEditor)).toBe("# Source draft\n\nUndo me.");
+
+    fireEvent.keyDown(sourceEditor, { ctrlKey: true, key: "z" });
+    await waitFor(() => {
+      expect(readMarkdownSource(sourceEditor)).toBe(originalSource);
+    });
+
+    fireEvent.keyDown(sourceEditor, { ctrlKey: true, key: "y" });
+    await waitFor(() => {
+      expect(readMarkdownSource(sourceEditor)).toBe("# Source draft\n\nUndo me.");
+    });
+  });
+
   it("keeps visual undo history after switching to source mode and back", async () => {
     const { container } = renderApp();
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -243,6 +243,7 @@ function WorkspaceApp() {
   const [aiSelectionToolbarHeadingLevel, setAiSelectionToolbarHeadingLevel] = useState<SelectionHeadingLevel | null>(null);
   const [aiSelectionToolbarCopySucceeded, setAiSelectionToolbarCopySucceeded] = useState(false);
   const [aiContextMenuActionPending, setAiContextMenuActionPending] = useState(false);
+  const [activeOutlineIndex, setActiveOutlineIndex] = useState<number | null>(null);
   const setAiSelectionToolbarAnchorIfChanged = useCallback((nextAnchor: SelectionAnchor | null) => {
     setAiSelectionToolbarAnchor((currentAnchor) =>
       selectionAnchorsEqual(currentAnchor, nextAnchor) ? currentAnchor : nextAnchor
@@ -401,6 +402,9 @@ function WorkspaceApp() {
       visualEditorReadyRevisionRef.current = null;
     }
   }, [handleMilkdownEditorReady]);
+  const handleActiveOutlineIndexChange = useCallback((index: number | null) => {
+    setActiveOutlineIndex((current) => current === index ? current : index);
+  }, []);
   useDefaultContextMenuBlocker();
   const fileTree = useMarkdownFileTree({
     onWorkspaceSessionChange: setAiAgentSessionId
@@ -503,6 +507,13 @@ function WorkspaceApp() {
     wordCount
   } = markdownDocument;
   documentRevisionRef.current = document.revision;
+  const activeDocumentOutlineIndex =
+    !sourceSurfaceActive &&
+    activeOutlineIndex !== null &&
+    activeOutlineIndex >= 0 &&
+    activeOutlineIndex < outlineItems.length
+      ? activeOutlineIndex
+      : null;
   visualEditorReadyDetailRef.current = {
     chars: document.content.length,
     path: document.path,
@@ -534,6 +545,9 @@ function WorkspaceApp() {
 
     handleVisualEditorReady(activeEditor, { autoFocus: false });
   }, [activeTabId, handleVisualEditorReady]);
+  useEffect(() => {
+    setActiveOutlineIndex(null);
+  }, [activeTabId, document.path]);
   const workspaceKey = document.path ?? fileTree.sourcePath ?? null;
   setWorkspaceBackupSyncSourcePath(fileTreeSourcePath ?? document.path);
   const workspaceSearch = useWorkspaceSearch({
@@ -597,13 +611,15 @@ function WorkspaceApp() {
     documentSearchOpen && documentSearchSurface === "source" ? sourceDocumentSearchMatches : [];
   const {
     isApplyingSourceToVisualSync,
-    markSourceEditForHistory
+    markSourceEditForHistory,
+    syncSourceEditsToVisualHistory
   } = useSharedEditorHistory({
     documentContent: document.content,
     documentRevision: document.revision,
     largeMarkdownVisualBlocked,
     replaceEditorMarkdown,
     sourceSurfaceActive,
+    syncSourceToVisual: splitMode && activeEditorSurface === "source",
     visualEditorReadySequence
   });
   const activeAiAgentSessionId = workspaceSessionId ?? aiAgentSessionId;
@@ -2145,11 +2161,12 @@ function WorkspaceApp() {
   }, []);
   const handleVisualMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (isApplyingSourceToVisualSync()) return;
+    if (sourceSurfaceActive) return;
     if (readOnlyMode) return;
 
     if (splitMode) setActiveEditorSurface("visual");
     handleMarkdownChange(content, options);
-  }, [handleMarkdownChange, isApplyingSourceToVisualSync, readOnlyMode, splitMode]);
+  }, [handleMarkdownChange, isApplyingSourceToVisualSync, readOnlyMode, sourceSurfaceActive, splitMode]);
   const handleSourceMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (readOnlyMode) return;
 
@@ -2256,14 +2273,6 @@ function WorkspaceApp() {
     syncVisualMarkdownAfterEditorCommand();
     return handled;
   }, [readOnlyMode, runEditorShortcut, syncVisualMarkdownAfterEditorCommand]);
-  const sourceEditorHistoryHandlers = useMemo(() => {
-    if (largeMarkdownVisualBlocked) return {};
-
-    return {
-      onRedo: () => handleRunEditorShortcut("z", { shiftKey: true }, { focusEditor: false }),
-      onUndo: () => handleRunEditorShortcut("z", {}, { focusEditor: false })
-    };
-  }, [handleRunEditorShortcut, largeMarkdownVisualBlocked]);
   const handleAiSelectionToolbarFormattingAction = useCallback((action: SelectionFormattingToolbarAction) => {
     if (readOnlyMode) return;
 
@@ -2491,6 +2500,7 @@ function WorkspaceApp() {
     captureActiveDocumentViewState();
 
     if (sourceMode) {
+      syncSourceEditsToVisualHistory();
       queueEditorModeScroll("visual");
       setEditorMode("visual");
       setActiveEditorSurface("visual");
@@ -2508,6 +2518,7 @@ function WorkspaceApp() {
     queueEditorModeScroll,
     sourceMode,
     sourceModeAvailable,
+    syncSourceEditsToVisualHistory,
     updateActiveAiSelection
   ]);
   const handleEditorSplitToggle = useCallback(() => {
@@ -3121,6 +3132,7 @@ function WorkspaceApp() {
               language={appLanguage.language}
               lineHeight={editorPreferences.preferences.lineHeight}
               markdownShortcuts={editorPreferences.preferences.markdownShortcuts}
+              onActiveOutlineIndexChange={tabActive ? handleActiveOutlineIndexChange : undefined}
               onEditorReady={(readyEditor, options) => handleMainVisualEditorReady(tab.id, readyEditor, options)}
               onMarkdownChange={(content) => {
                 const options = { documentRevision: tab.revision };
@@ -3205,6 +3217,7 @@ function WorkspaceApp() {
         <div className={workspaceLayoutClassName} style={workspaceLayoutStyle}>
           <div className="markdown-file-tree-slot min-h-0 overflow-hidden">
             <MarkdownFileTreeDrawer
+              activeOutlineIndex={activeDocumentOutlineIndex}
               currentPath={activeImageFile?.path ?? (hasOpenDocument ? document.path : null)}
               customTemplates={markdownTemplates}
               files={fileTreeFiles}
@@ -3362,7 +3375,6 @@ function WorkspaceApp() {
                           })}
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                          {...sourceEditorHistoryHandlers}
                           onScroll={handleSourcePaneScroll}
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}
@@ -3390,7 +3402,6 @@ function WorkspaceApp() {
                           })}
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
-                          {...sourceEditorHistoryHandlers}
                           onScroll={handleSourcePaneScroll}
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}

--- a/packages/app/src/components/LazyMarkdownSourceEditor.tsx
+++ b/packages/app/src/components/LazyMarkdownSourceEditor.tsx
@@ -43,7 +43,7 @@ function MarkdownSourceEditorFallback({
       ref={scrollRef}
     >
       <article
-        className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${markdownSourceTopInsetClassName(topInset)} text-[16px] leading-[1.65] text-(--text-primary) max-[900px]:px-5.25`}
+        className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 ${markdownSourceTopInsetClassName(topInset)} text-[16px] leading-[1.65] text-(--text-primary) max-[900px]:px-5.25`}
         data-editor-engine="source-loading"
         style={paperStyle}
       />

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1984,6 +1984,47 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(selectOutlineItem).toHaveBeenCalledWith({ level: 2, title: "Details" }, 1);
   });
 
+  it("marks the active outline heading and scrolls it into view", () => {
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView
+    });
+
+    try {
+      render(
+        <MarkdownFileTreeDrawer
+          activeOutlineIndex={1}
+          currentPath="/vault/Untitled.md"
+          files={markdownFiles}
+          open
+          outlineItems={[
+            { level: 1, title: "Intro" },
+            { level: 2, title: "Details" }
+          ]}
+          rootName="Obsidian Vault"
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      expect(screen.getByRole("button", { name: "Intro" })).not.toHaveAttribute("aria-current");
+      expect(screen.getByRole("button", { name: "Details" })).toHaveAttribute("aria-current", "location");
+      expect(screen.getByRole("button", { name: "Details" })).toHaveClass("bg-(--bg-active)", "text-(--text-heading)");
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "auto",
+        block: "nearest",
+        inline: "nearest"
+      });
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView
+      });
+    }
+  });
+
   it("renders inline markdown formatting in outline titles", () => {
     render(
       <MarkdownFileTreeDrawer

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -106,6 +106,7 @@ import {
 } from "./file-tree/outline-model";
 
 type MarkdownFileTreeDrawerProps = {
+  activeOutlineIndex?: number | null;
   currentPath: string | null;
   customTemplates?: readonly MarkdownTemplate[];
   files: NativeMarkdownFolderFile[];
@@ -208,6 +209,7 @@ function OutlineTitle({ item }: { item: MarkdownOutlineItem }) {
 }
 
 export function MarkdownFileTreeDrawer({
+  activeOutlineIndex = null,
   currentPath,
   customTemplates = emptyMarkdownTemplates,
   files,
@@ -243,6 +245,7 @@ export function MarkdownFileTreeDrawer({
 }: MarkdownFileTreeDrawerProps) {
   const resizeCleanupRef = useRef<(() => unknown) | null>(null);
   const outlineResizeCleanupRef = useRef<(() => unknown) | null>(null);
+  const activeOutlineButtonRefs = useRef(new Map<number, HTMLButtonElement>());
   const fileTreeBodyRef = useRef<HTMLDivElement | null>(null);
   const fileTreeScrollNodeRef = useRef<HTMLDivElement | null>(null);
   const fileTreeSortMenuRef = useRef<HTMLDivElement | null>(null);
@@ -415,6 +418,19 @@ export function MarkdownFileTreeDrawer({
   const folderAccessVisible = !tabbedSidebarLayout || activeSidebarPanel === "files";
   const outlineToolbarVisible = !tabbedSidebarLayout ||
     (outlinePanelOpen && (outlineItems.length > 0 || outlineExpansionAvailable));
+  useEffect(() => {
+    if (!outlinePanelOpen || !outlinePanelVisible || activeOutlineIndex === null) return;
+
+    const activeOutlineButton = activeOutlineButtonRefs.current.get(activeOutlineIndex);
+    if (typeof activeOutlineButton?.scrollIntoView !== "function") return;
+
+    activeOutlineButton.scrollIntoView({
+      behavior: "auto",
+      block: "nearest",
+      inline: "nearest"
+    });
+  }, [activeOutlineIndex, outlinePanelOpen, outlinePanelVisible, visibleOutlineItems]);
+
   useEffect(() => {
     return () => {
       resizeCleanupRef.current?.();
@@ -1334,6 +1350,10 @@ export function MarkdownFileTreeDrawer({
         {visibleOutlineItems.map(({ hasChildren, index, item, key }) => {
           const collapsed = collapsedOutlineKeys.has(key);
           const outlineIndent = (item.level - 1) * 12;
+          const active = activeOutlineIndex === index;
+          const outlineButtonClassName = active
+            ? "h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-(--bg-active) px-1 text-left text-[13px] leading-none font-[620] text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+            : "h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-transparent px-1 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none";
 
           return (
             <li key={key}>
@@ -1361,8 +1381,16 @@ export function MarkdownFileTreeDrawer({
                   <span className="size-6 shrink-0" aria-hidden="true" />
                 )}
                 <button
-                  className="h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-transparent px-1 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none"
+                  className={outlineButtonClassName}
                   type="button"
+                  aria-current={active ? "location" : undefined}
+                  ref={(element) => {
+                    if (element) {
+                      activeOutlineButtonRefs.current.set(index, element);
+                    } else {
+                      activeOutlineButtonRefs.current.delete(index);
+                    }
+                  }}
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => onSelectOutlineItem(item, index)}
                 >

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -785,18 +785,19 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".paper-scroll")).toHaveClass("h-full", "min-h-0", "overflow-auto");
   });
 
-  it("keeps enough bottom space for outline jumps near the end of a document", async () => {
+  it("does not add base bottom padding to the visual editor paper", async () => {
     const { container } = await renderEditor("# Synthetic heading");
     const paper = container.querySelector(".markdown-paper");
 
-    expect(paper?.getAttribute("style")).toContain("padding-bottom: calc(100vh - 4rem)");
+    expect(paper).not.toHaveClass("pb-30");
+    expect(paper?.getAttribute("style")).toContain("padding-bottom: 0px");
   });
 
-  it("adds bottom overlays to the outline jump reserve", async () => {
+  it("adds only bottom overlay spacing when a floating control is visible", async () => {
     const { container } = await renderEditor("# Synthetic heading", { bottomOverlayInset: 96 });
     const paper = container.querySelector(".markdown-paper");
 
-    expect(paper?.getAttribute("style")).toContain("padding-bottom: calc(96px + calc(100vh - 4rem))");
+    expect(paper?.getAttribute("style")).toContain("padding-bottom: 96px");
   });
 
   it("marks the editor paper with the default resolved app theme", async () => {

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -26,6 +26,7 @@ type MarkdownPaperProps = {
   language?: AppLanguage;
   lineHeight?: number;
   markdownShortcuts?: MarkdownPaperSurfaceProps["markdownShortcuts"];
+  onActiveOutlineIndexChange?: MarkdownPaperSurfaceProps["onActiveOutlineIndexChange"];
   onEditorReady: MarkdownPaperSurfaceProps["onEditorReady"];
   onMarkdownChange: MarkdownPaperSurfaceProps["onMarkdownChange"];
   onContentWidthChange?: (width: number) => unknown;
@@ -45,12 +46,10 @@ type MarkdownPaperProps = {
   wrapCodeBlocks?: boolean;
 };
 
-const editorBottomScrollReserve = "calc(100vh - 4rem)";
-
 function editorBottomPadding(bottomOverlayInset: number) {
-  if (bottomOverlayInset <= 0) return editorBottomScrollReserve;
+  if (bottomOverlayInset <= 0) return 0;
 
-  return `calc(${editorBottomScrollReserve} + ${bottomOverlayInset}px)`;
+  return `${bottomOverlayInset}px`;
 }
 
 export function MarkdownPaper({
@@ -69,6 +68,7 @@ export function MarkdownPaper({
   language = "en",
   lineHeight = 1.65,
   markdownShortcuts,
+  onActiveOutlineIndexChange,
   onEditorReady,
   onMarkdownChange,
   onContentWidthChange,
@@ -106,7 +106,7 @@ export function MarkdownPaper({
     >
       <article
         key={editorInstanceKey}
-        className={`markdown-paper relative mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
+        className={`markdown-paper relative mx-auto min-h-screen w-full max-w-215 px-18 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
         style={paperStyle}
         aria-label={t(language, "app.markdownEditor")}
         data-editor-engine="milkdown"
@@ -129,6 +129,7 @@ export function MarkdownPaper({
           initialContent={initialContent}
           language={language}
           markdownShortcuts={markdownShortcuts}
+          onActiveOutlineIndexChange={onActiveOutlineIndexChange}
           onEditorReady={onEditorReady}
           onMarkdownChange={onMarkdownChange}
           onSaveClipboardImage={onSaveClipboardImage}

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -72,6 +72,7 @@ export type MarkdownPaperSurfaceProps = {
   extendedSyntax?: ExtendedSyntaxPreferences;
   markdownShortcuts?: MarkdownShortcutMap;
   onEditorReady: (editor: Editor | null, options?: { autoFocus?: boolean }) => unknown;
+  onActiveOutlineIndexChange?: (index: number | null) => unknown;
   onMarkdownChange: (content: string) => unknown;
   onSaveClipboardImage?: SaveClipboardImage;
   onSaveRemoteClipboardImage?: SaveRemoteClipboardImage;
@@ -148,6 +149,7 @@ function MilkdownEditorSurface({
   language,
   markdownShortcuts,
   onEditorReady,
+  onActiveOutlineIndexChange,
   onMarkdownChange,
   onSaveClipboardImage,
   onSaveRemoteClipboardImage,
@@ -160,6 +162,7 @@ function MilkdownEditorSurface({
   const initialContentRef = useRef(initialContent);
   const documentPathRef = useRef(documentPath);
   const onMarkdownChangeRef = useRef(onMarkdownChange);
+  const onActiveOutlineIndexChangeRef = useRef(onActiveOutlineIndexChange);
   const openExternalUrlRef = useRef(openExternalUrl);
   const onSaveClipboardImageRef = useRef(onSaveClipboardImage);
   const onSaveRemoteClipboardImageRef = useRef(onSaveRemoteClipboardImage);
@@ -230,6 +233,10 @@ function MilkdownEditorSurface({
   useEffect(() => {
     onMarkdownChangeRef.current = onMarkdownChange;
   }, [onMarkdownChange]);
+
+  useEffect(() => {
+    onActiveOutlineIndexChangeRef.current = onActiveOutlineIndexChange;
+  }, [onActiveOutlineIndexChange]);
 
   useEffect(() => {
     openExternalUrlRef.current = openExternalUrl;
@@ -339,9 +346,16 @@ function MilkdownEditorSurface({
           })
         )
         .use(
-          markraTextSelectionObserverPlugin((selection) => {
-            onTextSelectionChangeRef.current?.(selection);
-          })
+          markraTextSelectionObserverPlugin(
+            (selection) => {
+              onTextSelectionChangeRef.current?.(selection);
+            },
+            {
+              onActiveOutlineIndexChange: (index) => {
+                onActiveOutlineIndexChangeRef.current?.(index);
+              }
+            }
+          )
         )
         .use(markraTableControlsPlugin(tableControlLabels))
         .use(markraTrailingParagraphPlugin)

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -28,7 +28,7 @@ function replaceCodeMirrorDoc(view: EditorView, value: string) {
 }
 
 describe("MarkdownSourceEditor", () => {
-  it("renders editable markdown with CodeMirror source highlighting", () => {
+  it("renders editable markdown with lightweight CodeMirror source highlighting", async () => {
     const content = [
       "# Title",
       "",
@@ -52,39 +52,53 @@ describe("MarkdownSourceEditor", () => {
     expect(view.state.doc.toString()).toBe(content);
     expect(container.querySelector(".cm-editor")).toBeInTheDocument();
     expect(container.querySelector(".cm-content")).toHaveTextContent("const answer = 42;");
+    await waitFor(() => {
+      expect(container.querySelector(".cm-line span[class]")).toBeInTheDocument();
+    });
 
     replaceCodeMirrorDoc(view, "# Changed");
 
     expect(handleChange).toHaveBeenCalledWith("# Changed");
   });
 
-  it("applies visible Markra token classes to common Markdown syntax", async () => {
-    const content = [
-      "# Title",
-      "",
-      "```ts",
-      "const answer = 42;",
-      "```",
-      "- Item",
-      "Text with `code`, [link](https://example.test), and **strong text**."
-    ].join("\n");
-
+  it("keeps literal markdown punctuation unchanged while editing", () => {
+    const handleChange = vi.fn();
     const { container } = render(
       <MarkdownSourceEditor
-        content={content}
-        onChange={() => {}}
+        content=""
+        onChange={handleChange}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    replaceCodeMirrorDoc(view, "**");
+
+    expect(view.state.doc.toString()).toBe("**");
+    expect(handleChange).toHaveBeenLastCalledWith("**");
+    expect(handleChange).not.toHaveBeenCalledWith("\\*\\*");
+  });
+
+  it("updates CodeMirror when content changes outside the editor", () => {
+    const handleChange = vi.fn();
+    const { container, rerender } = render(
+      <MarkdownSourceEditor
+        content="# First"
+        onChange={handleChange}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    replaceCodeMirrorDoc(view, "# Local");
+    expect(view.state.doc.toString()).toBe("# Local");
+
+    rerender(
+      <MarkdownSourceEditor
+        content="# External"
+        onChange={handleChange}
       />
     );
 
-    await waitFor(() => {
-      expect(container.querySelector(".markdown-source-token-heading")).toHaveTextContent("Title");
-      expect(container.querySelector(".markdown-source-token-code-fence")).toHaveTextContent("```");
-      expect(container.querySelector(".markdown-source-token-code")).toHaveTextContent("const answer = 42;");
-      expect(container.querySelector(".markdown-source-token-list-marker")).toHaveTextContent("-");
-      expect(container.querySelector(".markdown-source-token-inline-code")).toHaveTextContent("code");
-      expect(container.querySelector(".markdown-source-token-link")).toHaveTextContent("link");
-      expect(container.querySelector(".markdown-source-token-emphasis")).toHaveTextContent("strong text");
-    });
+    expect(view.state.doc.toString()).toBe("# External");
   });
 
   it("keeps source edits undoable and redoable", () => {
@@ -132,34 +146,19 @@ describe("MarkdownSourceEditor", () => {
     expect(handleRedo).toHaveBeenCalledTimes(1);
   });
 
-  it("highlights GitHub-style alert markers in CodeMirror source mode", async () => {
+  it("keeps source mode read-only when requested", () => {
     const { container } = render(
       <MarkdownSourceEditor
-        content="> [!TIP]\n> Keep notes portable."
+        content="# Read-only"
         onChange={() => {}}
+        readOnly
       />
     );
+    getMarkdownSourceView(container);
+    const sourceEditor = screen.getByRole("textbox", { name: "Markdown source" });
 
-    await waitFor(() => {
-      expect(container.querySelector(".markdown-source-token-callout")).toHaveTextContent("[!TIP]");
-      expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
-    });
-  });
-
-  it("leaves GitHub-style alert markers plain when the extension is disabled", () => {
-    const { container } = render(
-      <MarkdownSourceEditor
-        content="> [!TIP]\n> Keep notes portable."
-        extendedSyntax={{
-          githubAlerts: false,
-          highlight: true
-        }}
-        onChange={() => {}}
-      />
-    );
-
-    expect(container.querySelector(".markdown-source-token-callout")).not.toBeInTheDocument();
-    expect(container.querySelector(".markdown-source-token-quote-marker")).toHaveTextContent(">");
+    expect(sourceEditor).toHaveAttribute("aria-readonly", "true");
+    expect(sourceEditor).toHaveAttribute("contenteditable", "false");
   });
 
   it("selects exact search matches in source mode", async () => {
@@ -176,6 +175,37 @@ describe("MarkdownSourceEditor", () => {
     await waitFor(() => {
       expect(view.state.selection.main.from).toBe(5);
       expect(view.state.selection.main.to).toBe(6);
+    });
+  });
+
+  it("updates the selected source search match when active index changes", async () => {
+    const { container, rerender } = render(
+      <MarkdownSourceEditor
+        content="alpha beta gamma"
+        searchMatches={[{ from: 0, to: 5 }, { from: 11, to: 16 }]}
+        searchActiveIndex={0}
+        onChange={() => {}}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    await waitFor(() => {
+      expect(view.state.selection.main.from).toBe(0);
+      expect(view.state.selection.main.to).toBe(5);
+    });
+
+    rerender(
+      <MarkdownSourceEditor
+        content="alpha beta gamma"
+        searchMatches={[{ from: 0, to: 5 }, { from: 11, to: 16 }]}
+        searchActiveIndex={1}
+        onChange={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(view.state.selection.main.from).toBe(11);
+      expect(view.state.selection.main.to).toBe(16);
     });
   });
 });

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, type CSSProperties, type Ref, type UIEvent } from "react";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-import { Annotation, Compartment, EditorSelection, EditorState, Prec, Transaction, type Extension, type Range } from "@codemirror/state";
+import { Annotation, Compartment, EditorSelection, EditorState, Prec, Transaction, type Extension } from "@codemirror/state";
 import { Decoration, EditorView, keymap } from "@codemirror/view";
 import { minimalSetup } from "codemirror";
-import { parseMarkdownCalloutMarker, t, type AppLanguage, type SearchRange } from "@markra/shared";
+import { t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
   editorContentWidthPixels,
   editorCustomContentWidthMax,
@@ -39,10 +39,6 @@ export type MarkdownSourceEditorProps = {
 };
 
 const externalSourceUpdate = Annotation.define<boolean>();
-
-type FenceState = {
-  marker: "`" | "~" | null;
-};
 
 function markdownSourceContentAttributes(label: string, readOnly: boolean): Extension {
   return EditorView.contentAttributes.of({
@@ -112,137 +108,6 @@ function markdownSourceSearchExtension(matches: SearchRange[] = [], activeIndex 
   });
 }
 
-function addMarkdownSourceDecoration(
-  decorations: Range<Decoration>[],
-  from: number,
-  to: number,
-  className: string
-) {
-  if (to <= from) return;
-
-  decorations.push(Decoration.mark({ class: className }).range(from, to));
-}
-
-function markdownInlineTokenClassName(token: string) {
-  if (token.startsWith("`")) return "markdown-source-token-inline-code";
-  if (token.startsWith("!") || token.startsWith("[")) return "markdown-source-token-link";
-
-  return "markdown-source-token-emphasis";
-}
-
-function addMarkdownInlineSourceDecorations(decorations: Range<Decoration>[], text: string, from: number) {
-  const tokenPattern = /(!?\[[^\]]+\]\([^)]+\)|`[^`]+`|\*\*[^*]+?\*\*|__[^_]+?__|\*[^*\s][^*]*\*|_[^_\s][^_]*_)/gu;
-
-  for (const match of text.matchAll(tokenPattern)) {
-    const token = match[0];
-    const index = match.index ?? 0;
-    addMarkdownSourceDecoration(
-      decorations,
-      from + index,
-      from + index + token.length,
-      markdownInlineTokenClassName(token)
-    );
-  }
-}
-
-function markdownSourceSyntaxExtension(githubAlertsEnabled: boolean): Extension {
-  return EditorView.decorations.compute(["doc"], (state) => {
-    const decorations: Range<Decoration>[] = [];
-    const fenceState: FenceState = { marker: null };
-
-    for (let lineNumber = 1; lineNumber <= state.doc.lines; lineNumber += 1) {
-      const line = state.doc.line(lineNumber);
-      const fenceMatch = /^(\s*)(`{3,}|~{3,})(.*)$/u.exec(line.text);
-      if (fenceMatch && (!fenceState.marker || fenceMatch[2]!.startsWith(fenceState.marker))) {
-        const [, indent = "", fence = "", info = ""] = fenceMatch;
-        const fenceFrom = line.from + indent.length;
-        addMarkdownSourceDecoration(decorations, line.from, fenceFrom, "markdown-source-token-muted");
-        addMarkdownSourceDecoration(decorations, fenceFrom, fenceFrom + fence.length, "markdown-source-token-code-fence");
-        addMarkdownSourceDecoration(decorations, fenceFrom + fence.length, line.to, "markdown-source-token-code-info");
-        fenceState.marker = fenceState.marker ? null : fence[0] === "~" ? "~" : "`";
-        continue;
-      }
-
-      if (fenceState.marker) {
-        addMarkdownSourceDecoration(decorations, line.from, line.to, "markdown-source-token-code");
-        continue;
-      }
-
-      const headingMatch = /^(#{1,6})(\s.*)?$/u.exec(line.text);
-      if (headingMatch) {
-        const marker = headingMatch[1] ?? "";
-        addMarkdownSourceDecoration(decorations, line.from, line.from + marker.length, "markdown-source-token-heading-marker");
-        addMarkdownSourceDecoration(decorations, line.from + marker.length, line.to, "markdown-source-token-heading");
-        continue;
-      }
-
-      const blockquoteMatch = /^(\s*>+)(\s.*)?$/u.exec(line.text);
-      if (blockquoteMatch) {
-        const quoteMarker = blockquoteMatch[1] ?? "";
-        const quoteTo = line.from + quoteMarker.length;
-        addMarkdownSourceDecoration(decorations, line.from, quoteTo, "markdown-source-token-quote-marker");
-
-        const calloutContent = blockquoteMatch[2] ?? "";
-        const calloutStart = quoteTo;
-        const calloutPrefixMatch = /^(\s*)(.*)$/u.exec(calloutContent);
-        const calloutMarker = githubAlertsEnabled ? parseMarkdownCalloutMarker(calloutPrefixMatch?.[2] ?? "") : null;
-        if (calloutMarker && calloutPrefixMatch) {
-          const [, prefix = "", content = ""] = calloutPrefixMatch;
-          const contentStart = calloutStart + prefix.length;
-          const markerIndex = content.indexOf(calloutMarker.source);
-          if (markerIndex < 0) {
-            addMarkdownInlineSourceDecorations(decorations, calloutContent, calloutStart);
-            continue;
-          }
-
-          const markerFrom = contentStart + markerIndex;
-          if (markerIndex > 0) addMarkdownInlineSourceDecorations(decorations, content.slice(0, markerIndex), contentStart);
-          addMarkdownSourceDecoration(
-            decorations,
-            markerFrom,
-            markerFrom + calloutMarker.source.length,
-            "markdown-source-token-callout"
-          );
-          addMarkdownInlineSourceDecorations(
-            decorations,
-            content.slice(markerIndex + calloutMarker.source.length),
-            markerFrom + calloutMarker.source.length
-          );
-        } else {
-          addMarkdownInlineSourceDecorations(decorations, calloutContent, calloutStart);
-        }
-
-        continue;
-      }
-
-      const listMatch = /^(\s*)([-*+]|\d+[.)])(\s+.*)?$/u.exec(line.text);
-      if (listMatch) {
-        const indent = listMatch[1] ?? "";
-        const marker = listMatch[2] ?? "";
-        const markerFrom = line.from + indent.length;
-        const markerTo = markerFrom + marker.length;
-        addMarkdownSourceDecoration(decorations, line.from, markerFrom, "markdown-source-token-muted");
-        addMarkdownSourceDecoration(decorations, markerFrom, markerTo, "markdown-source-token-list-marker");
-        addMarkdownInlineSourceDecorations(decorations, listMatch[3] ?? "", markerTo);
-        continue;
-      }
-
-      const ruleMatch = /^(\s*)([-*_])(?:\s*\2){2,}\s*$/u.exec(line.text);
-      if (ruleMatch) {
-        const indent = ruleMatch[1] ?? "";
-        const ruleFrom = line.from + indent.length;
-        addMarkdownSourceDecoration(decorations, line.from, ruleFrom, "markdown-source-token-muted");
-        addMarkdownSourceDecoration(decorations, ruleFrom, line.to, "markdown-source-token-rule");
-        continue;
-      }
-
-      addMarkdownInlineSourceDecorations(decorations, line.text, line.from);
-    }
-
-    return Decoration.set(decorations, true);
-  });
-}
-
 function markdownSourceTheme(): Extension {
   return EditorView.theme({
     "&": {
@@ -261,19 +126,19 @@ function markdownSourceTheme(): Extension {
       backgroundColor: "transparent"
     },
     ".cm-content": {
-      caretColor: "var(--accent)",
       minHeight: "calc(100vh - 176px)",
       padding: "0",
       whiteSpace: "pre-wrap",
       wordBreak: "break-word"
     },
     ".cm-cursor": {
-      borderLeftColor: "var(--accent)"
+      borderLeftColor: "currentColor"
     },
     ".cm-line": {
       padding: "0"
     },
     ".cm-scroller": {
+      cursor: "text",
       fontFamily:
         'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
       lineHeight: "inherit",
@@ -293,7 +158,6 @@ export function MarkdownSourceEditor({
   contentWidthMax = editorCustomContentWidthMax,
   contentWidthMin = editorCustomContentWidthMin,
   contentWidthPx = null,
-  extendedSyntax,
   language = "en",
   lineHeight = 1.65,
   onChange,
@@ -318,9 +182,7 @@ export function MarkdownSourceEditor({
   const contentAttributesCompartmentRef = useRef(new Compartment());
   const editableCompartmentRef = useRef(new Compartment());
   const searchCompartmentRef = useRef(new Compartment());
-  const syntaxCompartmentRef = useRef(new Compartment());
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
-  const githubAlertsEnabled = extendedSyntax?.githubAlerts ?? true;
   const sourceLabel = t(language, "app.markdownSource");
   const paperStyle = {
     fontSize: `${bodyFontSize}px`,
@@ -358,7 +220,6 @@ export function MarkdownSourceEditor({
       contentAttributesCompartmentRef.current.of(markdownSourceContentAttributes(sourceLabel, readOnly)),
       editableCompartmentRef.current.of(EditorView.editable.of(!readOnly)),
       searchCompartmentRef.current.of(markdownSourceSearchExtension(searchMatches, searchActiveIndex)),
-      syntaxCompartmentRef.current.of(markdownSourceSyntaxExtension(githubAlertsEnabled)),
       EditorView.updateListener.of((update) => {
         if (!update.docChanged) return;
         if (update.transactions.some((transaction) => transaction.annotation(externalSourceUpdate))) return;
@@ -367,7 +228,7 @@ export function MarkdownSourceEditor({
       }),
       markdownSourceTheme()
     ],
-    [githubAlertsEnabled, sourceLabel]
+    [sourceLabel]
   );
 
   useEffect(() => {
@@ -445,15 +306,6 @@ export function MarkdownSourceEditor({
   }, [searchActiveIndex, searchMatches]);
 
   useEffect(() => {
-    const view = viewRef.current;
-    if (!view) return;
-
-    view.dispatch({
-      effects: syntaxCompartmentRef.current.reconfigure(markdownSourceSyntaxExtension(githubAlertsEnabled))
-    });
-  }, [githubAlertsEnabled]);
-
-  useEffect(() => {
     if (!autoFocus) return;
 
     viewRef.current?.focus();
@@ -467,7 +319,7 @@ export function MarkdownSourceEditor({
       ref={scrollRef}
     >
       <article
-        className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 pb-30 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) caret-(--accent) outline-none focus:outline-none max-[900px]:px-5.25`}
+        className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 ${topInsetClassName} text-[16px] leading-[1.65] text-(--text-primary) outline-none focus:outline-none max-[900px]:px-5.25`}
         style={paperStyle}
         aria-label={t(language, "app.markdownEditor")}
         data-editor-engine="source"

--- a/packages/app/src/components/markdown-paper-plugins.test.ts
+++ b/packages/app/src/components/markdown-paper-plugins.test.ts
@@ -1,0 +1,74 @@
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { activeOutlineIndexFromEditorView } from "./markdown-paper-plugins";
+
+type MockDocNode = {
+  position: number;
+  textContent: string;
+  type: { name: string };
+};
+
+function mockEditorView(selectionHead: number, nodes: MockDocNode[]) {
+  return {
+    state: {
+      doc: {
+        descendants(callback: (node: MockDocNode, position: number) => boolean | undefined) {
+          for (const node of nodes) {
+            callback(node, node.position);
+          }
+        }
+      },
+      selection: {
+        head: selectionHead
+      }
+    }
+  } as unknown as EditorView;
+}
+
+function heading(position: number, textContent: string): MockDocNode {
+  return {
+    position,
+    textContent,
+    type: { name: "heading" }
+  };
+}
+
+function paragraph(position: number, textContent: string): MockDocNode {
+  return {
+    position,
+    textContent,
+    type: { name: "paragraph" }
+  };
+}
+
+describe("markdown paper plugins", () => {
+  it("finds the nearest preceding non-empty outline heading from the cursor", () => {
+    const view = mockEditorView(32, [
+      paragraph(0, "Preface"),
+      heading(10, "Intro"),
+      paragraph(18, "Body"),
+      heading(40, "Details")
+    ]);
+
+    expect(activeOutlineIndexFromEditorView(view)).toBe(0);
+  });
+
+  it("ignores empty headings when matching outline indexes", () => {
+    const view = mockEditorView(52, [
+      heading(0, ""),
+      paragraph(4, "Body"),
+      heading(20, "Intro"),
+      heading(48, "Details")
+    ]);
+
+    expect(activeOutlineIndexFromEditorView(view)).toBe(1);
+  });
+
+  it("returns null when the cursor is before the first outline heading", () => {
+    const view = mockEditorView(6, [
+      paragraph(0, "Preface"),
+      heading(20, "Intro")
+    ]);
+
+    expect(activeOutlineIndexFromEditorView(view)).toBeNull();
+  });
+});

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -338,11 +338,48 @@ function editorViewIsComposing(view: EditorView) {
   return Boolean((view as EditorView & { composing?: boolean }).composing);
 }
 
+export function activeOutlineIndexFromEditorView(view: EditorView) {
+  const cursor = view.state.selection.head;
+  let outlineIndex = -1;
+  let activeOutlineIndex: number | null = null;
+
+  view.state.doc.descendants((node, position) => {
+    if (node.type.name !== "heading") return true;
+
+    if (node.textContent.trim()) {
+      outlineIndex += 1;
+      if (position <= cursor) {
+        activeOutlineIndex = outlineIndex;
+      }
+    }
+
+    return false;
+  });
+
+  return activeOutlineIndex;
+}
+
+type TextSelectionObserverOptions = {
+  onActiveOutlineIndexChange?: (index: number | null) => unknown;
+};
+
 export function markraTextSelectionObserverPlugin(
-  onTextSelectionChange: (selection: AiSelectionContext | null) => unknown
+  onTextSelectionChange: (selection: AiSelectionContext | null) => unknown,
+  options: TextSelectionObserverOptions = {}
 ) {
   return $prose(() => {
     let lastSignature = "";
+    let lastActiveOutlineIndex: number | null | undefined;
+
+    const notifyActiveOutlineIndexChange = (view: EditorView, force = false) => {
+      if (!options.onActiveOutlineIndexChange) return;
+
+      const activeOutlineIndex = activeOutlineIndexFromEditorView(view);
+      if (!force && activeOutlineIndex === lastActiveOutlineIndex) return;
+
+      lastActiveOutlineIndex = activeOutlineIndex;
+      options.onActiveOutlineIndexChange(activeOutlineIndex);
+    };
 
     const notifySelectionChange = (
       view: EditorView,
@@ -438,6 +475,8 @@ export function markraTextSelectionObserverPlugin(
       view(view) {
         const ownerDocument = view.dom.ownerDocument;
         let pointerSelectionPending = false;
+        notifyActiveOutlineIndexChange(view, true);
+
         const handleMouseDown = (event: MouseEvent) => {
           if (event.button !== 0) return;
 
@@ -467,11 +506,19 @@ export function markraTextSelectionObserverPlugin(
           destroy() {
             ownerDocument.removeEventListener("mousedown", handleMouseDown, true);
             ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
+            if (lastActiveOutlineIndex !== undefined) {
+              lastActiveOutlineIndex = undefined;
+              options.onActiveOutlineIndexChange?.(null);
+            }
           },
           update(view, previousState) {
             const { selection } = view.state;
             const selectionChanged = !selection.eq(previousState.selection);
+            const documentChanged = !view.state.doc.eq(previousState.doc);
             const selectionTextMayNeedRefresh = !selectionChanged && !selection.empty && !view.state.doc.eq(previousState.doc);
+            if (selectionChanged || documentChanged) {
+              notifyActiveOutlineIndexChange(view);
+            }
             if (!selectionChanged && !selectionTextMayNeedRefresh) return;
             if (pointerSelectionPending) return;
             notifySelectionChange(view, {

--- a/packages/app/src/hooks/useSharedEditorHistory.ts
+++ b/packages/app/src/hooks/useSharedEditorHistory.ts
@@ -12,6 +12,7 @@ type SharedEditorHistoryOptions = {
   largeMarkdownVisualBlocked: boolean;
   replaceEditorMarkdown: ReplaceEditorMarkdown;
   sourceSurfaceActive: boolean;
+  syncSourceToVisual: boolean;
   visualEditorReadySequence: number;
 };
 
@@ -21,6 +22,7 @@ export function useSharedEditorHistory({
   largeMarkdownVisualBlocked,
   replaceEditorMarkdown,
   sourceSurfaceActive,
+  syncSourceToVisual,
   visualEditorReadySequence
 }: SharedEditorHistoryOptions) {
   const pendingSourceHistoryRef = useRef(false);
@@ -36,31 +38,44 @@ export function useSharedEditorHistory({
     }
   }, [documentContent, documentRevision]);
 
-  useEffect(() => {
-    if (!sourceSurfaceActive || largeMarkdownVisualBlocked) {
-      pendingSourceHistoryRef.current = false;
-      return;
-    }
-
+  const syncSourceEditsToVisualHistory = useCallback(() => {
+    if (largeMarkdownVisualBlocked) return false;
     syncingSourceToVisualRef.current = true;
     try {
       const synced = replaceEditorMarkdown(documentContent, {
         addToHistory: pendingSourceHistoryRef.current
       });
       if (synced) pendingSourceHistoryRef.current = false;
+      return synced;
     } finally {
       syncingSourceToVisualRef.current = false;
     }
   }, [
     documentContent,
     largeMarkdownVisualBlocked,
-    replaceEditorMarkdown,
+    replaceEditorMarkdown
+  ]);
+
+  useEffect(() => {
+    if (!sourceSurfaceActive || largeMarkdownVisualBlocked) {
+      pendingSourceHistoryRef.current = false;
+      return;
+    }
+
+    if (!syncSourceToVisual) return;
+
+    syncSourceEditsToVisualHistory();
+  }, [
+    largeMarkdownVisualBlocked,
     sourceSurfaceActive,
+    syncSourceEditsToVisualHistory,
+    syncSourceToVisual,
     visualEditorReadySequence
   ]);
 
   return {
     isApplyingSourceToVisualSync,
-    markSourceEditForHistory
+    markSourceEditForHistory,
+    syncSourceEditsToVisualHistory
   };
 }

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -948,84 +948,16 @@
     user-select: none;
   }
 
-  .markdown-source-highlight code {
-    font-family: inherit;
-  }
-
-  .markdown-source-input {
-    -webkit-text-fill-color: transparent;
-    caret-color: var(--accent);
-    cursor: var(--editor-text-cursor);
-  }
-
-  .markdown-source-input::selection {
-    background: color-mix(in srgb, var(--accent) 22%, transparent);
-    -webkit-text-fill-color: transparent;
-  }
-
-  .markra-source-search-transparent {
-    color: transparent;
-  }
-
   .markra-cm-source-search-match,
-  .markra-source-search-match,
   .markra-search-match {
     border-radius: 2px;
     background: color-mix(in srgb, var(--accent) 16%, transparent);
   }
 
-  .markra-source-search-match {
-    color: transparent;
-  }
-
   .markra-cm-source-search-match-current,
-  .markra-source-search-match-current,
   .markra-search-match-current {
     background: color-mix(in srgb, var(--accent) 30%, transparent);
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
-  }
-
-  .markdown-source-token-muted {
-    color: color-mix(in srgb, var(--text-secondary) 62%, transparent);
-  }
-
-  .markdown-source-token-heading-marker,
-  .markdown-source-token-list-marker,
-  .markdown-source-token-quote-marker {
-    color: var(--text-md-char);
-    font-weight: 720;
-  }
-
-  .markdown-source-token-heading {
-    color: var(--text-heading);
-    font-weight: 680;
-  }
-
-  .markdown-source-token-code-fence,
-  .markdown-source-token-code-info,
-  .markdown-source-token-inline-code {
-    color: oklch(45% 0.15 258);
-  }
-
-  .markdown-source-token-code {
-    color: oklch(43% 0.13 151);
-  }
-
-  .markdown-source-token-callout {
-    color: color-mix(in srgb, var(--accent-hover) 82%, var(--text-primary));
-    font-weight: 700;
-  }
-
-  .markdown-source-token-link {
-    color: var(--link-color);
-  }
-
-  .markdown-source-token-emphasis {
-    color: oklch(42% 0.14 29);
-  }
-
-  .markdown-source-token-rule {
-    color: var(--text-md-char);
   }
 
   .markdown-paper {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -8,16 +8,16 @@ describe("editor stylesheet", () => {
     expect(styles).toContain('@source "../../../packages/ui/src"');
   });
 
-  it("uses theme-aware custom text cursors for editor text surfaces", () => {
+  it("uses theme-aware custom text cursors for visual editor text surfaces", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 
     expect(styles).toContain("--editor-text-cursor:");
     expect(styles).toContain(".markdown-paper .ProseMirror");
-    expect(styles).toContain(".markdown-source-input");
     expect(styles).toContain(".markdown-paper[data-editor-theme=\"solarized-dark\"]");
     expect(styles).toContain("cursor: var(--editor-text-cursor)");
     expect(styles).toContain("%231a1c1e");
     expect(styles).toContain("%23ffffff");
+    expect(styles).not.toContain(".markdown-source-input");
   });
 
   it("forces a grabbing cursor during document tab pointer drags", () => {
@@ -546,7 +546,6 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("--link-color: #2f56c6;");
     expect(styles).toContain("--link-color: #b7c5ff;");
     expect(styles).toContain("--editor-link-color: var(--link-color);");
-    expect(styles).toContain(".markdown-source-token-link");
     expect(styles).toContain("color: var(--link-color);");
     expect(styles).toContain(".markdown-paper a[href]::after");
     expect(styles).toContain(".markdown-paper .markra-live-link-label::after");


### PR DESCRIPTION
## Summary
- Render formatted Markdown heading titles in the outline.
- Sync the visual editor cursor position back to the outline, including active heading highlighting and automatic outline scrolling.
- Simplify source mode to a lightweight CodeMirror editor that preserves raw Markdown input and keeps source undo/redo local to CodeMirror.
- Remove the default editor bottom padding so visual/source mode no longer leaves a large blank area at the end of the document.

## Why
- Makes the outline show the current editing position instead of acting only as a jump list.
- Keeps source mode closer to a plain text editor with highlighting, without automatic escaping or heavy custom parsing.
- Removes the oversized bottom reserve that made the editor feel like it had extra blank content.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownSourceEditor.test.tsx src/App.test.tsx src/App.document-history.test.tsx src/styles.test.ts` passed.
- `pnpm --filter @markra/app test -- src/components/MarkdownFileTreeDrawer.test.tsx src/components/markdown-paper-plugins.test.ts` passed.
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx src/components/MarkdownSourceEditor.test.tsx src/hooks/useEditorController.test.ts` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/desktop build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Outline position sync is scoped to visual editor mode; source mode stays intentionally lightweight.
- Source/visual synchronization timing changed so source edits are applied back to the visual editor when switching surfaces.

## Related Issues
- Closes #287

