### PR TITLE
feat(app): improve side-by-side document tabs

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3098,6 +3098,14 @@ describe("Markra workspace", () => {
     mockedSaveStoredWorkspaceState.mockClear();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    const groupedTabs = container.querySelector(".document-tabs-side-by-side-group") as HTMLElement;
+    const mainPaneTab = within(groupedTabs).getByRole("tab", { name: /1\.md/ });
+    const sidePaneTab = within(groupedTabs).getByRole("tab", { name: /2\.md/ });
+    expect(mainPaneTab).toHaveAttribute("aria-selected", "true");
+    expect(sidePaneTab).toHaveAttribute("aria-selected", "false");
+    expect(mainPaneTab).toHaveAttribute("data-document-tab-pane-focus", "true");
+    expect(sidePaneTab).not.toHaveAttribute("data-document-tab-pane-focus");
+
     const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
     const sideSource = await within(sidePane).findByRole("textbox", { name: "Markdown source" });
     const mainSource = (await screen.findAllByRole("textbox", { name: "Markdown source" })).find((editor) =>
@@ -3105,13 +3113,26 @@ describe("Markra workspace", () => {
     ) as HTMLElement;
 
     fireEvent.focus(sideSource);
-    replaceMarkdownSource(sideSource, "# Second\n\nFocused side edit");
+    await waitFor(() => expect(sidePaneTab).toHaveAttribute("aria-selected", "true"));
+    expect(mainPaneTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.focus(mainSource);
+    await waitFor(() => expect(mainPaneTab).toHaveAttribute("aria-selected", "true"));
+    expect(sidePaneTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(sidePaneTab);
+    await waitFor(() => expect(sidePaneTab).toHaveAttribute("aria-selected", "true"));
+    expect(mainPaneTab).toHaveAttribute("aria-selected", "false");
+    expect(sidePaneTab).toHaveAttribute("data-document-tab-pane-focus", "true");
+    expect(mainPaneTab).not.toHaveAttribute("data-document-tab-pane-focus");
+    await waitFor(() => expect(document.activeElement).toBe(sideSource));
+    replaceMarkdownSource(sideSource, "# Second\n\nClicked side tab edit");
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));
 
     await waitFor(() =>
       expect(mockedSaveNativeMarkdownFile).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          contents: "# Second\n\nFocused side edit",
+          contents: "# Second\n\nClicked side tab edit",
           path: secondPath,
           suggestedName: "2.md"
         })
@@ -3140,7 +3161,12 @@ describe("Markra workspace", () => {
       })
     );
 
-    fireEvent.focus(mainSource);
+    fireEvent.click(mainPaneTab);
+    await waitFor(() => expect(mainPaneTab).toHaveAttribute("aria-selected", "true"));
+    expect(sidePaneTab).toHaveAttribute("aria-selected", "false");
+    expect(mainPaneTab).toHaveAttribute("data-document-tab-pane-focus", "true");
+    expect(sidePaneTab).not.toHaveAttribute("data-document-tab-pane-focus");
+    await waitFor(() => expect(document.activeElement).toBe(mainSource));
     replaceMarkdownSource(mainSource, "# First\n\nFocused main edit");
     fireEvent.keyDown(window, { key: "s", metaKey: true, shiftKey: true });
 
@@ -3237,7 +3263,7 @@ describe("Markra workspace", () => {
     await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).not.toBeInTheDocument());
 
     const inactiveGroup = container.querySelector(".document-tabs-side-by-side-group") as HTMLElement;
-    fireEvent.click(within(inactiveGroup).getByRole("tab", { name: /2\.md/ }));
+    fireEvent.click(within(inactiveGroup).getByRole("tab", { name: /1\.md/ }));
     await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole("button", { name: "Save Markdown" }));

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -297,6 +297,7 @@ function WorkspaceApp() {
     sizeBytes: null as number | null
   });
   const largeMarkdownVisualBlockedRef = useRef(false);
+  const mainDocumentPaneRef = useRef<HTMLDivElement | null>(null);
   const sourceScrollRef = useRef<HTMLElement | null>(null);
   const visualScrollRef = useRef<HTMLElement | null>(null);
   const mainVisualEditorsRef = useRef(new Map<string, MilkdownEditor>());
@@ -304,6 +305,7 @@ function WorkspaceApp() {
   const pendingEditorModeScrollRef = useRef<PendingEditorModeScroll | null>(null);
   const splitSurfaceRef = useRef<HTMLDivElement | null>(null);
   const sideDocumentSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const titlebarTabFocusTimerRef = useRef<number | null>(null);
   const splitScrollSyncTargetRef = useRef<EditorSurface | null>(null);
   const splitScrollSyncFrameRef = useRef<number | null>(null);
   const splitPaneResizeCleanupRef = useRef<(() => unknown) | null>(null);
@@ -3063,6 +3065,42 @@ function WorkspaceApp() {
     updateActiveAiSelection
   ]);
 
+  const focusEditorInDocumentPane = useCallback((target: "main" | "side") => {
+    if (titlebarTabFocusTimerRef.current !== null) {
+      window.clearTimeout(titlebarTabFocusTimerRef.current);
+      titlebarTabFocusTimerRef.current = null;
+    }
+
+    titlebarTabFocusTimerRef.current = window.setTimeout(() => {
+      titlebarTabFocusTimerRef.current = null;
+
+      const pane =
+        target === "side"
+          ? sideDocumentSurfaceRef.current?.querySelector<HTMLElement>(".side-document-pane") ?? null
+          : mainDocumentPaneRef.current;
+      if (!pane) return;
+
+      const sourceEditorSelector = ".markdown-source-editor [role='textbox']";
+      const visualEditorSelector = ".markdown-paper [role='textbox']";
+      const preferredSelector =
+        target === "side"
+          ? sourceMode ? sourceEditorSelector : visualEditorSelector
+          : sourceMode || (splitMode && activeEditorSurface === "source") ? sourceEditorSelector : visualEditorSelector;
+      const editor =
+        pane.querySelector<HTMLElement>(preferredSelector) ??
+        pane.querySelector<HTMLElement>("[role='textbox']");
+
+      editor?.focus({ preventScroll: true });
+    }, 0);
+  }, [activeEditorSurface, sourceMode, splitMode]);
+
+  useEffect(() => () => {
+    if (titlebarTabFocusTimerRef.current !== null) {
+      window.clearTimeout(titlebarTabFocusTimerRef.current);
+      titlebarTabFocusTimerRef.current = null;
+    }
+  }, []);
+
   const handleSelectTitlebarTab = useCallback((tabId: string) => {
     captureActiveDocumentViewState();
     setDocumentOperationTarget("main");
@@ -3086,6 +3124,11 @@ function WorkspaceApp() {
     selectMarkdownTab,
     updateActiveAiSelection
   ]);
+  const handleFocusTitlebarTab = useCallback((tabId: string) => {
+    const target = sideDocumentGroup?.sideTabId === tabId ? "side" : "main";
+    setDocumentOperationTarget(target);
+    focusEditorInDocumentPane(target);
+  }, [focusEditorInDocumentPane, sideDocumentGroup?.sideTabId]);
   const handleRenameTitlebarTab = useCallback(async (tab: MarkdownTabsBarDocumentItem, fileName: string) => {
     const file = documentTabAsFolderFile(tab);
     if (!file) return;
@@ -3101,12 +3144,14 @@ function WorkspaceApp() {
   const titlebarDocumentTabs = documentTabsVisible ? (
     <MarkdownTabsBar
       activeTabId={activeTitlebarTabId}
+      focusedTabId={focusedSideDocumentTabId ?? activeTitlebarTabId}
       items={titlebarItems}
       language={appLanguage.language}
       nativeDragRegionEnabled={nativeWindowChromeEnabled}
       placement="titlebar"
       onCancelSideBySide={handleCancelTitlebarSideBySide}
       onCloseTab={handleCloseTitlebarTab}
+      onFocusTab={handleFocusTitlebarTab}
       onNewTab={() => {
         captureActiveDocumentViewState();
         setActiveImageFile(null);
@@ -3437,7 +3482,11 @@ function WorkspaceApp() {
                   ref={sideDocumentOpen ? sideDocumentSurfaceRef : undefined}
                   style={sideDocumentOpen ? sideDocumentSurfaceStyle : undefined}
                 >
-                  <div className="relative h-full min-h-0 overflow-hidden" onFocusCapture={handleMainDocumentPaneFocus}>
+                  <div
+                    className="relative h-full min-h-0 overflow-hidden"
+                    ref={mainDocumentPaneRef}
+                    onFocusCapture={handleMainDocumentPaneFocus}
+                  >
                     {splitMode ? (
                     <div
                       className="editor-split-surface grid h-full min-h-0 grid-cols-1 grid-rows-[minmax(0,1fr)_minmax(0,1fr)] divide-y divide-(--border-default) min-[900px]:grid-cols-[minmax(0,var(--split-visual-pane))_8px_minmax(0,var(--split-source-pane))] min-[900px]:grid-rows-[minmax(0,1fr)] min-[900px]:divide-y-0"

--- a/packages/app/src/components/MarkdownTabsBar.test.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.test.tsx
@@ -187,6 +187,105 @@ describe("MarkdownTabsBar", () => {
     });
   });
 
+  it("uses the full tab path as the hover tooltip when available", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/workspace/docs/Alpha.md"
+          }
+        ]}
+        placement="titlebar"
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("tab", { name: /Alpha\.md/ })).toHaveAttribute(
+      "title",
+      "/synthetic/workspace/docs/Alpha.md"
+    );
+  });
+
+  it("uses the focused pane tab as the grouped tab active state", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        focusedTabId="tab-b"
+        items={[
+          [
+            {
+              dirty: false,
+              id: "tab-a",
+              name: "Alpha.md",
+              path: "/synthetic/alpha.md"
+            },
+            {
+              dirty: false,
+              id: "tab-b",
+              name: "Beta.md",
+              path: "/synthetic/beta.md"
+            }
+          ]
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaTab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+
+    expect(alphaTab).toHaveAttribute("aria-selected", "false");
+    expect(alphaTab).not.toHaveAttribute("data-document-tab-pane-focus");
+    expect(alphaTab.className).toContain("text-(--text-secondary)");
+    expect(betaTab).toHaveAttribute("aria-selected", "true");
+    expect(betaTab).toHaveAttribute("data-document-tab-pane-focus", "true");
+    expect(betaTab.className).toContain("text-(--text-heading)");
+  });
+
+  it("reports the clicked grouped tab as the requested focus target", () => {
+    const onFocusTab = vi.fn();
+    const onSelectTab = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          [
+            {
+              dirty: false,
+              id: "tab-a",
+              name: "Alpha.md",
+              path: "/synthetic/alpha.md"
+            },
+            {
+              dirty: false,
+              id: "tab-b",
+              name: "Beta.md",
+              path: "/synthetic/beta.md"
+            }
+          ]
+        ]}
+        onCloseTab={() => {}}
+        onFocusTab={onFocusTab}
+        onNewTab={() => {}}
+        onSelectTab={onSelectTab}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /Beta\.md/ }));
+
+    expect(onSelectTab).toHaveBeenCalledWith("tab-a");
+    expect(onFocusTab).toHaveBeenCalledWith("tab-b");
+  });
+
   it("omits titlebar empty drag space when native drag regions are unavailable", () => {
     const { container } = render(
       <MarkdownTabsBar
@@ -690,6 +789,112 @@ describe("MarkdownTabsBar", () => {
     expect(onOpenTabToSide).toHaveBeenCalledWith("tab-b", "tab-a");
     expect(elementFromPoint).toHaveBeenCalled();
     Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("shows a side drop insertion position while pointer dragging over a tab", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaTab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    alphaTab.getBoundingClientRect = vi.fn(() => ({
+      bottom: 32,
+      height: 28,
+      left: 10,
+      right: 110,
+      top: 4,
+      width: 100,
+      x: 10,
+      y: 4,
+      toJSON: () => ({})
+    }));
+    const elementFromPoint = mockElementFromPoint(alphaTab);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 0, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 24, clientY: 12, pointerId: 1 });
+
+    expect(alphaTab).toHaveAttribute("data-document-tab-drop-position", "before");
+
+    fireEvent.pointerMove(window, { clientX: 96, clientY: 12, pointerId: 1 });
+
+    expect(alphaTab).toHaveAttribute("data-document-tab-drop-position", "after");
+
+    fireEvent.pointerUp(window, { clientX: 96, clientY: 12, pointerId: 1 });
+    expect(elementFromPoint).toHaveBeenCalled();
+    Reflect.deleteProperty(document, "elementFromPoint");
+  });
+
+  it("uses the tab drop side to choose the side-by-side document order", () => {
+    const onOpenTabToSide = vi.fn();
+
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          },
+          {
+            dirty: false,
+            id: "tab-b",
+            name: "Beta.md",
+            path: "/synthetic/beta.md"
+          }
+        ]}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onOpenTabToSide={onOpenTabToSide}
+        onSelectTab={() => {}}
+      />
+    );
+
+    const alphaTab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    const betaTab = screen.getByRole("tab", { name: /Beta\.md/ });
+    alphaTab.getBoundingClientRect = vi.fn(() => ({
+      bottom: 32,
+      height: 28,
+      left: 10,
+      right: 110,
+      top: 4,
+      width: 100,
+      x: 10,
+      y: 4,
+      toJSON: () => ({})
+    }));
+    const elementFromPoint = mockElementFromPoint(alphaTab);
+
+    fireEvent.pointerDown(betaTab, { button: 0, clientX: 0, clientY: 12, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 24, clientY: 12, pointerId: 1 });
+    fireEvent.pointerUp(window, { clientX: 24, clientY: 12, pointerId: 1 });
+
+    expect(onOpenTabToSide).toHaveBeenCalledWith("tab-a", "tab-b");
+
+    Reflect.deleteProperty(document, "elementFromPoint");
+    elementFromPoint.mockClear();
   });
 
   it("uses the pointer drop target tab as the main side-by-side tab", () => {

--- a/packages/app/src/components/MarkdownTabsBar.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.tsx
@@ -22,12 +22,14 @@ export type MarkdownTabsBarItem = MarkdownTabsBarDocumentItem | MarkdownTabsBarD
 
 type MarkdownTabsBarProps = {
   activeTabId: string | null;
+  focusedTabId?: string | null;
   items: MarkdownTabsBarItem[];
   language?: AppLanguage;
   nativeDragRegionEnabled?: boolean;
   placement?: "editor" | "titlebar";
   onCancelSideBySide?: (tabId: string) => unknown;
   onCloseTab: (tabId: string) => unknown;
+  onFocusTab?: (tabId: string) => unknown;
   onNewTab: () => unknown;
   onOpenTabToSide?: (tabId: string, primaryTabId?: string) => unknown;
   onRevealTabInFileTree?: (path: string) => unknown;
@@ -54,18 +56,27 @@ type PointerTabDragPreview = {
   y: number;
 };
 
+type TabDropPosition = "after" | "before";
+
+type PointerTabDropTarget = {
+  position: TabDropPosition;
+  tabId: string;
+};
+
 export const markdownTabDragDataType = "application/x-markra-document-tab";
 const pointerTabDragThresholdPx = 6;
 const pointerTabDragPreviewOffsetPx = 12;
 
 export function MarkdownTabsBar({
   activeTabId,
+  focusedTabId,
   items,
   language = "en",
   nativeDragRegionEnabled = true,
   placement = "editor",
   onCancelSideBySide,
   onCloseTab,
+  onFocusTab,
   onNewTab,
   onOpenTabToSide,
   onRevealTabInFileTree,
@@ -79,7 +90,7 @@ export function MarkdownTabsBar({
   const renameCancelledRef = useRef(false);
   const [contextMenu, setContextMenu] = useState<TabContextMenuState | null>(null);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
-  const [dragOverTabId, setDragOverTabId] = useState<string | null>(null);
+  const [pointerTabDropTarget, setPointerTabDropTarget] = useState<PointerTabDropTarget | null>(null);
   const [pointerTabDragPreview, setPointerTabDragPreview] = useState<PointerTabDragPreview | null>(null);
   const pointerTabDragRef = useRef<PointerTabDragState | null>(null);
   const pointerDragCleanupRef = useRef<(() => unknown) | null>(null);
@@ -110,6 +121,7 @@ export function MarkdownTabsBar({
   const tabItemGroups = items.map((item) => Array.isArray(item) ? item : [item]);
   const documentItems = tabItemGroups.flatMap((item) => item);
   const documentTabIdsKey = documentItems.map((tab) => tab.id).join("\n");
+  const paneFocusedTabId = focusedTabId ?? activeTabId;
   const sideGroupedTabIds = new Set(
     items.flatMap((item) => Array.isArray(item) ? item.slice(1).map((tab) => tab.id) : [])
   );
@@ -187,26 +199,36 @@ export function MarkdownTabsBar({
 
     return {
       editorTarget,
+      tabTarget,
       targetTabId: tabTarget?.dataset.documentTabId ?? null
     };
   };
+  const pointerTabDropPosition = (target: HTMLElement | null | undefined, clientX: number): TabDropPosition => {
+    const rect = target?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) return "after";
+
+    return clientX < rect.left + rect.width / 2 ? "before" : "after";
+  };
   const updatePointerDropFeedback = (event: PointerEvent, draggedTab: MarkdownTabsBarDocumentItem) => {
-    const { editorTarget, targetTabId } = hitTestPointerDropTarget(event);
+    const { editorTarget, tabTarget, targetTabId } = hitTestPointerDropTarget(event);
     const targetTab = targetTabId ? documentItems.find((tab) => tab.id === targetTabId) ?? null : null;
 
     if (targetTab && tabAcceptsSideDrop(targetTab, draggedTab)) {
-      setDragOverTabId(targetTab.id);
+      setPointerTabDropTarget({
+        position: pointerTabDropPosition(tabTarget, event.clientX),
+        tabId: targetTab.id
+      });
       setPointerEditorDropTarget(null);
       return;
     }
 
     if (editorTarget && draggedTab.id !== activeTabId) {
-      setDragOverTabId(null);
+      setPointerTabDropTarget(null);
       setPointerEditorDropTarget(editorTarget);
       return;
     }
 
-    setDragOverTabId(null);
+    setPointerTabDropTarget(null);
     setPointerEditorDropTarget(null);
   };
   const finishPointerTabDrag = (event: PointerEvent | null, commit: boolean) => {
@@ -217,7 +239,7 @@ export function MarkdownTabsBar({
     clearPageDocumentTabDragging();
     clearPointerEditorDropTarget();
     setDraggingTabId(null);
-    setDragOverTabId(null);
+    setPointerTabDropTarget(null);
     setPointerTabDragPreview(null);
 
     if (!pointerDrag?.dragging) return;
@@ -231,10 +253,16 @@ export function MarkdownTabsBar({
     const draggedTab = documentItems.find((tab) => tab.id === pointerDrag.tabId) ?? null;
     if (!draggedTab || !tabCanDragToSide(draggedTab)) return;
 
-    const { editorTarget, targetTabId } = hitTestPointerDropTarget(event);
+    const { editorTarget, tabTarget, targetTabId } = hitTestPointerDropTarget(event);
     const targetTab = targetTabId ? documentItems.find((tab) => tab.id === targetTabId) ?? null : null;
 
     if (targetTab && tabAcceptsSideDrop(targetTab, draggedTab)) {
+      const dropPosition = pointerTabDropPosition(tabTarget, event.clientX);
+      if (dropPosition === "before") {
+        onOpenTabToSide?.(targetTab.id, draggedTab.id);
+        return;
+      }
+
       onOpenTabToSide?.(draggedTab.id, targetTab.id);
       return;
     }
@@ -440,10 +468,27 @@ export function MarkdownTabsBar({
     }
 
     onSelectTab(selectTabId);
+    onFocusTab?.(tab.id);
   };
-  const renderTabButton = (tab: MarkdownTabsBarDocumentItem, active: boolean, selectTabId = tab.id) => {
+  const renderTabDropIndicator = (position: TabDropPosition | null) => position ? (
+    <span
+      aria-hidden="true"
+      className={`pointer-events-none absolute top-1 bottom-1 z-10 w-0.5 rounded-full bg-(--accent) ${
+        position === "before" ? "left-0" : "right-0"
+      }`}
+      data-document-tab-drop-indicator="true"
+    />
+  ) : null;
+  const renderTabButton = (
+    tab: MarkdownTabsBarDocumentItem,
+    active: boolean,
+    paneFocused: boolean,
+    dropPosition: TabDropPosition | null,
+    selectTabId = tab.id
+  ) => {
     const TabIcon = tab.displayKind === "image" ? ImageIcon : FileText;
     const renaming = tab.id === renamingTabId;
+    const tabTitle = tab.path ?? (tab.name || "Untitled.md");
 
     return renaming ? (
       <div className="flex h-full min-w-0 items-center gap-1.5 rounded-l-md px-2">
@@ -480,6 +525,9 @@ export function MarkdownTabsBar({
         role="tab"
         aria-selected={active}
         data-document-tab-id={tab.id}
+        data-document-tab-pane-focus={paneFocused ? "true" : undefined}
+        data-document-tab-drop-position={dropPosition ?? undefined}
+        title={tabTitle}
         onClick={() => handleSelectTabClick(tab, selectTabId)}
         onDoubleClick={() => startRenamingTab(tab)}
         onDragStart={handlePreventNativeTabDrag}
@@ -506,13 +554,15 @@ export function MarkdownTabsBar({
     </button>
   );
   const renderDocumentTab = (tab: MarkdownTabsBarDocumentItem) => {
-    const active = tab.id === activeTabId;
+    const active = tab.id === paneFocusedTabId;
     const dragged = tab.id === draggingTabId;
-    const sideDropTarget = tab.id === dragOverTabId;
+    const paneFocused = tab.id === paneFocusedTabId;
+    const dropPosition = tab.id === pointerTabDropTarget?.tabId ? pointerTabDropTarget.position : null;
+    const sideDropTarget = Boolean(dropPosition);
 
     return (
       <div
-        className={`group/tab grid h-7 max-w-52 min-w-28 grid-cols-[minmax(0,1fr)_auto] items-center rounded-md border transition-colors duration-150 ease-out ${
+        className={`group/tab relative grid h-7 max-w-52 min-w-28 grid-cols-[minmax(0,1fr)_auto] items-center rounded-md border transition-colors duration-150 ease-out ${
           titlebarPlacement ? "" : "mb-1"
         } ${
           sideDropTarget
@@ -522,13 +572,16 @@ export function MarkdownTabsBar({
             : "border-transparent bg-transparent text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading)"
         } ${dragged ? "opacity-60" : ""}`}
         data-document-tab-id={tab.id}
+        data-document-tab-pane-focus={paneFocused ? "true" : undefined}
+        data-document-tab-drop-position={dropPosition ?? undefined}
         draggable={false}
         key={tab.id}
         onContextMenu={(event) => openTabContextMenu(event, tab)}
         onDragStart={handlePreventNativeTabDrag}
       >
-        {renderTabButton(tab, active)}
+        {renderTabButton(tab, active, paneFocused, dropPosition)}
         {renderCloseTabButton(tab, active)}
+        {renderTabDropIndicator(dropPosition)}
       </div>
     );
   };
@@ -544,23 +597,28 @@ export function MarkdownTabsBar({
         key={`group-${index}-${group.map((tab) => tab.id).join(":")}`}
       >
         {group.map((tab, tabIndex) => {
-          const active = tab.id === activeTabId;
+          const active = tab.id === paneFocusedTabId;
           const dragged = tab.id === draggingTabId;
-          const sideDropTarget = tab.id === dragOverTabId;
+          const paneFocused = tab.id === paneFocusedTabId;
+          const dropPosition = tab.id === pointerTabDropTarget?.tabId ? pointerTabDropTarget.position : null;
+          const sideDropTarget = Boolean(dropPosition);
 
           return (
             <div
-              className={`group/tab grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center transition-colors duration-150 ease-out ${
+              className={`group/tab relative grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center transition-colors duration-150 ease-out ${
                 tabIndex > 0 ? "border-l border-(--border-default)" : ""
               } ${sideDropTarget || active ? "bg-(--bg-active)" : "bg-transparent"} ${sideDropTarget ? "outline outline-(--accent) -outline-offset-1" : ""} ${dragged ? "opacity-60" : ""}`}
               data-document-tab-id={tab.id}
+              data-document-tab-pane-focus={paneFocused ? "true" : undefined}
+              data-document-tab-drop-position={dropPosition ?? undefined}
               draggable={false}
               key={tab.id}
               onContextMenu={(event) => openTabContextMenu(event, tab)}
               onDragStart={handlePreventNativeTabDrag}
             >
-              {renderTabButton(tab, active, groupPrimaryTabId)}
+              {renderTabButton(tab, active, paneFocused, dropPosition, groupPrimaryTabId)}
               {renderCloseTabButton(tab, active, true)}
+              {renderTabDropIndicator(dropPosition)}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- Add full-path hover titles to document tabs.
- Show a before/after drop indicator while dragging document tabs over another tab.
- Let grouped side-by-side tabs track the focused editor pane and focus the matching editor when clicked.
- Respect left/right drop position when creating a side-by-side tab group.

## Why
- Improves tab management clarity for side-by-side editing without changing the broader tab model.
- Fixes the case where dropping a tab on the left side still opened it on the right.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownTabsBar.test.tsx src/App.test.tsx` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed

## Risk
- Limited to document tab UI behavior and side-by-side focus/drop handling.

## Related Issues
- Refs #279
