### PR TITLE
fix(markdown): preserve numbered outline headings

### DIFF
--- a/packages/markdown/src/markdown.test.ts
+++ b/packages/markdown/src/markdown.test.ts
@@ -34,6 +34,20 @@ describe("markdown helpers", () => {
     ]);
   });
 
+  it("preserves numeric prefixes in readable heading titles", () => {
+    expect(
+      getMarkdownOutline(
+        [
+          "## 1. **Synthetic** heading",
+          "### 2) Follow-up heading"
+        ].join("\n\n")
+      )
+    ).toEqual([
+      { level: 2, title: "1. Synthetic heading", titleMarkdown: "1. **Synthetic** heading" },
+      { level: 3, title: "2) Follow-up heading" }
+    ]);
+  });
+
   it("extracts readable titles from Markra highlight and math headings", () => {
     expect(getMarkdownOutline("# ==Marked== formula $x^2$")).toEqual([
       { level: 1, title: "Marked formula x^2", titleMarkdown: "==Marked== formula $x^2$" }

--- a/packages/markdown/src/markdown.ts
+++ b/packages/markdown/src/markdown.ts
@@ -77,7 +77,7 @@ export function markraHighlightRemarkPlugin() {
 }
 
 function readableMarkdownHeadingTitle(title: string) {
-  return toString(inlineMarkdownParser.runSync(inlineMarkdownParser.parse(title))).trim();
+  return toString(inlineMarkdownParser.runSync(inlineMarkdownParser.parse(`# ${title}`))).trim();
 }
 
 export function getMarkdownOutline(text: string): MarkdownOutlineItem[] {


### PR DESCRIPTION
## Summary
- Parse outline heading titles in a heading context so ordered-list-style numeric prefixes remain part of the title text.
- Add regression coverage for `1.` and `2)` prefixed headings.

## Why
- Fixes outline display and navigation mismatch for headings like `## 1. ...`, because the generated outline title now matches the editor heading text.

## Validation
- `pnpm --filter @markra/markdown exec vitest run src/markdown.test.ts --environment jsdom --globals` passed, 6 tests.
- `pnpm --filter @markra/markdown test` passed, 8 tests.
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "scrolls to a formatted outline heading using its readable title" --environment jsdom --globals` passed.
- `pnpm --filter @markra/markdown build` passed.
- `pnpm --filter @markra/markdown typecheck:test` passed.

## Risk
- Low. The change is scoped to readable outline title parsing and covered by focused regression tests.

Closes #315