### PR TITLE
fix(editor): prevent blank clicks from jumping to document end

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -542,6 +542,17 @@ function editorTopLevelBlockElements(container: HTMLElement) {
   return editorTopLevelBlockElementsFromSurface(surface);
 }
 
+function mockTopLevelBlockRects(container: HTMLElement, rects: DOMRect[]) {
+  const blocks = editorTopLevelBlockElements(container);
+  if (blocks.length !== rects.length) {
+    throw new Error(`Expected ${rects.length} editor blocks, found ${blocks.length}.`);
+  }
+
+  for (const [index, block] of blocks.entries()) {
+    block.getBoundingClientRect = vi.fn(() => rects[index]);
+  }
+}
+
 function mockTopLevelBlockDragLayout(view: EditorView, container: HTMLElement) {
   return mockBlockDragLayout(
     view,
@@ -6987,6 +6998,55 @@ describe("MarkdownPaper editing", () => {
 
     expect(view.state.doc.child(1).textContent).toBe("Next body");
     expect(serializeMarkdown(view.state.doc)).toContain("Next body");
+  });
+
+  it("does not create a trailing paragraph after clicking paper blank space before the final block", async () => {
+    const { container, view } = await renderEditor("First\n\nSecond\n\nThird");
+
+    mockTopLevelBlockRects(container, [
+      {
+        bottom: 128,
+        height: 28,
+        left: 160,
+        right: 640,
+        top: 100,
+        width: 480,
+        x: 160,
+        y: 100,
+        toJSON: () => ({})
+      },
+      {
+        bottom: 188,
+        height: 28,
+        left: 160,
+        right: 640,
+        top: 160,
+        width: 480,
+        x: 160,
+        y: 160,
+        toJSON: () => ({})
+      },
+      {
+        bottom: 248,
+        height: 28,
+        left: 160,
+        right: 640,
+        top: 220,
+        width: 480,
+        x: 160,
+        y: 220,
+        toJSON: () => ({})
+      }
+    ] as DOMRect[]);
+
+    fireEvent.mouseDown(screen.getByLabelText("Markdown editor"), {
+      button: 0,
+      clientX: 672,
+      clientY: 174
+    });
+
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(2).textContent).toBe("Third");
   });
 
   it("creates a trailing paragraph after clicking paper blank space below a terminal body paragraph", async () => {

--- a/packages/editor/src/trailing-paragraph.ts
+++ b/packages/editor/src/trailing-paragraph.ts
@@ -42,6 +42,22 @@ function hasNonCollapsedNativeSelection(document: Document) {
   return Boolean(selection && !selection.isCollapsed);
 }
 
+function isTopLevelContentElement(element: Element): element is HTMLElement {
+  return element instanceof HTMLElement && !element.classList.contains("markra-trailing-paragraph");
+}
+
+function lastTopLevelContentElement(view: EditorView) {
+  return Array.from(view.dom.children).filter(isTopLevelContentElement).at(-1) ?? null;
+}
+
+function clickIsPastLastTopLevelBlock(view: EditorView, event: MouseEvent) {
+  const lastElement = lastTopLevelContentElement(view);
+  if (!lastElement) return true;
+
+  const rect = lastElement.getBoundingClientRect();
+  return event.clientY >= rect.bottom;
+}
+
 function insertTrailingParagraph(view: EditorView, paragraph: NodeType) {
   if (!view.editable) return false;
   if (!needsTrailingParagraphAffordance(view.state.doc, paragraph)) return false;
@@ -92,6 +108,7 @@ export function createTrailingParagraphPlugin(paragraph: NodeType) {
         const target = eventTargetElement(event.target);
         if (target !== paper) return;
         if (hasNonCollapsedNativeSelection(paper.ownerDocument)) return;
+        if (!clickIsPastLastTopLevelBlock(view, event)) return;
         if (!insertTrailingParagraph(view, paragraph)) return;
 
         event.preventDefault();
@@ -110,6 +127,7 @@ export function createTrailingParagraphPlugin(paragraph: NodeType) {
       handleDOMEvents: {
         mousedown(view, event) {
           if (event.target !== view.dom || !isPlainLeftMouseDown(event)) return false;
+          if (!clickIsPastLastTopLevelBlock(view, event)) return false;
           if (!insertTrailingParagraph(view, paragraph)) return false;
 
           event.preventDefault();


### PR DESCRIPTION
## Summary
- Restrict trailing paragraph insertion to clicks after the final top-level editor block.
- Add a regression test for clicking paper blank space before the final block.

## Why
- Clicking blank space beside or between middle document blocks could be mistaken for a request to edit the document end.
- That inserted a trailing paragraph and called `scrollIntoView()`, making the editor jump to the bottom.

## Validation
- `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx -t "does not create a trailing paragraph after clicking paper blank space before the final block"` passed; Vitest reported 82 files and 1191 tests passed.
- `pnpm --filter @markra/editor build` passed.

## Risk
- Low. The existing trailing-paragraph affordance remains, but article/editor blank clicks now only trigger it when the click is after the final content block.

Closes #294