### PR TITLE
fix(app): restore persisted settings state

### DIFF
--- a/packages/app/src/hooks/useAiSettings.test.tsx
+++ b/packages/app/src/hooks/useAiSettings.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { getStoredAiSettings, saveStoredAiSettings } from "../lib/settings/app-settings";
+import { getStoredAiSettings, saveStoredAiSettings, type AiProviderConfig } from "../lib/settings/app-settings";
 import { listenAppAiSettingsChanged, notifyAppAiSettingsChanged } from "../lib/settings/settings-events";
 import { useAiSettings } from "./useAiSettings";
 
@@ -281,5 +281,62 @@ describe("useAiSettings", () => {
         })
       ])
     );
+  });
+
+  it("keeps a live AI settings update when the initial stored settings resolve later", async () => {
+    let handleAiSettingsChanged: ((settings: Parameters<typeof mockedNotifyAppAiSettingsChanged>[0]) => unknown) | null = null;
+    let resolveStoredSettings: (settings: Awaited<ReturnType<typeof getStoredAiSettings>>) => void = () => {};
+
+    mockedGetStoredAiSettings.mockReturnValue(new Promise((resolve) => {
+      resolveStoredSettings = resolve;
+    }));
+    mockedListenAppAiSettingsChanged.mockImplementation(async (listener) => {
+      handleAiSettingsChanged = listener;
+      return () => {};
+    });
+
+    const openAiProvider: AiProviderConfig = {
+      apiKey: "openai-key",
+      baseUrl: "https://api.openai.com/v1",
+      defaultModelId: "gpt-5.5",
+      enabled: true,
+      id: "openai",
+      models: [{ capabilities: ["text"], enabled: true, id: "gpt-5.5", name: "GPT-5.5" }],
+      name: "OpenAI",
+      type: "openai" as const
+    };
+    const deepSeekProvider: AiProviderConfig = {
+      apiKey: "deepseek-key",
+      baseUrl: "https://api.deepseek.com/v1",
+      defaultModelId: "deepseek-v4-flash",
+      enabled: true,
+      id: "deepseek",
+      models: [{ capabilities: ["text", "reasoning"], enabled: true, id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" }],
+      name: "DeepSeek",
+      type: "deepseek" as const
+    };
+
+    const { result } = renderHook(() => useAiSettings());
+
+    act(() => {
+      handleAiSettingsChanged?.({
+        defaultModelId: "deepseek-v4-flash",
+        defaultProviderId: "deepseek",
+        providers: [openAiProvider, deepSeekProvider]
+      });
+    });
+    expect(result.current.activeProvider?.id).toBe("deepseek");
+
+    await act(async () => {
+      resolveStoredSettings({
+        defaultModelId: "gpt-5.5",
+        defaultProviderId: "openai",
+        providers: [openAiProvider, deepSeekProvider]
+      });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.activeProvider?.id).toBe("deepseek");
+    expect(result.current.defaultModelId).toBe("deepseek-v4-flash");
   });
 });

--- a/packages/app/src/hooks/useAiSettings.ts
+++ b/packages/app/src/hooks/useAiSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getStoredAiSettings,
   type AiProviderApiStyle,
@@ -22,6 +22,7 @@ export type AvailableAiTextModel = {
 export function useAiSettings() {
   const [settings, setSettings] = useState<AiProviderSettings | null>(null);
   const [loading, setLoading] = useState(true);
+  const liveSettingsReceivedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
@@ -29,10 +30,10 @@ export function useAiSettings() {
 
     getStoredAiSettings()
       .then((nextSettings) => {
-        if (alive) setSettings(nextSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(nextSettings);
       })
       .catch(() => {
-        if (alive) setSettings(null);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(null);
       })
       .finally(() => {
         if (alive) setLoading(false);
@@ -40,6 +41,7 @@ export function useAiSettings() {
 
     listenAppAiSettingsChanged((nextSettings) => {
       if (alive) {
+        liveSettingsReceivedRef.current = true;
         setSettings(nextSettings);
         setLoading(false);
       }
@@ -75,6 +77,7 @@ export function useAiSettings() {
       };
 
       setSettings(nextSettings);
+      liveSettingsReceivedRef.current = true;
       await saveStoredAiSettings(nextSettings);
       await notifyAppAiSettingsChanged(nextSettings);
     },
@@ -97,6 +100,7 @@ export function useAiSettings() {
       };
 
       setSettings(nextSettings);
+      liveSettingsReceivedRef.current = true;
       await saveStoredAiSettings(nextSettings);
       await notifyAppAiSettingsChanged(nextSettings);
     },

--- a/packages/app/src/hooks/useAppLanguage.ts
+++ b/packages/app/src/hooks/useAppLanguage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getStoredLanguage, saveStoredLanguage, type AppLanguage } from "../lib/settings/app-settings";
 import { listenAppLanguageChanged, notifyAppLanguageChanged } from "../lib/settings/settings-events";
 
@@ -9,12 +9,17 @@ function applyAppLanguage(language: AppLanguage) {
 export function useAppLanguage() {
   const [language, setLanguage] = useState<AppLanguage>("en");
   const [ready, setReady] = useState(false);
+  const liveLanguageReceivedRef = useRef(false);
 
   useEffect(() => {
     let active = true;
 
     getStoredLanguage().then((storedLanguage) => {
       if (!active) return;
+      if (liveLanguageReceivedRef.current) {
+        setReady(true);
+        return;
+      }
 
       setLanguage(storedLanguage);
       applyAppLanguage(storedLanguage);
@@ -36,6 +41,7 @@ export function useAppLanguage() {
     let cleanup: (() => unknown) | null = null;
 
     listenAppLanguageChanged((nextLanguage) => {
+      liveLanguageReceivedRef.current = true;
       setLanguage(nextLanguage);
       applyAppLanguage(nextLanguage);
       setReady(true);
@@ -56,6 +62,7 @@ export function useAppLanguage() {
 
   const selectLanguage = useCallback((nextLanguage: AppLanguage) => {
     setLanguage(nextLanguage);
+    liveLanguageReceivedRef.current = true;
     setReady(true);
     applyAppLanguage(nextLanguage);
 

--- a/packages/app/src/hooks/useAppTheme.ts
+++ b/packages/app/src/hooks/useAppTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getStoredCustomThemeCss,
   getStoredThemePreferences,
@@ -70,6 +70,8 @@ export function useAppTheme() {
   const [themePreferences, setThemePreferences] = useState<AppThemePreferences>(defaultAppThemePreferences);
   const [customThemeCss, setCustomThemeCss] = useState<CustomThemeCssValues>(defaultCustomThemeCssValues);
   const [systemTheme, setSystemTheme] = useState<ResolvedAppTheme>(() => getSystemTheme());
+  const liveCustomThemeCssReceivedRef = useRef(false);
+  const liveThemePreferencesReceivedRef = useRef(false);
   const editorTheme = resolveAppThemePreferencesEditorTheme(themePreferences, systemTheme);
   const resolvedTheme = resolveAppThemePreferencesAppearance(themePreferences, systemTheme);
 
@@ -77,11 +79,11 @@ export function useAppTheme() {
     let active = true;
 
     getStoredThemePreferences().then((storedPreferences) => {
-      if (active) setThemePreferences(storedPreferences);
+      if (active && !liveThemePreferencesReceivedRef.current) setThemePreferences(storedPreferences);
     }).catch(() => {});
 
     getStoredCustomThemeCss().then((storedCss) => {
-      if (active) setCustomThemeCss(storedCss);
+      if (active && !liveCustomThemeCssReceivedRef.current) setCustomThemeCss(storedCss);
     }).catch(() => {});
 
     return () => {
@@ -114,7 +116,10 @@ export function useAppTheme() {
     let cleanup: (() => unknown) | null = null;
 
     listenAppThemeChanged((nextPreferences) => {
-      if (active) setThemePreferences(nextPreferences);
+      if (active) {
+        liveThemePreferencesReceivedRef.current = true;
+        setThemePreferences(nextPreferences);
+      }
     }).then((stopListening) => {
       if (!active) {
         stopListening();
@@ -135,7 +140,10 @@ export function useAppTheme() {
     let cleanup: (() => unknown) | null = null;
 
     listenAppCustomThemeCssChanged((nextCss) => {
-      if (active) setCustomThemeCss(nextCss);
+      if (active) {
+        liveCustomThemeCssReceivedRef.current = true;
+        setCustomThemeCss(nextCss);
+      }
     }).then((stopListening) => {
       if (!active) {
         stopListening();
@@ -155,6 +163,7 @@ export function useAppTheme() {
     const normalizedPreferences = normalizeAppThemePreferences(nextPreferences);
 
     setThemePreferences(normalizedPreferences);
+    liveThemePreferencesReceivedRef.current = true;
     saveStoredThemePreferences(normalizedPreferences)
       .then(() => notifyAppThemeChanged(normalizedPreferences))
       .catch(() => {});
@@ -195,6 +204,7 @@ export function useAppTheme() {
     });
 
     setCustomThemeCss(normalizedCss);
+    liveCustomThemeCssReceivedRef.current = true;
     saveStoredCustomThemeCss(normalizedCss).then(() => notifyAppCustomThemeCssChanged(normalizedCss)).catch(() => {});
   }, [customThemeCss, resolvedTheme]);
 
@@ -205,6 +215,7 @@ export function useAppTheme() {
     });
 
     setCustomThemeCss(normalizedCss);
+    liveCustomThemeCssReceivedRef.current = true;
     saveStoredCustomThemeCss(normalizedCss).then(() => notifyAppCustomThemeCssChanged(normalizedCss)).catch(() => {});
   }, [customThemeCss]);
 
@@ -215,6 +226,7 @@ export function useAppTheme() {
     });
 
     setCustomThemeCss(normalizedCss);
+    liveCustomThemeCssReceivedRef.current = true;
     saveStoredCustomThemeCss(normalizedCss).then(() => notifyAppCustomThemeCssChanged(normalizedCss)).catch(() => {});
   }, [customThemeCss]);
 

--- a/packages/app/src/hooks/useBackupSettings.ts
+++ b/packages/app/src/hooks/useBackupSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   defaultBackupSettings,
   getStoredBackupSettings,
@@ -9,6 +9,7 @@ import { listenAppBackupSettingsChanged } from "../lib/settings/settings-events"
 export function useBackupSettings() {
   const [settings, setSettings] = useState<BackupSettings>(defaultBackupSettings);
   const [loading, setLoading] = useState(true);
+  const liveSettingsReceivedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
@@ -16,10 +17,10 @@ export function useBackupSettings() {
 
     getStoredBackupSettings()
       .then((storedSettings) => {
-        if (alive) setSettings(storedSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(storedSettings);
       })
       .catch(() => {
-        if (alive) setSettings(defaultBackupSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(defaultBackupSettings);
       })
       .finally(() => {
         if (alive) setLoading(false);
@@ -28,6 +29,7 @@ export function useBackupSettings() {
     listenAppBackupSettingsChanged((nextSettings) => {
       if (!alive) return;
 
+      liveSettingsReceivedRef.current = true;
       setSettings(nextSettings);
       setLoading(false);
     }).then((cleanup) => {

--- a/packages/app/src/hooks/useEditorPreferences.test.tsx
+++ b/packages/app/src/hooks/useEditorPreferences.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { defaultAiQuickActionPrompts } from "../lib/ai-actions";
-import { getStoredEditorPreferences } from "../lib/settings/app-settings";
+import { defaultEditorPreferences, getStoredEditorPreferences } from "../lib/settings/app-settings";
 import { listenAppEditorPreferencesChanged } from "../lib/settings/settings-events";
 import { useEditorPreferences } from "./useEditorPreferences";
 
@@ -288,5 +288,41 @@ describe("useEditorPreferences", () => {
     expect(result.current.preferences.bodyFontSize).toBe(18);
     expect(result.current.preferences.closeAiCommandOnAgentPanelOpen).toBe(true);
     expect(result.current.preferences.contentWidth).toBe("wide");
+  });
+
+  it("keeps a live preference update when the initial stored preferences resolve later", async () => {
+    let onPreferencesChanged: Parameters<typeof listenAppEditorPreferencesChanged>[0] | null = null;
+    let resolveStoredPreferences: (preferences: Awaited<ReturnType<typeof getStoredEditorPreferences>>) => void = () => {};
+    mockedGetStoredEditorPreferences.mockReturnValue(new Promise((resolve) => {
+      resolveStoredPreferences = resolve;
+    }));
+    mockedListenAppEditorPreferencesChanged.mockImplementation(async (listener) => {
+      onPreferencesChanged = listener;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useEditorPreferences());
+
+    act(() => {
+      onPreferencesChanged?.({
+        ...defaultEditorPreferences,
+        bodyFontSize: 18,
+        showWordCount: false
+      });
+    });
+    expect(result.current.preferences.bodyFontSize).toBe(18);
+    expect(result.current.preferences.showWordCount).toBe(false);
+
+    await act(async () => {
+      resolveStoredPreferences({
+        ...defaultEditorPreferences,
+        bodyFontSize: 16,
+        showWordCount: true
+      });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.preferences.bodyFontSize).toBe(18);
+    expect(result.current.preferences.showWordCount).toBe(false);
   });
 });

--- a/packages/app/src/hooks/useEditorPreferences.ts
+++ b/packages/app/src/hooks/useEditorPreferences.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   defaultEditorPreferences,
   getStoredEditorPreferences,
@@ -9,6 +9,7 @@ import { listenAppEditorPreferencesChanged } from "../lib/settings/settings-even
 export function useEditorPreferences() {
   const [preferences, setPreferences] = useState<EditorPreferences>(defaultEditorPreferences);
   const [loading, setLoading] = useState(true);
+  const livePreferencesReceivedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
@@ -16,17 +17,20 @@ export function useEditorPreferences() {
 
     getStoredEditorPreferences()
       .then((storedPreferences) => {
-        if (alive) setPreferences(storedPreferences);
+        if (alive && !livePreferencesReceivedRef.current) setPreferences(storedPreferences);
       })
       .catch(() => {
-        if (alive) setPreferences(defaultEditorPreferences);
+        if (alive && !livePreferencesReceivedRef.current) setPreferences(defaultEditorPreferences);
       })
       .finally(() => {
         if (alive) setLoading(false);
       });
 
     listenAppEditorPreferencesChanged((nextPreferences) => {
-      if (alive) setPreferences(nextPreferences);
+      if (alive) {
+        livePreferencesReceivedRef.current = true;
+        setPreferences(nextPreferences);
+      }
     }).then((cleanup) => {
       if (!alive) {
         cleanup();

--- a/packages/app/src/hooks/useExportSettings.ts
+++ b/packages/app/src/hooks/useExportSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   defaultExportSettings,
   getStoredExportSettings,
@@ -9,6 +9,7 @@ import { listenAppExportSettingsChanged } from "../lib/settings/settings-events"
 export function useExportSettings() {
   const [settings, setSettings] = useState<ExportSettings>(defaultExportSettings);
   const [loading, setLoading] = useState(true);
+  const liveSettingsReceivedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
@@ -16,17 +17,20 @@ export function useExportSettings() {
 
     getStoredExportSettings()
       .then((storedSettings) => {
-        if (alive) setSettings(storedSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(storedSettings);
       })
       .catch(() => {
-        if (alive) setSettings(defaultExportSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(defaultExportSettings);
       })
       .finally(() => {
         if (alive) setLoading(false);
       });
 
     listenAppExportSettingsChanged((nextSettings) => {
-      if (alive) setSettings(nextSettings);
+      if (alive) {
+        liveSettingsReceivedRef.current = true;
+        setSettings(nextSettings);
+      }
     }).then((cleanup) => {
       if (!alive) {
         cleanup();

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -435,6 +435,17 @@ describe("useMarkdownFileTree", () => {
     });
   });
 
+  it("restores the main file tree expansion state from workspace settings", async () => {
+    mockedGetStoredWorkspaceState.mockResolvedValue(mockWorkspaceState({
+      fileTreeOpen: true
+    }));
+
+    render(<FileTreeProbe />);
+
+    await waitFor(() => expect(screen.getByTestId("open-state")).toHaveTextContent("open"));
+    expect(screen.getByTestId("layout-columns")).toHaveTextContent("288px minmax(0,1fr)");
+  });
+
   it("opens a remembered markdown folder without showing the native picker", async () => {
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([
       { path: "/recent/notes/index.md", name: "index.md", relativePath: "index.md" }

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -68,6 +68,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
   const [width, setWidth] = useState(markdownFileTreeDefaultWidth);
   const [resizing, setResizing] = useState(false);
   const loadedSourcePathRef = useRef<string | null>(null);
+  const openChangedBeforeWorkspaceRestoreRef = useRef(false);
   const fileTreeWorkspacePath = fileTreeSortWorkspacePathFromSourcePath(sourcePath);
   const fileTreeSort = useMemo(
     () => fileTreeWorkspacePath
@@ -151,6 +152,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
         setFiles([]);
         setSourcePath(null);
         setRootName("No folder");
+        openChangedBeforeWorkspaceRestoreRef.current = true;
         setOpen(false);
       }
 
@@ -159,6 +161,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
 
     setSourcePath(path);
     setRootName(folderName);
+    openChangedBeforeWorkspaceRestoreRef.current = true;
     setOpen(openTree);
     loadedSourcePathRef.current = path;
     setFiles(nextFiles);
@@ -274,6 +277,7 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
 
   const toggle = useCallback(
     (fallbackPath: string | null = null) => {
+      openChangedBeforeWorkspaceRestoreRef.current = true;
       setOpen((currentOpen) => {
         const nextOpen = !currentOpen;
         if (nextOpen) refresh(fallbackPath);
@@ -317,7 +321,10 @@ export function useMarkdownFileTree({ onWorkspaceSessionChange }: UseMarkdownFil
     let active = true;
 
     getStoredWorkspaceState().then((workspace) => {
-      if (active) setRecentFoldersOpenState(workspace.recentFoldersOpen ?? true);
+      if (active) {
+        if (!openChangedBeforeWorkspaceRestoreRef.current) setOpen(workspace.fileTreeOpen);
+        setRecentFoldersOpenState(workspace.recentFoldersOpen ?? true);
+      }
     }).catch(() => {});
 
     return () => {

--- a/packages/app/src/hooks/useSyncSettings.ts
+++ b/packages/app/src/hooks/useSyncSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   defaultSyncSettings,
   getStoredSyncSettings,
@@ -9,6 +9,7 @@ import { listenAppSyncSettingsChanged } from "../lib/settings/settings-events";
 export function useSyncSettings() {
   const [settings, setSettings] = useState<SyncSettings>(defaultSyncSettings);
   const [loading, setLoading] = useState(true);
+  const liveSettingsReceivedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
@@ -16,10 +17,10 @@ export function useSyncSettings() {
 
     getStoredSyncSettings()
       .then((storedSettings) => {
-        if (alive) setSettings(storedSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(storedSettings);
       })
       .catch(() => {
-        if (alive) setSettings(defaultSyncSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(defaultSyncSettings);
       })
       .finally(() => {
         if (alive) setLoading(false);
@@ -28,6 +29,7 @@ export function useSyncSettings() {
     listenAppSyncSettingsChanged((nextSettings) => {
       if (!alive) return;
 
+      liveSettingsReceivedRef.current = true;
       setSettings(nextSettings);
       setLoading(false);
     }).then((cleanup) => {

--- a/packages/app/src/hooks/useWebSearchSettings.ts
+++ b/packages/app/src/hooks/useWebSearchSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   defaultWebSearchSettings,
   getStoredWebSearchSettings,
@@ -9,6 +9,7 @@ import { listenAppWebSearchSettingsChanged } from "../lib/settings/settings-even
 export function useWebSearchSettings() {
   const [settings, setSettings] = useState<WebSearchSettings>(defaultWebSearchSettings);
   const [loading, setLoading] = useState(true);
+  const liveSettingsReceivedRef = useRef(false);
 
   useEffect(() => {
     let alive = true;
@@ -16,10 +17,10 @@ export function useWebSearchSettings() {
 
     getStoredWebSearchSettings()
       .then((storedSettings) => {
-        if (alive) setSettings(storedSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(storedSettings);
       })
       .catch(() => {
-        if (alive) setSettings(defaultWebSearchSettings);
+        if (alive && !liveSettingsReceivedRef.current) setSettings(defaultWebSearchSettings);
       })
       .finally(() => {
         if (alive) setLoading(false);
@@ -28,6 +29,7 @@ export function useWebSearchSettings() {
     listenAppWebSearchSettingsChanged((nextSettings) => {
       if (!alive) return;
 
+      liveSettingsReceivedRef.current = true;
       setSettings(nextSettings);
       setLoading(false);
     }).then((cleanup) => {


### PR DESCRIPTION
## Summary
- restore the persisted workspace sidebar expanded/collapsed state during file tree startup
- prevent late initial settings loads from overwriting live settings updates
- add regression coverage for sidebar state restore and late settings-load races

## Why
- Windows could show the sidebar in the default state even when `fileTreeOpen` had been saved.
- Settings hooks could briefly accept a live user/cross-window update, then be overwritten by an older async startup read.

## Validation
- `pnpm --filter @markra/app test -- useEditorPreferences.test.tsx useAiSettings.test.tsx useMarkdownFileTree.test.tsx App.test.tsx` passed: 185 tests
- `pnpm --filter @markra/app test -- workspace-state.test.ts settings-events.test.ts` passed: 19 tests
- `pnpm --filter @markra/app typecheck:test` passed