### PR TITLE
fix(app): restore visual editor after hidden tab opens

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -938,6 +938,51 @@ describe("useMarkdownDocument", () => {
     expect(result.current.document.name).toBe("notes.md");
   });
 
+  it("keeps a visual editor tab available after opening a folder with document tabs disabled", async () => {
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nSynthetic content",
+      name: "guide.md",
+      path: "/mock-files/vault/docs/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: false,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    act(() => {
+      result.current.clearOpenDocument({ persistWorkspace: false });
+    });
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/vault/docs/guide.md",
+        relativePath: "docs/guide.md"
+      });
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "# Guide\n\nSynthetic content",
+      name: "guide.md",
+      path: "/mock-files/vault/docs/guide.md"
+    });
+    expect(result.current.activeTabId).toBe("file:/mock-files/vault/docs/guide.md");
+    expect(result.current.tabs).toEqual([
+      expect.objectContaining({
+        content: "# Guide\n\nSynthetic content",
+        id: "file:/mock-files/vault/docs/guide.md",
+        name: "guide.md",
+        path: "/mock-files/vault/docs/guide.md"
+      })
+    ]);
+  });
+
   it("asks before closing a dirty tab", async () => {
     const confirmDiscardUnsavedChanges = vi.fn(() => false);
     mockedReadNativeMarkdownFile.mockResolvedValue({

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -383,13 +383,21 @@ export function useMarkdownDocument({
     documentRef.current = nextDocument;
     setDocument(nextDocument);
 
-    const currentActiveTabId = activeTabIdRef.current;
+    const fallbackActiveTabId = nextDocument.open
+      ? nextDocument.path ? fileTabId(nextDocument.path) : "untitled:0"
+      : null;
+    const currentActiveTabId = activeTabIdRef.current ?? fallbackActiveTabId;
     if (!currentActiveTabId) return;
 
+    activeTabIdRef.current = currentActiveTabId;
+    setActiveTabId(currentActiveTabId);
+
     setTabs((currentTabs) => {
-      const nextTabs = currentTabs.map((tab) =>
-        tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab
-      );
+      const nextTab = createDocumentTab(nextDocument, currentActiveTabId);
+      const tabExists = currentTabs.some((tab) => tab.id === currentActiveTabId);
+      const nextTabs = tabExists
+        ? currentTabs.map((tab) => tab.id === currentActiveTabId ? nextTab : tab)
+        : [...currentTabs, nextTab];
       tabsRef.current = nextTabs;
       return nextTabs;
     });


### PR DESCRIPTION
## Summary
- Ensures opening a Markdown file from the file tree recreates and activates an editor tab when document tabs are disabled and the previous folder open cleared the active tab.
- Adds regression coverage for the hidden-tabs folder-to-file flow.

## Why
- Fixes the blank WYSIWYG editor reported in #324, where source mode loaded the document but the visual editor had no backing active tab.

## Validation
- `pnpm --filter @markra/app test -- useMarkdownDocument.test.tsx -t "keeps a visual editor tab available after opening a folder with document tabs disabled"` passed: 84 files, 1232 tests.
- `pnpm --filter @markra/app build` passed.
- Prerelease for reporter validation: [v0.12.5-beta.1](https://github.com/murongg/markra/releases/tag/v0.12.5-beta.1).

## Risk
- Low. The fallback tab is only synthesized when a document is open and no active tab exists.

## Related Issues
- Refs #324