### PR TITLE
fix(editor): ignore math delimiters in inline code

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2077,6 +2077,20 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(source);
   });
 
+  it("keeps literal math delimiter examples in inline code spans", async () => {
+    const source = "Math examples use `$...$` inline and `$$...$$` display.";
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(container.querySelector(".ProseMirror .markra-math-render")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror .markra-math-source-hidden")).not.toBeInTheDocument();
+    expect(Array.from(container.querySelectorAll(".ProseMirror code")).map((node) => node.textContent)).toEqual([
+      "$...$",
+      "$$...$$"
+    ]);
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(source);
+  });
+
   it("applies display math macro definitions to later formulas", async () => {
     const macroDefinition = ["$$", String.raw`\newcommand{\RR}{\mathbb{R}}`, "$$"].join("\n");
     const source = [macroDefinition, "", String.raw`The domain is $\RR$.`].join("\n");

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -553,6 +553,34 @@ function getMathRanges(text: string) {
   return ranges;
 }
 
+function hasCodeMark(node: ProseNode) {
+  return node.marks.some((mark) => mark.type.spec.code === true || ["code", "inlineCode"].includes(mark.type.name));
+}
+
+function mathRangeTouchesCodeMark(node: ProseNode, range: Pick<MathRange, "from" | "to">) {
+  let touchesCodeMark = false;
+
+  node.forEach((child, offset) => {
+    if (touchesCodeMark || offset >= range.to) return;
+
+    const childTo = offset + child.nodeSize;
+    if (childTo <= range.from || !child.isText) return;
+
+    if (hasCodeMark(child)) {
+      touchesCodeMark = true;
+      return false;
+    }
+  });
+
+  return touchesCodeMark;
+}
+
+function getMathRangesInTextblock(node: ProseNode) {
+  if (node.type.spec.code) return [];
+
+  return getMathRanges(node.textContent).filter((range) => !mathRangeTouchesCodeMark(node, range));
+}
+
 function makeAbsoluteRange(range: MathRange, blockStart: number): MathRange {
   return {
     ...range,
@@ -572,7 +600,7 @@ function findActiveMathRange(state: EditorState) {
 
   const from = Math.min($from.parentOffset, selection.$to.parentOffset);
   const to = Math.max($from.parentOffset, selection.$to.parentOffset);
-  const relativeRange = getMathRanges($from.parent.textContent).find((candidate) =>
+  const relativeRange = getMathRangesInTextblock($from.parent).find((candidate) =>
     selection.empty ? candidate.from < from && from < candidate.to : candidate.from <= from && to <= candidate.to
   );
 
@@ -587,7 +615,7 @@ function findMathRangeByBounds(doc: ProseNode, bounds: ActiveMathSource): MathRa
     if (!node.isTextblock || node.type.spec.code) return;
 
     const blockStart = position + 1;
-    for (const relativeRange of getMathRanges(node.textContent)) {
+    for (const relativeRange of getMathRangesInTextblock(node)) {
       const range = makeAbsoluteRange(relativeRange, blockStart);
       if (range.from !== bounds.from || range.to !== bounds.to) continue;
 
@@ -618,7 +646,7 @@ export function findHiddenDisplayMathSourceRanges(state: EditorState): MarkraHid
     if (!node.isTextblock || node.type.spec.code) return;
 
     const blockStart = position + 1;
-    for (const relativeRange of getMathRanges(node.textContent)) {
+    for (const relativeRange of getMathRangesInTextblock(node)) {
       if (relativeRange.kind !== "display") continue;
 
       const range = makeAbsoluteRange(relativeRange, blockStart);
@@ -647,7 +675,7 @@ function findAdjacentMathRange(state: EditorState, direction: "backward" | "forw
     if (!node.isTextblock || node.type.spec.code) return;
 
     const blockStart = position + 1;
-    for (const relativeRange of getMathRanges(node.textContent)) {
+    for (const relativeRange of getMathRangesInTextblock(node)) {
       const range = makeAbsoluteRange(relativeRange, blockStart);
       const touchesCursor = direction === "forward" ? range.from === cursor : range.to === cursor;
       if (!touchesCursor) continue;
@@ -661,7 +689,7 @@ function findAdjacentMathRange(state: EditorState, direction: "backward" | "forw
 }
 
 function displayMathRangeForWholeTextBlock(node: ProseNode, position: number): MathRange | null {
-  const relativeRanges = getMathRanges(node.textContent);
+  const relativeRanges = getMathRangesInTextblock(node);
   const range = relativeRanges.length === 1 ? relativeRanges[0] : null;
   if (!range || range.kind !== "display") return null;
   if (range.from !== 0 || range.to !== node.textContent.length) return null;
@@ -1116,7 +1144,7 @@ function buildMathDecorations(state: EditorState, activeRange: MathRange | null)
     if (!node.isTextblock || node.type.spec.code) return;
 
     const blockStart = position + 1;
-    for (const relativeRange of getMathRanges(node.textContent)) {
+    for (const relativeRange of getMathRangesInTextblock(node)) {
       const range = renderMathRange(makeAbsoluteRange(relativeRange, blockStart), macros);
       const isActive = activeRange?.from === range.from && activeRange.to === range.to;
       decorations.push(


### PR DESCRIPTION
## Summary
- Skip math rendering for delimiter ranges that overlap inline code marks.
- Add a MarkdownPaper regression test for literal `$...$` and `$$...$$` examples in code spans.

## Why
- The math plugin scanned a paragraph’s full `textContent`, so inline-code examples of math delimiters were still treated as KaTeX formulas.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t "keeps literal math delimiter examples in inline code spans"` passed
- `pnpm --filter @markra/editor test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed

## Risk
- Low. The change only filters math ranges that touch inline code marks; normal inline/display/Hugo math continues through the same parsing and rendering paths.