### PR TITLE
fix(editor): reduce horizontal rule click dead zone

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2755,7 +2755,7 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
-  it("ignores horizontal rule margin clicks", async () => {
+  it("only ignores horizontal rule margin clicks close to the divider", async () => {
     const { container, view } = await renderEditor("First\n\n---\n\nSecond");
     const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
     const surface = container.querySelector<HTMLElement>(".ProseMirror");
@@ -2763,20 +2763,38 @@ describe("MarkdownPaper editing", () => {
 
     const secondCursor = findTextPosition(view, "Second");
     moveCursor(view, secondCursor);
-    fireEvent.mouseDown(surface!, {
+    const upperWhitespaceResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
       clientY: 134
     });
+    expect(upperWhitespaceResult).toBe(true);
+    expect(view.state.selection.from).toBe(secondCursor);
+
+    const topGapResult = fireEvent.mouseDown(surface!, {
+      button: 0,
+      clientX: 200,
+      clientY: 138
+    });
+    expect(topGapResult).toBe(false);
     expect(view.state.selection.from).toBe(secondCursor);
 
     const firstCursor = findTextPosition(view, "First");
     moveCursor(view, firstCursor);
-    fireEvent.mouseDown(surface!, {
+    const bottomGapResult = fireEvent.mouseDown(surface!, {
+      button: 0,
+      clientX: 200,
+      clientY: 143
+    });
+    expect(bottomGapResult).toBe(false);
+    expect(view.state.selection.from).toBe(firstCursor);
+
+    const lowerWhitespaceResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
       clientY: 147
     });
+    expect(lowerWhitespaceResult).toBe(true);
     expect(view.state.selection.from).toBe(firstCursor);
 
     restoreLayout();

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -3034,7 +3034,7 @@
   }
 
   .markdown-paper hr {
-    @apply my-8 border-0;
+    @apply my-5 border-0;
     height: 12px;
     cursor: pointer;
     background: linear-gradient(var(--border-default), var(--border-default)) center / 100% 1px no-repeat;

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -181,6 +181,8 @@ describe("editor stylesheet", () => {
 
     expect(ruleStart).toBeGreaterThanOrEqual(0);
     expect(ruleEnd).toBeGreaterThan(ruleStart);
+    expect(ruleStyles).toContain("@apply my-5 border-0");
+    expect(ruleStyles).not.toContain("@apply my-8 border-0");
     expect(ruleStyles).toContain("height:");
     expect(ruleStyles).toContain("cursor: pointer");
     expect(ruleStyles).toContain("background:");

--- a/packages/editor/src/block-gap.ts
+++ b/packages/editor/src/block-gap.ts
@@ -3,7 +3,7 @@ import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
 const gapGuardedBlockNames = new Set(["hr"]);
-const fallbackGapPadding = 12;
+const maximumGuardedGapPadding = 4;
 
 function isPlainLeftMouseDown(event: MouseEvent) {
   return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
@@ -18,19 +18,26 @@ function pixelValue(value: string) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function guardedGapExtent(value: string) {
+  const pixels = pixelValue(value);
+  if (!pixels) return maximumGuardedGapPadding;
+
+  return Math.min(pixels, maximumGuardedGapPadding);
+}
+
 function blockGapExtents(element: Element) {
   const ownerWindow = element.ownerDocument.defaultView;
   if (!ownerWindow) {
     return {
-      bottom: fallbackGapPadding,
-      top: fallbackGapPadding
+      bottom: maximumGuardedGapPadding,
+      top: maximumGuardedGapPadding
     };
   }
 
   const style = ownerWindow.getComputedStyle(element);
   return {
-    bottom: pixelValue(style.marginBottom) || fallbackGapPadding,
-    top: pixelValue(style.marginTop) || fallbackGapPadding
+    bottom: guardedGapExtent(style.marginBottom),
+    top: guardedGapExtent(style.marginTop)
   };
 }
 


### PR DESCRIPTION
## Summary
- Reduce horizontal rule vertical spacing in the WYSIWYG editor.
- Limit the horizontal-rule gap guard to the small area closest to the divider so the surrounding whitespace is less likely to feel dead.
- Update regression coverage for the narrower protected click zone and the adjusted rule spacing.

## Why
#326 stopped caret jumps around horizontal rules by ignoring clicks in the rule margin. In practice that made a large area around dividers feel unresponsive. This keeps the anti-jump protection near the divider while making the surrounding whitespace less hostile to normal clicking.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "horizontal rule"` passed: 4 tests.
- `pnpm --filter @markra/app exec vitest run src/styles.test.ts` passed: 34 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Risk
- Low. The change is scoped to horizontal rule spacing and the existing horizontal-rule gap guard.
- The issue should stay open until users can try the next build and confirm whether the interaction feels better.

## Related Issues
- Refs #331. Keep the issue open while waiting for user feedback on a new version.
