### PR TITLE
fix(editor): correct split pane tabs and file reveal

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3189,6 +3189,65 @@ describe("Markra workspace", () => {
     );
   });
 
+  it("uses the focused side-by-side document as the active file tree path", async () => {
+    const firstPath = "/mock-files/vault/docs/1.md";
+    const secondPath = "/mock-files/vault/docs/2.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "1.md", path: firstPath, relativePath: "docs/1.md" },
+      { name: "2.md", path: secondPath, relativePath: "docs/2.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === firstPath) {
+        return {
+          content: "# First",
+          name: "1.md",
+          path: firstPath
+        };
+      }
+
+      return {
+        content: "# Second",
+        name: "2.md",
+        path: secondPath
+      };
+    });
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs" }));
+    fireEvent.click(await screen.findByRole("button", { name: "docs/1.md" }));
+    expect(await screen.findByText("First")).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "docs/2.md" }));
+    expect(await screen.findByText("Second")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /1\.md/ }));
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /2\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
+    await waitFor(() => expect(container.querySelector(".editor-side-by-side-surface")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
+    const sideSource = await within(sidePane).findByRole("textbox", { name: "Markdown source" });
+
+    expect(screen.getByRole("button", { name: "docs/1.md" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "docs/2.md" })).not.toHaveAttribute("aria-current");
+
+    fireEvent.focus(sideSource);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "docs/2.md" })).toHaveAttribute("aria-current", "page"));
+    expect(screen.getByRole("button", { name: "docs/1.md" })).not.toHaveAttribute("aria-current");
+  });
+
   it("returns save actions to the main document after switching away from a focused side editor", async () => {
     const firstPath = "/mock-files/vault/docs/1.md";
     const secondPath = "/mock-files/vault/docs/2.md";

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2212,6 +2212,11 @@ function WorkspaceApp() {
     editorPreferences.preferences.showDocumentTabs &&
     (hasOpenDocument || Boolean(activeImageFile)) &&
     titlebarTabs.some((tab) => titlebarTabs.length > 1 || tab.path !== null || tab.dirty);
+  const currentFileTreePath = activeImageFile?.path ?? (
+    focusedSideDocumentTabId && sideDocumentTab?.path
+      ? sideDocumentTab.path
+      : hasOpenDocument ? document.path : null
+  );
   const titleDocumentName = activeImageFile ? activeImageFile.name : hasOpenDocument ? document.name : fileTreeRootName;
   const titleDocumentKind = activeImageFile ? "image" : hasOpenDocument ? "file" : "folder";
   const sourceModeAvailable = hasOpenDocument && !activeImageFile;
@@ -3370,7 +3375,7 @@ function WorkspaceApp() {
           fileTree={{
             activeOutlineIndex: activeDocumentOutlineIndex,
             autoRevealActiveFile: editorPreferences.preferences.autoRevealActiveFile,
-            currentPath: activeImageFile?.path ?? (hasOpenDocument ? document.path : null),
+            currentPath: currentFileTreePath,
             customTemplates: markdownTemplates,
             fileTreeSort,
             files: fileTreeFiles,
@@ -3437,7 +3442,7 @@ function WorkspaceApp() {
               ) : null}
               {quickOpenOpen ? (
                 <QuickOpenPanel
-                  currentPath={activeImageFile?.path ?? (hasOpenDocument ? document.path : null)}
+                  currentPath={currentFileTreePath}
                   files={fileTreeFiles}
                   language={appLanguage.language}
                   openFilePaths={quickOpenFilePaths}

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -730,6 +730,47 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toHaveAttribute("aria-current", "page");
   });
 
+  it("scrolls the requested file into view instead of an earlier active file", async () => {
+    const scrollIntoViewCalls: string[] = [];
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value(this: HTMLElement) {
+        scrollIntoViewCalls.push(this.dataset.fileTreePath ?? "");
+      }
+    });
+
+    try {
+      render(
+        <MarkdownFileTreeDrawer
+          autoRevealActiveFile={false}
+          currentPath="/vault/docs/1.md"
+          files={[
+            { name: "1.md", path: "/vault/docs/1.md", relativePath: "docs/1.md" },
+            { name: "2.md", path: "/vault/docs/2.md", relativePath: "docs/2.md" }
+          ]}
+          open
+          outlineItems={[]}
+          revealPathRequest={{ id: 1, path: "/vault/docs/2.md" }}
+          rootPath="/vault"
+          rootName="Obsidian Vault"
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      expect(await screen.findByRole("button", { name: "docs/1.md" })).toHaveAttribute("aria-current", "page");
+      expect(screen.getByRole("button", { name: "docs/2.md" })).toBeInTheDocument();
+      await waitFor(() => expect(scrollIntoViewCalls).toContain("/vault/docs/2.md"));
+      expect(scrollIntoViewCalls).not.toContain("/vault/docs/1.md");
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView
+      });
+    }
+  });
+
   it("automatically reveals the active file when the current path changes", () => {
     const { rerender } = render(
       <MarkdownFileTreeDrawer

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -784,8 +784,9 @@ export function MarkdownFileTreeDrawer({
     }
 
     if (!virtualFileTreeEnabled) {
-      const activeFileTreeRow = fileTreeBodyRef.current
-        ?.querySelector<HTMLElement>("[data-reveal-file-tree-row='true'], [data-active-file-tree-row='true']");
+      const activeFileTreeRow =
+        fileTreeBodyRef.current?.querySelector<HTMLElement>("[data-reveal-file-tree-row='true']") ??
+        fileTreeBodyRef.current?.querySelector<HTMLElement>("[data-active-file-tree-row='true']");
 
       if (typeof activeFileTreeRow?.scrollIntoView === "function") {
         activeFileTreeRow.scrollIntoView({ block: "nearest", inline: "nearest" });

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -728,6 +728,24 @@
     background-color: color-mix(in srgb, var(--accent) 42%, transparent);
   }
 
+  .editor-content-slot .paper-scroll {
+    height: calc(100% - 2.5rem);
+    margin-top: 2.5rem;
+  }
+
+  .editor-content-slot .markdown-paper,
+  .editor-content-slot .markdown-source-paper {
+    min-height: calc(100vh - 2.5rem);
+    padding-top: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .editor-content-slot .markdown-paper,
+    .editor-content-slot .markdown-source-paper {
+      padding-top: 0;
+    }
+  }
+
   .markra-slash-menu {
     @apply fixed z-[60] w-60 rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 text-[13px] leading-5 text-(--text-primary);
     box-shadow: var(--ai-command-popover-shadow);

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -69,6 +69,24 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("background-clip: content-box");
   });
 
+  it("keeps editor scrollbars below the titlebar tab area", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const scrollRuleStart = styles.indexOf(".editor-content-slot .paper-scroll {");
+    const scrollRuleEnd = styles.indexOf(".editor-content-slot .markdown-paper,", scrollRuleStart);
+    const scrollRule = styles.slice(scrollRuleStart, scrollRuleEnd);
+    const paperRuleStart = styles.indexOf(".editor-content-slot .markdown-paper,");
+    const paperRuleEnd = styles.indexOf("@media (max-width: 900px)", paperRuleStart);
+    const paperRule = styles.slice(paperRuleStart, paperRuleEnd);
+
+    expect(scrollRuleStart).toBeGreaterThanOrEqual(0);
+    expect(scrollRuleEnd).toBeGreaterThan(scrollRuleStart);
+    expect(scrollRule).toContain("height: calc(100% - 2.5rem);");
+    expect(scrollRule).toContain("margin-top: 2.5rem;");
+    expect(paperRuleStart).toBeGreaterThanOrEqual(0);
+    expect(paperRuleEnd).toBeGreaterThan(paperRuleStart);
+    expect(paperRule).toContain("padding-top: 1rem;");
+  });
+
   it("keeps visible scrollbars for the macOS 27 WebKit scrolling workaround", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const workaroundStart = styles.indexOf('html[data-webkit-scroll-workaround="macos-27"]');


### PR DESCRIPTION
## Summary
- Track the focused side-by-side pane when deciding the active file tree path.
- Prefer explicit reveal targets over the current active row when scrolling the file tree.
- Keep editor scroll containers below the titlebar tab area so split scrollbars do not overlap tabs.

## Why
- Side-by-side editing kept the file tree anchored to the primary document, so focusing or revealing the secondary pane could still point at the first file.
- The file tree fallback selector could scroll the earlier active row before the requested reveal row.
- Editor scroll containers started at the top of the editor slot, which let scrollbars visually enter the tab/titlebar area.

## Validation
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx src/components/MarkdownFileTreeDrawer.test.tsx src/styles.test.ts` passed: 263 tests.
- `pnpm --filter @markra/app test` passed: 89 files, 1301 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification.

## Risk
- Low. The behavior change is scoped to split-pane active path selection, explicit file-tree reveal scrolling, and editor scroll-container spacing.

Closes #361