### PR TITLE
feat(app): remember recent folder section state

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -437,6 +437,7 @@ function WorkspaceApp() {
     openRecentFolder,
     removeRecentFolder,
     renameFile: renameMarkdownTreeFile,
+    recentFoldersOpen: recentMarkdownFoldersOpen,
     recentFolders: recentMarkdownFolders,
     refresh: refreshMarkdownFileTree,
     resizing: fileTreeResizing,
@@ -445,6 +446,7 @@ function WorkspaceApp() {
     sourcePath: fileTreeSourcePath,
     rootNameForDocument,
     setRootFromMarkdownFilePath,
+    setRecentFoldersOpen: setRecentMarkdownFoldersOpen,
     startResize: startFileTreeResize,
     toggle: toggleFileTree,
     width: fileTreeWidth,
@@ -3274,6 +3276,7 @@ function WorkspaceApp() {
               open={fileTreeOpen}
               outlineItems={outlineItems}
               recentFolders={recentMarkdownFolders}
+              recentFoldersOpen={recentMarkdownFoldersOpen}
               rootPath={fileTree.sourcePath}
               rootName={fileTreeRootName}
               sidebarLayoutMode={editorPreferences.preferences.sidebarLayoutMode}
@@ -3292,6 +3295,7 @@ function WorkspaceApp() {
               onOpenFolder={handleOpenMarkdownFolder}
               onOpenRecentFolder={handleOpenRecentMarkdownFolder}
               onOpenSettings={handleOpenSettings}
+              onRecentFoldersOpenChange={setRecentMarkdownFoldersOpen}
               onRemoveRecentFolder={removeRecentFolder}
               onRenameFile={handleRenameMarkdownTreeFile}
               onResize={resizeFileTree}

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -124,6 +124,7 @@ type MarkdownFileTreeDrawerProps = {
   outlineItems: MarkdownOutlineItem[];
   platform?: DesktopPlatform;
   recentFolders?: readonly RecentMarkdownFolder[];
+  recentFoldersOpen?: boolean;
   rootPath?: string | null;
   rootName: string;
   sidebarLayoutMode?: SidebarLayoutMode;
@@ -137,6 +138,7 @@ type MarkdownFileTreeDrawerProps = {
   onOpenFolder?: () => unknown | Promise<unknown>;
   onOpenRecentFolder?: (folder: RecentMarkdownFolder) => unknown | Promise<unknown>;
   onOpenSettings?: () => unknown | Promise<unknown>;
+  onRecentFoldersOpenChange?: (open: boolean) => unknown;
   onRemoveRecentFolder?: (folder: RecentMarkdownFolder) => unknown | Promise<unknown>;
   onMoveFile?: (file: NativeMarkdownFolderFile, targetParentPath: string | null) => unknown | Promise<unknown>;
   onRenameFile?: (file: NativeMarkdownFolderFile, fileName: string) => unknown | Promise<unknown>;
@@ -330,6 +332,7 @@ export function MarkdownFileTreeDrawer({
   outlineItems,
   platform = resolveDesktopPlatform(),
   recentFolders = [],
+  recentFoldersOpen: controlledRecentFoldersOpen,
   rootPath = null,
   rootName,
   sidebarLayoutMode = "stacked",
@@ -343,6 +346,7 @@ export function MarkdownFileTreeDrawer({
   onOpenFolder,
   onOpenRecentFolder,
   onOpenSettings = () => {},
+  onRecentFoldersOpenChange,
   onRemoveRecentFolder,
   onMoveFile,
   onRenameFile,
@@ -369,7 +373,7 @@ export function MarkdownFileTreeDrawer({
   const [focusedRecentFolderActionPath, setFocusedRecentFolderActionPath] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [recentFoldersOpen, setRecentFoldersOpen] = useState(true);
+  const [localRecentFoldersOpen, setLocalRecentFoldersOpen] = useState(true);
   const [outlineOpen, setOutlineOpen] = useState(true);
   const [outlineHeightPercent, setOutlineHeightPercent] = useState(defaultOutlineHeightPercent);
   const [creatingFile, setCreatingFile] = useState(false);
@@ -408,6 +412,14 @@ export function MarkdownFileTreeDrawer({
   );
   const fullTree = useMemo(() => buildMarkdownFileTree(files, rootPath, fileTreeSort), [files, rootPath, fileTreeSort]);
   const tree = useMemo(() => filterMarkdownFileTree(fullTree, searchQuery), [fullTree, searchQuery]);
+  const recentFoldersOpen = controlledRecentFoldersOpen ?? localRecentFoldersOpen;
+  const setRecentFoldersExpanded = useCallback((openRecentFolders: boolean) => {
+    if (controlledRecentFoldersOpen === undefined) {
+      setLocalRecentFoldersOpen(openRecentFolders);
+    }
+
+    onRecentFoldersOpenChange?.(openRecentFolders);
+  }, [controlledRecentFoldersOpen, onRecentFoldersOpenChange]);
   const visibleFileTreeRows = useMemo(
     () => buildVisibleFileTreeRows(
       tree,
@@ -1661,7 +1673,7 @@ export function MarkdownFileTreeDrawer({
                 className="rounded-md"
                 label={recentFoldersOpen ? label("app.hideRecentMarkdownFolders") : label("app.showRecentMarkdownFolders")}
                 pressed={recentFoldersOpen}
-                onClick={() => setRecentFoldersOpen((open) => !open)}
+                onClick={() => setRecentFoldersExpanded(!recentFoldersOpen)}
               >
                 {recentFoldersOpen ? (
                   <ChevronDown aria-hidden="true" size={14} />

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   createAiAgentSessionId,
   getStoredRecentMarkdownFolders,
+  getStoredWorkspaceState,
   removeStoredRecentMarkdownFolder,
   saveStoredRecentMarkdownFolder,
   saveStoredWorkspaceState,
@@ -33,6 +34,7 @@ vi.mock("../lib/tauri", () => ({
 vi.mock("../lib/settings/app-settings", () => ({
   createAiAgentSessionId: vi.fn(),
   getStoredRecentMarkdownFolders: vi.fn(),
+  getStoredWorkspaceState: vi.fn(),
   prependRecentMarkdownFolder: vi.fn((folders: RecentMarkdownFolder[], folder: RecentMarkdownFolder) => [
     folder,
     ...folders.filter((item) => item.path !== folder.path)
@@ -52,9 +54,25 @@ const mockedRenameNativeMarkdownTreeFile = vi.mocked(renameNativeMarkdownTreeFil
 const mockedWatchNativeMarkdownTree = vi.mocked(watchNativeMarkdownTree);
 const mockedCreateAiAgentSessionId = vi.mocked(createAiAgentSessionId);
 const mockedGetStoredRecentMarkdownFolders = vi.mocked(getStoredRecentMarkdownFolders);
+const mockedGetStoredWorkspaceState = vi.mocked(getStoredWorkspaceState);
 const mockedRemoveStoredRecentMarkdownFolder = vi.mocked(removeStoredRecentMarkdownFolder);
 const mockedSaveStoredRecentMarkdownFolder = vi.mocked(saveStoredRecentMarkdownFolder);
 const mockedSaveStoredWorkspaceState = vi.mocked(saveStoredWorkspaceState);
+
+function mockWorkspaceState(
+  patch: Partial<Awaited<ReturnType<typeof getStoredWorkspaceState>>> = {}
+): Awaited<ReturnType<typeof getStoredWorkspaceState>> {
+  return {
+    aiAgentSessionId: null,
+    filePath: null,
+    fileTreeOpen: false,
+    folderName: null,
+    folderPath: null,
+    openFilePaths: [],
+    openWindows: [],
+    ...patch
+  };
+}
 
 function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) {
   const tree = useMarkdownFileTree();
@@ -65,6 +83,7 @@ function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) 
       <p data-testid="open-state">{tree.open ? "open" : "closed"}</p>
       <p data-testid="tree-width">{tree.width}</p>
       <p data-testid="tree-resizing">{tree.resizing ? "resizing" : "idle"}</p>
+      <p data-testid="recent-folders-open-state">{tree.recentFoldersOpen ? "open" : "closed"}</p>
       <p data-testid="layout-class">{tree.workspaceLayoutClassName}</p>
       <p data-testid="layout-columns">{tree.workspaceLayoutStyle.gridTemplateColumns}</p>
       <button type="button" onClick={() => tree.openMarkdownFolder()}>
@@ -105,6 +124,12 @@ function FileTreeProbe({ currentPath = null }: { currentPath?: string | null }) 
       </button>
       <button type="button" onClick={tree.endResize}>
         End resize
+      </button>
+      <button type="button" onClick={() => tree.setRecentFoldersOpen?.(false)}>
+        Collapse recent folders
+      </button>
+      <button type="button" onClick={() => tree.setRecentFoldersOpen?.(true)}>
+        Expand recent folders
       </button>
       <button type="button" onClick={() => tree.createFile("Daily note")}>
         Create
@@ -166,11 +191,15 @@ describe("useMarkdownFileTree", () => {
     mockedWatchNativeMarkdownTree.mockReset();
     mockedCreateAiAgentSessionId.mockReset();
     mockedGetStoredRecentMarkdownFolders.mockReset();
+    mockedGetStoredWorkspaceState.mockReset();
     mockedRemoveStoredRecentMarkdownFolder.mockReset();
     mockedSaveStoredRecentMarkdownFolder.mockReset();
     mockedSaveStoredWorkspaceState.mockReset();
     mockedCreateAiAgentSessionId.mockReturnValue("session-folder");
     mockedGetStoredRecentMarkdownFolders.mockResolvedValue([]);
+    mockedGetStoredWorkspaceState.mockResolvedValue(mockWorkspaceState({
+      recentFoldersOpen: true
+    }));
     mockedRemoveStoredRecentMarkdownFolder.mockResolvedValue([]);
     mockedSaveStoredRecentMarkdownFolder.mockResolvedValue([]);
     mockedCreateNativeMarkdownTreeFile.mockResolvedValue({
@@ -293,6 +322,30 @@ describe("useMarkdownFileTree", () => {
 
     expect(await screen.findByText("/recent/notes")).toBeInTheDocument();
     expect(mockedGetStoredRecentMarkdownFolders).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores and persists the recent folder section expansion state", async () => {
+    mockedGetStoredWorkspaceState.mockResolvedValue(mockWorkspaceState({
+      recentFoldersOpen: false
+    }));
+
+    render(<FileTreeProbe />);
+
+    await waitFor(() => expect(screen.getByTestId("recent-folders-open-state")).toHaveTextContent("closed"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand recent folders" }));
+
+    expect(screen.getByTestId("recent-folders-open-state")).toHaveTextContent("open");
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      recentFoldersOpen: true
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse recent folders" }));
+
+    expect(screen.getByTestId("recent-folders-open-state")).toHaveTextContent("closed");
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      recentFoldersOpen: false
+    });
   });
 
   it("opens a remembered markdown folder without showing the native picker", async () => {

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from "re
 import {
   createAiAgentSessionId,
   getStoredRecentMarkdownFolders,
+  getStoredWorkspaceState,
   prependRecentMarkdownFolder,
   removeStoredRecentMarkdownFolder,
   saveStoredRecentMarkdownFolder,
@@ -49,6 +50,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
   const [sourcePath, setSourcePath] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
   const [recentFolders, setRecentFolders] = useState<RecentMarkdownFolder[]>([]);
+  const [recentFoldersOpen, setRecentFoldersOpenState] = useState(true);
   const [width, setWidth] = useState(markdownFileTreeDefaultWidth);
   const [resizing, setResizing] = useState(false);
   const loadedSourcePathRef = useRef<string | null>(null);
@@ -172,6 +174,11 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     forgetRecentFolder(folder.path);
   }, [forgetRecentFolder]);
 
+  const setRecentFoldersOpen = useCallback((openRecentFolders: boolean) => {
+    setRecentFoldersOpenState(openRecentFolders);
+    persistWorkspaceState({ recentFoldersOpen: openRecentFolders });
+  }, []);
+
   const createFile = useCallback(async (fileName: string, parentPath: string | null = null, contents?: string) => {
     if (!sourcePath) return null;
 
@@ -259,6 +266,18 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
   useEffect(() => {
     let active = true;
 
+    getStoredWorkspaceState().then((workspace) => {
+      if (active) setRecentFoldersOpenState(workspace.recentFoldersOpen ?? true);
+    }).catch(() => {});
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
     if (!sourcePath) {
       loadedSourcePathRef.current = null;
       setFiles([]);
@@ -319,6 +338,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     deleteFile,
     files,
     recentFolders,
+    recentFoldersOpen,
     resizing,
     width,
     maxWidth: markdownFileTreeMaxWidth,
@@ -327,6 +347,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     openFolderPath,
     openRecentFolder,
     removeRecentFolder,
+    setRecentFoldersOpen,
     moveFile,
     rootNameForDocument,
     refresh,

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -963,6 +963,7 @@ function workspaceWindowStateIsEmpty(state: StoredWorkspaceWindowState) {
     !state.folderName &&
     !state.folderPath &&
     state.openFilePaths.length === 0 &&
+    state.recentFoldersOpen !== false &&
     !state.sideBySideGroup
   );
 }

--- a/packages/app/src/lib/settings/workspace-state.test.ts
+++ b/packages/app/src/lib/settings/workspace-state.test.ts
@@ -225,6 +225,60 @@ describe("workspace state settings", () => {
     });
   });
 
+  it("persists recent folder collapse state for only the targeted window", async () => {
+    store.get.mockResolvedValue({
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/main.md"],
+          recentFoldersOpen: true
+        },
+        "markra-editor-1": {
+          aiAgentSessionId: "session-secondary",
+          filePath: "/mock-files/secondary.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/secondary.md"],
+          recentFoldersOpen: true
+        }
+      }
+    });
+
+    await saveStoredWorkspaceState({
+      recentFoldersOpen: false
+    }, { windowLabel: "markra-editor-1" });
+
+    expect(store.set).toHaveBeenCalledWith("workspace", {
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/main.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/main.md"],
+          recentFoldersOpen: true
+        },
+        "markra-editor-1": {
+          aiAgentSessionId: "session-secondary",
+          filePath: "/mock-files/secondary.md",
+          fileTreeOpen: true,
+          folderName: "mock-files",
+          folderPath: "/mock-files",
+          openFilePaths: ["/mock-files/secondary.md"],
+          recentFoldersOpen: false
+        }
+      }
+    });
+  });
+
   it("loads workspace state for the targeted window", async () => {
     store.get.mockResolvedValue({
       openWindows: [

--- a/packages/app/src/lib/settings/workspace-state.ts
+++ b/packages/app/src/lib/settings/workspace-state.ts
@@ -10,6 +10,7 @@ export type StoredWorkspaceState = {
   folderPath: string | null;
   openFilePaths: string[];
   openWindows?: StoredWorkspaceWindow[];
+  recentFoldersOpen?: boolean;
   sideBySideGroup?: StoredWorkspaceSideBySideGroup | null;
 };
 
@@ -71,6 +72,7 @@ export function normalizeWorkspaceState(value: unknown): StoredWorkspaceState {
     folderPath: normalizeNullableString(workspace.folderPath),
     openFilePaths,
     openWindows: normalizeWorkspaceWindows(workspace.openWindows),
+    ...(typeof workspace.recentFoldersOpen === "boolean" ? { recentFoldersOpen: workspace.recentFoldersOpen } : {}),
     ...(persistedSideBySideGroup ? { sideBySideGroup: persistedSideBySideGroup } : {})
   };
 }


### PR DESCRIPTION
## Summary
- Remember whether the recent directories section is expanded or collapsed.
- Persist that state in per-window workspace state so multiple open windows do not affect each other.
- Add regression coverage for workspace-state normalization, hook restore/persist behavior, and the controlled drawer toggle.

## Why
- The recent directories section behaves like a sidebar layout preference.
- Persisting it per window lets each editor window restore its own sidebar shape without turning this into a global preference.

## Validation
- `pnpm --filter @markra/app test -- workspace-state.test.ts useMarkdownFileTree.test.tsx MarkdownFileTreeDrawer.test.tsx` passed: 82 tests.
- `pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.
