### PR TITLE
chore: clean warning output

### DIFF
--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -315,6 +315,7 @@ fn application_about_metadata() -> AboutMetadata<'static> {
     }
 }
 
+#[cfg(any(windows, test))]
 fn native_about_full_version(metadata: &AboutMetadata<'_>) -> Option<String> {
     match (&metadata.version, &metadata.short_version) {
         (Some(version), Some(short_version)) => Some(format!("{version} ({short_version})")),
@@ -323,10 +324,12 @@ fn native_about_full_version(metadata: &AboutMetadata<'_>) -> Option<String> {
     }
 }
 
+#[cfg(any(windows, test))]
 fn native_about_dialog_title(metadata: &AboutMetadata<'_>) -> String {
     format!("About {}", metadata.name.as_deref().unwrap_or("Markra"))
 }
 
+#[cfg(any(windows, test))]
 fn native_about_dialog_message(metadata: &AboutMetadata<'_>) -> String {
     use std::fmt::Write;
 

--- a/packages/app/src/test/setup.ts
+++ b/packages/app/src/test/setup.ts
@@ -1,5 +1,5 @@
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
 
 expect.extend(matchers);
 
@@ -44,6 +44,14 @@ if (typeof Range !== "undefined" && !Range.prototype.getClientRects) {
 
 if (typeof Range !== "undefined" && !Range.prototype.getBoundingClientRect) {
   Range.prototype.getBoundingClientRect = getBoundingClientRect;
+}
+
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "scrollBy", {
+    configurable: true,
+    writable: true,
+    value: vi.fn()
+  });
 }
 
 type SvgLayoutPrototype = SVGElement & {


### PR DESCRIPTION
## Summary
- Add a `window.scrollBy` test-environment mock to quiet jsdom output in `@markra/app` tests.
- Gate Windows native About dialog helpers behind `#[cfg(windows)]` so non-Windows builds do not warn about unused functions.

## Why
- Keeps routine test and Rust checks focused on actionable output.
- Does not change product behavior; both changes are limited to test setup or platform-specific compilation.

## Validation
- `pnpm --filter @markra/app test` passed: 88 test files, 1272 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm test` passed across the workspace
- `cargo check` passed in `apps/desktop/src-tauri`
- `git diff --check` passed
