### PR TITLE
fix(app): prevent stale save prompts after visual saves

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3173,7 +3173,7 @@ function WorkspaceApp() {
                   return;
                 }
 
-                handleMarkdownTabChange(tab.id, content, options);
+                handleMarkdownTabChange(tab.id, content, { ...options, surface: "visual" });
               }}
               onContentWidthChange={handleEditorContentWidthChange}
               onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1870,6 +1870,151 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("ignores stale clean visual editor contents during native close after saving", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorReady = true;
+    let editorMarkdown = "# Guide\n\nSaved";
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValueOnce({
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        editorReady: () => editorReady,
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+    act(() => {
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+    const revisionBeforeSave = result.current.document.revision;
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+    expect(result.current.document.revision).toBeGreaterThan(revisionBeforeSave);
+
+    editorMarkdown = "# Guide\n\nOriginal";
+    editorReady = false;
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(result.current.document).toMatchObject({
+      content: "# Guide\n\nSaved",
+      dirty: false,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+  });
+
+  it("ignores stale clean visual editor changes emitted by an inactive tab after saving", async () => {
+    const confirmDiscardUnsavedChanges = vi.fn(() => true);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === "/mock-files/guide.md") {
+        return {
+          content: "# Guide\n\nOriginal",
+          name: "guide.md",
+          path
+        };
+      }
+
+      return {
+        content: "# Notes\n\nClean",
+        name: "notes.md",
+        path
+      };
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValueOnce({
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+    act(() => {
+      result.current.handleMarkdownChange("# Guide\n\nSaved", { surface: "visual" });
+    });
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "notes.md",
+        path: "/mock-files/notes.md",
+        relativePath: "notes.md"
+      });
+    });
+
+    const guideTab = result.current.tabs.find((tab) => tab.name === "guide.md");
+    expect(guideTab).toBeTruthy();
+
+    act(() => {
+      result.current.handleMarkdownTabChange(guideTab!.id, "# Guide\n\nOriginal", {
+        documentRevision: guideTab!.revision,
+        surface: "visual"
+      });
+    });
+
+    await act(async () => {
+      const canDiscard = await result.current.confirmCanDiscardCurrentDocument();
+      expect(canDiscard).toBe(true);
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(result.current.tabs.find((tab) => tab.id === guideTab!.id)).toMatchObject({
+      content: "# Guide\n\nSaved",
+      dirty: false,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+  });
+
   it("clears a saved file draft after saving the document", async () => {
     const guidePath = "/mock-files/vault/guide.md";
     mockedReadNativeMarkdownFile.mockResolvedValue({

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -520,6 +520,15 @@ export function useMarkdownDocument({
     setTabs((currentTabs) => {
       const nextTabs = currentTabs.map((tab) => {
         if (tab.id !== tabId || !tab.open || tab.content === content) return tab;
+        if (options.documentRevision !== undefined && options.documentRevision !== tab.revision) return tab;
+        if (
+          !tab.dirty &&
+          options.surface === "visual" &&
+          options.documentRevision !== undefined &&
+          !isEquivalentEditorMarkdown(tab.content, content)
+        ) {
+          return tab;
+        }
 
         return {
           ...tab,
@@ -1067,12 +1076,19 @@ export function useMarkdownDocument({
     const sourceContent = options.sourceContent ?? contents;
     const contentChangedAfterSaveStarted =
       targetDocument.content !== sourceContent && targetDocument.content !== contents;
+    const savedDocumentRefreshNeeded =
+      !contentChangedAfterSaveStarted &&
+      (targetDocument.dirty ||
+        targetDocument.content !== contents ||
+        targetDocument.path !== savedFile.path ||
+        targetDocument.name !== savedFile.name);
     const nextDocument = {
       ...targetDocument,
       path: savedFile.path,
       name: savedFile.name,
       content: contentChangedAfterSaveStarted ? targetDocument.content : contents,
-      dirty: contentChangedAfterSaveStarted ? true : false
+      dirty: contentChangedAfterSaveStarted ? true : false,
+      revision: savedDocumentRefreshNeeded ? targetDocument.revision + 1 : targetDocument.revision
     };
 
     const nextTabs = documentTabsEnabled
@@ -1206,12 +1222,19 @@ export function useMarkdownDocument({
 
       if (!savedFile) return null;
 
+      const sourceDocument = documentFromTab(tab);
+      const savedDocumentRefreshNeeded =
+        tab.dirty ||
+        tab.content !== contents ||
+        tab.path !== savedFile.path ||
+        tab.name !== savedFile.name;
       const nextDocument = {
-        ...documentFromTab(tab),
+        ...sourceDocument,
         path: savedFile.path,
         name: savedFile.name,
         content: contents,
-        dirty: false
+        dirty: false,
+        revision: savedDocumentRefreshNeeded ? sourceDocument.revision + 1 : sourceDocument.revision
       };
       const nextTabs = tabsRef.current.map((candidate) =>
         candidate.id === tabId ? createDocumentTab(nextDocument, candidate.id) : candidate


### PR DESCRIPTION
## Summary
- Refresh saved visual-editor documents after a successful save so stale editor contents are not read during close or folder switching.
- Ignore stale clean visual updates from inactive document tabs after a save.
- Add regression coverage for native close and inactive-tab save prompt races.

## Why
Issue #308 reports that Markra can show “saved” while still prompting to discard unsaved changes on close or root-folder switching. The root cause is a save-state race: after a clean save, an old visual editor instance can still expose or emit the pre-save markdown before the refreshed editor is ready.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx` passed: 40 tests.
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "wires native menu file actions to the current document commands"` passed: 1 test, 154 skipped.
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "switches away from a clean file with normalized markdown without asking to discard changes"` passed: 1 test, 154 skipped.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app test` passed: 84 files, 1206 tests.

## Risk
Low. The refresh is limited to successful saves that actually change the document’s clean baseline, path, or name. Clean inactive visual tab updates with matching revision are ignored only when they would make a previously clean tab dirty from visual serialization/stale content.

## Related Issues
Refs #308

