### PR TITLE
refactor(app): split editor width state

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -54,6 +54,7 @@ import { useAiAgentSessionList } from "./hooks/useAiAgentSessionList";
 import { useAiAgentSession } from "./hooks/useAiAgentSession";
 import { useAiSettings } from "./hooks/useAiSettings";
 import { useDocumentSearchState } from "./hooks/useDocumentSearchState";
+import { useEditorContentWidthState } from "./hooks/useEditorContentWidthState";
 import { useEditorPreferences } from "./hooks/useEditorPreferences";
 import { useDeferredAiSelectionReveal } from "./hooks/ai-selection-reveal";
 import { useExportSettings } from "./hooks/useExportSettings";
@@ -90,7 +91,6 @@ import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
 import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
-import type { EditorContentWidth } from "./lib/editor-width";
 import { saveEditorImage } from "./lib/image-upload";
 import { aiCommandSelection, automaticAiSelection } from "./lib/ai-selection";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
@@ -243,8 +243,6 @@ function WorkspaceApp() {
   const webSearchSettings = useWebSearchSettings();
   const [markdownTemplates, setMarkdownTemplates] = useState<MarkdownTemplate[]>([]);
   const [aiAgentSessionId, setAiAgentSessionId] = useState<string | null>(null);
-  const [editorContentWidth, setEditorContentWidth] = useState<EditorContentWidth>("default");
-  const [editorContentWidthPx, setEditorContentWidthPx] = useState<number | null>(null);
   const [aiResults, setAiResults] = useState<AiDiffResult[]>([]);
   const [activeImageFile, setActiveImageFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [imageTabs, setImageTabs] = useState<ImageDocumentTab[]>([]);
@@ -281,7 +279,6 @@ function WorkspaceApp() {
   const aiContextMenuActionIdRef = useRef(0);
   const aiSelectionCopySuccessTimerRef = useRef<number | null>(null);
   const exportRequestIdRef = useRef(0);
-  const pendingEditorContentWidthPxRef = useRef<number | null>(null);
   const pendingSplitVisualPanePercentRef = useRef(defaultSplitVisualPanePercent);
   const pendingSideDocumentMainPanePercentRef = useRef(defaultSideDocumentMainPanePercent);
   const lastDocumentSearchRevealRevisionRef = useRef(0);
@@ -643,8 +640,30 @@ function WorkspaceApp() {
   });
   const activeAiAgentSessionId = workspaceSessionId ?? aiAgentSessionId;
   const aiResult = aiResults.at(-1) ?? null;
-  const activeEditorContentWidth = editorContentWidth;
-  const activeEditorContentWidthPx = editorContentWidthPx ?? editorPreferences.preferences.contentWidthPx ?? null;
+  const commitEditorContentWidth = useCallback((nextWidth: {
+    contentWidth: typeof editorPreferences.preferences.contentWidth;
+    contentWidthPx: number;
+  }) => {
+    const nextPreferences = {
+      ...editorPreferences.preferences,
+      contentWidth: nextWidth.contentWidth,
+      contentWidthPx: nextWidth.contentWidthPx
+    };
+
+    saveStoredEditorPreferences(nextPreferences)
+      .then(() => notifyAppEditorPreferencesChanged(nextPreferences))
+      .catch(() => {});
+  }, [editorPreferences.preferences]);
+  const {
+    activeWidth: activeEditorContentWidth,
+    activeWidthPx: activeEditorContentWidthPx,
+    onResizeEnd: handleEditorContentWidthResizeEnd,
+    onWidthChange: handleEditorContentWidthChange
+  } = useEditorContentWidthState({
+    contentWidth: editorPreferences.preferences.contentWidth,
+    contentWidthPx: editorPreferences.preferences.contentWidthPx ?? null,
+    onCommit: commitEditorContentWidth
+  });
   const resolvedSplitVisualPanePercent =
     clampNumber(splitVisualPanePercent, splitVisualPanePercentMin, splitVisualPanePercentMax) ?? defaultSplitVisualPanePercent;
   const resolvedSideDocumentMainPanePercent =
@@ -1455,13 +1474,6 @@ function WorkspaceApp() {
   }, [handleSaveClipboardImage, readOnlyMode, translate]);
 
   useEffect(() => {
-    const storedWidth = editorPreferences.preferences.contentWidthPx ?? null;
-    setEditorContentWidth(editorPreferences.preferences.contentWidth);
-    setEditorContentWidthPx(storedWidth);
-    pendingEditorContentWidthPxRef.current = storedWidth;
-  }, [editorPreferences.preferences.contentWidth, editorPreferences.preferences.contentWidthPx]);
-
-  useEffect(() => {
     setSplitVisualPanePercent(editorPreferences.preferences.splitVisualPanePercent);
     pendingSplitVisualPanePercentRef.current = editorPreferences.preferences.splitVisualPanePercent;
   }, [editorPreferences.preferences.splitVisualPanePercent]);
@@ -1479,25 +1491,6 @@ function WorkspaceApp() {
     };
   }, []);
 
-  const handleEditorContentWidthChange = useCallback((width: number) => {
-    pendingEditorContentWidthPxRef.current = width;
-    setEditorContentWidthPx(width);
-  }, []);
-
-  const handleEditorContentWidthResizeEnd = useCallback(() => {
-    const nextWidth = pendingEditorContentWidthPxRef.current;
-    if (nextWidth === null) return;
-
-    const nextPreferences = {
-      ...editorPreferences.preferences,
-      contentWidth: activeEditorContentWidth,
-      contentWidthPx: nextWidth
-    };
-
-    saveStoredEditorPreferences(nextPreferences)
-      .then(() => notifyAppEditorPreferencesChanged(nextPreferences))
-      .catch(() => {});
-  }, [activeEditorContentWidth, editorPreferences.preferences]);
   const resizeSplitVisualPane = useCallback((nextPercent: number | null) => {
     if (nextPercent === null) return;
 

--- a/packages/app/src/hooks/useEditorContentWidthState.test.tsx
+++ b/packages/app/src/hooks/useEditorContentWidthState.test.tsx
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import type { EditorContentWidth } from "../lib/editor-width";
+import { useEditorContentWidthState } from "./useEditorContentWidthState";
+
+describe("useEditorContentWidthState", () => {
+  it("syncs local state from stored editor preferences", () => {
+    const onCommit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ contentWidth, contentWidthPx }) => useEditorContentWidthState({
+        contentWidth,
+        contentWidthPx,
+        onCommit
+      }),
+      {
+        initialProps: {
+          contentWidth: "default" as EditorContentWidth,
+          contentWidthPx: null as number | null
+        }
+      }
+    );
+
+    expect(result.current.width).toBe("default");
+    expect(result.current.widthPx).toBeNull();
+
+    rerender({
+      contentWidth: "wide",
+      contentWidthPx: 1040
+    });
+
+    expect(result.current.width).toBe("wide");
+    expect(result.current.widthPx).toBe(1040);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("tracks a pending resized width and commits it on resize end", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useEditorContentWidthState({
+      contentWidth: "default",
+      contentWidthPx: null,
+      onCommit
+    }));
+
+    act(() => result.current.onWidthChange(960));
+
+    expect(result.current.widthPx).toBe(960);
+    expect(result.current.activeWidthPx).toBe(960);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    act(() => result.current.onResizeEnd());
+
+    expect(onCommit).toHaveBeenCalledWith({
+      contentWidth: "default",
+      contentWidthPx: 960
+    });
+  });
+
+  it("does not commit when no resized width is pending", () => {
+    const onCommit = vi.fn();
+    const { result } = renderHook(() => useEditorContentWidthState({
+      contentWidth: "narrow",
+      contentWidthPx: null,
+      onCommit
+    }));
+
+    act(() => result.current.onResizeEnd());
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("uses the stored pixel width as the active fallback", () => {
+    const { result } = renderHook(() => useEditorContentWidthState({
+      contentWidth: "wide",
+      contentWidthPx: 1120,
+      onCommit: () => {}
+    }));
+
+    expect(result.current.activeWidth).toBe("wide");
+    expect(result.current.activeWidthPx).toBe(1120);
+  });
+});

--- a/packages/app/src/hooks/useEditorContentWidthState.ts
+++ b/packages/app/src/hooks/useEditorContentWidthState.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { EditorContentWidth } from "../lib/editor-width";
+
+type EditorContentWidthCommit = {
+  contentWidth: EditorContentWidth;
+  contentWidthPx: number;
+};
+
+type UseEditorContentWidthStateOptions = {
+  contentWidth: EditorContentWidth;
+  contentWidthPx: number | null;
+  onCommit: (commit: EditorContentWidthCommit) => unknown;
+};
+
+export function useEditorContentWidthState({
+  contentWidth,
+  contentWidthPx,
+  onCommit
+}: UseEditorContentWidthStateOptions) {
+  const [width, setWidth] = useState<EditorContentWidth>(contentWidth);
+  const [widthPx, setWidthPx] = useState<number | null>(contentWidthPx);
+  const pendingWidthPxRef = useRef<number | null>(contentWidthPx);
+
+  useEffect(() => {
+    setWidth(contentWidth);
+    setWidthPx(contentWidthPx);
+    pendingWidthPxRef.current = contentWidthPx;
+  }, [contentWidth, contentWidthPx]);
+
+  const onWidthChange = useCallback((nextWidthPx: number) => {
+    pendingWidthPxRef.current = nextWidthPx;
+    setWidthPx(nextWidthPx);
+  }, []);
+
+  const onResizeEnd = useCallback(() => {
+    const nextWidthPx = pendingWidthPxRef.current;
+    if (nextWidthPx === null) return;
+
+    onCommit({
+      contentWidth: width,
+      contentWidthPx: nextWidthPx
+    });
+  }, [onCommit, width]);
+
+  return {
+    activeWidth: width,
+    activeWidthPx: widthPx ?? contentWidthPx ?? null,
+    onResizeEnd,
+    onWidthChange,
+    width,
+    widthPx
+  };
+}


### PR DESCRIPTION
## Summary
- Move editor content width and resized pixel width state into useEditorContentWidthState.
- Keep App.tsx responsible for persisting editor preference commits through the existing settings path.
- Add focused hook coverage for preference sync, resize tracking, commit behavior, and active width fallback.

## Why
- Continues splitting App.tsx state ownership into small feature-owned hooks.
- Keeps this PR narrowly focused now that #337 has merged into main.

## Validation
- `pnpm --filter @markra/app test -- useEditorContentWidthState.test.tsx App.test.tsx App.ai.test.tsx` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check origin/main...HEAD` passed

## Risk
- Behavior-preserving refactor. The main risk is content width resize preference persistence, covered by the new hook tests and App tests.