### PR TITLE
fix(app): restore Windows context menu paste

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markra/desktop",
-  "version": "0.11.9",
+  "version": "0.11.10-beta.3",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -57,6 +57,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +486,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -926,6 +952,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
@@ -2105,8 +2137,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markra"
-version = "0.11.9"
+version = "0.11.10-beta.3"
 dependencies = [
+ "arboard",
  "dirs",
  "dispatch2",
  "hmac",
@@ -2349,6 +2382,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -5821,6 +5855,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markra"
-version = "0.11.9"
+version = "0.11.10-beta.3"
 description = "AI-native Markdown editor"
 authors = ["Markra contributors"]
 license = "AGPL-3.0-only"
@@ -15,6 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.6.0", features = [] }
 
 [dependencies]
+arboard = { version = "3.6.1", default-features = false }
 notify = "8.2.0"
 dirs = "6.0.0"
 hmac = "0.12.1"

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -1,0 +1,38 @@
+fn clipboard_text_from_result(
+    result: Result<String, arboard::Error>,
+) -> Result<Option<String>, String> {
+    match result {
+        Ok(text) => Ok(Some(text)),
+        Err(arboard::Error::ContentNotAvailable) => Ok(None),
+        Err(error) => Err(format!("Could not read clipboard text: {error}")),
+    }
+}
+
+#[tauri::command]
+pub(crate) fn read_clipboard_text() -> Result<Option<String>, String> {
+    let mut clipboard = arboard::Clipboard::new()
+        .map_err(|error| format!("Could not access clipboard: {error}"))?;
+
+    clipboard_text_from_result(clipboard.get_text())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clipboard_text_from_result;
+
+    #[test]
+    fn returns_none_when_clipboard_text_is_unavailable() {
+        assert_eq!(
+            clipboard_text_from_result(Err(arboard::Error::ContentNotAvailable)),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn returns_clipboard_text() {
+        assert_eq!(
+            clipboard_text_from_result(Ok("mock clipboard".to_string())),
+            Ok(Some("mock clipboard".to_string()))
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod ai_http;
 mod app_exit;
 mod backup;
+mod clipboard;
 mod external_urls;
 mod image_upload;
 mod language;
@@ -20,6 +21,7 @@ use std::time::Duration;
 use ai_http::{request_ai_provider_json, request_native_chat, request_native_chat_stream};
 use app_exit::handle_app_exit_requested;
 use backup::backup_markdown_folder;
+use clipboard::read_clipboard_text;
 use external_urls::open_external_url;
 use image_upload::{upload_picgo_image, upload_s3_image, upload_webdav_image};
 use markdown_files::{
@@ -184,6 +186,7 @@ pub fn run() {
             write_markdown_template_file,
             delete_markdown_template_file,
             save_clipboard_image,
+            read_clipboard_text,
             minimize_current_window,
             open_blank_editor_window,
             open_settings_window,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markra",
-  "version": "0.11.9",
+  "version": "0.11.10-beta.3",
   "identifier": "dev.markra.app",
   "build": {
     "beforeDevCommand": "pnpm dev --host 127.0.0.1 --port 1420 --strictPort",

--- a/apps/desktop/src/runtime/tauri/menu.test.ts
+++ b/apps/desktop/src/runtime/tauri/menu.test.ts
@@ -355,6 +355,42 @@ describe("native menu", () => {
     expect(domMenuItemById("markra:context:table").textContent).toContain("Cmd/Ctrl+Shift+T");
   });
 
+  it("uses the native clipboard command for editor context menu paste", async () => {
+    const target = document.createElement("main");
+    const paper = document.createElement("article");
+    const execCommand = vi.fn((command: string) => command !== "paste");
+    const browserReadText = vi.fn().mockResolvedValue("browser clipboard text");
+    paper.className = "markdown-paper";
+    target.append(paper);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText: browserReadText
+      }
+    });
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === "read_clipboard_text") return "native clipboard text";
+
+      return undefined;
+    });
+
+    await installNativeEditorContextMenu(target, {}, "en");
+
+    paper.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    domMenuItemById("markra:context:paste").click();
+    await flushNativeMenuPopup();
+    await flushNativeMenuPopup();
+
+    expect(mockedInvoke).toHaveBeenCalledWith("read_clipboard_text");
+    expect(browserReadText).not.toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenNthCalledWith(1, "insertText", false, "native clipboard text");
+  });
+
   it("passes customized app shortcuts to the native application menu", async () => {
     await installNativeApplicationMenu({}, "en", {
       openQuickOpen: "Mod+Alt+P",

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -36,9 +36,18 @@ export type NativeMarkdownFileTreeContextMenuHandlers = {
   saveFileAsTemplate?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
 };
 
+export type NativeClipboardTextReader = () => string | null | undefined | Promise<string | null | undefined>;
+
 export type NativeEditorContextMenuOptions = {
   getAiCommandsAvailable?: () => boolean;
   markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardText?: NativeClipboardTextReader;
+};
+
+export type NativeEditorContextMenuEntryOptions = {
+  aiCommandsAvailable?: boolean;
+  markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardText?: NativeClipboardTextReader;
 };
 
 export type NativeStaticMenuCommand =
@@ -147,12 +156,29 @@ function normalizeRecentFilesForNativeMenu(files: readonly RecentMarkdownFile[])
   });
 }
 
+async function readNativeClipboardText() {
+  try {
+    const text = await invoke<string | null>("read_clipboard_text");
+
+    return typeof text === "string" ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+function withNativeClipboardText<TOptions extends { readClipboardText?: NativeClipboardTextReader }>(options: TOptions) {
+  return {
+    ...options,
+    readClipboardText: options.readClipboardText ?? readNativeClipboardText
+  };
+}
+
 export function createNativeEditorContextMenuItems(
   handlers: NativeMenuHandlers,
   language: AppLanguage = "en",
-  options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap } = {}
+  options: NativeEditorContextMenuEntryOptions = {}
 ): ContextMenuEntry[] {
-  return createEditorContextMenuEntries(handlers, language, options, desktopContextMenuIdPrefixes);
+  return createEditorContextMenuEntries(handlers, language, withNativeClipboardText(options), desktopContextMenuIdPrefixes);
 }
 
 export async function installNativeEditorContextMenu(
@@ -175,7 +201,7 @@ export async function installNativeEditorContextMenu(
       entries: createEditorContextMenuEntriesFromOptions(
         handlers,
         language,
-        options,
+        withNativeClipboardText(options),
         desktopContextMenuIdPrefixes
       ),
       position: contextMenuPositionFromEvent(mouseEvent)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markra-workspace",
-  "version": "0.11.9",
+  "version": "0.11.10-beta.3",
   "license": "AGPL-3.0-only",
   "private": true,
   "packageManager": "pnpm@10.30.3",

--- a/packages/app/src/lib/tauri/menu.ts
+++ b/packages/app/src/lib/tauri/menu.ts
@@ -24,9 +24,18 @@ export type NativeMarkdownFileTreeContextMenuHandlers = {
   saveFileAsTemplate?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
 };
 
+export type NativeClipboardTextReader = () => string | null | undefined | Promise<string | null | undefined>;
+
 export type NativeEditorContextMenuOptions = {
   getAiCommandsAvailable?: () => boolean;
   markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardText?: NativeClipboardTextReader;
+};
+
+export type NativeEditorContextMenuEntryOptions = {
+  aiCommandsAvailable?: boolean;
+  markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardText?: NativeClipboardTextReader;
 };
 
 export type NativeStaticMenuCommand =
@@ -94,7 +103,7 @@ export function installNativeApplicationMenu(
 export function createNativeEditorContextMenuItems(
   handlers: NativeMenuHandlers,
   language: AppLanguage = "en",
-  options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap } = {}
+  options: NativeEditorContextMenuEntryOptions = {}
 ) {
   return getAppRuntime().menu.createEditorContextMenuItems(handlers, language, options);
 }

--- a/packages/app/src/runtime/context-menu-items.test.ts
+++ b/packages/app/src/runtime/context-menu-items.test.ts
@@ -1,0 +1,125 @@
+import { createEditorContextMenuEntries } from "./context-menu-items";
+import type { ContextMenuEntry, ContextMenuItem } from "../components/ContextMenu";
+
+function menuItemById(entries: ContextMenuEntry[], id: string): ContextMenuItem {
+  const item = entries.find((entry) => entry.kind === "item" && entry.id === id);
+  if (!item || item.kind !== "item") throw new Error(`Menu item not found: ${id}`);
+
+  return item;
+}
+
+describe("editor context menu entries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to clipboard text insertion when the browser paste command is unavailable", async () => {
+    const execCommand = vi.fn((command: string) => command !== "paste");
+    const readText = vi.fn().mockResolvedValue("pasted text");
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText
+      }
+    });
+
+    const paste = menuItemById(createEditorContextMenuEntries({}, "en"), "markra:context:paste");
+
+    await Promise.resolve(paste.onSelect?.());
+
+    expect(execCommand).toHaveBeenNthCalledWith(1, "paste");
+    expect(readText).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenNthCalledWith(2, "insertText", false, "pasted text");
+  });
+
+  it("falls back to clipboard text insertion when the browser paste command throws", async () => {
+    const execCommand = vi.fn((command: string) => {
+      if (command === "paste") throw new Error("Paste is blocked.");
+
+      return true;
+    });
+    const readText = vi.fn().mockResolvedValue("blocked paste text");
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText
+      }
+    });
+
+    const paste = menuItemById(createEditorContextMenuEntries({}, "en"), "markra:context:paste");
+
+    await Promise.resolve(paste.onSelect?.());
+
+    expect(execCommand).toHaveBeenNthCalledWith(1, "paste");
+    expect(readText).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenNthCalledWith(2, "insertText", false, "blocked paste text");
+  });
+
+  it("uses an injected clipboard text reader before the browser paste command", async () => {
+    const execCommand = vi.fn((command: string) => command !== "paste");
+    const readText = vi.fn().mockResolvedValue("browser clipboard text");
+    const readClipboardText = vi.fn().mockResolvedValue("platform clipboard text");
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText
+      }
+    });
+
+    const paste = menuItemById(
+      createEditorContextMenuEntries({}, "en", {
+        readClipboardText
+      }),
+      "markra:context:paste"
+    );
+
+    await Promise.resolve(paste.onSelect?.());
+
+    expect(readClipboardText).toHaveBeenCalledTimes(1);
+    expect(readText).not.toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenNthCalledWith(1, "insertText", false, "platform clipboard text");
+  });
+
+  it("falls back to the browser paste command when injected clipboard text is unavailable", async () => {
+    const execCommand = vi.fn((command: string) => command === "paste");
+    const readText = vi.fn().mockResolvedValue("browser clipboard text");
+    const readClipboardText = vi.fn().mockResolvedValue(null);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText
+      }
+    });
+
+    const paste = menuItemById(
+      createEditorContextMenuEntries({}, "en", {
+        readClipboardText
+      }),
+      "markra:context:paste"
+    );
+
+    await Promise.resolve(paste.onSelect?.());
+
+    expect(readClipboardText).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenNthCalledWith(1, "paste");
+    expect(readText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/runtime/context-menu-items.ts
+++ b/packages/app/src/runtime/context-menu-items.ts
@@ -14,6 +14,7 @@ import {
   type ContextMenuEntry
 } from "../components/ContextMenu";
 import type {
+  NativeEditorContextMenuEntryOptions,
   NativeEditorContextMenuOptions,
   NativeMarkdownFileTreeContextMenuHandlers,
   NativeMenuCommand,
@@ -22,6 +23,8 @@ import type {
 import type { NativeMarkdownFolderFile } from "../lib/tauri/file";
 
 type BrowserEditCommand = "copy" | "cut" | "paste" | "selectAll";
+
+type EditorContextMenuEntryOptions = NativeEditorContextMenuEntryOptions;
 
 export type ContextMenuIdPrefixes = {
   editor: string;
@@ -84,18 +87,82 @@ export function nativeAcceleratorsForMarkdownShortcuts(shortcuts: MarkdownShortc
   return accelerators;
 }
 
-function runBrowserEditCommand(command: BrowserEditCommand) {
-  const documentTarget = typeof document === "undefined" ? null : document;
-  const execCommand = documentTarget
-    ? (documentTarget as unknown as Record<string, unknown>)["execCommand"]
-    : null;
-  if (typeof execCommand === "function") {
-    execCommand.call(documentTarget, command);
+function runDocumentEditCommand(
+  documentTarget: Document,
+  command: string,
+  showDefaultUI?: boolean,
+  value?: string
+) {
+  const execCommand = (documentTarget as unknown as Record<string, unknown>)["execCommand"];
+  if (typeof execCommand !== "function") return false;
+
+  try {
+    if (showDefaultUI === undefined && value === undefined) {
+      return Boolean(execCommand.call(documentTarget, command));
+    }
+
+    return Boolean(execCommand.call(documentTarget, command, showDefaultUI, value));
+  } catch {
+    return false;
   }
 }
 
-function browserItem(id: string, label: string, accelerator: string, command: BrowserEditCommand) {
-  return contextMenuItem(id, label, accelerator, () => runBrowserEditCommand(command), false);
+async function readBrowserClipboardText(documentTarget: Document) {
+  const clipboard = documentTarget.defaultView?.navigator.clipboard;
+  const readText = clipboard?.readText;
+  if (typeof readText !== "function") return null;
+
+  return readText.call(clipboard);
+}
+
+async function pasteClipboardText(
+  documentTarget: Document,
+  readClipboardText?: NativeEditorContextMenuOptions["readClipboardText"]
+) {
+  const readText = readClipboardText ?? (() => readBrowserClipboardText(documentTarget));
+
+  try {
+    const text = await readText();
+    if (!text) return false;
+
+    return runDocumentEditCommand(documentTarget, "insertText", false, text);
+  } catch {
+    return false;
+  }
+}
+
+async function runInjectedClipboardPasteCommand(
+  documentTarget: Document,
+  readClipboardText: NonNullable<NativeEditorContextMenuOptions["readClipboardText"]>
+) {
+  const handled = await pasteClipboardText(documentTarget, readClipboardText);
+  if (handled) return true;
+
+  return runDocumentEditCommand(documentTarget, "paste");
+}
+
+function runBrowserEditCommand(command: BrowserEditCommand, options: Pick<EditorContextMenuEntryOptions, "readClipboardText"> = {}) {
+  const documentTarget = typeof document === "undefined" ? null : document;
+  if (!documentTarget) return false;
+
+  if (command === "paste" && options.readClipboardText) {
+    return runInjectedClipboardPasteCommand(documentTarget, options.readClipboardText);
+  }
+
+  const handled = runDocumentEditCommand(documentTarget, command);
+  if (handled || command !== "paste") return handled;
+
+  return pasteClipboardText(documentTarget);
+}
+
+function browserItem(
+  id: string,
+  label: string,
+  accelerator: string,
+  command: BrowserEditCommand,
+  options: Pick<EditorContextMenuEntryOptions, "readClipboardText"> = {}
+) {
+  return contextMenuItem(id, label, accelerator, () => runBrowserEditCommand(command, options), false);
 }
 
 function readAiCommandsAvailable(options: NativeEditorContextMenuOptions) {
@@ -109,7 +176,7 @@ function readAiCommandsAvailable(options: NativeEditorContextMenuOptions) {
 export function createEditorContextMenuEntries(
   handlers: NativeMenuHandlers,
   language: AppLanguage = "en",
-  options: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap } = {},
+  options: EditorContextMenuEntryOptions = {},
   idPrefixes: Partial<ContextMenuIdPrefixes> = {}
 ): ContextMenuEntry[] {
   const prefixes = {
@@ -152,10 +219,10 @@ export function createEditorContextMenuEntries(
     contextMenuItem(editorId("export-latex"), label("menu.exportLatex"), undefined, handlers.exportLatex)
   ]);
   const entries: ContextMenuEntry[] = [
-    browserItem(editorId("cut"), label("menu.cut"), "CmdOrCtrl+X", "cut"),
-    browserItem(editorId("copy"), label("menu.copy"), "CmdOrCtrl+C", "copy"),
-    browserItem(editorId("paste"), label("menu.paste"), "CmdOrCtrl+V", "paste"),
-    browserItem(editorId("select-all"), label("menu.selectAll"), "CmdOrCtrl+A", "selectAll"),
+    browserItem(editorId("cut"), label("menu.cut"), "CmdOrCtrl+X", "cut", options),
+    browserItem(editorId("copy"), label("menu.copy"), "CmdOrCtrl+C", "copy", options),
+    browserItem(editorId("paste"), label("menu.paste"), "CmdOrCtrl+V", "paste", options),
+    browserItem(editorId("select-all"), label("menu.selectAll"), "CmdOrCtrl+A", "selectAll", options),
     contextMenuSeparator(),
     contextMenuSubmenu(editorId("format"), label("menu.format"), formatItems),
     contextMenuSeparator(),
@@ -195,7 +262,8 @@ export function createEditorContextMenuEntriesFromOptions(
     language,
     {
       aiCommandsAvailable: readAiCommandsAvailable(options),
-      markdownShortcuts: options.markdownShortcuts
+      markdownShortcuts: options.markdownShortcuts,
+      readClipboardText: options.readClipboardText
     },
     idPrefixes
   );

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -45,6 +45,7 @@ import type {
   UploadNativeWebDavImageInput
 } from "../lib/tauri/file";
 import type {
+  NativeEditorContextMenuEntryOptions,
   NativeEditorContextMenuOptions,
   NativeMarkdownFileTreeContextMenuHandlers,
   NativeMenuHandlers
@@ -190,7 +191,7 @@ export type AppMenuRuntime = {
   createEditorContextMenuItems: (
     handlers: NativeMenuHandlers,
     language?: AppLanguage,
-    options?: { aiCommandsAvailable?: boolean; markdownShortcuts?: MarkdownShortcutMap }
+    options?: NativeEditorContextMenuEntryOptions
   ) => ContextMenuEntry[];
   createMarkdownFileTreeContextMenuItems: (
     handlers: NativeMarkdownFileTreeContextMenuHandlers,


### PR DESCRIPTION
## Summary
- Add a text fallback for the editor context menu Paste action when WebView2 blocks or rejects `document.execCommand("paste")`.
- Keep the existing browser edit command path for cut/copy/select-all and successful paste commands.
- Prepare prerelease version `0.11.10-beta.1` for publishing a Windows validation build.

## Why
Windows WebView2 can treat script-triggered paste from the self-drawn context menu differently from native Paste UI or Ctrl+V. When `execCommand("paste")` returns false or throws, the right-click Paste command silently does nothing.

## Validation
- `pnpm --dir packages/app exec vitest run src/runtime/context-menu-items.test.ts` passed
- `pnpm --dir apps/desktop exec vitest run src/runtime/tauri/menu.test.ts` passed
- `pnpm --dir packages/app build` passed
- `pnpm test:release` passed
- `pnpm --dir packages/app test` passed on rerun: 82 files / 1188 tests
- Version alignment check passed for package.json, desktop package.json, Tauri config, and Cargo.toml at `0.11.10-beta.1`

## Notes
- The first full `packages/app` test run hit an unrelated transient editor initialization timeout in `selection-formatting.test.tsx`; that file passed alone and the full suite passed on rerun.

Closes #300