### PR TITLE
fix(editor): avoid highlights across inline code

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6490,6 +6490,20 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("does not render highlight syntax across separate inline code blocks", async () => {
+    const { container } = await renderEditor("Check `left == value`, `right == value`", {
+      extendedSyntax: {
+        githubAlerts: true,
+        highlight: true
+      }
+    });
+
+    expect(container.querySelectorAll(".ProseMirror code")).toHaveLength(2);
+    expect(container.querySelector(".ProseMirror .markra-live-mark-highlight")).not.toBeInTheDocument();
+    expectHiddenMarkdownDelimiters(container, 0);
+    await settleMarkdownListener();
+  });
+
   it("keeps typing inside filled inline delimiters styled", async () => {
     const strong = await renderEditor();
     typeText(strong.view, "****");

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -266,6 +266,78 @@ function hasManagedMark(marks: readonly Mark[] | null | undefined, markTypes: Ma
   return Boolean(marks?.some((mark) => markTypes.includes(mark.type)));
 }
 
+function getMarkTypesForKind(specs: LiveMarkdownSpec[], kind: LiveMarkdownKind) {
+  const markTypes: MarkType[] = [];
+
+  for (const spec of specs) {
+    for (const mark of spec.marks) {
+      if (mark.kind === kind && !markTypes.includes(mark.markType)) {
+        markTypes.push(mark.markType);
+      }
+    }
+  }
+
+  return markTypes;
+}
+
+function textRangeAvoidsMarks(
+  node: ProseNode,
+  from: number,
+  to: number,
+  markTypes: MarkType[]
+) {
+  let cursor = from;
+  let valid = true;
+
+  node.forEach((child, offset) => {
+    if (!valid || offset >= to) return;
+
+    const childTo = offset + child.nodeSize;
+    if (childTo <= cursor) return;
+
+    if (offset > cursor) {
+      valid = false;
+      return;
+    }
+
+    const overlapTo = Math.min(childTo, to);
+    if (!child.isText || hasManagedMark(child.marks, markTypes)) {
+      valid = false;
+      return;
+    }
+
+    cursor = overlapTo;
+  });
+
+  return valid && cursor >= to;
+}
+
+function liveMarkdownRangeHasEligibleDelimiters(
+  node: ProseNode,
+  range: LiveMarkdownRange,
+  excludedDelimiterMarkTypes: MarkType[]
+) {
+  const closingFrom = range.to - range.marker.length;
+
+  return (
+    textRangeAvoidsMarks(node, range.from, range.contentFrom, excludedDelimiterMarkTypes) &&
+    textRangeAvoidsMarks(node, closingFrom, range.to, excludedDelimiterMarkTypes)
+  );
+}
+
+function getLiveMarkdownRangesInTextblock(
+  node: ProseNode,
+  specs: LiveMarkdownSpec[]
+) {
+  if (node.type.spec.code) return [];
+
+  const inlineCodeMarkTypes = getMarkTypesForKind(specs, "inlineCode");
+
+  return getLiveMarkdownRanges(node.textContent, specs).filter((range) =>
+    liveMarkdownRangeHasEligibleDelimiters(node, range, inlineCodeMarkTypes)
+  );
+}
+
 function selectionContainsManagedMark(state: EditorState, markTypes: MarkType[]) {
   const { selection } = state;
   if (selection.empty) return false;
@@ -387,7 +459,7 @@ function deleteTextAfterLiveMarkdownRange(
   if (!$from.parent.isTextblock) return false;
 
   const cursor = $from.parentOffset;
-  const range = getLiveMarkdownRanges($from.parent.textContent, specs).find(
+  const range = getLiveMarkdownRangesInTextblock($from.parent, specs).find(
     (candidate) => candidate.to + 1 === cursor
   );
   if (!range) return false;
@@ -482,7 +554,7 @@ function buildLiveMarkdownDecorations(
     if (!node.isTextblock) return;
 
     const blockStart = position + 1;
-    const ranges = getLiveMarkdownRanges(node.textContent, specs);
+    const ranges = getLiveMarkdownRangesInTextblock(node, specs);
 
     for (const range of ranges) {
       const from = blockStart + range.from;
@@ -571,7 +643,7 @@ function findActiveLiveMarkdownRange(state: EditorState, specs: LiveMarkdownSpec
   const { $from } = selection;
   if (!$from.parent.isTextblock) return null;
 
-  const ranges = getLiveMarkdownRanges($from.parent.textContent, specs)
+  const ranges = getLiveMarkdownRangesInTextblock($from.parent, specs)
     .filter((range) => range.content.trim().length > 0)
     .filter((range) => range.from <= $from.parentOffset && $from.parentOffset <= range.to)
     .sort((left, right) => left.to - left.from - (right.to - right.from));


### PR DESCRIPTION
## Summary
- Prevent live markdown highlight detection from pairing `==` delimiters inside separate inline code spans.
- Add a regression test for inline code containing equality operators.

## Why
- Live markdown scans used textblock `textContent`, which made finalized inline code spans look contiguous and allowed highlight syntax to cross code boundaries.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx -t "does not render highlight syntax across separate inline code blocks"` passed: 1 test passed, 371 skipped.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- Note: `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx -t "does not render highlight syntax across separate inline code blocks"` imported the broader app test set and failed in unrelated `selection-formatting.test.tsx`; the exact file-targeted rerun above passed.

## Risk
- Low. The change only filters live markdown delimiter eligibility around inline code marks and skips live markdown scanning in code textblocks.

## Related Issues
- Closes #303