### PR TITLE
fix(app): prevent compact text clipping

### DIFF
--- a/packages/app/src/components/AiProviderBadge.test.tsx
+++ b/packages/app/src/components/AiProviderBadge.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import type { AiProviderConfig } from "@markra/providers";
+import { AiProviderBadge } from "./AiProviderBadge";
+
+function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
+  return {
+    enabled: true,
+    id: "mock-provider",
+    models: [],
+    name: "gap provider",
+    type: "openai-compatible",
+    ...overrides
+  };
+}
+
+describe("AiProviderBadge", () => {
+  it("uses safe line height for fallback provider initials", () => {
+    render(<AiProviderBadge provider={provider()} translate={(key) => key} />);
+
+    expect(screen.getByText("ga")).toHaveClass("leading-4");
+  });
+});

--- a/packages/app/src/components/AiProviderBadge.tsx
+++ b/packages/app/src/components/AiProviderBadge.tsx
@@ -67,7 +67,7 @@ export function AiProviderBadge({ provider, translate }: { provider: AiProviderC
   const logo = providerLogoById[provider.id] ?? providerLogoByType[provider.type];
 
   return (
-    <span className="inline-flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full border border-(--border-default) bg-[oklch(0.985_0.004_255)] leading-none font-[750] text-(--accent)">
+    <span className="inline-flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full border border-(--border-default) bg-[oklch(0.985_0.004_255)] leading-4 font-[750] text-(--accent)">
       {logo ? (
         <img
           className="size-5 object-contain"

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -135,6 +135,44 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(container.querySelector(".markdown-file-tree-outline")).toContainElement(container.querySelector(".lucide-table-of-contents"));
   });
 
+  it("uses safe line height for truncated compact labels", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          { level: 1, title: "plugin gap" }
+        ]}
+        recentFolders={[
+          { name: "docs", path: "/mock-workspaces/alpha/docs" },
+          { name: "docs", path: "/mock-workspaces/beta/docs" }
+        ]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onOpenRecentFolder={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const fileButton = screen.getByRole("button", { name: "Untitled.md" });
+    const folderButton = screen.getByRole("button", { name: "deploy" });
+    const outlineButton = screen.getByRole("button", { name: "plugin gap" });
+    const recentSection = screen.getByRole("region", { name: "Recently used directories" });
+    const recentHeader = within(recentSection).getByRole("heading", { name: "Recently used directories" });
+    const recentFolder = within(recentSection).getByRole("button", {
+      name: "docs /mock-workspaces/alpha/docs"
+    });
+
+    expect(within(fileButton).getByText("Untitled.md")).toHaveClass("truncate", "leading-5");
+    expect(within(folderButton).getByText("deploy")).toHaveClass("truncate", "leading-5");
+    expect(outlineButton).toHaveClass("truncate", "leading-5");
+    expect(outlineButton).not.toHaveClass("leading-none");
+    expect(recentHeader).toHaveClass("truncate", "leading-5");
+    expect(within(recentFolder).getByText("docs")).toHaveClass("truncate", "leading-4");
+    expect(within(recentFolder).getByText("/mock-workspaces/alpha/docs")).toHaveClass("truncate", "leading-4");
+  });
+
   it("switches file and outline panels in the tabbed sidebar layout", () => {
     const { container } = render(
       <MarkdownFileTreeDrawer
@@ -1798,7 +1836,10 @@ describe("MarkdownFileTreeDrawer", () => {
     fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 42 });
     fireEvent.mouseMove(document, { buttons: 1, clientX: 24, clientY: 16 });
 
-    expect(screen.getByTestId("file-tree-drag-overlay")).toHaveTextContent("AWS.md");
+    const dragOverlay = screen.getByTestId("file-tree-drag-overlay");
+
+    expect(dragOverlay).toHaveTextContent("AWS.md");
+    expect(within(dragOverlay).getByText("AWS.md")).toHaveClass("truncate", "leading-5");
     expect(deployFolder).toHaveClass("bg-(--bg-active)");
 
     fireEvent.mouseUp(document, { clientX: 24, clientY: 16 });

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -1255,7 +1255,7 @@ export function MarkdownFileTreeDrawer({
           <input
             aria-label={label("app.newMarkdownFileName")}
             autoFocus
-            className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-none text-(--text-primary) outline-none"
+            className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-5 text-(--text-primary) outline-none"
             type="text"
             value={newFileName}
             placeholder="Untitled.md"
@@ -1296,7 +1296,7 @@ export function MarkdownFileTreeDrawer({
         <input
           aria-label={label("app.newMarkdownFolderName")}
           autoFocus
-          className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-none text-(--text-primary) outline-none"
+          className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-5 text-(--text-primary) outline-none"
           type="text"
           value={newFolderName}
           placeholder={label("app.newMarkdownFolder")}
@@ -1373,7 +1373,7 @@ export function MarkdownFileTreeDrawer({
         <input
           aria-label={folder ? label("app.renameMarkdownFolder") : label("app.renameMarkdownFile")}
           autoFocus
-          className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-none text-(--text-primary) outline-none"
+          className="h-6 min-w-0 rounded-md border border-(--accent) bg-(--bg-primary) px-1.5 text-[13px] leading-5 text-(--text-primary) outline-none"
           type="text"
           value={renameFileName}
           onChange={(event) => setRenameFileName(event.target.value)}
@@ -1446,7 +1446,7 @@ export function MarkdownFileTreeDrawer({
                   <ChevronRight aria-hidden="true" className="shrink-0" size={13} />
                 )}
                 <Folder aria-hidden="true" className="shrink-0" size={16} />
-                <span className="min-w-0 truncate">{node.name}</span>
+                <span className="min-w-0 truncate leading-5">{node.name}</span>
               </button>
             )}
           </FileTreeDragSource>
@@ -1486,7 +1486,7 @@ export function MarkdownFileTreeDrawer({
             {...dragSource.listeners}
           >
             <FileIcon aria-hidden="true" className="shrink-0" size={15} />
-            <span className="min-w-0 truncate">{node.name}</span>
+            <span className="min-w-0 truncate leading-5">{node.name}</span>
           </button>
         )}
       </FileTreeDragSource>
@@ -1587,8 +1587,8 @@ export function MarkdownFileTreeDrawer({
           const outlineIndent = (item.level - 1) * 12;
           const active = activeOutlineIndex === index;
           const outlineButtonClassName = active
-            ? "h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-(--bg-active) px-1 text-left text-[13px] leading-none font-[620] text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
-            : "h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-transparent px-1 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none";
+            ? "h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-(--bg-active) px-1 text-left text-[13px] leading-5 font-[620] text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+            : "h-7 min-w-0 cursor-pointer truncate rounded-sm border-0 bg-transparent px-1 text-left text-[13px] leading-5 text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none";
 
           return (
             <li key={key}>
@@ -1718,7 +1718,7 @@ export function MarkdownFileTreeDrawer({
             aria-label={label("app.recentMarkdownFolders")}
           >
             <div className="flex h-8 items-center gap-1 px-3 pr-2 text-[12px] text-(--text-secondary)">
-              <h3 className="m-0 min-w-0 flex-1 truncate text-[12px] leading-none font-[560] tracking-normal text-(--text-secondary)">
+              <h3 className="m-0 min-w-0 flex-1 truncate text-[12px] leading-5 font-[560] tracking-normal text-(--text-secondary)">
                 {label("app.recentMarkdownFolders")}
               </h3>
               <IconButton
@@ -1766,9 +1766,9 @@ export function MarkdownFileTreeDrawer({
                       >
                         <RecentFolderIcon aria-hidden="true" className="shrink-0" size={14} />
                         <span className="flex min-w-0 flex-col gap-0.5">
-                          <span className="min-w-0 truncate">{folder.name}</span>
+                          <span className="min-w-0 truncate leading-4">{folder.name}</span>
                           {duplicateName ? (
-                            <span className="min-w-0 truncate text-[10px] leading-none text-(--text-tertiary)">
+                            <span className="min-w-0 truncate text-[10px] leading-4 text-(--text-tertiary)">
                               {folderPathLabel}
                             </span>
                           ) : null}
@@ -1897,7 +1897,7 @@ export function MarkdownFileTreeDrawer({
         ) : null}
         {!tabbedSidebarLayout ? (
           <div className="grid h-10 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center border-b border-(--border-default) px-3">
-            <h2 className="m-0 truncate text-[14px] font-[560] tracking-normal text-(--text-heading)">
+            <h2 className="m-0 truncate text-[14px] leading-5 font-[560] tracking-normal text-(--text-heading)">
               {label("app.files")}
             </h2>
             <div className="markdown-file-tree-header-actions flex items-center gap-0.5">
@@ -1955,7 +1955,7 @@ export function MarkdownFileTreeDrawer({
                         onContextMenu={(event) => openContextMenu(event)}
                       >
                         <Folder aria-hidden="true" size={16} />
-                        <span className="min-w-0 truncate">{rootName}</span>
+                        <span className="min-w-0 truncate leading-5">{rootName}</span>
                       </div>
                     )}
                   </FileTreeDropTarget>
@@ -2163,7 +2163,7 @@ export function MarkdownFileTreeDrawer({
                   {!tabbedSidebarLayout ? (
                     <>
                       <TableOfContents aria-hidden="true" size={16} />
-                      <h3 className="m-0 min-w-0 flex-1 truncate text-[13px] leading-none font-[560] tracking-normal text-(--text-secondary)">
+                      <h3 className="m-0 min-w-0 flex-1 truncate text-[13px] leading-5 font-[560] tracking-normal text-(--text-secondary)">
                         {label("app.outline")}
                       </h3>
                     </>

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -45,6 +45,7 @@ describe("NativeTitleBar", () => {
 
     expect(screen.getByLabelText("Window drag region")).toHaveAttribute("data-tauri-drag-region");
     expect(screen.getByRole("heading", { name: "Draft.md" })).toBeInTheDocument();
+    expect(screen.getByText("Draft.md")).toHaveClass("truncate", "leading-5");
     expect(screen.getByRole("button", { name: "Open Markdown or Folder" }).closest(".titlebar-spacer")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Markdown" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Switch to dark theme" })).toBeInTheDocument();
@@ -481,6 +482,7 @@ describe("NativeTitleBar", () => {
     expect(workspaceContext?.closest(".windows-app-chrome-center")).toBeInTheDocument();
     expect(workspaceContext?.closest(".windows-app-chrome-center")).toHaveClass("absolute", "left-1/2", "-translate-x-1/2");
     expect(workspaceContext).toHaveTextContent("Desktop");
+    expect(within(workspaceContext as HTMLElement).getByText("Desktop")).toHaveClass("truncate", "leading-4");
     expect(screen.queryByRole("heading", { name: "Desktop" })).not.toBeInTheDocument();
   });
 
@@ -507,7 +509,9 @@ describe("NativeTitleBar", () => {
 
     expect(workspaceContext).toBeInTheDocument();
     expect(workspaceContext).toHaveTextContent("Desktop");
+    expect(within(workspaceContext as HTMLElement).getByText("Desktop")).toHaveClass("truncate", "leading-4");
     expect(screen.getByRole("heading", { name: "Draft.md" })).toBeInTheDocument();
+    expect(screen.getByText("Draft.md")).toHaveClass("truncate", "leading-5");
   });
 
   it("opens self-drawn Windows app menu dropdowns from the top chrome", () => {

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -642,7 +642,7 @@ export function NativeTitleBar({
           style={{ transform: titleTransform }}
         >
           <TitleIcon aria-hidden="true" size={15} />
-          <span className="min-w-0 truncate" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
+          <span className="min-w-0 truncate leading-5" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
             {documentName}
           </span>
           {dirty ? (

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -290,7 +290,7 @@ export function WindowsNativeTitleBar({
       title={windowsWorkspaceName}
     >
       <FolderOpen aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={13} />
-      <span className="min-w-0 truncate" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
+      <span className="min-w-0 truncate leading-4" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
         {windowsWorkspaceName}
       </span>
     </span>
@@ -449,7 +449,7 @@ export function WindowsNativeTitleBar({
             style={{ transform: windowsTitleTransform }}
           >
             <TitleIcon aria-hidden="true" size={15} />
-            <span className="min-w-0 truncate" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
+            <span className="min-w-0 truncate leading-5" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
               {documentName}
             </span>
             {dirty ? (

--- a/packages/app/src/components/file-tree/FileTreeDnd.tsx
+++ b/packages/app/src/components/file-tree/FileTreeDnd.tsx
@@ -197,7 +197,7 @@ export function FileTreeDragOverlay({
       data-testid="file-tree-drag-overlay"
     >
       <FileIcon aria-hidden="true" className="shrink-0" size={15} />
-      <span className="min-w-0 truncate">{file.relativePath}</span>
+      <span className="min-w-0 truncate leading-5">{file.relativePath}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add safe line-height classes to truncated compact labels in the file tree, outline, recent folders, and native title bars.
- Adjust compact create/rename inputs and provider fallback badges so descenders are not clipped.
- Add regression coverage for the affected compact text surfaces.

## Why
- `truncate` applies hidden overflow, and several compact labels inherited `leading-none`, which could crop the bottom of rendered text.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownFileTreeDrawer.test.tsx src/components/NativeTitleBar.test.tsx src/components/AiProviderBadge.test.tsx` passed: 103 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Low. This keeps existing compact row heights and only gives clipped text nodes safer line boxes.