### PR TITLE
fix(editor): ignore horizontal rule margin clicks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2731,6 +2731,33 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
+  it("ignores horizontal rule margin clicks", async () => {
+    const { container, view } = await renderEditor("First\n\n---\n\nSecond");
+    const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    expect(surface?.querySelector("hr")).toBeInTheDocument();
+
+    const secondCursor = findTextPosition(view, "Second");
+    moveCursor(view, secondCursor);
+    fireEvent.mouseDown(surface!, {
+      button: 0,
+      clientX: 200,
+      clientY: 134
+    });
+    expect(view.state.selection.from).toBe(secondCursor);
+
+    const firstCursor = findTextPosition(view, "First");
+    moveCursor(view, firstCursor);
+    fireEvent.mouseDown(surface!, {
+      button: 0,
+      clientX: 200,
+      clientY: 147
+    });
+    expect(view.state.selection.from).toBe(firstCursor);
+
+    restoreLayout();
+  });
+
   it("serializes horizontal rules without creating a setext-heading trap in source mode", async () => {
     const { editor, view } = await renderEditor("First\n\n---\n\nSecond");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -19,6 +19,7 @@ import {
   markraAiEditorPreviewPlugin,
   markraAiSelectionHoldPlugin,
   markraBlockDragPlugin,
+  markraBlockGapPlugin,
   markraCalloutPlugin,
   markraCalloutRemarkPlugin,
   markraCalloutSerializerPlugin,
@@ -339,6 +340,7 @@ function MilkdownEditorSurface({
         .use(markraAiEditorPreviewPlugin)
         .use(markraSearchPlugin())
         .use(markraFootnotePreviewPlugin())
+        .use(markraBlockGapPlugin)
         .use(markraBlockDragPlugin(blockDragLabels))
         .use(markraHeadingTogglePlugin(headingToggleLabels))
         .use(markraListTogglePlugin(listToggleLabels))

--- a/packages/editor/src/block-gap.ts
+++ b/packages/editor/src/block-gap.ts
@@ -1,0 +1,93 @@
+import { Plugin } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+const gapGuardedBlockNames = new Set(["hr"]);
+const fallbackGapPadding = 12;
+
+function isPlainLeftMouseDown(event: MouseEvent) {
+  return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
+}
+
+function eventTargetElement(target: EventTarget | null) {
+  return target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+}
+
+function pixelValue(value: string) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function blockGapExtents(element: Element) {
+  const ownerWindow = element.ownerDocument.defaultView;
+  if (!ownerWindow) {
+    return {
+      bottom: fallbackGapPadding,
+      top: fallbackGapPadding
+    };
+  }
+
+  const style = ownerWindow.getComputedStyle(element);
+  return {
+    bottom: pixelValue(style.marginBottom) || fallbackGapPadding,
+    top: pixelValue(style.marginTop) || fallbackGapPadding
+  };
+}
+
+function horizontalPointIsInsideRect(left: number, rect: DOMRect) {
+  return left >= rect.left && left <= rect.right;
+}
+
+function verticalPointIsInsideBlockGap(top: number, rect: DOMRect, gap: { bottom: number; top: number }) {
+  if (top >= rect.top - gap.top && top < rect.top) return true;
+  if (top > rect.bottom && top <= rect.bottom + gap.bottom) return true;
+
+  return false;
+}
+
+function eventTargetsEditorSurface(view: EditorView, target: EventTarget | null) {
+  return eventTargetElement(target) === view.dom;
+}
+
+function pointIsInGuardedBlockGap(view: EditorView, left: number, top: number) {
+  let isInGap = false;
+
+  view.state.doc.descendants((node, position) => {
+    if (!gapGuardedBlockNames.has(node.type.name)) return true;
+
+    const dom = view.nodeDOM(position);
+    const element = eventTargetElement(dom);
+    const rect = element?.getBoundingClientRect();
+    if (!element || !rect || !horizontalPointIsInsideRect(left, rect)) return false;
+
+    const gap = blockGapExtents(element);
+    if (verticalPointIsInsideBlockGap(top, rect, gap)) {
+      isInGap = true;
+      return false;
+    }
+
+    return false;
+  });
+
+  return isInGap;
+}
+
+export function createBlockGapPlugin() {
+  return new Plugin({
+    props: {
+      handleDOMEvents: {
+        mousedown(view, event) {
+          if (!view.editable || !isPlainLeftMouseDown(event)) return false;
+          if (!eventTargetsEditorSurface(view, event.target)) return false;
+          if (!pointIsInGuardedBlockGap(view, event.clientX, event.clientY)) return false;
+
+          event.preventDefault();
+          event.stopPropagation();
+          return true;
+        }
+      }
+    }
+  });
+}
+
+export const markraBlockGapPlugin = $prose(() => createBlockGapPlugin());

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./ai-preview.ts";
 export * from "./block-drag.ts";
+export * from "./block-gap.ts";
 export * from "./callout.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";


### PR DESCRIPTION
## Summary
- Add an editor gap guard for horizontal rule margin clicks.
- Keep the current selection unchanged when users click the visual whitespace above or below a horizontal rule.
- Cover the behavior with a MarkdownPaper regression test.

## Why
Horizontal rule spacing is visual layout, not an editable target. Treating that whitespace as a caret target made clicks near dividers feel unstable because the cursor could jump to a neighboring block.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "horizontal rule"` passed, 4 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.

## Risk
- Low. The guard only handles plain left clicks targeting the editor surface and falling inside guarded `hr` margins.

## Related Issues
- Closes #326