### PR TITLE
fix(app): preserve undo history after save

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -1420,14 +1420,14 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
   });
 
-  it("recreates the editor when an untitled document receives a saved path", async () => {
+  it("keeps the editor mounted when an untitled document receives a saved path", async () => {
     let editor: Editor | null = null;
     const savedContent = "# Scratch\n\nSaved immediately.";
     const { container, rerender } = render(
       <MarkdownPaper
         documentKey="untitled:0"
         documentPath={null}
-        initialContent=""
+        initialContent={savedContent}
         onEditorReady={(instance) => {
           editor = instance;
         }}
@@ -1437,7 +1437,10 @@ describe("MarkdownPaper editing", () => {
     );
 
     await waitFor(() => expect(editor).not.toBeNull());
-    expect(container.querySelector(".ProseMirror")).not.toHaveTextContent("Saved immediately.");
+    const initialEditor = editor;
+    const initialPaper = container.querySelector('[data-editor-engine="milkdown"]');
+    expect(initialPaper).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror")).toHaveTextContent("Saved immediately.");
 
     rerender(
       <MarkdownPaper
@@ -1452,7 +1455,9 @@ describe("MarkdownPaper editing", () => {
       />
     );
 
-    await waitFor(() => expect(container.querySelector(".ProseMirror")).toHaveTextContent("Saved immediately."));
+    expect(container.querySelector('[data-editor-engine="milkdown"]')).toBe(initialPaper);
+    expect(editor).toBe(initialEditor);
+    expect(container.querySelector(".ProseMirror")).toHaveTextContent("Saved immediately.");
   });
 
   it("renders fenced code blocks with syntax highlighting and line numbers", async () => {

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -129,7 +129,7 @@ export function MarkdownPaper({
     paddingBottom: editorBottomPadding(bottomOverlayInset)
   } satisfies MarkdownPaperStyle;
   const topInsetClassName = topInset === "tabs" ? "pt-24 max-[900px]:pt-20" : "pt-14 max-[900px]:pt-10";
-  const editorInstanceKey = `${documentKey ?? "untitled"}:${documentPath ?? "unsaved"}:${revision}`;
+  const editorInstanceKey = `${documentKey ?? "untitled"}:${revision}`;
 
   return (
     <section

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1915,6 +1915,132 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("does not advance the document revision when saving only clears dirty state", async () => {
+    let editorMarkdown = "# Guide\n\nSaved";
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValueOnce({
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+    act(() => {
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+
+    const revisionBeforeSave = result.current.document.revision;
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "# Guide\n\nSaved",
+      dirty: false,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    expect(result.current.document.revision).toBe(revisionBeforeSave);
+  });
+
+  it("does not advance the document revision when saving assigns an untitled document path", async () => {
+    const editorMarkdown = "# Scratch\n\nSaved immediately.";
+    mockedSaveNativeMarkdownFile.mockResolvedValueOnce({
+      name: "scratch.md",
+      path: "/mock-files/scratch.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    act(() => {
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+
+    const revisionBeforeSave = result.current.document.revision;
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: editorMarkdown,
+      dirty: false,
+      name: "scratch.md",
+      path: "/mock-files/scratch.md"
+    });
+    expect(result.current.document.revision).toBe(revisionBeforeSave);
+  });
+
+  it("does not advance the document revision when saving fresher editor content", async () => {
+    const editorMarkdown = "# Guide\n\nSaved from editor.";
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValueOnce({
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    const revisionBeforeSave = result.current.document.revision;
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: editorMarkdown,
+      dirty: false,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    expect(result.current.document.revision).toBe(revisionBeforeSave);
+  });
+
   it("ignores stale clean visual editor contents during native close after saving", async () => {
     let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
     let editorReady = true;
@@ -1962,7 +2088,7 @@ describe("useMarkdownDocument", () => {
     await act(async () => {
       await result.current.saveCurrentDocument();
     });
-    expect(result.current.document.revision).toBeGreaterThan(revisionBeforeSave);
+    expect(result.current.document.revision).toBe(revisionBeforeSave);
 
     editorMarkdown = "# Guide\n\nOriginal";
     editorReady = false;

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -1084,19 +1084,13 @@ export function useMarkdownDocument({
     const sourceContent = options.sourceContent ?? contents;
     const contentChangedAfterSaveStarted =
       targetDocument.content !== sourceContent && targetDocument.content !== contents;
-    const savedDocumentRefreshNeeded =
-      !contentChangedAfterSaveStarted &&
-      (targetDocument.dirty ||
-        targetDocument.content !== contents ||
-        targetDocument.path !== savedFile.path ||
-        targetDocument.name !== savedFile.name);
     const nextDocument = {
       ...targetDocument,
       path: savedFile.path,
       name: savedFile.name,
       content: contentChangedAfterSaveStarted ? targetDocument.content : contents,
       dirty: contentChangedAfterSaveStarted ? true : false,
-      revision: savedDocumentRefreshNeeded ? targetDocument.revision + 1 : targetDocument.revision
+      revision: targetDocument.revision
     };
 
     const nextTabs = documentTabsEnabled
@@ -1231,18 +1225,13 @@ export function useMarkdownDocument({
       if (!savedFile) return null;
 
       const sourceDocument = documentFromTab(tab);
-      const savedDocumentRefreshNeeded =
-        tab.dirty ||
-        tab.content !== contents ||
-        tab.path !== savedFile.path ||
-        tab.name !== savedFile.name;
       const nextDocument = {
         ...sourceDocument,
         path: savedFile.path,
         name: savedFile.name,
         content: contents,
         dirty: false,
-        revision: savedDocumentRefreshNeeded ? sourceDocument.revision + 1 : sourceDocument.revision
+        revision: sourceDocument.revision
       };
       const nextTabs = tabsRef.current.map((candidate) =>
         candidate.id === tabId ? createDocumentTab(nextDocument, candidate.id) : candidate


### PR DESCRIPTION
## Summary
- Keep saved Markdown documents on the same revision so saving no longer remounts the visual editor or clears Milkdown undo/redo history.
- Remove the saved file path from the MarkdownPaper instance key so first save / Save As path changes keep the editor mounted.
- Add regression coverage for normal save, first save, fast save with fresher editor content, and saved-path rerenders.

## Why
- Saving was treated like an external document refresh: it advanced document revision, and first save also changed the editor key through documentPath.
- Milkdown stores undo/redo history inside the editor instance, so those remounts discarded the operation history immediately after save.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx` passed: 44 tests.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 377 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app test` failed locally in unrelated `MarkdownFileTreeDrawer.test.tsx` expectations while the working tree contained uncommitted file-tree/titlebar/provider changes that are not included in this PR.

## Risk
- Low. Save still updates path, name, content, dirty state, recent files, and workspace state; editor remounts remain driven by document identity/revision changes for true document refreshes.
