### PR TITLE
fix(editor): ignore horizontal rule surrounding clicks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2774,7 +2774,7 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
-  it("only ignores horizontal rule margin clicks close to the divider", async () => {
+  it("ignores horizontal rule surrounding clicks", async () => {
     const { container, view } = await renderEditor("First\n\n---\n\nSecond");
     const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
     const surface = container.querySelector<HTMLElement>(".ProseMirror");
@@ -2785,15 +2785,15 @@ describe("MarkdownPaper editing", () => {
     const upperWhitespaceResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
-      clientY: 134
+      clientY: 130
     });
-    expect(upperWhitespaceResult).toBe(true);
+    expect(upperWhitespaceResult).toBe(false);
     expect(view.state.selection.from).toBe(secondCursor);
 
     const topGapResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
-      clientY: 138
+      clientY: 134
     });
     expect(topGapResult).toBe(false);
     expect(view.state.selection.from).toBe(secondCursor);
@@ -2803,7 +2803,7 @@ describe("MarkdownPaper editing", () => {
     const bottomGapResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
-      clientY: 143
+      clientY: 147
     });
     expect(bottomGapResult).toBe(false);
     expect(view.state.selection.from).toBe(firstCursor);
@@ -2811,10 +2811,43 @@ describe("MarkdownPaper editing", () => {
     const lowerWhitespaceResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
-      clientY: 147
+      clientY: 153
     });
-    expect(lowerWhitespaceResult).toBe(true);
+    expect(lowerWhitespaceResult).toBe(false);
     expect(view.state.selection.from).toBe(firstCursor);
+
+    restoreLayout();
+  });
+
+  it("ignores clicks above the visual line inside a horizontal rule hit target", async () => {
+    const { container, view } = await renderEditor("First\n\n---\n\nSecond");
+    const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const rule = surface?.querySelector<HTMLElement>("hr");
+    expect(rule).toBeInTheDocument();
+
+    rule!.getBoundingClientRect = vi.fn(() => ({
+      bottom: 146,
+      height: 12,
+      left: 160,
+      right: 640,
+      top: 134,
+      width: 480,
+      x: 160,
+      y: 134,
+      toJSON: () => ({})
+    } as DOMRect));
+
+    const secondCursor = findTextPosition(view, "Second");
+    moveCursor(view, secondCursor);
+    const upperHitTargetResult = fireEvent.mouseDown(rule!, {
+      button: 0,
+      clientX: 200,
+      clientY: 136
+    });
+
+    expect(upperHitTargetResult).toBe(false);
+    expect(view.state.selection.from).toBe(secondCursor);
 
     restoreLayout();
   });

--- a/packages/editor/src/block-gap.ts
+++ b/packages/editor/src/block-gap.ts
@@ -3,7 +3,7 @@ import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
 const gapGuardedBlockNames = new Set(["hr"]);
-const maximumGuardedGapPadding = 4;
+const fallbackGuardedGapPadding = 20;
 
 function isPlainLeftMouseDown(event: MouseEvent) {
   return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
@@ -20,17 +20,17 @@ function pixelValue(value: string) {
 
 function guardedGapExtent(value: string) {
   const pixels = pixelValue(value);
-  if (!pixels) return maximumGuardedGapPadding;
+  if (!pixels) return fallbackGuardedGapPadding;
 
-  return Math.min(pixels, maximumGuardedGapPadding);
+  return pixels;
 }
 
 function blockGapExtents(element: Element) {
   const ownerWindow = element.ownerDocument.defaultView;
   if (!ownerWindow) {
     return {
-      bottom: maximumGuardedGapPadding,
-      top: maximumGuardedGapPadding
+      bottom: fallbackGuardedGapPadding,
+      top: fallbackGuardedGapPadding
     };
   }
 
@@ -52,8 +52,17 @@ function verticalPointIsInsideBlockGap(top: number, rect: DOMRect, gap: { bottom
   return false;
 }
 
-function eventTargetsEditorSurface(view: EditorView, target: EventTarget | null) {
-  return eventTargetElement(target) === view.dom;
+function verticalPointIsInsideBlockHitTarget(top: number, rect: DOMRect) {
+  return top >= rect.top && top <= rect.bottom;
+}
+
+function verticalPointIsInsideGuardedBlockZone(top: number, rect: DOMRect, gap: { bottom: number; top: number }) {
+  return verticalPointIsInsideBlockGap(top, rect, gap) || verticalPointIsInsideBlockHitTarget(top, rect);
+}
+
+function eventTargetsEditorContent(view: EditorView, target: EventTarget | null) {
+  const element = eventTargetElement(target);
+  return Boolean(element && (element === view.dom || view.dom.contains(element)));
 }
 
 function pointIsInGuardedBlockGap(view: EditorView, left: number, top: number) {
@@ -68,7 +77,7 @@ function pointIsInGuardedBlockGap(view: EditorView, left: number, top: number) {
     if (!element || !rect || !horizontalPointIsInsideRect(left, rect)) return false;
 
     const gap = blockGapExtents(element);
-    if (verticalPointIsInsideBlockGap(top, rect, gap)) {
+    if (verticalPointIsInsideGuardedBlockZone(top, rect, gap)) {
       isInGap = true;
       return false;
     }
@@ -85,7 +94,7 @@ export function createBlockGapPlugin() {
       handleDOMEvents: {
         mousedown(view, event) {
           if (!view.editable || !isPlainLeftMouseDown(event)) return false;
-          if (!eventTargetsEditorSurface(view, event.target)) return false;
+          if (!eventTargetsEditorContent(view, event.target)) return false;
           if (!pointIsInGuardedBlockGap(view, event.clientX, event.clientY)) return false;
 
           event.preventDefault();


### PR DESCRIPTION
## Summary
- Treat clicks on horizontal rules and their surrounding spacing as no-op in WYSIWYG editing.
- Use the horizontal rule margin and hit target as the guarded zone so nearby clicks do not move the caret into adjacent content.
- Update regression coverage for surrounding clicks and clicks inside the rule hit target.

## Why
#331 showed that narrowing the horizontal-rule guard still allowed nearby clicks to jump the caret to content below the divider. After weighing the trade-off, keeping the divider area inert is the more stable and general behavior across platform rendering, zoom, font size, and click habits.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "horizontal rule"` passed: 5 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Risk
- Low. The change is scoped to horizontal rule click handling.
- Users can no longer place the caret by clicking in the horizontal-rule spacing itself, but that area is intentionally treated as layout rather than editable text.

## Related Issues
- Refs #331.