### PR TITLE
fix(app): reset settings scroll on category changes

### DIFF
--- a/packages/app/src/components/SettingsShell.test.tsx
+++ b/packages/app/src/components/SettingsShell.test.tsx
@@ -189,4 +189,22 @@ describe("SettingsShell", () => {
 
     expect(screen.getByRole("heading", { name: "Providers" })).toBeInTheDocument();
   });
+
+  it("resets the content scroll position when switching settings categories", () => {
+    const { container, rerender } = render(
+      <SettingsContent activeCategory="ai" translate={translate}>
+        <div />
+      </SettingsContent>
+    );
+    const settingsScroll = container.querySelector(".settings-scroll") as HTMLElement;
+    settingsScroll.scrollTop = 48;
+
+    rerender(
+      <SettingsContent activeCategory="providers" translate={translate}>
+        <div />
+      </SettingsContent>
+    );
+
+    expect(settingsScroll.scrollTop).toBe(0);
+  });
 });

--- a/packages/app/src/components/SettingsShell.tsx
+++ b/packages/app/src/components/SettingsShell.tsx
@@ -15,7 +15,7 @@ import {
   X,
   type LucideIcon
 } from "lucide-react";
-import type { ReactNode } from "react";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
 import type { SettingsCategory } from "../hooks/useSettingsWindowState";
 import type { DesktopPlatform } from "../lib/platform";
 import type { I18nKey } from "@markra/shared";
@@ -193,9 +193,17 @@ export function SettingsContent({
   platform?: DesktopPlatform;
   translate: Translate;
 }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
   const contentSurfaceClassName = platform === "windows"
     ? "border-t border-l border-(--border-default) rounded-tl-md"
     : "";
+
+  useLayoutEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    scrollElement.scrollTop = 0;
+  }, [activeCategory]);
 
   return (
     <section className={`settings-content flex min-h-0 min-w-0 flex-col bg-(--bg-primary) ${contentSurfaceClassName}`}>
@@ -219,6 +227,7 @@ export function SettingsContent({
       </header>
 
       <div
+        ref={scrollRef}
         className={
           activeCategory === "providers"
             ? "settings-scroll min-h-0 flex-1 overflow-hidden overscroll-none p-0"


### PR DESCRIPTION
## Summary
- Reset the shared settings content scroll container whenever the active settings category changes.
- Add regression coverage for switching from a scrolled AI settings panel into Providers.

## Why
- The Providers panel uses the same outer settings scroll container as other tabs but switches it to `overflow-hidden`.
- If a previous tab leaves a non-zero scroll offset, WebView can render the Providers panel clipped upward, matching #313.

## Validation
- `pnpm --filter @markra/app test -- SettingsShell.test.tsx` passed: 84 files, 1207 tests.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low: only resets scroll position on settings category changes.

Closes #313