### PR TITLE
feat(editor): add paragraph option to heading controls

### DIFF
--- a/packages/app/src/components/AiSelectionToolbar.test.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.test.tsx
@@ -140,6 +140,31 @@ describe("AiSelectionToolbar", () => {
     expect(onSetHeadingLevel).toHaveBeenCalledWith(3);
   });
 
+  it("routes paragraph choices from the heading level menu", () => {
+    const onRunFormattingAction = vi.fn();
+
+    render(
+      <AiSelectionToolbar
+        activeHeadingLevel={2}
+        anchor={anchor}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={onRunFormattingAction}
+        onRunAction={vi.fn()}
+        onSetHeadingLevel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Heading Level H2" }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Paragraph" }));
+
+    expect(onRunFormattingAction).toHaveBeenCalledWith("paragraph");
+    expect(screen.queryByRole("menu", { name: "Heading Level" })).not.toBeInTheDocument();
+  });
+
   it("renders the heading level menu outside the scrollable toolbar shell", () => {
     render(
       <AiSelectionToolbar

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -21,6 +21,7 @@ import {
   List,
   ListOrdered,
   PenLine,
+  Pilcrow,
   Plus,
   Quote,
   Sparkles,
@@ -61,7 +62,16 @@ type HeadingLevelOption = {
   icon: LucideIcon;
   label: string;
   level: SelectionHeadingLevel;
+  type: "heading";
 };
+
+type ParagraphLevelOption = {
+  icon: LucideIcon;
+  labelKey: I18nKey;
+  type: "paragraph";
+};
+
+type HeadingMenuOption = HeadingLevelOption | ParagraphLevelOption;
 
 type AiSelectionToolbarProps = {
   anchor: SelectionAnchor | null;
@@ -165,8 +175,17 @@ const headingLevelIcons: Record<SelectionHeadingLevel, LucideIcon> = {
 const headingLevelOptions: HeadingLevelOption[] = selectionHeadingLevels.map((level) => ({
   icon: headingLevelIcons[level],
   label: `H${level}`,
-  level
+  level,
+  type: "heading"
 }));
+const headingMenuOptions: HeadingMenuOption[] = [
+  {
+    icon: Pilcrow,
+    labelKey: "menu.paragraph",
+    type: "paragraph"
+  },
+  ...headingLevelOptions
+];
 
 export function AiSelectionToolbar({
   anchor,
@@ -193,7 +212,7 @@ export function AiSelectionToolbar({
     setHeadingLevelMenuStyle(
       anchoredPopoverStyle(button, headingLevelMenuRef.current, {
         fallbackSize: {
-          height: 76,
+          height: 112,
           width: 112
         },
         gap: 4
@@ -281,9 +300,10 @@ export function AiSelectionToolbar({
             role="menu"
             aria-label={label("menu.headingLevel")}
           >
-            {headingLevelOptions.map((option) => {
+            {headingMenuOptions.map((option) => {
               const HeadingLevelIcon = option.icon;
-              const selected = option.level === activeHeadingLevel;
+              const optionLabel = option.type === "paragraph" ? label(option.labelKey) : option.label;
+              const selected = option.type === "heading" && option.level === activeHeadingLevel;
 
               return (
                 <button
@@ -292,14 +312,19 @@ export function AiSelectionToolbar({
                       ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
                       : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
                   }`}
-                  key={option.level}
+                  key={option.type === "paragraph" ? "paragraph" : option.level}
                   type="button"
                   role="menuitemradio"
-                  aria-label={option.label}
+                  aria-label={optionLabel}
                   aria-checked={selected}
-                  title={option.label}
+                  title={optionLabel}
                   onClick={() => {
                     setHeadingLevelMenuOpen(false);
+                    if (option.type === "paragraph") {
+                      onRunFormattingAction("paragraph");
+                      return;
+                    }
+
                     onSetHeadingLevel(option.level);
                   }}
                 >

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6838,6 +6838,7 @@ describe("MarkdownPaper editing", () => {
 
     expect(screen.getByRole("listbox", { name: "Heading level" })).toBeInTheDocument();
     expect(screen.getAllByRole("option").map((option) => option.textContent)).toEqual([
+      "Paragraph",
       "H1",
       "H2",
       "H3",
@@ -6853,6 +6854,22 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("### Title");
     expect(screen.queryByRole("listbox", { name: "Heading level" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Heading level H3" })).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("converts a heading to paragraph from the heading level list", async () => {
+    const { container, editor, view } = await renderEditor("## Title");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    focusEditor(view);
+    moveCursor(view, findTextPosition(view, "Title"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Heading level H2" }));
+    fireEvent.click(screen.getByRole("option", { name: "Paragraph" }));
+
+    expect(container.querySelector(".ProseMirror p")).toHaveTextContent("Title");
+    expect(container.querySelector(".ProseMirror h2")).not.toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc).trim()).toBe("Title");
+    expect(screen.queryByRole("listbox", { name: "Heading level" })).not.toBeInTheDocument();
   });
 
   it("keeps inline heading formatting rendered while editing the heading", async () => {

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -201,6 +201,9 @@ function MilkdownEditorSurface({
     collapseSection: t(language, "editor.collapseSection"),
     expandSection: t(language, "editor.expandSection")
   };
+  const headingLevelLabels = {
+    paragraph: t(language, "menu.paragraph")
+  };
   const listToggleLabels = {
     collapseListItem: t(language, "editor.collapseListItem"),
     expandListItem: t(language, "editor.expandListItem")
@@ -360,7 +363,7 @@ function MilkdownEditorSurface({
         .use(markraTableControlsPlugin(tableControlLabels))
         .use(markraTrailingParagraphPlugin)
         .use(markraLinkImageLivePlugin(resolveCurrentImageSrc))
-        .use(markraHeadingLevelPlugin)
+        .use(markraHeadingLevelPlugin(headingLevelLabels))
         .use(
           markraRawHtmlPlugin({
             htmlSourceApplyLabel: t(language, "editor.htmlSourceApply"),

--- a/packages/app/src/lib/selection-formatting.ts
+++ b/packages/app/src/lib/selection-formatting.ts
@@ -21,6 +21,7 @@ export const selectionFormattingToolbarActions = [
   "inlineCode",
   "highlight",
   "clearFormatting",
+  "paragraph",
   "heading1",
   "quote",
   "bulletList",

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1547,6 +1547,11 @@
     line-height: 1;
   }
 
+  .markdown-paper .markra-heading-level-list [data-heading-level="paragraph"] {
+    grid-column: 1 / -1;
+    padding-inline: 0.5rem;
+  }
+
   .markdown-paper .markra-heading-level-list [role="option"]:hover,
   .markdown-paper .markra-heading-level-list [role="option"]:focus-visible {
     background: var(--editor-bg-secondary);

--- a/packages/editor/src/heading-level.test.ts
+++ b/packages/editor/src/heading-level.test.ts
@@ -1,0 +1,121 @@
+import { Schema, type Node as ProseNode, type NodeType } from "@milkdown/kit/prose/model";
+import { EditorState, TextSelection } from "@milkdown/kit/prose/state";
+import { EditorView } from "@milkdown/kit/prose/view";
+import { createHeadingLevelPlugin } from "./heading-level";
+
+const emptyRect = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  toJSON: () => ({}),
+  top: 0,
+  width: 0,
+  x: 0,
+  y: 0
+} as DOMRect;
+const originalElementGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+const originalElementGetClientRects = Element.prototype.getClientRects;
+const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
+const originalRangeGetClientRects = Range.prototype.getClientRects;
+const textPrototype = Text.prototype as Text & {
+  getBoundingClientRect?: () => DOMRect;
+  getClientRects?: () => DOMRectList;
+};
+const originalTextGetBoundingClientRect = textPrototype.getBoundingClientRect;
+const originalTextGetClientRects = textPrototype.getClientRects;
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    heading: {
+      attrs: { level: { default: 1 } },
+      content: "inline*",
+      group: "block",
+      toDOM: (node: ProseNode) => [`h${node.attrs.level}`, 0]
+    },
+    paragraph: {
+      content: "inline*",
+      group: "block",
+      toDOM: () => ["p", 0]
+    },
+    text: { group: "inline" }
+  }
+});
+
+function createDoc() {
+  return schema.node("doc", null, [
+    schema.node("heading", { level: 2 }, [schema.text("Synthetic heading")]),
+    schema.node("paragraph", null, [schema.text("Synthetic body")])
+  ]);
+}
+
+function click(element: Element) {
+  element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+describe("heading level plugin", () => {
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = () => emptyRect;
+    Element.prototype.getClientRects = () => [emptyRect] as unknown as DOMRectList;
+    Range.prototype.getBoundingClientRect = () => emptyRect;
+    Range.prototype.getClientRects = () => [emptyRect] as unknown as DOMRectList;
+    Object.assign(Text.prototype, {
+      getBoundingClientRect: () => emptyRect,
+      getClientRects: () => [emptyRect] as unknown as DOMRectList
+    });
+  });
+
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = originalElementGetBoundingClientRect;
+    Element.prototype.getClientRects = originalElementGetClientRects;
+    Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
+    Range.prototype.getClientRects = originalRangeGetClientRects;
+
+    if (originalTextGetBoundingClientRect) {
+      textPrototype.getBoundingClientRect = originalTextGetBoundingClientRect;
+    } else {
+      delete textPrototype.getBoundingClientRect;
+    }
+
+    if (originalTextGetClientRects) {
+      textPrototype.getClientRects = originalTextGetClientRects;
+    } else {
+      delete textPrototype.getClientRects;
+    }
+  });
+
+  it("converts the active heading to a paragraph from the level menu", () => {
+    const heading = schema.nodes.heading as NodeType;
+    const paragraph = schema.nodes.paragraph as NodeType;
+    const doc = createDoc();
+    const host = document.createElement("div");
+    const view = new EditorView(host, {
+      state: EditorState.create({
+        doc,
+        selection: TextSelection.create(doc, 2),
+        plugins: [createHeadingLevelPlugin(heading, paragraph)]
+      })
+    });
+
+    document.body.append(host);
+    view.dom.dispatchEvent(new Event("focus"));
+
+    const menuButton = host.querySelector(".markra-heading-level-button");
+    expect(menuButton).toBeInstanceOf(HTMLButtonElement);
+    click(menuButton as HTMLButtonElement);
+
+    const paragraphOption = host.querySelector('[data-heading-level="paragraph"]');
+    expect(paragraphOption).toBeInstanceOf(HTMLButtonElement);
+    expect(paragraphOption?.textContent).toBe("Paragraph");
+    click(paragraphOption as HTMLButtonElement);
+
+    expect(view.state.doc.child(0).type).toBe(paragraph);
+    expect(view.state.doc.child(0).textContent).toBe("Synthetic heading");
+    expect(view.state.selection.$head.parent.type).toBe(paragraph);
+
+    view.destroy();
+    host.remove();
+  });
+});

--- a/packages/editor/src/heading-level.ts
+++ b/packages/editor/src/heading-level.ts
@@ -1,4 +1,4 @@
-import { headingSchema } from "@milkdown/kit/preset/commonmark";
+import { headingSchema, paragraphSchema } from "@milkdown/kit/preset/commonmark";
 import type { Node as ProseNode, NodeType } from "@milkdown/kit/prose/model";
 import { Plugin, PluginKey, TextSelection, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
 import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
@@ -31,12 +31,31 @@ type ActiveHeading = {
   to: number;
 };
 
+export type HeadingLevelLabels = {
+  changeHeadingLevel: string;
+  headingLevel: string;
+  paragraph: string;
+};
+
 const headingLevels = [1, 2, 3, 4, 5, 6] as const;
 const headingLevelKey = new PluginKey<HeadingLevelState>("markra-heading-level");
 const emptyHeadingLevelState: HeadingLevelState = {
   focused: false,
   openFrom: null
 };
+const defaultHeadingLevelLabels: HeadingLevelLabels = {
+  changeHeadingLevel: "Change heading level",
+  headingLevel: "Heading level",
+  paragraph: "Paragraph"
+};
+
+function normalizeHeadingLevelLabels(labels: Partial<HeadingLevelLabels> = {}): HeadingLevelLabels {
+  return {
+    changeHeadingLevel: labels.changeHeadingLevel?.trim() || defaultHeadingLevelLabels.changeHeadingLevel,
+    headingLevel: labels.headingLevel?.trim() || defaultHeadingLevelLabels.headingLevel,
+    paragraph: labels.paragraph?.trim() || defaultHeadingLevelLabels.paragraph
+  };
+}
 
 function headingLevel(node: ProseNode) {
   const level = Number(node.attrs.level ?? 1);
@@ -125,6 +144,22 @@ function changeHeadingLevel(view: EditorView, heading: NodeType, headingFrom: nu
   return true;
 }
 
+function changeHeadingToParagraph(view: EditorView, heading: NodeType, paragraph: NodeType, headingFrom: number) {
+  const node = view.state.doc.nodeAt(headingFrom);
+  if (!node || node.type !== heading || !paragraph.validContent(node.content)) return false;
+
+  view.dispatch(
+    view.state.tr
+      .setMeta(headingLevelKey, {
+        type: "close"
+      } satisfies HeadingLevelMeta)
+      .setNodeMarkup(headingFrom, paragraph)
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
 function createHeadingLevelOption(
   view: EditorView,
   heading: NodeType,
@@ -159,12 +194,48 @@ function createHeadingLevelOption(
   return option;
 }
 
+function createParagraphLevelOption(
+  view: EditorView,
+  heading: NodeType,
+  paragraph: NodeType,
+  getHeadingFrom: () => number,
+  labels: HeadingLevelLabels
+) {
+  const option = view.dom.ownerDocument.createElement("button");
+
+  option.type = "button";
+  option.className = "markra-heading-level-option";
+  option.contentEditable = "false";
+  option.draggable = false;
+  option.dataset.headingLevel = "paragraph";
+  option.setAttribute("role", "option");
+  option.setAttribute("aria-label", labels.paragraph);
+  option.setAttribute("aria-selected", "false");
+  option.title = labels.paragraph;
+  option.textContent = labels.paragraph;
+
+  option.addEventListener("mousedown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  option.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    changeHeadingToParagraph(view, heading, paragraph, getHeadingFrom());
+  });
+
+  return option;
+}
+
 function createHeadingLevelControl(
   view: EditorView,
   heading: NodeType,
+  paragraph: NodeType,
   getHeadingFrom: () => number,
   level: number,
-  menuOpen: boolean
+  menuOpen: boolean,
+  labels: HeadingLevelLabels
 ) {
   const ownerDocument = view.dom.ownerDocument;
   const control = ownerDocument.createElement("span");
@@ -179,10 +250,10 @@ function createHeadingLevelControl(
   button.contentEditable = "false";
   button.draggable = false;
   button.dataset.headingLevel = label;
-  button.setAttribute("aria-label", `Heading level ${label}`);
+  button.setAttribute("aria-label", `${labels.headingLevel} ${label}`);
   button.setAttribute("aria-expanded", String(menuOpen));
   button.setAttribute("aria-haspopup", "listbox");
-  button.title = "Change heading level";
+  button.title = labels.changeHeadingLevel;
 
   button.addEventListener("mousedown", (event) => {
     event.preventDefault();
@@ -202,7 +273,9 @@ function createHeadingLevelControl(
   list.className = "markra-heading-level-list";
   list.contentEditable = "false";
   list.setAttribute("role", "listbox");
-  list.setAttribute("aria-label", "Heading level");
+  list.setAttribute("aria-label", labels.headingLevel);
+
+  list.append(createParagraphLevelOption(view, heading, paragraph, getHeadingFrom, labels));
 
   for (const optionLevel of headingLevels) {
     list.append(createHeadingLevelOption(view, heading, getHeadingFrom, level, optionLevel));
@@ -261,21 +334,34 @@ function applyHeadingLevelState(transaction: Transaction, state: HeadingLevelSta
   } satisfies HeadingLevelState;
 }
 
-function createHeadingLevelWidget(activeHeading: ActiveHeading, heading: NodeType, menuOpen: boolean) {
+function createHeadingLevelWidget(
+  activeHeading: ActiveHeading,
+  heading: NodeType,
+  paragraph: NodeType,
+  menuOpen: boolean,
+  labels: HeadingLevelLabels
+) {
   return (view: EditorView, getPos: () => number | undefined) =>
     createHeadingLevelControl(
       view,
       heading,
+      paragraph,
       () => {
         const position = getPos();
         return typeof position === "number" ? Math.max(0, position - 1) : activeHeading.from;
       },
       activeHeading.level,
-      menuOpen
+      menuOpen,
+      labels
     );
 }
 
-function buildHeadingEditingDecorations(state: EditorState, heading: NodeType) {
+function buildHeadingEditingDecorations(
+  state: EditorState,
+  heading: NodeType,
+  paragraph: NodeType,
+  labels: HeadingLevelLabels
+) {
   const { focused, openFrom } = headingLevelKey.getState(state) ?? emptyHeadingLevelState;
   if (!focused) return null;
 
@@ -290,7 +376,7 @@ function buildHeadingEditingDecorations(state: EditorState, heading: NodeType) {
       class: "markra-heading-editing",
       "data-heading-level": headingLevelLabel(activeHeading.level)
     }),
-    Decoration.widget(activeHeading.from + 1, createHeadingLevelWidget(activeHeading, heading, menuOpen), {
+    Decoration.widget(activeHeading.from + 1, createHeadingLevelWidget(activeHeading, heading, paragraph, menuOpen, labels), {
       ignoreSelection: true,
       key: `markra-heading-level-${activeHeading.from}-${activeHeading.level}-${menuOpen ? "open" : "closed"}`,
       side: -1
@@ -298,8 +384,12 @@ function buildHeadingEditingDecorations(state: EditorState, heading: NodeType) {
   ]);
 }
 
-export const markraHeadingLevelPlugin = $prose((ctx) => {
-  const heading = headingSchema.type(ctx);
+export function createHeadingLevelPlugin(
+  heading: NodeType,
+  paragraph: NodeType,
+  labels: Partial<HeadingLevelLabels> = {}
+) {
+  const resolvedLabels = normalizeHeadingLevelLabels(labels);
 
   return new Plugin({
     key: headingLevelKey,
@@ -339,7 +429,7 @@ export const markraHeadingLevelPlugin = $prose((ctx) => {
     },
     appendTransaction: (_transactions, _oldState, newState) => closeInactiveHeadingLevelMenu(newState, heading),
     props: {
-      decorations: (state) => buildHeadingEditingDecorations(state, heading),
+      decorations: (state) => buildHeadingEditingDecorations(state, heading, paragraph, resolvedLabels),
       handleKeyDown: (view, event) => {
         const { openFrom } = headingLevelKey.getState(view.state) ?? emptyHeadingLevelState;
         if (openFrom === null || event.key !== "Escape") return false;
@@ -350,4 +440,13 @@ export const markraHeadingLevelPlugin = $prose((ctx) => {
       }
     }
   });
-});
+}
+
+export function markraHeadingLevelPlugin(labels?: Partial<HeadingLevelLabels>) {
+  return $prose((ctx) => {
+    const heading = headingSchema.type(ctx);
+    const paragraph = paragraphSchema.type(ctx);
+
+    return createHeadingLevelPlugin(heading, paragraph, labels);
+  });
+}


### PR DESCRIPTION
## Summary
- Add a localized Paragraph/段落 option to the active heading level menu so headings can be converted back to body text.
- Add the same paragraph option to the selection toolbar heading menu using the Pilcrow icon and existing paragraph formatting command.
- Cover the new heading-to-paragraph behavior with editor, toolbar, and MarkdownPaper tests.

## Why
- Closes #284 by making the heading-to-body-text workflow discoverable from the heading controls.

## Validation
- `pnpm --filter @markra/app test` passed on rerun. An earlier heavily parallel validation run timed out once while waiting for the editor to initialize in `selection-formatting.test.tsx`; the standalone rerun passed.
- `pnpm --filter @markra/editor test` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/editor typecheck:test` passed.

## Risk
- Low. The behavior is scoped to heading level controls and the selection toolbar format menu.
- App tests still print existing jsdom `Window.scrollBy()` not implemented warnings, but the final run exited successfully.

## Related Issues
- Closes #284