### PR TITLE
fix(desktop): isolate editor window state

### DIFF
--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -36,6 +36,8 @@ pub(crate) struct NativeMenuCommand {
     pub(crate) command: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) recent_file: Option<NativeRecentFile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) target_window_label: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -253,13 +255,29 @@ pub(crate) fn remember_native_menu_window_from_event<R: tauri::Runtime>(
     }
 }
 
+fn focused_native_menu_window_label<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Option<String> {
+    app.webview_windows()
+        .into_iter()
+        .find(|(_, window)| window.is_focused().unwrap_or(false))
+        .map(|(label, _)| label)
+}
+
 pub(crate) fn emit_native_menu_command_payload<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
-    payload: NativeMenuCommand,
+    mut payload: NativeMenuCommand,
 ) {
-    let target_label = app.state::<NativeMenuTargetState>().label();
+    let target_label = focused_native_menu_window_label(app)
+        .or_else(|| app.state::<NativeMenuTargetState>().label());
 
-    if let Some(window) = target_label.and_then(|label| app.get_webview_window(&label)) {
+    if let Some(label) = target_label {
+        payload.target_window_label = Some(label.clone());
+        let Some(window) = app.get_webview_window(&label) else {
+            let _ = app.emit(NATIVE_MENU_COMMAND_EVENT, payload);
+            return;
+        };
+
         let _ = window.emit(NATIVE_MENU_COMMAND_EVENT, payload);
         return;
     }
@@ -598,6 +616,7 @@ pub(crate) fn native_menu_command_from_id<R: tauri::Runtime>(
             .map(|recent_file| NativeMenuCommand {
                 command: OPEN_RECENT_FILE_COMMAND.to_string(),
                 recent_file: Some(recent_file),
+                target_window_label: None,
             });
     }
 
@@ -605,6 +624,7 @@ pub(crate) fn native_menu_command_from_id<R: tauri::Runtime>(
         return Some(NativeMenuCommand {
             command: command.to_string(),
             recent_file: None,
+            target_window_label: None,
         });
     }
 
@@ -1146,6 +1166,25 @@ mod tests {
         state.remember("markra-editor-1");
 
         assert_eq!(state.label().as_deref(), Some("markra-editor-1"));
+    }
+
+    #[test]
+    fn native_menu_command_payload_serializes_target_window_label() {
+        let payload = NativeMenuCommand {
+            command: "toggleSourceMode".to_string(),
+            recent_file: None,
+            target_window_label: Some("markra-editor-1".to_string()),
+        };
+
+        let value = serde_json::to_value(payload).expect("payload should serialize");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "command": "toggleSourceMode",
+                "targetWindowLabel": "markra-editor-1"
+            })
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -8,15 +9,15 @@ const MARKDOWN_FILE_CHANGED_EVENT: &str = "markra://file-changed";
 const MARKDOWN_TREE_CHANGED_EVENT: &str = "markra://tree-changed";
 
 struct ActiveMarkdownWatcher {
-    path: PathBuf,
+    subscriber_count: usize,
     _watcher: RecommendedWatcher,
 }
 
 #[derive(Default)]
-pub(crate) struct MarkdownFileWatcherState(Mutex<Option<ActiveMarkdownWatcher>>);
+pub(crate) struct MarkdownFileWatcherState(Mutex<HashMap<PathBuf, ActiveMarkdownWatcher>>);
 
 #[derive(Default)]
-pub(crate) struct MarkdownTreeWatcherState(Mutex<Option<ActiveMarkdownWatcher>>);
+pub(crate) struct MarkdownTreeWatcherState(Mutex<HashMap<PathBuf, ActiveMarkdownWatcher>>);
 
 #[derive(Clone, serde::Serialize)]
 struct MarkdownFileChanged {
@@ -97,6 +98,78 @@ fn markdown_tree_event_path<'a>(event: &'a Event, root: &Path) -> Option<&'a Pat
     })
 }
 
+fn remove_path_entry<T>(entries: &mut HashMap<PathBuf, T>, path: &Path) -> Option<T> {
+    entries.remove(path)
+}
+
+fn release_active_watcher_subscription(subscriber_count: &mut usize) -> bool {
+    if *subscriber_count > 1 {
+        *subscriber_count -= 1;
+        return false;
+    }
+
+    true
+}
+
+fn has_active_watcher_subscription(
+    watcher_state: &Mutex<HashMap<PathBuf, ActiveMarkdownWatcher>>,
+    path: &Path,
+) -> Result<bool, String> {
+    let mut active_watchers = watcher_state
+        .lock()
+        .map_err(|_| "markdown watcher state lock is poisoned".to_string())?;
+
+    if let Some(watcher) = active_watchers.get_mut(path) {
+        watcher.subscriber_count += 1;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn remember_active_watcher(
+    watcher_state: &Mutex<HashMap<PathBuf, ActiveMarkdownWatcher>>,
+    path: PathBuf,
+    watcher: RecommendedWatcher,
+) -> Result<(), String> {
+    let mut active_watchers = watcher_state
+        .lock()
+        .map_err(|_| "markdown watcher state lock is poisoned".to_string())?;
+
+    if let Some(existing_watcher) = active_watchers.get_mut(&path) {
+        existing_watcher.subscriber_count += 1;
+        return Ok(());
+    }
+
+    active_watchers.insert(
+        path.clone(),
+        ActiveMarkdownWatcher {
+            subscriber_count: 1,
+            _watcher: watcher,
+        },
+    );
+
+    Ok(())
+}
+
+fn release_active_watcher(
+    watcher_state: &Mutex<HashMap<PathBuf, ActiveMarkdownWatcher>>,
+    path: &Path,
+) -> Result<(), String> {
+    let mut active_watchers = watcher_state
+        .lock()
+        .map_err(|_| "markdown watcher state lock is poisoned".to_string())?;
+
+    if let Some(watcher) = active_watchers.get_mut(path) {
+        if !release_active_watcher_subscription(&mut watcher.subscriber_count) {
+            return Ok(());
+        }
+    }
+
+    remove_path_entry(&mut active_watchers, path);
+    Ok(())
+}
+
 #[tauri::command]
 pub(crate) fn watch_markdown_file(
     app: tauri::AppHandle,
@@ -104,6 +177,10 @@ pub(crate) fn watch_markdown_file(
     path: String,
 ) -> Result<(), String> {
     let watched_path = PathBuf::from(&path);
+    if has_active_watcher_subscription(&watcher_state.0, &watched_path)? {
+        return Ok(());
+    }
+
     let watch_root = watched_path
         .parent()
         .map(Path::to_path_buf)
@@ -144,16 +221,7 @@ pub(crate) fn watch_markdown_file(
         .watch(&watch_root, RecursiveMode::Recursive)
         .map_err(|error| error.to_string())?;
 
-    let mut active_watcher = watcher_state
-        .0
-        .lock()
-        .map_err(|_| "markdown file watcher state lock is poisoned".to_string())?;
-    *active_watcher = Some(ActiveMarkdownWatcher {
-        path: watched_path,
-        _watcher: watcher,
-    });
-
-    Ok(())
+    remember_active_watcher(&watcher_state.0, watched_path, watcher)
 }
 
 #[tauri::command]
@@ -162,19 +230,7 @@ pub(crate) fn unwatch_markdown_file(
     path: String,
 ) -> Result<(), String> {
     let watched_path = PathBuf::from(path);
-    let mut active_watcher = watcher_state
-        .0
-        .lock()
-        .map_err(|_| "markdown file watcher state lock is poisoned".to_string())?;
-
-    if active_watcher
-        .as_ref()
-        .is_some_and(|watcher| watcher.path == watched_path)
-    {
-        *active_watcher = None;
-    }
-
-    Ok(())
+    release_active_watcher(&watcher_state.0, &watched_path)
 }
 
 #[tauri::command]
@@ -184,6 +240,10 @@ pub(crate) fn watch_markdown_tree(
     root_path: String,
 ) -> Result<(), String> {
     let source_path = PathBuf::from(&root_path);
+    if has_active_watcher_subscription(&watcher_state.0, &source_path)? {
+        return Ok(());
+    }
+
     let watch_root = if source_path.is_dir() {
         source_path.clone()
     } else {
@@ -216,16 +276,7 @@ pub(crate) fn watch_markdown_tree(
         .watch(&watch_root, RecursiveMode::Recursive)
         .map_err(|error| error.to_string())?;
 
-    let mut active_watcher = watcher_state
-        .0
-        .lock()
-        .map_err(|_| "markdown tree watcher state lock is poisoned".to_string())?;
-    *active_watcher = Some(ActiveMarkdownWatcher {
-        path: source_path,
-        _watcher: watcher,
-    });
-
-    Ok(())
+    remember_active_watcher(&watcher_state.0, source_path, watcher)
 }
 
 #[tauri::command]
@@ -234,25 +285,14 @@ pub(crate) fn unwatch_markdown_tree(
     root_path: String,
 ) -> Result<(), String> {
     let watched_path = PathBuf::from(root_path);
-    let mut active_watcher = watcher_state
-        .0
-        .lock()
-        .map_err(|_| "markdown tree watcher state lock is poisoned".to_string())?;
-
-    if active_watcher
-        .as_ref()
-        .is_some_and(|watcher| watcher.path == watched_path)
-    {
-        *active_watcher = None;
-    }
-
-    Ok(())
+    release_active_watcher(&watcher_state.0, &watched_path)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use notify::event::{CreateKind, DataChange, ModifyKind};
+    use std::collections::HashMap;
 
     #[test]
     fn matches_target_file_modifications_in_the_watched_directory() {
@@ -297,5 +337,27 @@ mod tests {
             .add_path(PathBuf::from("/mock-files/node_modules/pkg/readme.md"));
 
         assert!(markdown_tree_event_path(&event, &root).is_none());
+    }
+
+    #[test]
+    fn removing_an_active_watcher_keeps_other_paths() {
+        let mut entries = HashMap::from([
+            (PathBuf::from("/mock-files/first.md"), "first"),
+            (PathBuf::from("/mock-files/second.md"), "second"),
+        ]);
+
+        remove_path_entry(&mut entries, Path::new("/mock-files/first.md"));
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries.contains_key(Path::new("/mock-files/second.md")));
+    }
+
+    #[test]
+    fn shared_active_watchers_release_only_after_last_subscription() {
+        let mut subscriber_count = 2;
+
+        assert!(!release_active_watcher_subscription(&mut subscriber_count));
+        assert_eq!(subscriber_count, 1);
+        assert!(release_active_watcher_subscription(&mut subscriber_count));
     }
 }

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1,5 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::menu::remember_native_menu_webview_window;
+
 #[cfg(target_os = "macos")]
 use std::{ops::Deref, time::Duration};
 
@@ -313,6 +315,7 @@ where
 
         match builder.build() {
             Ok(window) => {
+                remember_native_menu_webview_window(&window);
                 hide_native_macos_window_controls(&window);
                 hide_native_menu_for_settings_window(&window);
             }
@@ -740,6 +743,24 @@ mod tests {
         assert!(is_blank_editor_window_label(&first));
         assert!(is_blank_editor_window_label(&second));
         assert!(!is_blank_editor_window_label("main"));
+    }
+
+    #[test]
+    fn secondary_editor_windows_become_native_menu_targets_when_created() {
+        let source = include_str!("windows.rs");
+        let start = source
+            .find("pub(crate) fn spawn_editor_window")
+            .expect("spawn_editor_window should exist");
+        let end = source[start..]
+            .find("fn editor_window_transparent")
+            .map(|offset| start + offset)
+            .expect("spawn_editor_window should end before editor_window_transparent");
+        let spawn_editor_window_source = &source[start..end];
+
+        assert!(
+            spawn_editor_window_source.contains("remember_native_menu_webview_window(&window);"),
+            "secondary editor windows should become native menu targets as soon as they are created"
+        );
     }
 
     #[test]

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -124,6 +124,7 @@ export const desktopRuntime = {
   window: {
     closeWindow: windowRuntime.closeNativeWindow,
     exitApp: windowRuntime.exitNativeApp,
+    getCurrentWindowLabel: windowRuntime.getCurrentNativeWindowLabel,
     listEditorWindowRestoreStates: windowRuntime.listNativeEditorWindowRestoreStates,
     listenAppExitRequested: windowRuntime.listenNativeAppExitRequested,
     listenSettingsWindowTarget: windowRuntime.listenNativeSettingsWindowTarget,

--- a/apps/desktop/src/runtime/tauri/menu.test.ts
+++ b/apps/desktop/src/runtime/tauri/menu.test.ts
@@ -122,6 +122,7 @@ describe("native menu", () => {
     mockedInvoke.mockResolvedValue(undefined);
     mockedListen.mockResolvedValue(unlisten);
     mockedGetCurrentWindow.mockReturnValue({
+      label: "main",
       isFocused
     } as unknown as ReturnType<typeof getCurrentWindow>);
     isFocused.mockResolvedValue(true);
@@ -211,6 +212,24 @@ describe("native menu", () => {
     await listener?.({ payload: { command: "saveDocument" } } as Parameters<NonNullable<typeof listener>>[0]);
 
     expect(handlers.saveDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores targeted native application menu commands for another window", async () => {
+    const handlers: NativeMenuHandlers = {
+      toggleSourceMode: vi.fn()
+    };
+
+    await listenNativeApplicationMenuCommands(handlers);
+    const listener = mockedListen.mock.calls[0]?.[1];
+
+    await listener?.({
+      payload: {
+        command: "toggleSourceMode",
+        targetWindowLabel: "markra-editor-1"
+      }
+    } as unknown as Parameters<NonNullable<typeof listener>>[0]);
+
+    expect(handlers.toggleSourceMode).not.toHaveBeenCalled();
   });
 
   it("shows a self-drawn context menu only inside the markdown paper", async () => {

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -1,5 +1,6 @@
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   createEditorContextMenuEntries,
   createEditorContextMenuEntriesFromOptions,
@@ -101,9 +102,27 @@ export type NativeMenuCommand =
 type NativeMenuCommandPayload = {
   command: NativeMenuCommand;
   recentFile?: RecentMarkdownFile;
+  targetWindowLabel?: string;
 };
 
+function currentNativeWindowLabel() {
+  try {
+    return getCurrentWindow().label;
+  } catch {
+    return null;
+  }
+}
+
+function shouldRunNativeMenuAction(payload: NativeMenuCommandPayload) {
+  const targetWindowLabel = payload.targetWindowLabel?.trim();
+  if (!targetWindowLabel) return true;
+
+  return currentNativeWindowLabel() === targetWindowLabel;
+}
+
 function runNativeMenuAction(payload: NativeMenuCommandPayload, handlers: NativeMenuHandlers) {
+  if (!shouldRunNativeMenuAction(payload)) return;
+
   if (payload.command === "openRecentFile") {
     if (!payload.recentFile) return;
 

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -5,6 +5,7 @@ import { exit } from "@tauri-apps/plugin-process";
 import {
   closeNativeWindow,
   exitNativeApp,
+  getCurrentNativeWindowLabel,
   listenNativeAppExitRequested,
   listenNativeWindowCloseRequested,
   listenNativeSettingsWindowTarget,
@@ -124,6 +125,12 @@ describe("native window actions", () => {
 
     expect(show).toHaveBeenCalledTimes(1);
     expect(setFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the current Tauri window label", async () => {
+    mockedGetCurrentWindow.mockReturnValue({ label: "markra-editor-1" } as unknown as ReturnType<typeof getCurrentWindow>);
+
+    await expect(getCurrentNativeWindowLabel()).resolves.toBe("markra-editor-1");
   });
 
   it("keeps the window show action successful when focusing fails", async () => {

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -86,6 +86,10 @@ async function getCurrentNativeWindow() {
   return getCurrentWindow();
 }
 
+export async function getCurrentNativeWindowLabel() {
+  return (await getCurrentNativeWindow())?.label ?? null;
+}
+
 function normalizeNativeEditorWindowRestoreStates(value: unknown): NativeEditorWindowRestoreState[] {
   if (!Array.isArray(value)) return [];
 

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -68,6 +68,7 @@ import {
   type StoredWorkspaceDraftTab,
   type StoredWorkspaceSideBySideGroup,
   type StoredWorkspaceState,
+  type StoredWorkspaceWindowState,
   type StoredWorkspaceWindow
 } from "./workspace-state";
 
@@ -129,6 +130,7 @@ export type {
   StoredWorkspaceDraftTab,
   StoredWorkspaceSideBySideGroup,
   StoredWorkspaceState,
+  StoredWorkspaceWindowState,
   StoredWorkspaceWindow
 } from "./workspace-state";
 
@@ -157,6 +159,22 @@ const syncSettingsKey = "syncSettings";
 const workspaceKey = "workspace";
 const recentMarkdownFilesKey = "recentMarkdownFiles";
 const recentMarkdownFoldersKey = "recentMarkdownFolders";
+const mainWorkspaceWindowLabel = "main";
+const settingsWorkspaceWindowLabel = "markra-settings";
+
+type StoredWorkspaceStateOptions = {
+  windowLabel?: string | null;
+};
+
+type StoredWorkspaceStore = {
+  legacyState: StoredWorkspaceState;
+  openWindows: StoredWorkspaceWindow[];
+  windowStates: Record<string, StoredWorkspaceWindowState>;
+};
+
+type StoredWorkspaceStoreValue = Partial<StoredWorkspaceState> & {
+  windowStates?: unknown;
+};
 
 export type ResolvedAppTheme = "light" | "dark";
 export const appAppearanceModeOptions = ["system", "light", "dark"] as const;
@@ -917,19 +935,147 @@ export async function saveStoredSyncSettings(settings: SyncSettings) {
   await store.save();
 }
 
-export async function getStoredWorkspaceState(): Promise<StoredWorkspaceState> {
-  const store = await loadSettingsStore();
-  const workspace = await store.get<StoredWorkspaceState>(workspaceKey);
-
-  return normalizeWorkspaceState(workspace);
+function normalizeWorkspaceWindowLabel(label: string | null | undefined) {
+  const trimmedLabel = label?.trim();
+  return trimmedLabel ? trimmedLabel : mainWorkspaceWindowLabel;
 }
 
-export async function saveStoredWorkspaceState(patch: Partial<StoredWorkspaceState>) {
-  const store = await loadSettingsStore();
-  const current = normalizeWorkspaceState(await store.get<StoredWorkspaceState>(workspaceKey));
-  const workspace = normalizeWorkspaceState({ ...current, ...patch });
+function workspaceWindowStateFromWorkspaceState(state: StoredWorkspaceState): StoredWorkspaceWindowState {
+  const { openWindows: _openWindows, ...windowState } = state;
+  return windowState;
+}
 
-  await store.set(workspaceKey, workspace);
+function workspaceWindowStateIsEmpty(state: StoredWorkspaceWindowState) {
+  return (
+    !state.activeDraftId &&
+    !state.draftTabs?.length &&
+    !state.aiAgentSessionId &&
+    !state.filePath &&
+    !state.fileTreeOpen &&
+    !state.folderName &&
+    !state.folderPath &&
+    state.openFilePaths.length === 0 &&
+    !state.sideBySideGroup
+  );
+}
+
+function normalizeWorkspaceWindowStates(value: unknown) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  const states: Record<string, StoredWorkspaceWindowState> = {};
+
+  Object.entries(value as Record<string, unknown>).forEach(([label, state]) => {
+    states[normalizeWorkspaceWindowLabel(label)] = workspaceWindowStateFromWorkspaceState(normalizeWorkspaceState(state));
+  });
+
+  return states;
+}
+
+function normalizeWorkspaceStore(value: unknown): StoredWorkspaceStore {
+  const legacyState = normalizeWorkspaceState(value);
+  const candidate = typeof value === "object" && value !== null
+    ? value as StoredWorkspaceStoreValue
+    : {};
+  const legacyWindowState = workspaceWindowStateFromWorkspaceState(legacyState);
+  const legacyWindowStates: Record<string, StoredWorkspaceWindowState> = {};
+
+  if (!workspaceWindowStateIsEmpty(legacyWindowState)) {
+    legacyWindowStates[mainWorkspaceWindowLabel] = legacyWindowState;
+  }
+
+  return {
+    legacyState,
+    openWindows: legacyState.openWindows ?? [],
+    windowStates: {
+      ...legacyWindowStates,
+      ...normalizeWorkspaceWindowStates(candidate.windowStates)
+    }
+  };
+}
+
+async function resolveStoredWorkspaceWindowLabel(options: StoredWorkspaceStateOptions = {}) {
+  if ("windowLabel" in options) {
+    return normalizeWorkspaceWindowLabel(options.windowLabel);
+  }
+
+  try {
+    return normalizeWorkspaceWindowLabel(await getAppRuntime().window.getCurrentWindowLabel());
+  } catch {
+    return mainWorkspaceWindowLabel;
+  }
+}
+
+function workspaceStateForWindowLabel(store: StoredWorkspaceStore, label: string): StoredWorkspaceState {
+  const targetLabel = label === settingsWorkspaceWindowLabel ? mainWorkspaceWindowLabel : label;
+  const windowState =
+    store.windowStates[targetLabel] ??
+    (targetLabel === mainWorkspaceWindowLabel
+      ? workspaceWindowStateFromWorkspaceState(store.legacyState)
+      : workspaceWindowStateFromWorkspaceState(defaultWorkspaceState));
+
+  return {
+    ...windowState,
+    openWindows: store.openWindows
+  };
+}
+
+function workspaceWindowPatchFromStatePatch(patch: Partial<StoredWorkspaceState>) {
+  const { openWindows: _openWindows, ...windowPatch } = patch;
+  return windowPatch;
+}
+
+function workspacePatchHasWindowState(patch: Partial<StoredWorkspaceState>) {
+  return Object.keys(patch).some((key) => key !== "openWindows");
+}
+
+function serializedWorkspaceStore(store: StoredWorkspaceStore) {
+  return {
+    openWindows: store.openWindows,
+    windowStates: store.windowStates
+  };
+}
+
+export async function getStoredWorkspaceState(options: StoredWorkspaceStateOptions = {}): Promise<StoredWorkspaceState> {
+  const store = await loadSettingsStore();
+  const workspace = normalizeWorkspaceStore(await store.get<StoredWorkspaceStoreValue>(workspaceKey));
+  const windowLabel = await resolveStoredWorkspaceWindowLabel(options);
+
+  return workspaceStateForWindowLabel(workspace, windowLabel);
+}
+
+export async function saveStoredWorkspaceState(
+  patch: Partial<StoredWorkspaceState>,
+  options: StoredWorkspaceStateOptions = {}
+) {
+  const store = await loadSettingsStore();
+  const current = normalizeWorkspaceStore(await store.get<StoredWorkspaceStoreValue>(workspaceKey));
+
+  if (patch.openWindows !== undefined) {
+    current.openWindows = normalizeWorkspaceState({ openWindows: patch.openWindows }).openWindows ?? [];
+  }
+
+  if (workspacePatchHasWindowState(patch)) {
+    const windowLabel = await resolveStoredWorkspaceWindowLabel(options);
+    const targetLabel = windowLabel === settingsWorkspaceWindowLabel ? mainWorkspaceWindowLabel : windowLabel;
+    const currentWindowState = workspaceStateForWindowLabel(current, targetLabel);
+    const nextWindowState = workspaceWindowStateFromWorkspaceState(
+      normalizeWorkspaceState({
+        ...currentWindowState,
+        ...workspaceWindowPatchFromStatePatch(patch),
+        openWindows: []
+      })
+    );
+
+    if (workspaceWindowStateIsEmpty(nextWindowState)) {
+      delete current.windowStates[targetLabel];
+    } else {
+      current.windowStates[targetLabel] = nextWindowState;
+    }
+  }
+
+  await store.set(workspaceKey, serializedWorkspaceStore(current));
   await store.save();
 }
 

--- a/packages/app/src/lib/settings/workspace-state.test.ts
+++ b/packages/app/src/lib/settings/workspace-state.test.ts
@@ -1,4 +1,5 @@
 import { createSettingsStoreHarness, resetSettingsStoreRuntime, setupSettingsStoreHarness } from "../../test/settings-store";
+import { configureAppRuntime, createDefaultAppRuntime } from "../../runtime";
 import { getStoredWorkspaceState, saveStoredWorkspaceState } from "./app-settings";
 
 const settingsStore = createSettingsStoreHarness();
@@ -151,22 +152,177 @@ describe("workspace state settings", () => {
     });
 
     expect(store.set).toHaveBeenCalledWith("workspace", {
-      aiAgentSessionId: "session-a",
-      filePath: "/mock-files/vault/README.md",
-      fileTreeOpen: true,
-      folderName: "vault",
-      folderPath: "/mock-files/vault",
-      openFilePaths: [
-        "/mock-files/vault/README.md",
-        "/mock-files/vault/notes.md"
-      ],
       openWindows: [],
-      sideBySideGroup: {
-        primaryFilePath: "/mock-files/vault/README.md",
-        sideFilePath: "/mock-files/vault/notes.md"
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-a",
+          filePath: "/mock-files/vault/README.md",
+          fileTreeOpen: true,
+          folderName: "vault",
+          folderPath: "/mock-files/vault",
+          openFilePaths: [
+            "/mock-files/vault/README.md",
+            "/mock-files/vault/notes.md"
+          ],
+          sideBySideGroup: {
+            primaryFilePath: "/mock-files/vault/README.md",
+            sideFilePath: "/mock-files/vault/notes.md"
+          }
+        }
       }
     });
     expect(store.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists workspace state updates for only the targeted window", async () => {
+    store.get.mockResolvedValue({
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/main.md"]
+        },
+        "markra-editor-1": {
+          aiAgentSessionId: "session-secondary",
+          filePath: "/mock-files/secondary.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/secondary.md"]
+        }
+      }
+    });
+
+    await saveStoredWorkspaceState({
+      filePath: "/mock-files/secondary-next.md",
+      openFilePaths: ["/mock-files/secondary-next.md"]
+    }, { windowLabel: "markra-editor-1" });
+
+    expect(store.set).toHaveBeenCalledWith("workspace", {
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/main.md"]
+        },
+        "markra-editor-1": {
+          aiAgentSessionId: "session-secondary",
+          filePath: "/mock-files/secondary-next.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/secondary-next.md"]
+        }
+      }
+    });
+  });
+
+  it("loads workspace state for the targeted window", async () => {
+    store.get.mockResolvedValue({
+      openWindows: [
+        {
+          filePath: "/mock-files/main.md",
+          label: "main",
+          openFilePaths: ["/mock-files/main.md"]
+        }
+      ],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/main.md"]
+        },
+        "markra-editor-1": {
+          aiAgentSessionId: "session-secondary",
+          filePath: "/mock-files/secondary.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/secondary.md"]
+        }
+      }
+    });
+
+    await expect(getStoredWorkspaceState({ windowLabel: "markra-editor-1" })).resolves.toEqual({
+      aiAgentSessionId: "session-secondary",
+      filePath: "/mock-files/secondary.md",
+      fileTreeOpen: true,
+      folderName: "mock-files",
+      folderPath: "/mock-files",
+      openFilePaths: ["/mock-files/secondary.md"],
+      openWindows: [
+        {
+          filePath: "/mock-files/main.md",
+          label: "main",
+          openFilePaths: ["/mock-files/main.md"]
+        }
+      ]
+    });
+  });
+
+  it("uses the current runtime window label when no explicit window label is provided", async () => {
+    const runtime = createDefaultAppRuntime();
+    configureAppRuntime({
+      ...runtime,
+      settings: {
+        loadStore: mockedLoadStore
+      },
+      window: {
+        ...runtime.window,
+        getCurrentWindowLabel: async () => "markra-editor-2"
+      }
+    });
+    store.get.mockResolvedValue({
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/main.md"]
+        }
+      }
+    });
+
+    await saveStoredWorkspaceState({
+      filePath: "/mock-files/secondary.md",
+      openFilePaths: ["/mock-files/secondary.md"]
+    });
+
+    expect(store.set).toHaveBeenCalledWith("workspace", {
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/main.md"]
+        },
+        "markra-editor-2": {
+          aiAgentSessionId: null,
+          filePath: "/mock-files/secondary.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/secondary.md"]
+        }
+      }
+    });
   });
 
   it("clears the saved side-by-side workspace group", async () => {
@@ -191,16 +347,20 @@ describe("workspace state settings", () => {
     });
 
     expect(store.set).toHaveBeenCalledWith("workspace", {
-      aiAgentSessionId: "session-a",
-      filePath: "/mock-files/vault/README.md",
-      fileTreeOpen: true,
-      folderName: "vault",
-      folderPath: "/mock-files/vault",
-      openFilePaths: [
-        "/mock-files/vault/README.md",
-        "/mock-files/vault/notes.md"
-      ],
-      openWindows: []
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-a",
+          filePath: "/mock-files/vault/README.md",
+          fileTreeOpen: true,
+          folderName: "vault",
+          folderPath: "/mock-files/vault",
+          openFilePaths: [
+            "/mock-files/vault/README.md",
+            "/mock-files/vault/notes.md"
+          ]
+        }
+      }
     });
     expect(store.save).toHaveBeenCalledTimes(1);
   });
@@ -230,13 +390,17 @@ describe("workspace state settings", () => {
     });
 
     expect(store.set).toHaveBeenCalledWith("workspace", {
-      aiAgentSessionId: "session-a",
-      filePath: null,
-      fileTreeOpen: false,
-      folderName: null,
-      folderPath: null,
-      openFilePaths: [],
-      openWindows: []
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-a",
+          filePath: null,
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: []
+        }
+      }
     });
     expect(store.save).toHaveBeenCalledTimes(1);
   });

--- a/packages/app/src/lib/settings/workspace-state.ts
+++ b/packages/app/src/lib/settings/workspace-state.ts
@@ -13,6 +13,8 @@ export type StoredWorkspaceState = {
   sideBySideGroup?: StoredWorkspaceSideBySideGroup | null;
 };
 
+export type StoredWorkspaceWindowState = Omit<StoredWorkspaceState, "openWindows">;
+
 export type StoredWorkspaceDraftTab = {
   content: string;
   id: string;

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -256,6 +256,7 @@ export type AppFeatureRuntime = {
 export type AppWindowRuntime = {
   closeWindow: () => Promise<unknown>;
   exitApp: () => Promise<unknown>;
+  getCurrentWindowLabel: () => Promise<string | null>;
   listEditorWindowRestoreStates: () => Promise<NativeEditorWindowRestoreState[]>;
   listenAppExitRequested: (onExitRequested: () => unknown | Promise<unknown>) => Promise<RuntimeCleanup>;
   listenSettingsWindowTarget: (onTarget: (target: NativeSettingsWindowTarget) => unknown) => Promise<RuntimeCleanup>;
@@ -415,6 +416,7 @@ export function createDefaultAppRuntime(): AppRuntime {
     window: {
       closeWindow: async () => undefined,
       exitApp: async () => undefined,
+      getCurrentWindowLabel: async () => "main",
       listEditorWindowRestoreStates: async () => [],
       listenAppExitRequested: async () => () => undefined,
       listenSettingsWindowTarget: async () => () => undefined,


### PR DESCRIPTION
## Summary
- target native menu shortcut commands to the focused editor window
- persist workspace state per editor window label instead of one global workspace slot
- keep file and tree watchers per path with subscription counts so windows do not replace each other's watchers

## Why
Multiple editor windows could share non-settings state through global menu events, workspace persistence, and watcher state. This meant actions such as switching source mode or opening/watching files in one window could affect another window.

Closes #321

## Validation
- `pnpm --filter @markra/app exec vitest run src/lib/settings/workspace-state.test.ts src/hooks/useMarkdownDocument.test.tsx src/hooks/useMarkdownFileTree.test.tsx src/hooks/useSideBySideTabs.test.tsx` passed, 64 tests
- `pnpm --filter @markra/desktop exec vitest run src/runtime/tauri/window.test.ts src/runtime/tauri/menu.test.ts` passed, 33 tests
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` passed, 156 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `cargo fmt --check --manifest-path apps/desktop/src-tauri/Cargo.toml` passed
- `git diff --check` passed

## Risk
- Existing top-level workspace state is treated as the main window state for compatibility.
- Settings remain globally shared by design; this change focuses on editor window state isolation.