### PR TITLE
fix(app): sync sidebar collapse animation

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -51,12 +51,61 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.queryByRole("button", { name: "Toggle file list" })).not.toBeInTheDocument();
     expect(settings).toHaveClass("fixed", "bottom-3", "left-3");
     expect(settings).toContainElement(container.querySelector(".lucide-settings"));
-    expect(container.querySelector(".markdown-file-tree")).toHaveClass("opacity-0", "-translate-x-4");
+    expect(container.querySelector(".markdown-file-tree")).toHaveStyle({
+      maxWidth: "0px",
+      minWidth: "0px",
+      width: "0px"
+    });
     expect(container.querySelector(".markdown-file-tree")).toHaveAttribute("aria-hidden", "true");
 
     fireEvent.click(settings);
 
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses its own width so the drawer contents clip with the workspace animation", () => {
+    const { container, rerender } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const drawer = container.querySelector(".markdown-file-tree");
+
+    expect(drawer).toHaveClass("transition-[width,min-width,max-width]");
+    expect(drawer).not.toHaveClass("opacity-100", "opacity-0");
+    expect(container.querySelector(".markdown-file-tree-content")).toHaveClass("transition-opacity", "opacity-100");
+    expect(drawer).toHaveStyle({
+      maxWidth: "288px",
+      minWidth: "288px",
+      width: "288px"
+    });
+
+    rerender(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open={false}
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".markdown-file-tree")).toHaveStyle({
+      maxWidth: "0px",
+      minWidth: "0px",
+      width: "0px"
+    });
+    expect(container.querySelector(".markdown-file-tree")).not.toHaveClass("opacity-0");
+    expect(container.querySelector(".markdown-file-tree-content")).toHaveClass("opacity-0");
   });
 
   it("shows file and outline panels together", () => {
@@ -586,7 +635,9 @@ describe("MarkdownFileTreeDrawer", () => {
 
     expect(sidebar).toBeInTheDocument();
     expect(sidebar).not.toHaveClass("fixed");
-    expect(sidebar).toHaveClass("transition-[transform,opacity]", "translate-x-0", "opacity-100");
+    expect(sidebar).toHaveClass("transition-[width,min-width,max-width]");
+    expect(sidebar).not.toHaveClass("opacity-100", "opacity-0");
+    expect(container.querySelector(".markdown-file-tree-content")).toHaveClass("transition-opacity", "opacity-100");
     expect(sidebar).toHaveClass("bg-(--bg-secondary)");
     expect(screen.getByText("Files")).toBeInTheDocument();
     expect(screen.getByText("Obsidian Vault")).toBeInTheDocument();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -515,12 +515,12 @@ export function MarkdownFileTreeDrawer({
     [outlineRenderItems]
   );
   const label = (key: Parameters<typeof t>[1]) => t(language, key);
-  const drawerStateClass = open
-    ? "translate-x-0 opacity-100"
-    : "pointer-events-none -translate-x-4 opacity-0";
+  const drawerStateClass = open ? "" : "pointer-events-none";
+  const drawerContentStateClass = open ? "opacity-100" : "opacity-0";
   const resolvedMinWidth = Math.max(160, minWidth);
   const resolvedMaxWidth = Math.max(resolvedMinWidth, maxWidth);
   const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
+  const drawerWidth = resolvedWidth === null ? null : open ? resolvedWidth : 0;
   const showWindowsOpenFolderAction = platform === "windows" && onOpenFolder;
   const drawerTopPaddingClassName = platform === "windows" ? "pt-0" : "pt-10";
   const fileCreationAvailable = Boolean(onCreateFile);
@@ -1862,12 +1862,13 @@ export function MarkdownFileTreeDrawer({
       ) : null}
 
       <aside
-        className={`markdown-file-tree relative flex h-full min-h-0 w-full flex-col border-r border-(--border-default) ${fileTreeSurfaceClassName} ${drawerTopPaddingClassName} will-change-transform transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${drawerStateClass}`}
+        className={`markdown-file-tree relative flex h-full min-h-0 w-full flex-col overflow-hidden border-r border-(--border-default) ${fileTreeSurfaceClassName} ${drawerTopPaddingClassName} will-change-[width,min-width,max-width] transition-[width,min-width,max-width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${drawerStateClass}`}
         aria-label={label("app.markdownFileTree")}
         aria-hidden={!open}
         inert={!open}
-        style={resolvedWidth === null ? undefined : { maxWidth: resolvedWidth, minWidth: resolvedWidth, width: resolvedWidth }}
+        style={drawerWidth === null ? undefined : { maxWidth: drawerWidth, minWidth: drawerWidth, width: drawerWidth }}
       >
+        <div className={`markdown-file-tree-content flex min-h-0 flex-1 flex-col transition-opacity duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${drawerContentStateClass}`}>
         {renderSidebarPanelTabs()}
         {open && onResize && resolvedWidth !== null ? (
           <div
@@ -2242,6 +2243,7 @@ export function MarkdownFileTreeDrawer({
 
           </div>
         ) : null}
+        </div>
       </aside>
     </>
   );

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -88,14 +88,74 @@ describe("NativeTitleBar", () => {
     expect(screen.getByRole("tab", { name: "Draft.md" }).closest("[data-tauri-drag-region]")).toBeNull();
     expect(container.querySelector(".native-titlebar")).toHaveClass("bg-(--bg-primary)");
     expect(container.querySelector(".native-titlebar")).not.toHaveClass("border-b");
-    expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      background: "linear-gradient(to right, var(--bg-secondary) 0 220px, var(--bg-primary) 220px 100%)"
-    });
-    expect(container.querySelector(".native-titlebar-sidebar-divider")).toHaveStyle({ left: "219px" });
+    const sidebarSurface = container.querySelector<HTMLElement>(".native-titlebar-sidebar-surface");
+    const sidebarDivider = container.querySelector<HTMLElement>(".native-titlebar-sidebar-divider");
+    expect(sidebarSurface).toHaveStyle({ width: "220px" });
+    expect(sidebarSurface).toContainElement(sidebarDivider);
+    expect(sidebarDivider).toHaveClass("right-0", "opacity-100");
     expect(container.querySelector(".native-title-slot")).toHaveStyle({
       marginLeft: "56px"
     });
     expect(container.querySelector(".native-title-slot")).not.toHaveStyle({ transform: "translateX(110px)" });
+  });
+
+  it("keeps the titlebar sidebar surface mounted so it animates with the workspace columns", () => {
+    const { container, rerender } = render(
+      <NativeTitleBar
+        aiAgentOpen={false}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen
+        markdownFilesWidth={288}
+        theme="light"
+        titleContent={(
+          <div role="tablist" aria-label="Open documents">
+            <button type="button" role="tab" aria-selected="true">Draft.md</button>
+          </div>
+        )}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    const surface = container.querySelector<HTMLElement>(".native-titlebar-sidebar-surface");
+    const divider = container.querySelector<HTMLElement>(".native-titlebar-sidebar-divider");
+
+    expect(surface).toBeInTheDocument();
+    expect(surface).toHaveClass("transition-[width]", "duration-200", "ease-[cubic-bezier(0.22,1,0.36,1)]");
+    expect(surface).toHaveStyle({ width: "288px" });
+    expect(divider).toBeInTheDocument();
+    expect(surface).toContainElement(divider);
+    expect(divider).toHaveClass("right-0", "opacity-100");
+    expect(divider).not.toHaveClass("transition-[left]");
+    expect(divider).not.toHaveStyle({ left: "287px" });
+
+    rerender(
+      <NativeTitleBar
+        aiAgentOpen={false}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen={false}
+        markdownFilesWidth={288}
+        theme="light"
+        titleContent={(
+          <div role="tablist" aria-label="Open documents">
+            <button type="button" role="tab" aria-selected="true">Draft.md</button>
+          </div>
+        )}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    expect(container.querySelector(".native-titlebar-sidebar-surface")).toHaveStyle({ width: "0px" });
+    expect(container.querySelector(".native-titlebar-sidebar-divider")).not.toHaveStyle({ left: "0px" });
   });
 
   it("keeps the shifted titlebar sidebar gap draggable when tabs are visible", () => {

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -621,16 +621,14 @@ export function NativeTitleBar({
   const titlebarSurfaceClassName = "bg-(--bg-primary)";
   const windowsAppChromeSurfaceClassName = "bg-(--bg-chrome)";
   const windowsTitlebarSurfaceClassName = titlebarSurfaceClassName;
-  const titlebarSurfaceStyle: CSSProperties | undefined = nativeWindowChrome && markdownFilesOpen
-    ? {
-      background: `linear-gradient(to right, var(--bg-secondary) 0 ${markdownFilesWidth}px, var(--bg-primary) ${markdownFilesWidth}px 100%)`
-    }
-    : undefined;
+  const titlebarSidebarWidth = nativeWindowChrome && markdownFilesOpen ? markdownFilesWidth : 0;
+  const titlebarSidebarWidthTransitionClassName = markdownFilesResizing
+    ? "transition-none"
+    : "transition-[width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none";
   const windowsTitlebarActionsTransitionClassName = aiAgentResizing
     ? "transition-none"
     : "transition-[opacity,background-color,color,transform] duration-150 ease-out";
   const titlebarGridStyle: CSSProperties = {
-    ...(titlebarSurfaceStyle ?? {}),
     ...(!nativeWindowChrome && markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
     gridTemplateColumns: nativeWindowChrome
       ? `${titlebarSideSlotWidth}px minmax(0,1fr) ${titlebarSideSlotWidth}px`
@@ -642,12 +640,17 @@ export function NativeTitleBar({
       {titleContent}
     </div>
   );
-  const renderMarkdownFilesDivider = () => nativeWindowChrome && markdownFilesOpen ? (
+  const renderTitlebarSidebarSurface = () => nativeWindowChrome ? (
     <span
       aria-hidden="true"
-      className="native-titlebar-sidebar-divider pointer-events-none absolute top-0 bottom-0 z-30 w-px bg-(--border-default)"
-      style={{ left: Math.max(0, markdownFilesWidth - 1) }}
-    />
+      className={`native-titlebar-sidebar-surface pointer-events-none absolute top-0 bottom-0 left-0 z-0 bg-(--bg-secondary) ${titlebarSidebarWidthTransitionClassName}`}
+      style={{ width: titlebarSidebarWidth }}
+    >
+      <span
+        aria-hidden="true"
+        className="native-titlebar-sidebar-divider pointer-events-none absolute top-0 right-0 bottom-0 w-px bg-(--border-default) opacity-100"
+      />
+    </span>
   ) : null;
   const renderTitlebarSidebarDragFill = () => {
     if (!nativeWindowChrome || !markdownFilesOpen || !titleContent) return null;
@@ -880,7 +883,7 @@ export function NativeTitleBar({
       aria-label={label("app.windowDragRegion")}
       data-tauri-drag-region={nativeWindowChrome && !titleContent ? true : undefined}
     >
-      {renderMarkdownFilesDivider()}
+      {renderTitlebarSidebarSurface()}
       {renderTitlebarSidebarDragFill()}
       <div
         className={`titlebar-spacer relative z-20 flex h-10 items-center gap-1 ${titlebarLeftPaddingClassName}`}


### PR DESCRIPTION
## Summary
- Keep the native titlebar sidebar surface mounted and animate its width instead of swapping a gradient.
- Collapse the file tree drawer by width while fading only its content layer.
- Attach the titlebar divider to the animated sidebar surface so top and bottom borders share the same movement.
- Add focused regression coverage for titlebar and file tree collapse states.

## Why
The sidebar collapse animation was visually split across independent elements: the workspace grid, the drawer, the titlebar background, and the titlebar divider each animated different properties. That caused mid-animation drift, missing border segments, and mismatched opacity.

## Validation
- `pnpm run typecheck:test` passed
- `pnpm --filter @markra/app exec vitest run src/components/NativeTitleBar.test.tsx` passed
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownFileTreeDrawer.test.tsx` passed
- `pnpm --filter @markra/desktop build` passed
- GitHub checks passed: Frontend, Tauri Rust, Vercel

## Risk
- Low. The change is scoped to sidebar/titlebar animation classes and related tests.