### PR TITLE
fix(desktop): add macOS 27 WebKit scroll workaround

### DIFF
--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -1,5 +1,5 @@
 import { emit, listen } from "@tauri-apps/api/event";
-import { platform as tauriPlatform, type Platform as TauriPlatform } from "@tauri-apps/plugin-os";
+import { platform as tauriPlatform, version as tauriVersion, type Platform as TauriPlatform } from "@tauri-apps/plugin-os";
 import { load } from "@tauri-apps/plugin-store";
 import { hasTauriRuntime } from "@markra/shared";
 import type { AppRuntime } from "@markra/app/runtime";
@@ -26,6 +26,14 @@ function normalizeDesktopPlatform(platform: string | null | undefined): DesktopP
 function resolveDesktopPlatform() {
   try {
     return normalizeDesktopPlatform(tauriPlatform() satisfies TauriPlatform);
+  } catch {
+    return null;
+  }
+}
+
+function resolveDesktopOsVersion() {
+  try {
+    return tauriVersion() || null;
   } catch {
     return null;
   }
@@ -108,6 +116,7 @@ export const desktopRuntime = {
     showMarkdownFileTreeContextMenu: menu.showNativeMarkdownFileTreeContextMenu
   },
   platform: {
+    resolveDesktopOsVersion,
     resolveDesktopPlatform
   },
   settings: {

--- a/apps/web/src/runtime/index.ts
+++ b/apps/web/src/runtime/index.ts
@@ -37,6 +37,7 @@ export function createWebRuntime(options: WebRuntimeOptions = {}): AppRuntime {
     files: createWebFileRuntime(settings, options),
     menu: createWebMenuRuntime(defaultRuntime.menu, options),
     platform: {
+      resolveDesktopOsVersion: () => null,
       resolveDesktopPlatform: () => "windows"
     },
     settings,

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -61,6 +61,7 @@ import {
   mockedRemoveStoredRecentMarkdownFolder,
   mockedResetWelcomeDocumentState,
   mockedRenameNativeMarkdownTreeFile,
+  mockedResolveDesktopOsVersion,
   mockedResolveDesktopPlatform,
   mockedSaveNativeHtmlFile,
   mockedSaveNativeMarkdownFile,
@@ -116,6 +117,8 @@ const defaultImageUpload = {
     username: ""
   }
 };
+
+const webKitScrollWorkaroundAttribute = "data-webkit-scroll-workaround";
 
 function mockElementFromPoint(element: Element) {
   const mock = vi.fn(() => element);
@@ -279,6 +282,29 @@ function mockTitlebarActionRects(actionIds: string[]) {
 }
 
 describe("Markra workspace", () => {
+  it("marks macOS 27 windows for the WebKit scrolling workaround", async () => {
+    mockedResolveDesktopPlatform.mockReturnValue("macos");
+    mockedResolveDesktopOsVersion.mockReturnValue("27.0");
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(document.documentElement).toHaveAttribute(webKitScrollWorkaroundAttribute, "macos-27");
+    });
+  });
+
+  it("clears the WebKit scrolling workaround outside macOS 27", async () => {
+    document.documentElement.setAttribute(webKitScrollWorkaroundAttribute, "macos-27");
+    mockedResolveDesktopPlatform.mockReturnValue("macos");
+    mockedResolveDesktopOsVersion.mockReturnValue("26.6");
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(document.documentElement).not.toHaveAttribute(webKitScrollWorkaroundAttribute);
+    });
+  });
+
   afterEach(() => {
     resetAppRuntimeForTests();
   });
@@ -492,6 +518,7 @@ describe("Markra workspace", () => {
         updater: true
       },
       platform: {
+        resolveDesktopOsVersion: () => null,
         resolveDesktopPlatform: () => "windows"
       }
     });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -96,7 +96,11 @@ import { aiCommandSelection, automaticAiSelection } from "./lib/ai-selection";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
 import { replaceMovedPath } from "./lib/path-move";
-import { resolveDesktopPlatform } from "./lib/platform";
+import {
+  resolveDesktopOsVersion,
+  resolveDesktopPlatform,
+  webKitScrollWorkaroundForPlatform
+} from "./lib/platform";
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
 import { runEditorLinkCommand } from "./app/editor-link-command";
 import { isPandocSetupError, runPandocSetupAction } from "./app/pandoc-setup";
@@ -225,6 +229,8 @@ function SettingsRouteApp() {
 
 function WorkspaceApp() {
   const desktopPlatform = resolveDesktopPlatform();
+  const desktopOsVersion = resolveDesktopOsVersion();
+  const webKitScrollWorkaround = webKitScrollWorkaroundForPlatform(desktopPlatform, desktopOsVersion);
   const appFeatures = getAppRuntime().features;
   const aiFeatureEnabled = appFeatures.ai;
   const exportFeatureEnabled = appFeatures.export;
@@ -315,6 +321,23 @@ function WorkspaceApp() {
     thinkingEnabled: false,
     webSearchEnabled: false
   });
+
+  useEffect(() => {
+    const root = globalThis.document?.documentElement;
+    if (!root) return;
+
+    if (webKitScrollWorkaround) {
+      root.dataset.webkitScrollWorkaround = webKitScrollWorkaround;
+      return () => {
+        if (root.dataset.webkitScrollWorkaround === webKitScrollWorkaround) {
+          delete root.dataset.webkitScrollWorkaround;
+        }
+      };
+    }
+
+    delete root.dataset.webkitScrollWorkaround;
+  }, [webKitScrollWorkaround]);
+
   const translate = useCallback((key: I18nKey) => t(appLanguage.language, key), [appLanguage.language]);
   const clearAiSelectionToolbarCopySuccess = useCallback(() => {
     if (aiSelectionCopySuccessTimerRef.current !== null) {

--- a/packages/app/src/lib/platform.test.ts
+++ b/packages/app/src/lib/platform.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { configureAppRuntime, createDefaultAppRuntime, resetAppRuntimeForTests } from "../runtime";
-import { resolveDesktopPlatform } from "./platform";
+import {
+  macosWebKitScrollWorkaroundAttribute,
+  resolveDesktopPlatform,
+  webKitScrollWorkaroundForPlatform
+} from "./platform";
 
 const originalNavigatorPlatform = navigator.platform;
 
@@ -21,6 +25,7 @@ describe("resolveDesktopPlatform", () => {
     configureAppRuntime({
       ...createDefaultAppRuntime(),
       platform: {
+        resolveDesktopOsVersion: () => null,
         resolveDesktopPlatform: () => "windows"
       }
     });
@@ -32,11 +37,27 @@ describe("resolveDesktopPlatform", () => {
     configureAppRuntime({
       ...createDefaultAppRuntime(),
       platform: {
+        resolveDesktopOsVersion: () => null,
         resolveDesktopPlatform: () => null
       }
     });
     setNavigatorPlatform("MacIntel");
 
     expect(resolveDesktopPlatform()).toBe("macos");
+  });
+});
+
+describe("webKitScrollWorkaroundForPlatform", () => {
+  it("enables the macOS 27 WebKit scrolling workaround", () => {
+    expect(webKitScrollWorkaroundForPlatform("macos", "27.0")).toBe(macosWebKitScrollWorkaroundAttribute);
+    expect(webKitScrollWorkaroundForPlatform("macos", "27.1.2")).toBe(macosWebKitScrollWorkaroundAttribute);
+  });
+
+  it("leaves other platforms and macOS releases untouched", () => {
+    expect(webKitScrollWorkaroundForPlatform("macos", "26.6")).toBeNull();
+    expect(webKitScrollWorkaroundForPlatform("windows", "27.0")).toBeNull();
+    expect(webKitScrollWorkaroundForPlatform("linux", "27.0")).toBeNull();
+    expect(webKitScrollWorkaroundForPlatform(null, "27.0")).toBeNull();
+    expect(webKitScrollWorkaroundForPlatform("macos", null)).toBeNull();
   });
 });

--- a/packages/app/src/lib/platform.ts
+++ b/packages/app/src/lib/platform.ts
@@ -2,6 +2,8 @@ import { getAppRuntime } from "../runtime";
 
 export type DesktopPlatform = "macos" | "windows" | "linux";
 
+export const macosWebKitScrollWorkaroundAttribute = "macos-27";
+
 export function normalizeDesktopPlatform(platform: string | null | undefined): DesktopPlatform | null {
   if (platform === "windows" || platform === "macos" || platform === "linux") {
     return platform;
@@ -32,4 +34,14 @@ function resolveBrowserDesktopPlatform(): DesktopPlatform {
 
 export function resolveDesktopPlatform(): DesktopPlatform {
   return getAppRuntime().platform.resolveDesktopPlatform() ?? resolveBrowserDesktopPlatform();
+}
+
+export function resolveDesktopOsVersion() {
+  return getAppRuntime().platform.resolveDesktopOsVersion();
+}
+
+export function webKitScrollWorkaroundForPlatform(platform: DesktopPlatform | null, osVersion: string | null) {
+  if (platform !== "macos" || !osVersion) return null;
+
+  return /^27(?:\.|$)/u.test(osVersion.trim()) ? macosWebKitScrollWorkaroundAttribute : null;
 }

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -96,6 +96,7 @@ export type AppEventsRuntime = {
 };
 
 export type AppPlatformRuntime = {
+  resolveDesktopOsVersion: () => string | null;
   resolveDesktopPlatform: () => DesktopPlatform | null;
 };
 
@@ -425,6 +426,7 @@ export function createDefaultAppRuntime(): AppRuntime {
       showMarkdownFileTreeContextMenu: async () => undefined
     },
     platform: {
+      resolveDesktopOsVersion: () => null,
       resolveDesktopPlatform: () => null
     },
     settings: createMemorySettingsRuntime(),

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -653,6 +653,25 @@
     height: 0;
   }
 
+  html[data-webkit-scroll-workaround="macos-27"],
+  html[data-webkit-scroll-workaround="macos-27"] * {
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    scrollbar-width: thin;
+  }
+
+  html[data-webkit-scroll-workaround="macos-27"] *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  html[data-webkit-scroll-workaround="macos-27"] *::-webkit-scrollbar-thumb {
+    min-height: 48px;
+    border: 2px solid transparent;
+    border-radius: 999px;
+    background-color: var(--scrollbar-thumb);
+    background-clip: content-box;
+  }
+
   html,
   body,
   #root {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -69,6 +69,26 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("background-clip: content-box");
   });
 
+  it("keeps visible scrollbars for the macOS 27 WebKit scrolling workaround", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const workaroundStart = styles.indexOf('html[data-webkit-scroll-workaround="macos-27"]');
+    const workaroundEnd = styles.indexOf("  html,\n  body,", workaroundStart);
+    const workaroundStyles = styles.slice(workaroundStart, workaroundEnd);
+
+    expect(workaroundStart).toBeGreaterThanOrEqual(0);
+    expect(workaroundEnd).toBeGreaterThan(workaroundStart);
+    expect(workaroundStyles).toContain('html[data-webkit-scroll-workaround="macos-27"]');
+    expect(workaroundStyles).toContain('html[data-webkit-scroll-workaround="macos-27"] *');
+    expect(workaroundStyles).toContain("scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track)");
+    expect(workaroundStyles).toContain("scrollbar-width: thin");
+    expect(workaroundStyles).toContain('html[data-webkit-scroll-workaround="macos-27"] *::-webkit-scrollbar');
+    expect(workaroundStyles).toContain("width: 10px");
+    expect(workaroundStyles).toContain("height: 10px");
+    expect(workaroundStyles).not.toContain("scrollbar-color: auto");
+    expect(workaroundStyles).not.toContain("width: auto");
+    expect(workaroundStyles).not.toContain("height: auto");
+  });
+
   it("keeps primary editor headings free of divider underlines", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const headingStart = styles.indexOf(".markdown-paper h1 {");

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -127,7 +127,7 @@ import {
 } from "../lib/settings/settings-events";
 import { fetchAiProviderModels, testAiProviderConnection } from "@markra/providers";
 import { chatCompletion, generateAiAgentSessionTitle } from "@markra/ai";
-import { resolveDesktopPlatform } from "../lib/platform";
+import { resolveDesktopOsVersion, resolveDesktopPlatform } from "../lib/platform";
 
 const testAiQuickActionPrompts = vi.hoisted(() => ({
   continue: "",
@@ -208,6 +208,7 @@ vi.mock("../lib/platform", async (importOriginal) => {
 
   return {
     ...actual,
+    resolveDesktopOsVersion: vi.fn(() => null),
     resolveDesktopPlatform: vi.fn(() => "macos")
   };
 });
@@ -783,6 +784,7 @@ export const mockedExitNativeApp = vi.mocked(exitNativeApp);
 export const mockedListenNativeAppExitRequested = vi.mocked(listenNativeAppExitRequested);
 export const mockedListenNativeWindowCloseRequested = vi.mocked(listenNativeWindowCloseRequested);
 export const mockedCheckNativeAppUpdate = vi.mocked(checkNativeAppUpdate);
+export const mockedResolveDesktopOsVersion = vi.mocked(resolveDesktopOsVersion);
 export const mockedResolveDesktopPlatform = vi.mocked(resolveDesktopPlatform);
 export const mockedConsumeWelcomeDocumentState = vi.mocked(consumeWelcomeDocumentState);
 export const mockedCreateAiAgentSessionId = vi.mocked(createAiAgentSessionId);
@@ -972,6 +974,7 @@ export function installAppTestHarness() {
     mockedListenNativeAppExitRequested.mockReset();
     mockedListenNativeWindowCloseRequested.mockReset();
     mockedCheckNativeAppUpdate.mockReset();
+    mockedResolveDesktopOsVersion.mockReset();
     mockedResolveDesktopPlatform.mockReset();
     mockedOpenSettingsWindow.mockReset();
     mockedGetStoredLanguage.mockReset();
@@ -1041,6 +1044,7 @@ export function installAppTestHarness() {
     mockedInstallNativeShellCommand.mockReset();
     mockedUninstallNativeShellCommand.mockReset();
     document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-webkit-scroll-workaround");
     document.documentElement.removeAttribute("data-window");
     document.getElementById("markra-custom-theme-style")?.remove();
     mockedWatchNativeMarkdownFile.mockResolvedValue(() => {});
@@ -1081,6 +1085,7 @@ export function installAppTestHarness() {
       status: "missing"
     });
     mockedCheckNativeAppUpdate.mockResolvedValue(null);
+    mockedResolveDesktopOsVersion.mockReturnValue(null);
     mockedResolveDesktopPlatform.mockReturnValue("macos");
     mockedOpenSettingsWindow.mockResolvedValue(undefined);
     mockedReadNativeMarkdownImageFile.mockResolvedValue({


### PR DESCRIPTION
## Summary
- Add a macOS 27-only WebKit scrolling workaround marker based on the desktop OS version.
- Keep Markra custom scrollbars visible while the workaround is active.
- Cover platform detection, root attribute cleanup, and scrollbar styles with focused tests.

## Why
- The crash log points at a macOS 27 WebKit scrolling tree failure inside WKWebView.
- The workaround is scoped to macOS 27.x so other platforms and macOS releases keep their existing behavior.

## Validation
- `pnpm --filter @markra/app exec vitest run src/styles.test.ts -t "visible scrollbars"` passed
- `pnpm --filter @markra/app exec vitest run src/lib/platform.test.ts` passed
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "WebKit scrolling workaround"` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed
- `pnpm --filter @markra/web build` passed

## Risk
- This is a targeted WKWebView workaround, not a root WebKit fix. It can be removed or narrowed when macOS/WebKit behavior stabilizes.