### PR TITLE
fix(app): ignore stale visual editor changes after save

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2165,14 +2165,14 @@ function WorkspaceApp() {
     if (readOnlyMode) return;
 
     if (splitMode) setActiveEditorSurface("visual");
-    handleMarkdownChange(content, options);
+    handleMarkdownChange(content, { ...options, surface: "visual" });
   }, [handleMarkdownChange, isApplyingSourceToVisualSync, readOnlyMode, sourceSurfaceActive, splitMode]);
   const handleSourceMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (readOnlyMode) return;
 
     markSourceEditForHistory(content, options);
     if (splitMode) setActiveEditorSurface("source");
-    handleMarkdownChange(content, options);
+    handleMarkdownChange(content, { ...options, surface: "source" });
   }, [handleMarkdownChange, markSourceEditForHistory, readOnlyMode, splitMode]);
   const syncSplitPaneScrollPosition = useCallback((sourceSurface: EditorSurface, sourceElement: HTMLElement) => {
     if (!splitMode) return false;

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1808,6 +1808,68 @@ describe("useMarkdownDocument", () => {
     ]);
   });
 
+  it("ignores stale clean editor changes emitted after saving", async () => {
+    let editorMarkdown = "# Guide\n\nSaved";
+    const confirmDiscardUnsavedChanges = vi.fn(() => true);
+    mockedOpenNativeMarkdownPath.mockResolvedValueOnce({
+      kind: "file",
+      file: {
+        content: "# Notes\n\nClean",
+        name: "notes.md",
+        path: "/mock-files/notes.md"
+      }
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValueOnce({
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+    act(() => {
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nOriginal", { surface: "visual" });
+    });
+    await act(async () => {
+      await result.current.openMarkdownFile();
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(result.current.document).toMatchObject({
+      content: "# Notes\n\nClean",
+      dirty: false,
+      name: "notes.md",
+      path: "/mock-files/notes.md"
+    });
+  });
+
   it("clears a saved file draft after saving the document", async () => {
     const guidePath = "/mock-files/vault/guide.md";
     mockedReadNativeMarkdownFile.mockResolvedValue({

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -82,6 +82,7 @@ type CreateBlankDocumentOptions = {
 
 type MarkdownChangeOptions = {
   documentRevision?: number;
+  surface?: "source" | "visual";
 };
 
 type SaveCurrentDocumentContentOptions = {
@@ -488,6 +489,15 @@ export function useMarkdownDocument({
     if (options.documentRevision !== undefined && options.documentRevision !== current.revision) return;
     if (!current.open || current.content === content) return;
     const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
+    if (
+      !current.dirty &&
+      options.surface === "visual" &&
+      editorContentEquivalent === true &&
+      !isEquivalentEditorMarkdown(current.content, content) &&
+      isActiveEditorMarkdownEquivalent(content) === false
+    ) {
+      return;
+    }
     const nextDocument =
       !current.dirty && (editorContentEquivalent === true || isEquivalentEditorMarkdown(current.content, content))
         ? { ...current, content, dirty: false }


### PR DESCRIPTION
## Summary
- Tag Markdown changes with source/visual origin.
- Ignore stale clean visual editor events after save when the live editor still matches the saved state.
- Add regression coverage for switching files after a clean save without a discard prompt.

## Why
- Fixes an intermittent save-state race where a document could show no dirty marker but still prompt to discard changes on close or folder/file switching.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx` passed: 38 tests.
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "keeps source and visual editors synchronized in split mode"` passed: 1 test, 154 skipped.
- `pnpm --filter @markra/app test` passed: 79 files, 1182 tests.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low. The stale-event guard is limited to visual editor events, while source editor changes remain treated as user edits.

## Related Issues
- Closes #293