### PR TITLE
fix(app): clarify duplicate recent folders

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -196,6 +196,86 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(removeRecentFolder).not.toHaveBeenCalled();
   });
 
+  it("disambiguates recent folders with the same name by path", () => {
+    const openRecentFolder = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        recentFolders={[
+          { name: "docs", path: "/mock-workspaces/alpha/docs" },
+          { name: "docs", path: "/mock-workspaces/beta/docs" }
+        ]}
+        rootPath="/mock-workspaces/beta/docs"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onOpenRecentFolder={openRecentFolder}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const recentSection = screen.getByRole("region", { name: "Recently used directories" });
+    const alphaDocs = within(recentSection).getByRole("button", {
+      name: "docs /mock-workspaces/alpha/docs"
+    });
+    const betaDocs = within(recentSection).getByRole("button", {
+      name: "docs /mock-workspaces/beta/docs"
+    });
+
+    expect(alphaDocs).toHaveTextContent("/mock-workspaces/alpha/docs");
+    expect(betaDocs).toHaveTextContent("/mock-workspaces/beta/docs");
+    expect(alphaDocs).not.toHaveAttribute("aria-current");
+    expect(betaDocs).toHaveAttribute("aria-current", "page");
+    expect(betaDocs.querySelector(".lucide-folder-open")).toBeInTheDocument();
+
+    fireEvent.click(betaDocs);
+
+    expect(openRecentFolder).toHaveBeenCalledWith({
+      name: "docs",
+      path: "/mock-workspaces/beta/docs"
+    });
+  });
+
+  it("middle-truncates long duplicate recent folder paths while keeping the full path label", () => {
+    const alphaPath = "/mock-workspaces/team-alpha/projects/handbook/content/docs";
+    const betaPath = "/mock-workspaces/team-beta/projects/handbook/content/docs";
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        recentFolders={[
+          { name: "docs", path: alphaPath },
+          { name: "docs", path: betaPath }
+        ]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onOpenRecentFolder={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const recentSection = screen.getByRole("region", { name: "Recently used directories" });
+    const alphaDocs = within(recentSection).getByRole("button", {
+      name: `docs ${alphaPath}`
+    });
+    const betaDocs = within(recentSection).getByRole("button", {
+      name: `docs ${betaPath}`
+    });
+
+    expect(alphaDocs).toHaveAttribute("title", alphaPath);
+    expect(betaDocs).toHaveAttribute("title", betaPath);
+    expect(within(alphaDocs).getByText("/mock-workspaces/team-alpha/.../content/docs")).toBeInTheDocument();
+    expect(within(betaDocs).getByText("/mock-workspaces/team-beta/.../content/docs")).toBeInTheDocument();
+    expect(alphaDocs).not.toHaveTextContent(alphaPath);
+    expect(betaDocs).not.toHaveTextContent(betaPath);
+  });
+
   it("collapses recent folders and removes a recent folder without opening it", () => {
     const openRecentFolder = vi.fn();
     const removeRecentFolder = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -159,6 +159,7 @@ const minOutlineHeightPercent = 24;
 const maxOutlineHeightPercent = 72;
 const outlineResizeKeyboardStepPercent = 5;
 const outlineResizeFallbackHeight = 320;
+const recentFolderPathDisplayMaxLength = 48;
 const fileTreeContextRowSelectionClassName = "select-none [-webkit-user-select:none]";
 const fileTreeDropTargetClassName = "bg-(--bg-active) text-(--text-heading)";
 const fileTreeDropListTargetClassName = "rounded-sm bg-(--bg-active)";
@@ -198,6 +199,42 @@ const outlineTitleMarkdownComponents = {
 
 function sidebarPanelTabClassName(selected: boolean) {
   return `${sidebarPanelTabBaseClassName} ${selected ? sidebarPanelTabActiveClassName : sidebarPanelTabInactiveClassName}`;
+}
+
+function recentFolderNameKey(folder: RecentMarkdownFolder) {
+  return folder.name.trim().toLocaleLowerCase();
+}
+
+function duplicateRecentFolderNameKeys(folders: readonly RecentMarkdownFolder[]) {
+  const counts = new Map<string, number>();
+
+  folders.forEach((folder) => {
+    const key = recentFolderNameKey(folder);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+
+  return new Set(Array.from(counts.entries()).filter(([, count]) => count > 1).map(([key]) => key));
+}
+
+function compactRecentFolderPath(path: string, maxLength = recentFolderPathDisplayMaxLength) {
+  if (path.length <= maxLength) return path;
+
+  const separator = path.includes("\\") && !path.includes("/") ? "\\" : "/";
+  const hasLeadingSeparator = path.startsWith("/") || path.startsWith("\\");
+  const segments = path.split(/[\\/]/u).filter(Boolean);
+
+  if (segments.length >= 4) {
+    const leadingPath = segments.slice(0, 2).join(separator);
+    const trailingPath = segments.slice(-2).join(separator);
+    const candidate = `${hasLeadingSeparator ? separator : ""}${leadingPath}${separator}...${separator}${trailingPath}`;
+    if (candidate.length <= maxLength) return candidate;
+  }
+
+  const remainingLength = Math.max(2, maxLength - 3);
+  const leadingLength = Math.ceil(remainingLength / 2);
+  const trailingLength = Math.floor(remainingLength / 2);
+
+  return `${path.slice(0, leadingLength)}...${path.slice(-trailingLength)}`;
 }
 
 function OutlineTitle({ item }: { item: MarkdownOutlineItem }) {
@@ -510,7 +547,11 @@ export function MarkdownFileTreeDrawer({
     return null;
   }, [currentPath, normalizeTreeCreateParentPath, rootPath]);
   const activeCreateParentPath = selectedCreateParentPath ?? currentDocumentCreateParentPath;
-  const recentFolderChoices = recentFolders.slice(0, 5);
+  const recentFolderChoices = useMemo(() => recentFolders.slice(0, 5), [recentFolders]);
+  const duplicateRecentFolderNames = useMemo(
+    () => duplicateRecentFolderNameKeys(recentFolderChoices),
+    [recentFolderChoices]
+  );
   const recentFolderAreaVisible = recentFolderChoices.length > 0 && Boolean(onOpenRecentFolder);
   const tabbedSidebarLayout = sidebarLayoutMode === "tabs";
   const filePanelAvailable = folderOpen || (open && fileCreationAvailable);
@@ -1672,49 +1713,69 @@ export function MarkdownFileTreeDrawer({
             </div>
             {recentFoldersOpen ? (
               <div className="space-y-0.5 px-2 pb-1">
-                {recentFolderChoices.map((folder) => (
-                  <div
-                    className="markdown-file-tree-recent-folder grid h-7 grid-cols-[minmax(0,1fr)_auto] items-center gap-1"
-                    key={folder.path}
-                    onMouseEnter={() => setHoveredRecentFolderPath(folder.path)}
-                    onMouseLeave={() => {
-                      setHoveredRecentFolderPath((path) => (path === folder.path ? null : path));
-                      setFocusedRecentFolderActionPath((path) => (path === folder.path ? null : path));
-                    }}
-                  >
-                    <button
-                      className="flex h-7 min-w-0 cursor-pointer items-center gap-2 rounded-sm border-0 bg-transparent px-2 text-left text-[12px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none"
-                      type="button"
-                      title={folder.path}
-                      onClick={() => onOpenRecentFolder(folder)}
-                    >
-                      <Folder aria-hidden="true" className="shrink-0" size={14} />
-                      <span className="min-w-0 truncate">{folder.name}</span>
-                    </button>
-                    {onRemoveRecentFolder ? (
-                      (() => {
-                        const actionVisible =
-                          hoveredRecentFolderPath === folder.path || focusedRecentFolderActionPath === folder.path;
+                {recentFolderChoices.map((folder) => {
+                  const duplicateName = duplicateRecentFolderNames.has(recentFolderNameKey(folder));
+                  const currentRecentFolder = Boolean(rootPath && sameNativePath(folder.path, rootPath));
+                  const folderActionLabel = duplicateName ? `${folder.name} ${folder.path}` : folder.name;
+                  const folderPathLabel = compactRecentFolderPath(folder.path);
+                  const RecentFolderIcon = currentRecentFolder ? FolderOpen : Folder;
+                  const recentFolderButtonStateClassName = currentRecentFolder
+                    ? "bg-(--bg-active) text-(--text-heading) hover:bg-(--bg-active) focus-visible:bg-(--bg-active)"
+                    : "bg-transparent text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)";
 
-                        return (
-                          <IconButton
-                            className="rounded-md transition-opacity duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]"
-                            label={`${label("app.removeRecentMarkdownFolder")}: ${folder.name}`}
-                            style={{
-                              opacity: actionVisible ? 1 : 0,
-                              pointerEvents: actionVisible ? "auto" : "none"
-                            }}
-                            onBlur={() => setFocusedRecentFolderActionPath((path) => (path === folder.path ? null : path))}
-                            onFocus={() => setFocusedRecentFolderActionPath(folder.path)}
-                            onClick={() => onRemoveRecentFolder(folder)}
-                          >
-                            <X aria-hidden="true" size={13} />
-                          </IconButton>
-                        );
-                      })()
-                    ) : null}
-                  </div>
-                ))}
+                  return (
+                    <div
+                      className={`markdown-file-tree-recent-folder grid ${duplicateName ? "h-10" : "h-7"} grid-cols-[minmax(0,1fr)_auto] items-center gap-1`}
+                      key={folder.path}
+                      onMouseEnter={() => setHoveredRecentFolderPath(folder.path)}
+                      onMouseLeave={() => {
+                        setHoveredRecentFolderPath((path) => (path === folder.path ? null : path));
+                        setFocusedRecentFolderActionPath((path) => (path === folder.path ? null : path));
+                      }}
+                    >
+                      <button
+                        aria-label={folderActionLabel}
+                        aria-current={currentRecentFolder ? "page" : undefined}
+                        className={`flex ${duplicateName ? "h-10 items-center" : "h-7 items-center"} min-w-0 cursor-pointer gap-2 rounded-sm border-0 px-2 text-left text-[12px] leading-none focus-visible:outline-none ${recentFolderButtonStateClassName}`}
+                        type="button"
+                        title={folder.path}
+                        onClick={() => onOpenRecentFolder(folder)}
+                      >
+                        <RecentFolderIcon aria-hidden="true" className="shrink-0" size={14} />
+                        <span className="flex min-w-0 flex-col gap-0.5">
+                          <span className="min-w-0 truncate">{folder.name}</span>
+                          {duplicateName ? (
+                            <span className="min-w-0 truncate text-[10px] leading-none text-(--text-tertiary)">
+                              {folderPathLabel}
+                            </span>
+                          ) : null}
+                        </span>
+                      </button>
+                      {onRemoveRecentFolder ? (
+                        (() => {
+                          const actionVisible =
+                            hoveredRecentFolderPath === folder.path || focusedRecentFolderActionPath === folder.path;
+
+                          return (
+                            <IconButton
+                              className="rounded-md transition-opacity duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]"
+                              label={`${label("app.removeRecentMarkdownFolder")}: ${folderActionLabel}`}
+                              style={{
+                                opacity: actionVisible ? 1 : 0,
+                                pointerEvents: actionVisible ? "auto" : "none"
+                              }}
+                              onBlur={() => setFocusedRecentFolderActionPath((path) => (path === folder.path ? null : path))}
+                              onFocus={() => setFocusedRecentFolderActionPath(folder.path)}
+                              onClick={() => onRemoveRecentFolder(folder)}
+                            >
+                              <X aria-hidden="true" size={13} />
+                            </IconButton>
+                          );
+                        })()
+                      ) : null}
+                    </div>
+                  );
+                })}
               </div>
             ) : null}
           </section>

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   createNativeMarkdownTreeFile,
   createNativeMarkdownTreeFolder,
@@ -78,6 +78,12 @@ function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) 
         onClick={() => tree.openRecentFolder?.({ name: "notes", path: "/recent/notes" })}
       >
         Open recent folder
+      </button>
+      <button
+        type="button"
+        onClick={() => tree.openRecentFolder?.({ name: "docs", path: "/mock-workspaces/beta/docs" })}
+      >
+        Open second docs folder
       </button>
       <button
         type="button"
@@ -311,6 +317,38 @@ describe("useMarkdownFileTree", () => {
     expect(mockedSaveStoredRecentMarkdownFolder).toHaveBeenCalledWith({
       name: "notes",
       path: "/recent/notes"
+    });
+  });
+
+  it("moves an opened recent folder to the top of the recent list", async () => {
+    mockedGetStoredRecentMarkdownFolders.mockResolvedValue([
+      { name: "docs", path: "/mock-workspaces/alpha/docs" },
+      { name: "docs", path: "/mock-workspaces/beta/docs" }
+    ]);
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { path: "/mock-workspaces/beta/docs/index.md", name: "index.md", relativePath: "index.md" }
+    ]);
+
+    render(<FileTreeProbe />);
+
+    const recentList = await screen.findByRole("list", { name: "Recent folders" });
+    expect(within(recentList).getAllByRole("listitem").map((item) => item.textContent)).toEqual([
+      "/mock-workspaces/alpha/docs",
+      "/mock-workspaces/beta/docs"
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+    expect(screen.getByTestId("root-name")).toHaveTextContent("docs");
+    expect(within(recentList).getAllByRole("listitem").map((item) => item.textContent)).toEqual([
+      "/mock-workspaces/beta/docs",
+      "/mock-workspaces/alpha/docs"
+    ]);
+    expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith("/mock-workspaces/beta/docs");
+    expect(mockedSaveStoredRecentMarkdownFolder).toHaveBeenCalledWith({
+      name: "docs",
+      path: "/mock-workspaces/beta/docs"
     });
   });
 


### PR DESCRIPTION
## Summary
- Disambiguate duplicate recent folders by showing a compact middle-truncated path under repeated names.
- Preserve LRU reordering when a recent folder opens, and mark the currently opened recent folder with active state, `FolderOpen`, and `aria-current`.
- Add regression coverage for duplicate recent folder display, compact path labels, and LRU reordering.

## Why
- Duplicate folder names such as `docs` looked identical in the recent directories list.
- Opening one of them moved it in the LRU list, which made the UI feel like the items were jumping between folders instead of clearly opening the selected path.

## Validation
- `pnpm --filter @markra/app test -- MarkdownFileTreeDrawer.test.tsx` passed: 61 tests.
- `pnpm --filter @markra/app test -- useMarkdownFileTree.test.tsx` passed: 14 tests.
- `pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Related Issues
Closes #334
