### PR TITLE
fix(app): restore file tree input editing commands

### DIFF
--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -103,6 +103,7 @@ export const desktopRuntime = {
     installApplicationMenu: menu.installNativeApplicationMenu,
     installEditorContextMenu: menu.installNativeEditorContextMenu,
     listenApplicationMenuCommands: menu.listenNativeApplicationMenuCommands,
+    readClipboardText: menu.readNativeClipboardText,
     showMarkdownFileTreeContextMenu: menu.showNativeMarkdownFileTreeContextMenu
   },
   platform: {

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -175,7 +175,7 @@ function normalizeRecentFilesForNativeMenu(files: readonly RecentMarkdownFile[])
   });
 }
 
-async function readNativeClipboardText() {
+export async function readNativeClipboardText() {
   try {
     const text = await invoke<string | null>("read_clipboard_text");
 

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1,13 +1,15 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MarkdownFileTreeDrawer } from "./MarkdownFileTreeDrawer";
 import { getMarkdownOutline } from "@markra/markdown";
-import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
+import { readNativeClipboardText, showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
 
 vi.mock("../lib/tauri", () => ({
+  readNativeClipboardText: vi.fn(),
   showNativeMarkdownFileTreeContextMenu: vi.fn()
 }));
 
 const mockedShowNativeMarkdownFileTreeContextMenu = vi.mocked(showNativeMarkdownFileTreeContextMenu);
+const mockedReadNativeClipboardText = vi.mocked(readNativeClipboardText);
 
 const markdownFiles = [
   { name: "Untitled.md", path: "/vault/Untitled.md", relativePath: "Untitled.md" },
@@ -25,6 +27,8 @@ describe("MarkdownFileTreeDrawer", () => {
   beforeEach(() => {
     mockedShowNativeMarkdownFileTreeContextMenu.mockReset();
     mockedShowNativeMarkdownFileTreeContextMenu.mockResolvedValue(undefined);
+    mockedReadNativeClipboardText.mockReset();
+    mockedReadNativeClipboardText.mockResolvedValue(null);
   });
 
   it("keeps settings fixed in the lower-left", () => {
@@ -793,6 +797,44 @@ describe("MarkdownFileTreeDrawer", () => {
     fireEvent.keyDown(renameInput, { key: "Enter" });
 
     expect(renameFile).toHaveBeenCalledWith(markdownFiles[0], "Renamed.md");
+  });
+
+  it("shows text editing actions when right-clicking a file name input", async () => {
+    const createFile = vi.fn();
+    mockedReadNativeClipboardText.mockResolvedValue("Pasted note");
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onCreateFile={createFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+
+    const newFileInput = screen.getByRole("textbox", { name: "New file name" }) as HTMLInputElement;
+    fireEvent.contextMenu(newFileInput, { clientX: 24, clientY: 36 });
+
+    expect(mockedShowNativeMarkdownFileTreeContextMenu).not.toHaveBeenCalled();
+    expect(screen.getByRole("menuitem", { name: /Cut/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Copy/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Paste/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Select All/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /Paste/ }));
+
+    await waitFor(() => expect(newFileInput).toHaveValue("Pasted note"));
+
+    fireEvent.keyDown(newFileInput, { key: "Enter" });
+
+    expect(createFile).toHaveBeenCalledWith("Pasted note");
   });
 
   it("keeps the rename input visible until an async rename finishes", async () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -4,10 +4,12 @@ import {
   useMemo,
   useRef,
   useState,
+  type Dispatch,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type SetStateAction,
   type UIEvent as ReactUIEvent
 } from "react";
 import {
@@ -48,7 +50,7 @@ import { IconButton } from "@markra/ui";
 import { markraHighlightRemarkPlugin, type MarkdownOutlineItem } from "@markra/markdown";
 import type { NativeMarkdownFolderFile } from "../lib/tauri";
 import { normalizeMovedPath, sameNativePath } from "../lib/path-move";
-import { showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
+import { readNativeClipboardText, showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
 import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
 import type { RecentMarkdownFolder, SidebarLayoutMode } from "../lib/settings/app-settings";
 import {
@@ -102,6 +104,12 @@ import {
   buildOutlineRenderItems,
   visibleOutlineRenderItems
 } from "./file-tree/outline-model";
+import {
+  contextMenuItem,
+  contextMenuPositionFromEvent,
+  contextMenuSeparator,
+  showContextMenu
+} from "./ContextMenu";
 
 type MarkdownFileTreeDrawerProps = {
   activeOutlineIndex?: number | null;
@@ -204,6 +212,108 @@ function OutlineTitle({ item }: { item: MarkdownOutlineItem }) {
       {item.titleMarkdown}
     </ReactMarkdown>
   );
+}
+
+type EditableTextInput = HTMLInputElement | HTMLTextAreaElement;
+type TextInputValueSetter = Dispatch<SetStateAction<string>>;
+
+function textInputSelection(input: EditableTextInput) {
+  const valueLength = input.value.length;
+  const start = input.selectionStart ?? valueLength;
+  const end = input.selectionEnd ?? start;
+  const normalizedStart = clampNumber(start, 0, valueLength) ?? valueLength;
+  const normalizedEnd = clampNumber(end, normalizedStart, valueLength) ?? normalizedStart;
+
+  return {
+    end: normalizedEnd,
+    start: normalizedStart
+  };
+}
+
+function selectedTextInputText(input: EditableTextInput) {
+  const { end, start } = textInputSelection(input);
+
+  return input.value.slice(start, end);
+}
+
+async function writeBrowserClipboardText(input: EditableTextInput, text: string) {
+  const clipboard = input.ownerDocument.defaultView?.navigator.clipboard;
+  const writeText = clipboard?.writeText;
+  if (typeof writeText !== "function") return false;
+
+  try {
+    await writeText.call(clipboard, text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runTextInputDocumentCommand(input: EditableTextInput, command: string) {
+  const documentTarget = input.ownerDocument;
+  const execCommand = (documentTarget as unknown as Record<string, unknown>)["execCommand"];
+  if (typeof execCommand !== "function") return false;
+
+  try {
+    input.focus({ preventScroll: true });
+    return Boolean(execCommand.call(documentTarget, command));
+  } catch {
+    return false;
+  }
+}
+
+function restoreTextInputSelection(input: EditableTextInput, start: number, end = start) {
+  const restoreSelection = () => {
+    input.focus({ preventScroll: true });
+    input.setSelectionRange(start, end);
+  };
+
+  input.ownerDocument.defaultView?.setTimeout(restoreSelection, 0);
+}
+
+function replaceTextInputSelection(
+  input: EditableTextInput,
+  setValue: TextInputValueSetter,
+  replacement: string
+) {
+  const { end, start } = textInputSelection(input);
+  const nextValue = `${input.value.slice(0, start)}${replacement}${input.value.slice(end)}`;
+  const nextSelectionStart = start + replacement.length;
+
+  setValue(nextValue);
+  restoreTextInputSelection(input, nextSelectionStart);
+}
+
+async function copyTextInputSelection(input: EditableTextInput) {
+  const selectedText = selectedTextInputText(input);
+  if (!selectedText) return false;
+
+  const wroteClipboardText = await writeBrowserClipboardText(input, selectedText);
+  if (wroteClipboardText) return true;
+
+  return runTextInputDocumentCommand(input, "copy");
+}
+
+async function cutTextInputSelection(input: EditableTextInput, setValue: TextInputValueSetter) {
+  if (input.readOnly || input.disabled) return false;
+  const selectedText = selectedTextInputText(input);
+  if (!selectedText) return false;
+
+  const copied = await copyTextInputSelection(input);
+  if (!copied) return false;
+
+  replaceTextInputSelection(input, setValue, "");
+  return true;
+}
+
+async function pasteTextInputSelection(input: EditableTextInput, setValue: TextInputValueSetter) {
+  if (input.readOnly || input.disabled) return false;
+
+  const clipboardText = await readNativeClipboardText();
+  if (!clipboardText) return false;
+
+  replaceTextInputSelection(input, setValue, clipboardText);
+  return true;
 }
 
 export function MarkdownFileTreeDrawer({
@@ -790,6 +900,56 @@ export function MarkdownFileTreeDrawer({
     ).catch(() => {});
   };
 
+  const openTextInputContextMenu = (
+    event: ReactMouseEvent<HTMLInputElement>,
+    setValue: TextInputValueSetter
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const input = event.currentTarget;
+    const selectedText = selectedTextInputText(input);
+    const canEditInput = !input.readOnly && !input.disabled;
+
+    showContextMenu(input.ownerDocument, {
+      entries: [
+        contextMenuItem(
+          "markra:file-tree-input:cut",
+          label("menu.cut"),
+          "CmdOrCtrl+X",
+          () => cutTextInputSelection(input, setValue),
+          !canEditInput || !selectedText
+        ),
+        contextMenuItem(
+          "markra:file-tree-input:copy",
+          label("menu.copy"),
+          "CmdOrCtrl+C",
+          () => copyTextInputSelection(input),
+          !selectedText
+        ),
+        contextMenuItem(
+          "markra:file-tree-input:paste",
+          label("menu.paste"),
+          "CmdOrCtrl+V",
+          () => pasteTextInputSelection(input, setValue),
+          !canEditInput
+        ),
+        contextMenuSeparator(),
+        contextMenuItem(
+          "markra:file-tree-input:select-all",
+          label("menu.selectAll"),
+          "CmdOrCtrl+A",
+          () => {
+            input.focus({ preventScroll: true });
+            input.setSelectionRange(0, input.value.length);
+          },
+          input.value.length === 0
+        )
+      ],
+      position: contextMenuPositionFromEvent(event.nativeEvent)
+    });
+  };
+
   const dragTargetKey = (targetParentPath: string | null) => targetParentPath ?? "__root__";
 
   const canMoveFileToParent = (file: NativeMarkdownFolderFile, targetParentPath: string | null) => {
@@ -1025,6 +1185,7 @@ export function MarkdownFileTreeDrawer({
             value={newFileName}
             placeholder="Untitled.md"
             onChange={(event) => setNewFileName(event.target.value)}
+            onContextMenu={(event) => openTextInputContextMenu(event, setNewFileName)}
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
@@ -1065,6 +1226,7 @@ export function MarkdownFileTreeDrawer({
           value={newFolderName}
           placeholder={label("app.newMarkdownFolder")}
           onChange={(event) => setNewFolderName(event.target.value)}
+          onContextMenu={(event) => openTextInputContextMenu(event, setNewFolderName)}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
               event.preventDefault();
@@ -1140,6 +1302,7 @@ export function MarkdownFileTreeDrawer({
           type="text"
           value={renameFileName}
           onChange={(event) => setRenameFileName(event.target.value)}
+          onContextMenu={(event) => openTextInputContextMenu(event, setRenameFileName)}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
               event.preventDefault();

--- a/packages/app/src/hooks/useDefaultContextMenuBlocker.test.tsx
+++ b/packages/app/src/hooks/useDefaultContextMenuBlocker.test.tsx
@@ -4,7 +4,17 @@ import { useDefaultContextMenuBlocker } from "./useDefaultContextMenuBlocker";
 function ContextMenuHarness({ enabled }: { enabled: boolean }) {
   useDefaultContextMenuBlocker(enabled);
 
-  return <div data-testid="context-target" />;
+  return (
+    <div>
+      <div data-testid="context-target" />
+      <input data-testid="text-input" defaultValue="Draft note" />
+      <textarea data-testid="textarea" defaultValue="Draft note" />
+      <div contentEditable data-testid="editable" suppressContentEditableWarning>
+        Draft note
+      </div>
+      <input data-testid="checkbox" type="checkbox" />
+    </div>
+  );
 }
 
 function dispatchContextMenu(target: EventTarget) {
@@ -25,6 +35,15 @@ describe("useDefaultContextMenuBlocker", () => {
     const event = dispatchContextMenu(getByTestId("context-target"));
 
     expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves editable text control context menus available when enabled", () => {
+    const { getByTestId } = render(<ContextMenuHarness enabled />);
+
+    expect(dispatchContextMenu(getByTestId("text-input")).defaultPrevented).toBe(false);
+    expect(dispatchContextMenu(getByTestId("textarea")).defaultPrevented).toBe(false);
+    expect(dispatchContextMenu(getByTestId("editable")).defaultPrevented).toBe(false);
+    expect(dispatchContextMenu(getByTestId("checkbox")).defaultPrevented).toBe(true);
   });
 
   it("leaves context menus alone when disabled", () => {

--- a/packages/app/src/hooks/useDefaultContextMenuBlocker.ts
+++ b/packages/app/src/hooks/useDefaultContextMenuBlocker.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { editableTextControlFromTarget } from "../lib/editable-target";
 
 export function shouldBlockDefaultContextMenu() {
   return import.meta.env.PROD;
@@ -9,6 +10,8 @@ export function useDefaultContextMenuBlocker(enabled = shouldBlockDefaultContext
     if (!enabled) return;
 
     const blockDefaultContextMenu = (event: MouseEvent) => {
+      if (editableTextControlFromTarget(event.target)) return;
+
       event.preventDefault();
     };
 

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -124,6 +124,40 @@ describe("useNativeMenuHandlers", () => {
     });
   });
 
+  it("keeps native edit history commands inside a focused text input", () => {
+    const runEditorShortcut = vi.fn();
+    const execCommand = vi.fn().mockReturnValue(true);
+    const input = document.createElement("input");
+    const originalExecCommand = document.execCommand;
+    input.type = "text";
+    document.body.append(input);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    const { result } = renderHook(() =>
+      useNativeMenuHandlers({
+        ...baseOptions,
+        runEditorShortcut
+      })
+    );
+
+    input.focus();
+
+    result.current.editUndo?.();
+    result.current.editRedo?.();
+
+    expect(execCommand).toHaveBeenNthCalledWith(1, "undo");
+    expect(execCommand).toHaveBeenNthCalledWith(2, "redo");
+    expect(runEditorShortcut).not.toHaveBeenCalled();
+
+    input.remove();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: originalExecCommand
+    });
+  });
+
   it("routes the native all-folds command through the configured editor shortcut", () => {
     const runEditorShortcut = vi.fn();
     const { result } = renderHook(() =>

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -21,6 +21,7 @@ import {
 } from "@markra/shared";
 import { defaultAiQuickActionPrompt } from "../lib/ai-actions";
 import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
+import { focusedEditableTextInput } from "../lib/editable-target";
 
 type NativeAiQuickActionIntent = Exclude<AiEditIntent, "custom">;
 
@@ -78,6 +79,25 @@ type ApplicationShortcutOptions = {
 };
 
 const emptyRecentMarkdownFiles: readonly RecentMarkdownFile[] = [];
+
+function runFocusedEditableTextCommand(command: "redo" | "undo") {
+  if (typeof document === "undefined") return false;
+
+  const control = focusedEditableTextInput(document);
+  if (!control) return false;
+
+  const documentTarget = control.ownerDocument;
+  const execCommand = (documentTarget as unknown as Record<string, unknown>)["execCommand"];
+  if (typeof execCommand !== "function") return true;
+
+  try {
+    execCommand.call(documentTarget, command);
+  } catch {
+    // Keep the command scoped to the focused text control even if the WebView refuses it.
+  }
+
+  return true;
+}
 
 export function useNativeMenuHandlers({
   checkForUpdates,
@@ -181,8 +201,16 @@ export function useNativeMenuHandlers({
         openFolder: () => latestOptionsRef.current.openFolder(),
         saveDocument: () => latestOptionsRef.current.saveDocument(),
         saveDocumentAs: () => latestOptionsRef.current.saveDocumentAs(),
-        editUndo: () => latestOptionsRef.current.runEditorShortcut("z"),
-        editRedo: () => latestOptionsRef.current.runEditorShortcut("z", { shiftKey: true }),
+        editUndo: () => {
+          if (runFocusedEditableTextCommand("undo")) return;
+
+          latestOptionsRef.current.runEditorShortcut("z");
+        },
+        editRedo: () => {
+          if (runFocusedEditableTextCommand("redo")) return;
+
+          latestOptionsRef.current.runEditorShortcut("z", { shiftKey: true });
+        },
         formatBold: () => runMarkdownShortcut("bold"),
         formatItalic: () => runMarkdownShortcut("italic"),
         formatStrikethrough: () => runMarkdownShortcut("strikethrough"),

--- a/packages/app/src/lib/editable-target.ts
+++ b/packages/app/src/lib/editable-target.ts
@@ -1,0 +1,54 @@
+export type EditableTextInput = HTMLInputElement | HTMLTextAreaElement;
+export type EditableTextControl = EditableTextInput | HTMLElement;
+
+const editableInputTypes = new Set([
+  "date",
+  "datetime-local",
+  "email",
+  "month",
+  "number",
+  "password",
+  "search",
+  "tel",
+  "text",
+  "time",
+  "url",
+  "week"
+]);
+
+function editableTextInputFromElement(element: Element | null): EditableTextInput | null {
+  if (element instanceof HTMLInputElement) {
+    return !element.disabled && editableInputTypes.has(element.type) ? element : null;
+  }
+
+  if (element instanceof HTMLTextAreaElement) {
+    return !element.disabled ? element : null;
+  }
+
+  return null;
+}
+
+function editableTextControlFromElement(element: Element | null): EditableTextControl | null {
+  const input = editableTextInputFromElement(element);
+  if (input) return input;
+
+  if (element instanceof HTMLElement && element.hasAttribute("contenteditable")) {
+    return element.getAttribute("contenteditable")?.toLowerCase() !== "false" ? element : null;
+  }
+
+  return null;
+}
+
+export function editableTextControlFromTarget(target: EventTarget | null): EditableTextControl | null {
+  if (!(target instanceof Element)) return null;
+
+  return editableTextControlFromElement(target.closest("input, textarea, [contenteditable]"));
+}
+
+export function focusedEditableTextControl(documentTarget: Document): EditableTextControl | null {
+  return editableTextControlFromElement(documentTarget.activeElement);
+}
+
+export function focusedEditableTextInput(documentTarget: Document): EditableTextInput | null {
+  return editableTextInputFromElement(documentTarget.activeElement);
+}

--- a/packages/app/src/lib/tauri/menu.ts
+++ b/packages/app/src/lib/tauri/menu.ts
@@ -91,6 +91,10 @@ export function listenNativeApplicationMenuCommands(handlers: NativeMenuHandlers
   return getAppRuntime().menu.listenApplicationMenuCommands(handlers);
 }
 
+export function readNativeClipboardText() {
+  return getAppRuntime().menu.readClipboardText();
+}
+
 export function installNativeApplicationMenu(
   handlers: NativeMenuHandlers,
   language: AppLanguage = "en",

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -213,6 +213,7 @@ export type AppMenuRuntime = {
     options?: NativeEditorContextMenuOptions
   ) => Promise<RuntimeCleanup>;
   listenApplicationMenuCommands: (handlers: NativeMenuHandlers) => Promise<RuntimeCleanup>;
+  readClipboardText: () => Promise<string | null>;
   showMarkdownFileTreeContextMenu: (
     handlers: NativeMarkdownFileTreeContextMenuHandlers,
     language?: AppLanguage,
@@ -330,6 +331,18 @@ function unsupportedFeature(feature: string): Promise<never> {
   return Promise.reject(new Error(`${feature} is unavailable without a configured app runtime.`));
 }
 
+async function readBrowserClipboardText() {
+  const clipboard = typeof navigator === "undefined" ? null : navigator.clipboard;
+  const readText = clipboard?.readText;
+  if (typeof readText !== "function") return null;
+
+  try {
+    return await readText.call(clipboard);
+  } catch {
+    return null;
+  }
+}
+
 function createDefaultFileRuntime(): AppFileRuntime {
   return {
     confirmMarkdownFileDelete: async () => false,
@@ -406,6 +419,7 @@ export function createDefaultAppRuntime(): AppRuntime {
       installApplicationMenu: async () => () => undefined,
       installEditorContextMenu: async () => () => undefined,
       listenApplicationMenuCommands: async () => () => undefined,
+      readClipboardText: readBrowserClipboardText,
       showMarkdownFileTreeContextMenu: async () => undefined
     },
     platform: {


### PR DESCRIPTION
## Summary
- Add a text editing context menu for file tree create and rename inputs with Cut, Copy, Paste, and Select All.
- Route custom Paste through the app runtime so desktop builds can read the native Tauri clipboard.
- Keep native Undo/Redo commands scoped to focused text inputs while preserving Markra editor history for the document editor.
- Share editable text target detection across context menu blocking and native menu handling.

## Why
File tree name inputs could inherit the surrounding file tree context menu, so right-clicking did not provide text editing actions. Desktop menu Undo/Redo also routed directly to the editor history even when a rename input was focused.

## Validation
- `pnpm --filter @markra/app test -- src/hooks/useNativeBindings.test.tsx`
- `pnpm --filter @markra/app test -- src/components/MarkdownFileTreeDrawer.test.tsx`
- `pnpm --filter @markra/app test -- src/hooks/useDefaultContextMenuBlocker.test.tsx`
- `pnpm --filter @markra/app test -- src/lib/selection-formatting.test.tsx`
- `pnpm --filter @markra/app build`
- `pnpm --filter @markra/desktop test -- src/runtime/tauri/menu.test.ts`
- `pnpm --filter @markra/desktop build`
- `pnpm --filter @markra/web build`

## Risk
Low to medium: this touches shared text-input detection and native menu routing. Tests cover file tree input context menus, global context menu blocking, native Undo/Redo routing, and editor history regression behavior.

Closes #306
