### PR TITLE
fix(app): ignore stale visual editor state after saves

### DIFF
--- a/packages/app/src/hooks/markdown-document/editor-sync.test.ts
+++ b/packages/app/src/hooks/markdown-document/editor-sync.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createEditorSyncState } from "./editor-sync";
+
+describe("editor sync state", () => {
+  it("recognizes previous clean visual content as stale only after the newer content is saved", () => {
+    const state = createEditorSyncState();
+
+    state.rememberCleanVisualContentBeforeDirty("file:/mock/guide.md", "# Guide\n\nOriginal", "# Guide\n\nDraft", "visual");
+    state.rememberSavedVisualEditorStaleContent("file:/mock/guide.md", "# Guide\n\nDraft");
+
+    expect(state.isSavedVisualEditorStaleContent(
+      "file:/mock/guide.md",
+      "# Guide\n\nDraft",
+      "# Guide\n\nOriginal"
+    )).toBe(true);
+    expect(state.isSavedVisualEditorStaleContent(
+      "file:/mock/guide.md",
+      "# Guide\n\nDraft",
+      "# Guide\n\nDifferent"
+    )).toBe(false);
+  });
+
+  it("does not treat source edits as stale visual editor content", () => {
+    const state = createEditorSyncState();
+
+    state.rememberCleanVisualContentBeforeDirty("file:/mock/guide.md", "# Guide\n\nOriginal", "# Guide\n\nDraft", "source");
+    state.rememberSavedVisualEditorStaleContent("file:/mock/guide.md", "# Guide\n\nDraft");
+
+    expect(state.isSavedVisualEditorStaleContent(
+      "file:/mock/guide.md",
+      "# Guide\n\nDraft",
+      "# Guide\n\nOriginal"
+    )).toBe(false);
+  });
+});

--- a/packages/app/src/hooks/markdown-document/editor-sync.ts
+++ b/packages/app/src/hooks/markdown-document/editor-sync.ts
@@ -1,0 +1,82 @@
+import { isEquivalentEditorMarkdown } from "./document-model";
+
+type EditorSurface = "source" | "visual";
+
+type SavedVisualEditorStaleContent = {
+  savedContent: string;
+  staleContent: string;
+};
+
+export function createEditorSyncState() {
+  const cleanVisualContentBeforeDirty = new Map<string, string>();
+  const savedVisualEditorStaleContent = new Map<string, SavedVisualEditorStaleContent>();
+
+  function clear(tabId: string | null | undefined) {
+    if (!tabId) return;
+
+    cleanVisualContentBeforeDirty.delete(tabId);
+    savedVisualEditorStaleContent.delete(tabId);
+  }
+
+  function clearAll() {
+    cleanVisualContentBeforeDirty.clear();
+    savedVisualEditorStaleContent.clear();
+  }
+
+  function isSavedVisualEditorStaleContent(
+    tabId: string | null | undefined,
+    savedContent: string,
+    editorContent: string
+  ) {
+    if (!tabId) return false;
+
+    const staleContent = savedVisualEditorStaleContent.get(tabId);
+    return Boolean(
+      staleContent &&
+      isEquivalentEditorMarkdown(staleContent.savedContent, savedContent) &&
+      isEquivalentEditorMarkdown(staleContent.staleContent, editorContent)
+    );
+  }
+
+  function rememberCleanVisualContentBeforeDirty(
+    tabId: string | null | undefined,
+    previousContent: string,
+    nextContent: string,
+    surface: EditorSurface | undefined
+  ) {
+    if (!tabId || surface !== "visual" || isEquivalentEditorMarkdown(previousContent, nextContent)) return;
+
+    cleanVisualContentBeforeDirty.set(tabId, previousContent);
+    savedVisualEditorStaleContent.delete(tabId);
+  }
+
+  function rememberSavedVisualEditorStaleContent(
+    tabId: string | null | undefined,
+    savedContent: string
+  ) {
+    if (!tabId) return;
+
+    const staleContent = cleanVisualContentBeforeDirty.get(tabId);
+    cleanVisualContentBeforeDirty.delete(tabId);
+
+    if (!staleContent || isEquivalentEditorMarkdown(staleContent, savedContent)) {
+      savedVisualEditorStaleContent.delete(tabId);
+      return;
+    }
+
+    savedVisualEditorStaleContent.set(tabId, {
+      savedContent,
+      staleContent
+    });
+  }
+
+  return {
+    clear,
+    clearAll,
+    isSavedVisualEditorStaleContent,
+    rememberCleanVisualContentBeforeDirty,
+    rememberSavedVisualEditorStaleContent
+  };
+}
+
+export type EditorSyncState = ReturnType<typeof createEditorSyncState>;

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -2294,6 +2294,215 @@ describe("useMarkdownDocument", () => {
     }
   });
 
+  it("allows native close after automatic save when the visual editor exposes previous clean content", async () => {
+    vi.useFakeTimers();
+
+    try {
+      let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+      const guidePath = "/mock-files/vault/guide.md";
+      let editorMarkdown = "# Guide\n\nOriginal";
+      const confirmDiscardUnsavedChanges = vi.fn(() => false);
+      mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+        closeRequestHandler = handler;
+        return () => {};
+      });
+      mockedReadNativeMarkdownFile.mockResolvedValue({
+        content: "# Guide\n\nOriginal",
+        name: "guide.md",
+        path: guidePath
+      });
+      mockedSaveNativeMarkdownFile.mockResolvedValue({
+        name: "guide.md",
+        path: guidePath
+      });
+      const { result } = renderHook(() =>
+        useMarkdownDocument({
+          autoSaveEnabled: true,
+          autoSaveIntervalMinutes: 1,
+          confirmDiscardUnsavedChanges,
+          getCurrentMarkdown: () => editorMarkdown,
+          isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+          onTreeRootFromFilePath: vi.fn(),
+          onTreeRootFromFolderPath: vi.fn(),
+          preferencesReady: false,
+          restoreWorkspaceOnStartup: false
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled();
+
+      await act(async () => {
+        await result.current.openTreeMarkdownFile({
+          name: "guide.md",
+          path: guidePath,
+          relativePath: "guide.md"
+        });
+      });
+
+      editorMarkdown = "# Guide\n\nAutosaved edit.";
+      act(() => {
+        result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+        await Promise.resolve();
+      });
+
+      expect(result.current.document).toMatchObject({
+        content: "# Guide\n\nAutosaved edit.",
+        dirty: false,
+        name: "guide.md",
+        path: guidePath
+      });
+
+      editorMarkdown = "# Guide\n\nOriginal";
+      const preventDefault = vi.fn();
+      await act(async () => {
+        if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+        await closeRequestHandler({ preventDefault });
+      });
+
+      expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(result.current.document).toMatchObject({
+        content: "# Guide\n\nAutosaved edit.",
+        dirty: false,
+        name: "guide.md",
+        path: guidePath
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prompts after automatic save when the visual editor explicitly changes back to previous content", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const guidePath = "/mock-files/vault/guide.md";
+      const confirmDiscardUnsavedChanges = vi.fn(() => false);
+      mockedReadNativeMarkdownFile.mockResolvedValue({
+        content: "# Guide\n\nOriginal",
+        name: "guide.md",
+        path: guidePath
+      });
+      mockedSaveNativeMarkdownFile.mockResolvedValue({
+        name: "guide.md",
+        path: guidePath
+      });
+      const { result } = renderHook(() =>
+        useMarkdownDocument({
+          autoSaveEnabled: true,
+          autoSaveIntervalMinutes: 1,
+          confirmDiscardUnsavedChanges,
+          getCurrentMarkdown: (fallbackContent) => fallbackContent,
+          onTreeRootFromFilePath: vi.fn(),
+          onTreeRootFromFolderPath: vi.fn(),
+          preferencesReady: false,
+          restoreWorkspaceOnStartup: false
+        })
+      );
+
+      await act(async () => {
+        await result.current.openTreeMarkdownFile({
+          name: "guide.md",
+          path: guidePath,
+          relativePath: "guide.md"
+        });
+      });
+
+      act(() => {
+        result.current.handleMarkdownChange("# Guide\n\nAutosaved edit.", { surface: "visual" });
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+        await Promise.resolve();
+      });
+      act(() => {
+        result.current.handleMarkdownChange("# Guide\n\nOriginal", { surface: "visual" });
+      });
+
+      await act(async () => {
+        const canDiscard = await result.current.confirmCanDiscardCurrentDocument();
+        expect(canDiscard).toBe(false);
+      });
+
+      expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({
+        content: "# Guide\n\nOriginal",
+        dirty: true,
+        name: "guide.md",
+        path: guidePath
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the clean document state when saving while the visual editor exposes previous clean content", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const guidePath = "/mock-files/vault/guide.md";
+      let editorMarkdown = "# Guide\n\nOriginal";
+      mockedReadNativeMarkdownFile.mockResolvedValue({
+        content: "# Guide\n\nOriginal",
+        name: "guide.md",
+        path: guidePath
+      });
+      mockedSaveNativeMarkdownFile.mockResolvedValue({
+        name: "guide.md",
+        path: guidePath
+      });
+      const { result } = renderHook(() =>
+        useMarkdownDocument({
+          autoSaveEnabled: true,
+          autoSaveIntervalMinutes: 1,
+          getCurrentMarkdown: () => editorMarkdown,
+          isCurrentMarkdownEquivalent: (markdown) => markdown === editorMarkdown,
+          onTreeRootFromFilePath: vi.fn(),
+          onTreeRootFromFolderPath: vi.fn(),
+          preferencesReady: false,
+          restoreWorkspaceOnStartup: false
+        })
+      );
+
+      await act(async () => {
+        await result.current.openTreeMarkdownFile({
+          name: "guide.md",
+          path: guidePath,
+          relativePath: "guide.md"
+        });
+      });
+
+      editorMarkdown = "# Guide\n\nAutosaved edit.";
+      act(() => {
+        result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+        await Promise.resolve();
+      });
+
+      mockedSaveNativeMarkdownFile.mockClear();
+      editorMarkdown = "# Guide\n\nOriginal";
+      await act(async () => {
+        await result.current.saveCurrentDocument();
+      });
+
+      expect(mockedSaveNativeMarkdownFile).toHaveBeenCalledWith(expect.objectContaining({
+        contents: "# Guide\n\nAutosaved edit.",
+        path: guidePath,
+        suggestedName: "guide.md"
+      }));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not automatically prompt to save untitled documents", async () => {
     vi.useFakeTimers();
 

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -60,6 +60,7 @@ import {
   restoreFilePathsFromWorkspace,
   type MarkdownDocumentTab
 } from "./markdown-document/document-model";
+import { createEditorSyncState, type EditorSyncState } from "./markdown-document/editor-sync";
 
 export type { MarkdownDocumentTab } from "./markdown-document/document-model";
 
@@ -223,6 +224,9 @@ export function useMarkdownDocument({
   const openedFromNativeRef = useRef(false);
   const startupWorkspaceRestoreAttemptedRef = useRef(false);
   const dirtyFileSavePromiseRef = useRef<Promise<unknown> | null>(null);
+  const editorSyncStateRef = useRef<EditorSyncState | null>(null);
+  if (editorSyncStateRef.current === null) editorSyncStateRef.current = createEditorSyncState();
+  const editorSyncState = editorSyncStateRef.current;
   const largeDocumentSummariesBlocked = useMemo(
     () => shouldBlockLargeMarkdownVisual(document.content, { sizeBytes: document.sizeBytes }),
     [document.content, document.sizeBytes]
@@ -441,6 +445,13 @@ export function useMarkdownDocument({
 
     const content = currentMarkdown();
     if (current.content === content) return current;
+    const currentActiveTabId = activeTabIdRef.current;
+    if (
+      !current.dirty &&
+      editorSyncState.isSavedVisualEditorStaleContent(currentActiveTabId, current.content, content)
+    ) {
+      return current;
+    }
 
     const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
     const nextDocument =
@@ -448,14 +459,13 @@ export function useMarkdownDocument({
         ? { ...current, content, dirty: false }
         : { ...current, content, dirty: true };
 
-    const currentActiveTabId = activeTabIdRef.current;
     const nextTabs = currentActiveTabId
       ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
       : tabsRef.current;
     setActiveDocument(nextDocument);
     persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, currentActiveTabId));
     return nextDocument;
-  }, [currentMarkdown, isActiveEditorMarkdownEquivalent, setActiveDocument]);
+  }, [currentMarkdown, editorSyncState, isActiveEditorMarkdownEquivalent, setActiveDocument]);
 
   const hasDiscardableUnsavedChanges = useCallback(() => {
     const current = documentRef.current;
@@ -465,16 +475,18 @@ export function useMarkdownDocument({
     if (!current.dirty) {
       const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
       if (editorContentEquivalent) return false;
-      if (editorContentEquivalent === false && current.path !== null) return true;
 
       const editorMarkdown = currentMarkdown();
+      if (editorSyncState.isSavedVisualEditorStaleContent(activeTabIdRef.current, current.content, editorMarkdown)) return false;
+      if (editorContentEquivalent === false && current.path !== null) return true;
+
       return !isEquivalentEditorMarkdown(editorMarkdown, current.content) && (current.path !== null || editorMarkdown.trim().length > 0);
     }
     if (current.path) return true;
 
     const editorMarkdown = currentMarkdown();
     return editorMarkdown.trim().length > 0;
-  }, [currentMarkdown, isActiveEditorMarkdownEquivalent]);
+  }, [currentMarkdown, editorSyncState, isActiveEditorMarkdownEquivalent]);
 
   const hasDiscardableTabChanges = useCallback((tab: MarkdownDocumentTab) => {
     if (tab.id === activeTabIdRef.current) return hasDiscardableUnsavedChanges();
@@ -484,6 +496,15 @@ export function useMarkdownDocument({
 
     return false;
   }, [hasDiscardableUnsavedChanges]);
+
+  const currentMarkdownForSave = useCallback((current: DocumentState, tabId: string | null | undefined) => {
+    const content = currentMarkdown();
+    if (!current.dirty && editorSyncState.isSavedVisualEditorStaleContent(tabId, current.content, content)) {
+      return current.content;
+    }
+
+    return content;
+  }, [currentMarkdown, editorSyncState]);
 
   const confirmCanDiscardCurrentDocument = useCallback(() => {
     const dirtyTab = tabsRef.current.find((tab) => hasDiscardableTabChanges(tab));
@@ -501,6 +522,7 @@ export function useMarkdownDocument({
     const current = documentRef.current;
     if (options.documentRevision !== undefined && options.documentRevision !== current.revision) return;
     if (!current.open || current.content === content) return;
+    const currentActiveTabId = activeTabIdRef.current;
     const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
     if (
       !current.dirty &&
@@ -511,18 +533,25 @@ export function useMarkdownDocument({
     ) {
       return;
     }
+    if (!current.dirty) {
+      editorSyncState.rememberCleanVisualContentBeforeDirty(currentActiveTabId, current.content, content, options.surface);
+    }
     const nextDocument =
       !current.dirty && (editorContentEquivalent === true || isEquivalentEditorMarkdown(current.content, content))
         ? { ...current, content, dirty: false }
         : { ...current, content, dirty: true };
 
-    const currentActiveTabId = activeTabIdRef.current;
     const nextTabs = currentActiveTabId
       ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
       : tabsRef.current;
     setActiveDocument(nextDocument);
     persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, currentActiveTabId));
-  }, [editorReady, isActiveEditorMarkdownEquivalent, setActiveDocument]);
+  }, [
+    editorSyncState,
+    editorReady,
+    isActiveEditorMarkdownEquivalent,
+    setActiveDocument
+  ]);
 
   const handleMarkdownTabChange = useCallback((tabId: string, content: string, options: MarkdownChangeOptions = {}) => {
     if (tabId === activeTabIdRef.current) {
@@ -542,6 +571,7 @@ export function useMarkdownDocument({
         ) {
           return tab;
         }
+        if (!tab.dirty) editorSyncState.rememberCleanVisualContentBeforeDirty(tab.id, tab.content, content, options.surface);
 
         return {
           ...tab,
@@ -554,7 +584,7 @@ export function useMarkdownDocument({
       persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current));
       return nextTabs;
     });
-  }, [handleMarkdownChange]);
+  }, [editorSyncState, handleMarkdownChange]);
 
   const restoreDocumentContent = useCallback((content: string) => {
     const current = documentRef.current;
@@ -651,6 +681,7 @@ export function useMarkdownDocument({
     };
     tabsRef.current = [];
     activeTabIdRef.current = null;
+    editorSyncState.clearAll();
     setTabs([]);
     setActiveTabId(null);
     setDocument(nextDocument);
@@ -664,7 +695,7 @@ export function useMarkdownDocument({
         openFilePaths: []
       });
     }
-  }, [registerWindowRestoreState]);
+  }, [editorSyncState, registerWindowRestoreState]);
 
   const readMarkdownFileWithPerformance = useCallback(
     (path: string, reason: string) =>
@@ -1101,6 +1132,11 @@ export function useMarkdownDocument({
     const nextTabs = documentTabsEnabled
       ? currentTabs.map((tab) => tab.id === fallbackTabId ? createDocumentTab(nextDocument, tab.id) : tab)
       : [createDocumentTab(nextDocument, fallbackTabId)];
+    if (nextDocument.dirty) {
+      editorSyncState.clear(fallbackTabId);
+    } else {
+      editorSyncState.rememberSavedVisualEditorStaleContent(fallbackTabId, contents);
+    }
     tabsRef.current = nextTabs;
     setTabs(nextTabs);
     if (fallbackTabId === activeTabIdRef.current) {
@@ -1121,7 +1157,13 @@ export function useMarkdownDocument({
       openFilePaths: nextOpenFilePaths,
       ...(options.retargetWorkspaceRoot ? { folderName: null, folderPath: null } : {})
     });
-  }, [documentTabsEnabled, onTreeRootFromFilePath, registerWindowRestoreState, rememberRecentMarkdownFile]);
+  }, [
+    documentTabsEnabled,
+    editorSyncState,
+    onTreeRootFromFilePath,
+    registerWindowRestoreState,
+    rememberRecentMarkdownFile
+  ]);
 
   const saveCurrentDocument = useCallback(
     async (saveAs = false) => {
@@ -1129,7 +1171,7 @@ export function useMarkdownDocument({
       if (!current.open) return null;
 
       const targetTabId = activeTabIdRef.current;
-      const contents = currentMarkdown();
+      const contents = currentMarkdownForSave(current, targetTabId);
       const savePath = saveAs ? null : current.path;
       const savedFile = await saveNativeMarkdownFile({
         ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
@@ -1147,7 +1189,7 @@ export function useMarkdownDocument({
       });
       return savedFile;
     },
-    [applySavedCurrentDocument, currentMarkdown, defaultSaveDirectory]
+    [applySavedCurrentDocument, currentMarkdownForSave, defaultSaveDirectory]
   );
 
   const saveMarkdownTabContent = useCallback(
@@ -1246,7 +1288,9 @@ export function useMarkdownDocument({
       const tab = tabsRef.current.find((candidate) => candidate.id === tabId);
       if (!tab?.open) return null;
 
-      const contents = tab.id === activeTabIdRef.current ? currentMarkdown() : tab.content;
+      const contents = tab.id === activeTabIdRef.current
+        ? currentMarkdownForSave(documentFromTab(tab), tab.id)
+        : tab.content;
       const savePath = saveAs ? null : tab.path;
       const savedFile = await saveNativeMarkdownFile({
         ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
@@ -1269,6 +1313,11 @@ export function useMarkdownDocument({
       const nextTabs = tabsRef.current.map((candidate) =>
         candidate.id === tabId ? createDocumentTab(nextDocument, candidate.id) : candidate
       );
+      if (nextDocument.dirty) {
+        editorSyncState.clear(tabId);
+      } else {
+        editorSyncState.rememberSavedVisualEditorStaleContent(tabId, contents);
+      }
 
       tabsRef.current = nextTabs;
       setTabs(nextTabs);
@@ -1290,8 +1339,9 @@ export function useMarkdownDocument({
       return savedFile;
     },
     [
-      currentMarkdown,
+      currentMarkdownForSave,
       defaultSaveDirectory,
+      editorSyncState,
       onTreeRootFromFilePath,
       registerWindowRestoreState,
       rememberRecentMarkdownFile,
@@ -1363,6 +1413,7 @@ export function useMarkdownDocument({
         ? nextTabs[Math.max(0, tabIndex - 1)] ?? nextTabs[0] ?? null
         : nextTabs.find((candidate) => candidate.id === activeTabIdRef.current) ?? null;
 
+    editorSyncState.clear(tabId);
     setActiveTabState(nextTabs, nextActiveTab?.id ?? null);
     registerWindowRestoreState(nextActiveTab?.path ?? null, openFilePathsFromTabs(nextTabs));
     persistWorkspaceState({
@@ -1371,7 +1422,14 @@ export function useMarkdownDocument({
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
     return true;
-  }, [confirmDiscardUnsavedChanges, hasDiscardableTabChanges, registerWindowRestoreState, setActiveTabState, syncActiveDocumentFromEditor]);
+  }, [
+    confirmDiscardUnsavedChanges,
+    editorSyncState,
+    hasDiscardableTabChanges,
+    registerWindowRestoreState,
+    setActiveTabState,
+    syncActiveDocumentFromEditor
+  ]);
 
   const isCurrentDocumentEmptyUntitled = useCallback(() => {
     const current = documentRef.current;


### PR DESCRIPTION
## Summary
- Add an editor sync state helper to distinguish saved document state from stale visual editor content.
- Route close/discard checks and manual saves through the same stale-content guard.
- Add regression coverage for automatic save, real visual edits back to old content, and stale save reads.

## Why
- Refs #308. Keeps saved document state authoritative when Milkdown exposes old content after auto-save or save without rebuilding the editor.
- Prevents both false unsaved prompts and accidental re-saving of old visual editor content.

## Validation
- pnpm --filter @markra/app exec vitest run src/hooks/markdown-document/editor-sync.test.ts src/hooks/useMarkdownDocument.test.tsx
- pnpm --filter @markra/app build
- git diff --check

## Risk
- Medium-low: touches save/dirty-state coordination, covered by focused hook and state-machine tests.