### PR TITLE
feat(app): show selected word count in status

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -324,6 +324,30 @@ describe("Markra workspace", () => {
     expect(shell).toHaveClass("overscroll-none");
   });
 
+  it("replaces the document word count with the selected word count in the quiet status line", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+    const view = getMarkdownSourceView(sourceEditor);
+    const start = view.state.doc.toString().indexOf("Welcome");
+
+    act(() => {
+      view.dispatch({
+        selection: {
+          anchor: start,
+          head: start + "Welcome to Markra".length
+        }
+      });
+    });
+
+    await waitFor(() => expect(container.querySelector(".quiet-status")).toHaveTextContent("3 words"));
+    expect(container.querySelector(".quiet-status")).not.toHaveTextContent("75 words");
+  });
+
   it("restores a selected history version into the current document", async () => {
     mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
     mockOpenMarkdownFile({

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -88,7 +88,7 @@ import {
   type I18nKey
 } from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
-import { createMarkdownImageSrcResolver } from "@markra/markdown";
+import { createMarkdownImageSrcResolver, getWordCount } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
 import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
 import { saveEditorImage } from "./lib/image-upload";
@@ -247,6 +247,7 @@ function WorkspaceApp() {
   const [activeImageFile, setActiveImageFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [imageTabs, setImageTabs] = useState<ImageDocumentTab[]>([]);
   const [activeAiSelection, setActiveAiSelection] = useState<AiSelectionContext | null>(null);
+  const [selectedWordCount, setSelectedWordCount] = useState<number | null>(null);
   const [aiCommandOverlayInset, setAiCommandOverlayInset] = useState(0);
   const [aiSelectionToolbarAnchor, setAiSelectionToolbarAnchor] = useState<SelectionAnchor | null>(null);
   const [aiSelectionToolbarActiveActions, setAiSelectionToolbarActiveActions] = useState<SelectionFormattingAction[]>([]);
@@ -522,6 +523,9 @@ function WorkspaceApp() {
     path: document.path,
     sizeBytes: document.sizeBytes ?? null
   };
+  useEffect(() => {
+    setSelectedWordCount(null);
+  }, [activeImageFile?.path, activeTabId, editorMode]);
   const handleMainVisualEditorReady = useCallback((
     tabId: string,
     readyEditor: MilkdownEditor | null,
@@ -783,6 +787,10 @@ function WorkspaceApp() {
     await openNativeExternalUrl(href);
   }, [captureActiveDocumentViewState, document.path, fileTreeFiles, openTreeMarkdownFile]);
   const getActiveAiSelection = useCallback(() => activeAiSelectionRef.current, []);
+  const updateSelectedWordCount = useCallback((selectedText: string | null | undefined) => {
+    const count = selectedText?.trim() ? getWordCount(selectedText) : 0;
+    setSelectedWordCount(count > 0 ? count : null);
+  }, []);
   const updateActiveAiSelection = useCallback((selection: AiSelectionContext | null) => {
     activeAiSelectionRef.current = selection;
     setActiveAiSelection(selection);
@@ -1056,6 +1064,7 @@ function WorkspaceApp() {
   const handleTextSelectionChange = useCallback((selection: AiSelectionContext | null) => {
     const automaticSelection = automaticAiSelection(selection);
 
+    updateSelectedWordCount(selection?.source === "selection" ? selection.text : null);
     updateActiveAiSelection(automaticSelection);
     clearAiSelectionToolbarCopySuccess();
     setAiSelectionToolbarActiveActions([]);
@@ -1147,6 +1156,7 @@ function WorkspaceApp() {
     clearAiSelectionToolbarCopySuccess,
     readOnlyMode,
     setAiSelectionToolbarAnchorIfChanged,
+    updateSelectedWordCount,
     updateActiveAiSelection
   ]);
   const getEditorSelection = editor.getSelection;
@@ -3420,6 +3430,7 @@ function WorkspaceApp() {
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                           onScroll={handleSourcePaneScroll}
+                          onSelectionTextChange={updateSelectedWordCount}
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}
                           searchMatches={visibleSourceDocumentSearchMatches}
@@ -3448,6 +3459,7 @@ function WorkspaceApp() {
                           onContentWidthChange={handleEditorContentWidthChange}
                           onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
                           onScroll={handleSourcePaneScroll}
+                          onSelectionTextChange={updateSelectedWordCount}
                           readOnly={readOnlyMode}
                           searchActiveIndex={normalizedDocumentSearchActiveIndex}
                           searchMatches={visibleSourceDocumentSearchMatches}
@@ -3462,6 +3474,7 @@ function WorkspaceApp() {
                     dirty={document.dirty}
                     language={appLanguage.language}
                     readOnly={readOnlyMode}
+                    selectedWordCount={selectedWordCount}
                     showWordCount={editorPreferences.preferences.showWordCount}
                     syncLabel={syncStatusLabel}
                     wordCount={wordCount}

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -133,6 +133,40 @@ describe("MarkdownSourceEditor", () => {
     expect(view.state.doc.toString()).toBe("# External");
   });
 
+  it("notifies selected source text changes", () => {
+    const handleSelectionTextChange = vi.fn();
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="alpha beta gamma"
+        onChange={() => {}}
+        onSelectionTextChange={handleSelectionTextChange}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    act(() => {
+      view.dispatch({
+        selection: {
+          anchor: 6,
+          head: 10
+        }
+      });
+    });
+
+    expect(handleSelectionTextChange).toHaveBeenLastCalledWith("beta");
+
+    act(() => {
+      view.dispatch({
+        selection: {
+          anchor: 10,
+          head: 10
+        }
+      });
+    });
+
+    expect(handleSelectionTextChange).toHaveBeenLastCalledWith(null);
+  });
+
   it("keeps source edits undoable and redoable", () => {
     const handleChange = vi.fn();
     const { container } = render(

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -35,6 +35,7 @@ export type MarkdownSourceEditorProps = {
   onContentWidthResizeStart?: () => unknown;
   onScroll?: (event: UIEvent<HTMLElement>) => unknown;
   onRedo?: () => unknown;
+  onSelectionTextChange?: (text: string | null) => unknown;
   onUndo?: () => unknown;
   readOnly?: boolean;
   searchActiveIndex?: number;
@@ -117,6 +118,16 @@ function markdownSourceSearchExtension(matches: SearchRange[] = [], activeIndex 
   });
 }
 
+function selectedSourceTextFromState(state: EditorState) {
+  const text = state.selection.ranges
+    .filter((range) => !range.empty)
+    .map((range) => state.sliceDoc(range.from, range.to))
+    .join("\n")
+    .trim();
+
+  return text ? text : null;
+}
+
 function markdownSourceTheme(): Extension {
   return EditorView.theme({
     "&": {
@@ -176,6 +187,7 @@ export function MarkdownSourceEditor({
   onContentWidthResizeStart,
   onScroll,
   onRedo,
+  onSelectionTextChange,
   onUndo,
   readOnly = false,
   searchActiveIndex = -1,
@@ -187,6 +199,7 @@ export function MarkdownSourceEditor({
   const initialContentRef = useRef(content);
   const onChangeRef = useRef(onChange);
   const onRedoRef = useRef(onRedo);
+  const onSelectionTextChangeRef = useRef(onSelectionTextChange);
   const onUndoRef = useRef(onUndo);
   const viewRef = useRef<EditorView | null>(null);
   const contentAttributesCompartmentRef = useRef(new Compartment());
@@ -217,6 +230,10 @@ export function MarkdownSourceEditor({
   }, [onRedo]);
 
   useEffect(() => {
+    onSelectionTextChangeRef.current = onSelectionTextChange;
+  }, [onSelectionTextChange]);
+
+  useEffect(() => {
     onUndoRef.current = onUndo;
   }, [onUndo]);
 
@@ -233,6 +250,10 @@ export function MarkdownSourceEditor({
       editableCompartmentRef.current.of(EditorView.editable.of(!readOnly)),
       searchCompartmentRef.current.of(markdownSourceSearchExtension(searchMatches, searchActiveIndex)),
       EditorView.updateListener.of((update) => {
+        if (update.selectionSet || update.docChanged) {
+          onSelectionTextChangeRef.current?.(selectedSourceTextFromState(update.state));
+        }
+
         if (!update.docChanged) return;
         if (update.transactions.some((transaction) => transaction.annotation(externalSourceUpdate))) return;
 
@@ -260,6 +281,7 @@ export function MarkdownSourceEditor({
     if (autoFocus) view.focus();
 
     return () => {
+      onSelectionTextChangeRef.current?.(null);
       view.destroy();
       viewRef.current = null;
     };

--- a/packages/app/src/components/QuietStatus.test.tsx
+++ b/packages/app/src/components/QuietStatus.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { QuietStatus } from "./QuietStatus";
+
+describe("QuietStatus", () => {
+  it("shows the document word count when no text is selected", () => {
+    render(
+      <QuietStatus
+        dirty={false}
+        wordCount={5}
+      />
+    );
+
+    expect(screen.getByLabelText("Document status")).toHaveTextContent("5 words");
+  });
+
+  it("shows the selected word count instead of the document word count when text is selected", () => {
+    render(
+      <QuietStatus
+        dirty={false}
+        selectedWordCount={2}
+        wordCount={5}
+      />
+    );
+
+    expect(screen.getByLabelText("Document status")).toHaveTextContent("2 words");
+    expect(screen.getByLabelText("Document status")).not.toHaveTextContent("5 words");
+  });
+});

--- a/packages/app/src/components/QuietStatus.tsx
+++ b/packages/app/src/components/QuietStatus.tsx
@@ -5,6 +5,7 @@ type QuietStatusProps = {
   dirty: boolean;
   language?: AppLanguage;
   readOnly?: boolean;
+  selectedWordCount?: number | null;
   showWordCount?: boolean;
   syncLabel?: string | null;
   wordCount: number;
@@ -15,11 +16,13 @@ export function QuietStatus({
   dirty,
   language = "en",
   readOnly = false,
+  selectedWordCount = null,
   showWordCount = true,
   syncLabel = null,
   wordCount
 }: QuietStatusProps) {
   const label = (key: Parameters<typeof t>[1]) => t(language, key);
+  const wordCountText = `${selectedWordCount ?? wordCount}`;
 
   return (
     <footer
@@ -28,7 +31,7 @@ export function QuietStatus({
     >
       {showWordCount ? (
         <span>
-          {wordCount} {label("app.words")}
+          {wordCountText} {label("app.words")}
         </span>
       ) : null}
       {backupLabel ? <span>{backupLabel}</span> : null}


### PR DESCRIPTION
## Summary
- Replace the editor status word count with the selected text word count while text is selected.
- Track selected text in both the visual editor and source editor.
- Add focused coverage for QuietStatus, source editor selection changes, and the app status-line behavior.

## Why
- Matches the Obsidian-style behavior requested in #340: the status slot stays quiet and shows the most relevant count for the current selection state.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/QuietStatus.test.tsx src/components/MarkdownSourceEditor.test.tsx` passed
- `pnpm --dir packages/app exec vitest run src/App.test.tsx -t "replaces the document word count"` passed
- `pnpm --dir packages/app build` passed
- `git diff --check` passed

## Related Issues
- Closes #340
