### PR TITLE
fix(editor): hide pane-level horizontal scrollbars

### DIFF
--- a/packages/app/src/components/LazyMarkdownSourceEditor.tsx
+++ b/packages/app/src/components/LazyMarkdownSourceEditor.tsx
@@ -39,7 +39,7 @@ function MarkdownSourceEditorFallback({
   return (
     <section
       aria-hidden="true"
-      className="paper-scroll h-full min-h-0 overflow-auto overscroll-none bg-transparent"
+      className="paper-scroll h-full min-h-0 overflow-x-hidden overflow-y-auto overscroll-none bg-transparent"
       ref={scrollRef}
     >
       <article

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -789,11 +789,16 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".markra-search-match-current")).toHaveTextContent(",");
   });
 
-  it("keeps the writing surface from macOS-style scroll dragging", async () => {
+  it("keeps the writing surface from macOS-style scroll dragging without pane-level horizontal scroll", async () => {
     const { container } = await renderEditor();
 
     expect(container.querySelector(".paper-scroll")).toHaveClass("overscroll-none");
-    expect(container.querySelector(".paper-scroll")).toHaveClass("h-full", "min-h-0", "overflow-auto");
+    expect(container.querySelector(".paper-scroll")).toHaveClass(
+      "h-full",
+      "min-h-0",
+      "overflow-x-hidden",
+      "overflow-y-auto"
+    );
   });
 
   it("does not add base bottom padding to the visual editor paper", async () => {

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -115,7 +115,7 @@ export function MarkdownPaper({
 
   return (
     <section
-      className="paper-scroll h-full min-h-0 overflow-auto overscroll-none bg-transparent"
+      className="paper-scroll h-full min-h-0 overflow-x-hidden overflow-y-auto overscroll-none bg-transparent"
       aria-label={t(language, "app.writingSurface")}
       onScroll={onScroll}
       ref={scrollRef}

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -61,6 +61,22 @@ describe("MarkdownSourceEditor", () => {
     expect(handleChange).toHaveBeenCalledWith("# Changed");
   });
 
+  it("keeps source scrolling vertical without pane-level horizontal scroll", () => {
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="# Source"
+        onChange={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".paper-scroll")).toHaveClass(
+      "h-full",
+      "min-h-0",
+      "overflow-x-hidden",
+      "overflow-y-auto"
+    );
+  });
+
   it("keeps literal markdown punctuation unchanged while editing", () => {
     const handleChange = vi.fn();
     const { container } = render(

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -313,7 +313,7 @@ export function MarkdownSourceEditor({
 
   return (
     <section
-      className="paper-scroll h-full min-h-0 overflow-auto overscroll-none bg-transparent"
+      className="paper-scroll h-full min-h-0 overflow-x-hidden overflow-y-auto overscroll-none bg-transparent"
       aria-label={t(language, "app.writingSurface")}
       onScroll={onScroll}
       ref={scrollRef}


### PR DESCRIPTION
## Summary
- Hide pane-level horizontal overflow on visual and source editor scroll containers
- Keep vertical editor scrolling intact for the source editor loading state as well
- Add coverage for visual and source editor scroll container classes

## Why
- The editor pane used `overflow-auto`, so narrow split/sidebar layouts could show an unnecessary bottom scrollbar when child chrome overflowed horizontally.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx src/components/MarkdownSourceEditor.test.tsx`
- `pnpm --filter @markra/app typecheck:test`
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "split"`

## Related Issues
- Refs #263