### PR TITLE
fix(editor): stabilize image block interactions

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -4629,7 +4629,7 @@ describe("Markra workspace", () => {
   it("keeps visual undo history after switching to source mode and back", async () => {
     const { container } = renderApp();
 
-    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Welcome to Markra");
     await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalledTimes(1));
     const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls[0]?.[0] as NativeMenuHandlers;
 
@@ -4656,6 +4656,48 @@ describe("Markra workspace", () => {
       menuHandlers.editRedo?.();
     });
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+  });
+
+  it("inserts the default menu image as an immediately clickable image block", async () => {
+    const { container } = renderApp();
+
+    await expectVisibleMilkdownText(container, "Welcome to Markra");
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalledTimes(1));
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls[0]?.[0] as NativeMenuHandlers;
+
+    act(() => {
+      menuHandlers.insertImage?.();
+    });
+
+    const image = await waitFor(() => {
+      const insertedImage = container.querySelector<HTMLImageElement>(
+        '.ProseMirror .markra-image-node img[src="assets/image.png"]'
+      );
+      expect(insertedImage).toBeInTheDocument();
+      return insertedImage!;
+    });
+
+    expect(image).toHaveAttribute("alt", "alt");
+    expect(container.querySelector(".ProseMirror .markra-live-image-preview")).not.toBeInTheDocument();
+
+    const initialSource = await waitFor(() => {
+      const sourceInput = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
+      expect(sourceInput).toBeInTheDocument();
+      return sourceInput!;
+    });
+    expect(initialSource).toHaveFocus();
+    expect(initialSource.selectionStart).toBe("![alt](".length);
+    expect(initialSource.selectionEnd).toBe("![alt](assets/image.png".length);
+
+    expect(fireEvent.mouseDown(image)).toBe(false);
+    fireEvent.click(image);
+
+    const source = await waitFor(() => {
+      const sourceInput = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
+      expect(sourceInput).toBeInTheDocument();
+      return sourceInput!;
+    });
+    expect(source).toHaveValue("![alt](assets/image.png)");
   });
 
   it("keeps source edits undoable after switching back to visual mode", async () => {
@@ -5486,13 +5528,14 @@ describe("Markra workspace", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
     expect(fireEvent.mouseDown(image!)).toBe(false);
+    fireEvent.click(image!);
 
     const sourceInput = await waitFor(() => {
       const input = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
       expect(input).toBeInTheDocument();
       return input!;
     });
-    await waitFor(() => expect(sourceInput).toHaveFocus());
+    expect(sourceInput).not.toHaveFocus();
     expect(image?.closest(".markra-image-node")).toHaveClass("markra-image-node-selected");
 
     fireEvent.keyDown(window, { key: "f", metaKey: true });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -380,6 +380,7 @@ function WorkspaceApp() {
   const findEditorSearchMatches = editor.findSearchMatches;
   const getEditorCurrentMarkdown = editor.getCurrentMarkdown;
   const handleMilkdownEditorReady = editor.handleEditorReady;
+  const insertEditorMarkdownImage = editor.insertMarkdownImage;
   const insertEditorMarkdownLink = editor.insertMarkdownLink;
   const insertEditorMarkdownSnippet = editor.insertMarkdownSnippet;
   const insertEditorMarkdownTable = editor.insertMarkdownTable;
@@ -2324,6 +2325,12 @@ function WorkspaceApp() {
     insertEditorMarkdownSnippet(...args);
     syncVisualMarkdownAfterEditorCommand();
   }, [insertEditorMarkdownSnippet, readOnlyMode, syncVisualMarkdownAfterEditorCommand]);
+  const handleInsertMarkdownImage = useCallback(() => {
+    if (readOnlyMode) return;
+
+    insertEditorMarkdownImage();
+    syncVisualMarkdownAfterEditorCommand();
+  }, [insertEditorMarkdownImage, readOnlyMode, syncVisualMarkdownAfterEditorCommand]);
   const handleInsertMarkdownLink = useCallback(() => {
     runEditorLinkCommand({
       insertMarkdownLink: insertEditorMarkdownLink,
@@ -2812,6 +2819,7 @@ function WorkspaceApp() {
     exportHtml: exportFeatureEnabled ? exportHtmlDocument : undefined,
     exportLatex: exportFeatureEnabled && pandocFeatureEnabled ? exportLatexDocument : undefined,
     exportPdf: exportFeatureEnabled ? exportPdfDocument : undefined,
+    insertMarkdownImage: handleInsertMarkdownImage,
     insertMarkdownLink: handleInsertMarkdownLink,
     insertMarkdownSnippet: handleInsertMarkdownSnippet,
     insertMarkdownTable: handleInsertMarkdownTable,

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -156,6 +156,12 @@ function selectText(view: EditorView, from: number, to: number) {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
 }
 
+function clickFinalizedImage(target: Element) {
+  const mouseDownResult = fireEvent.mouseDown(target);
+  fireEvent.click(target);
+  return mouseDownResult;
+}
+
 function findFirstTextBlockCursor(view: EditorView) {
   let position: number | null = null;
 
@@ -1380,9 +1386,195 @@ describe("MarkdownPaper editing", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    fireEvent.mouseDown(image!);
+    clickFinalizedImage(image!);
 
     expect(container.querySelector(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+  });
+
+  it("selects the finalized image block before editing its source input", async () => {
+    const { container, editor, view } = await renderEditor(
+      ["Intro", "", "![Screenshot](assets/pasted-image.png)", "", "Following content"].join("\n")
+    );
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+
+    expect(image).toBeInTheDocument();
+
+    moveCursor(view, findTextPosition(view, "Following content", "Following".length));
+    fireEvent.mouseDown(image!);
+
+    await waitFor(() => expect(view.state.selection).toBeInstanceOf(NodeSelection));
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "image"));
+    expect(view.dom).toHaveFocus();
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+
+    fireEvent.click(image!);
+
+    const sourceInput = await waitFor(() => {
+      const input = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
+      expect(input).toBeInTheDocument();
+      return input!;
+    });
+    expect(sourceInput).not.toHaveFocus();
+
+    const sourceCursor = sourceInput.value.length;
+    sourceInput.setSelectionRange(sourceCursor, sourceCursor);
+    fireEvent.mouseDown(sourceInput);
+
+    await waitFor(() => expect(sourceInput).toHaveFocus());
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+    expect(sourceInput.selectionStart).toBe(sourceCursor);
+    expect(sourceInput.selectionEnd).toBe(sourceCursor);
+
+    moveCursor(view, findTextPosition(view, "Following content", "Following".length));
+    expect(sourceInput).toBeInTheDocument();
+    expect(sourceInput).toHaveFocus();
+
+    fireEvent.input(sourceInput, { target: { value: "" } });
+
+    await waitFor(() =>
+      expect(
+        container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]')
+      ).not.toBeInTheDocument()
+    );
+    expect(serializeMarkdown(view.state.doc)).toContain("Following content");
+    expect(serializeMarkdown(view.state.doc)).not.toContain("assets/pasted-image.png");
+  });
+
+  it("focuses the finalized image source input when its source row is clicked", async () => {
+    const { container } = await renderEditor("![Screenshot](assets/pasted-image.png)");
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+
+    expect(image).toBeInTheDocument();
+
+    clickFinalizedImage(image!);
+
+    const sourceRow = await waitFor(() => {
+      const row = container.querySelector<HTMLElement>(".ProseMirror .markra-image-node-source-row");
+      expect(row).toBeInTheDocument();
+      return row!;
+    });
+    const sourceInput = sourceRow.querySelector<HTMLInputElement>(".markra-image-node-source");
+
+    expect(sourceInput).toBeInTheDocument();
+    expect(sourceRow).toHaveAttribute("contenteditable", "true");
+    expect(sourceInput).toHaveAttribute("contenteditable", "true");
+    expect(sourceInput).not.toHaveFocus();
+
+    fireEvent.mouseDown(sourceRow);
+
+    await waitFor(() => expect(sourceInput).toHaveFocus());
+    expect(sourceInput?.selectionStart).toBe(sourceInput?.value.length);
+    expect(sourceInput?.selectionEnd).toBe(sourceInput?.value.length);
+  });
+
+  it("can select a finalized image block after another text range was selected", async () => {
+    const { container, view } = await renderEditor(
+      ["Intro text", "", "![Screenshot](assets/pasted-image.png)", "", "Following content"].join("\n")
+    );
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+
+    expect(image).toBeInTheDocument();
+
+    const from = findTextPosition(view, "Following");
+    const to = findTextPosition(view, "Following", "Following".length);
+    const followingText = Array.from(container.querySelectorAll(".ProseMirror p"))
+      .find((paragraph) => paragraph.textContent?.includes("Following"))
+      ?.firstChild;
+
+    expect(followingText).toBeInstanceOf(Text);
+
+    const range = document.createRange();
+    range.setStart(followingText!, 0);
+    range.setEnd(followingText!, "Following".length);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+    selectText(view, from, to);
+    expect(view.state.selection.empty).toBe(false);
+    expect(document.getSelection()?.toString()).toBe("Following");
+
+    fireEvent.mouseDown(image!);
+
+    await waitFor(() => expect(view.state.selection).toBeInstanceOf(NodeSelection));
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "image"));
+    expect(document.getSelection()?.toString()).toBe("");
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+
+    fireEvent.click(image!);
+
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).toBeInTheDocument();
+  });
+
+  it("clears the native text caret when a finalized image block is selected", async () => {
+    const { container, view } = await renderEditor(
+      ["Intro text", "", "![Screenshot](assets/pasted-image.png)", "", "Following content"].join("\n")
+    );
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+    const introText = Array.from(container.querySelectorAll(".ProseMirror p"))
+      .find((paragraph) => paragraph.textContent?.includes("Intro text"))
+      ?.firstChild;
+
+    expect(image).toBeInTheDocument();
+    expect(introText).toBeInstanceOf(Text);
+
+    const range = document.createRange();
+    range.setStart(introText!, "Intro text".length);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+    moveCursor(view, findTextPosition(view, "Intro text", "Intro text".length));
+    expect(document.getSelection()?.anchorNode).toBe(introText);
+
+    fireEvent.mouseDown(image!);
+
+    await waitFor(() => expect(view.state.selection).toBeInstanceOf(NodeSelection));
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "image"));
+    await waitFor(() => expect(document.getSelection()?.rangeCount).toBe(0));
+    expect(document.getSelection()?.anchorNode).not.toBe(introText);
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+  });
+
+  it("selects a finalized image block when its outer block surface is pressed after text focus", async () => {
+    const { container, view } = await renderEditor(
+      ["Intro text", "", "![Screenshot](assets/pasted-image.png)"].join("\n")
+    );
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+    const imageNode = image?.closest<HTMLElement>(".markra-image-node");
+
+    expect(image).toBeInTheDocument();
+    expect(imageNode).toBeInTheDocument();
+
+    moveCursor(view, findTextPosition(view, "Intro", "Intro".length));
+    expect(view.state.selection.empty).toBe(true);
+
+    fireEvent.mouseDown(imageNode!);
+
+    await waitFor(() => expect(view.state.selection).toBeInstanceOf(NodeSelection));
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "image"));
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+
+    fireEvent.click(imageNode!);
+
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).toBeInTheDocument();
+  });
+
+  it("waits until the image click completes before showing finalized image source controls", async () => {
+    const { container } = await renderEditor("Intro text\n\n![Screenshot](assets/pasted-image.png)");
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+
+    expect(image).toBeInTheDocument();
+
+    fireEvent.mouseDown(image!);
+
+    expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).not.toBeInTheDocument();
+
+    fireEvent.click(image!);
+
+    await waitFor(() =>
+      expect(container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source")).toBeInTheDocument()
+    );
   });
 
   it("hides open finalized image source controls when read-only is enabled", async () => {
@@ -1403,7 +1595,7 @@ describe("MarkdownPaper editing", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    fireEvent.mouseDown(image!);
+    clickFinalizedImage(image!);
     expect(container.querySelector(".ProseMirror .markra-image-node-source")).toBeInTheDocument();
 
     rerender(
@@ -8078,6 +8270,15 @@ describe("MarkdownPaper editing", () => {
     expect(imageNode?.parentElement).toBe(container.querySelector(".ProseMirror"));
   });
 
+  it("renders escaped image alt text as a finalized image node", async () => {
+    const { container, view } = await renderEditor(String.raw`![A \] bracket \\ slash](assets/image.png)`);
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/image.png"]');
+
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute("alt", String.raw`A ] bracket \ slash`);
+    expect(view.state.doc.child(0).type.name).toBe("image");
+  });
+
   it("splits paragraph image markdown into block image nodes", async () => {
     const { container, view } = await renderEditor("Before ![Screenshot](assets/pasted-image.png) after");
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
@@ -8114,7 +8315,7 @@ describe("MarkdownPaper editing", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    expect(fireEvent.mouseDown(image!)).toBe(false);
+    expect(clickFinalizedImage(image!)).toBe(false);
 
     const sourceRow = container.querySelector<HTMLElement>(".ProseMirror .markra-image-node-source-row");
     expect(sourceRow?.querySelector(".markra-image-node-source-icon")).toHaveAttribute("aria-hidden", "true");
@@ -8140,10 +8341,13 @@ describe("MarkdownPaper editing", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    expect(fireEvent.mouseDown(image!)).toBe(false);
+    expect(clickFinalizedImage(image!)).toBe(false);
 
     const source = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
     expect(source).toHaveValue("![Screenshot](assets/pasted-image.png)");
+
+    fireEvent.mouseDown(source!);
+    await waitFor(() => expect(source).toHaveFocus());
 
     expect(fireEvent.keyDown(source!, { key: "Enter" })).toBe(false);
 
@@ -8163,7 +8367,7 @@ describe("MarkdownPaper editing", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    expect(fireEvent.mouseDown(image!)).toBe(false);
+    expect(clickFinalizedImage(image!)).toBe(false);
 
     const source = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
     expect(source).toHaveValue("![Screenshot](assets/pasted-image.png)");
@@ -8177,13 +8381,35 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.selection).toBeInstanceOf(NodeSelection);
   });
 
+  it("deletes the selected finalized image block on Backspace", async () => {
+    const { container, editor, view } = await renderEditor(
+      ["Intro", "", "![Screenshot](assets/pasted-image.png)", "", "Outro"].join("\n")
+    );
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
+
+    expect(image).toBeInTheDocument();
+
+    clickFinalizedImage(image!);
+    await waitFor(() => expect(view.state.selection).toBeInstanceOf(NodeSelection));
+
+    expect(fireEvent.keyDown(view.dom, { key: "Backspace", bubbles: true, cancelable: true })).toBe(false);
+
+    expect(
+      container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]')
+    ).not.toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).toContain("Intro");
+    expect(serializeMarkdown(view.state.doc)).toContain("Outro");
+    expect(serializeMarkdown(view.state.doc)).not.toContain("assets/pasted-image.png");
+  });
+
   it("deletes a finalized image when its markdown source is cleared", async () => {
     const { container, editor, view } = await renderEditor("Intro\n\n![Screenshot](assets/pasted-image.png)");
 
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    expect(fireEvent.mouseDown(image!)).toBe(false);
+    expect(clickFinalizedImage(image!)).toBe(false);
 
     const source = container.querySelector<HTMLInputElement>(".ProseMirror .markra-image-node-source");
     expect(source).toHaveValue("![Screenshot](assets/pasted-image.png)");
@@ -8204,7 +8430,7 @@ describe("MarkdownPaper editing", () => {
     const image = container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/pasted-image.png"]');
     expect(image).toBeInTheDocument();
 
-    expect(fireEvent.mouseDown(image!)).toBe(false);
+    expect(clickFinalizedImage(image!)).toBe(false);
     expect(container.querySelector(".ProseMirror .markra-image-node-source")).toBeInTheDocument();
 
     fireEvent.mouseDown(document.body);
@@ -8237,6 +8463,23 @@ describe("MarkdownPaper editing", () => {
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     expect(serializeMarkdown(view.state.doc)).toContain("<https://example.test/articles/about>");
     await settleMarkdownListener();
+  });
+
+  it("pastes URLs over a selected raw image source as plain text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+    const pastedSrc = "https://cdn.example.test/images/pasted.png";
+
+    insertTextDirectly(view, "![alt](assets/image.png)");
+    const sourceFrom = findTextPosition(view, "assets/image.png");
+    selectText(view, sourceFrom, sourceFrom + "assets/image.png".length);
+
+    expect(pasteText(view, pastedSrc)).toBe(true);
+
+    expect(container.querySelector<HTMLAnchorElement>(`.ProseMirror a[href="${pastedSrc}"]`)).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror")?.textContent).toBe(`![alt](${pastedSrc})`);
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining(`![alt](${pastedSrc})`)));
   });
 
   it("keeps typed image markdown editable until it folds into a live preview", async () => {

--- a/packages/app/src/hooks/useEditorController.test.ts
+++ b/packages/app/src/hooks/useEditorController.test.ts
@@ -1,4 +1,5 @@
 import {
+  markdownImageInsertionForSelection,
   markdownLinkInsertionForSelection,
   scrollElementToContainerTop,
   scrollElementsAboveContainerBottomInset,
@@ -154,6 +155,30 @@ describe("editor controller link insertion", () => {
       cursorOffset: "[text".length,
       insertedText: "[text](https://)",
       kind: "snippet"
+    });
+  });
+});
+
+describe("editor controller image insertion", () => {
+  it("uses a local asset path placeholder and selects the image source", () => {
+    expect(markdownImageInsertionForSelection("Synthetic alt")).toEqual({
+      alt: "Synthetic alt",
+      insertedText: "![Synthetic alt](assets/image.png)",
+      selectionFromOffset: "![Synthetic alt](".length,
+      selectionToOffset: "![Synthetic alt](assets/image.png".length,
+      src: "assets/image.png"
+    });
+  });
+
+  it("escapes selected text before using it as image alt markdown", () => {
+    const insertion = markdownImageInsertionForSelection(String.raw`A ] bracket \ slash`);
+
+    expect(insertion).toEqual({
+      alt: String.raw`A ] bracket \ slash`,
+      insertedText: String.raw`![A \] bracket \\ slash](assets/image.png)`,
+      selectionFromOffset: String.raw`![A \] bracket \\ slash](`.length,
+      selectionToOffset: String.raw`![A \] bracket \\ slash](assets/image.png`.length,
+      src: "assets/image.png"
     });
   });
 });

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef } from "react";
 import { editorViewCtx, parserCtx, serializerCtx, type Editor } from "@milkdown/kit/core";
 import { imageSchema, linkSchema } from "@milkdown/kit/preset/commonmark";
-import { Slice, type Node as ProseNode } from "@milkdown/kit/prose/model";
-import { TextSelection } from "@milkdown/kit/prose/state";
+import { Slice, type Node as ProseNode, type NodeType } from "@milkdown/kit/prose/model";
+import { NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import type { AiDiffResult, AiDocumentAnchor, AiHeadingAnchor, AiSelectionContext } from "@markra/ai";
 import {
   applyAiEditorResult,
+  clearFinalizedImageSourceEditing,
   clearAiSelectionHold,
   clearAiEditorPreview,
   confirmAiEditorResultApplied,
@@ -67,6 +68,14 @@ type MarkdownLinkInsertion =
       selectionFromOffset: number;
       selectionToOffset: number;
     };
+
+type MarkdownImageInsertion = {
+  alt: string;
+  insertedText: string;
+  selectionFromOffset: number;
+  selectionToOffset: number;
+  src: string;
+};
 
 function comparableSerializedMarkdown(markdown: string) {
   return markdown
@@ -168,6 +177,59 @@ export function markdownLinkInsertionForSelection(selectedText: string): Markdow
     insertedText,
     kind: "snippet"
   };
+}
+
+export function markdownImageInsertionForSelection(selectedText: string): MarkdownImageInsertion {
+  const alt = selectedText || "alt";
+  const markdownAlt = alt.replace(/\\/gu, "\\\\").replace(/\]/gu, "\\]");
+  const src = "assets/image.png";
+  const insertedText = `![${markdownAlt}](${src})`;
+  const selectionFromOffset = markdownAlt.length + 4;
+
+  return {
+    alt,
+    insertedText,
+    selectionFromOffset,
+    selectionToOffset: selectionFromOffset + src.length,
+    src
+  };
+}
+
+function findInsertedImageNodePosition(
+  doc: ProseNode,
+  image: NodeType,
+  insertion: MarkdownImageInsertion,
+  preferredPosition: number
+) {
+  let bestPosition: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  doc.descendants((node, position) => {
+    if (node.type !== image) return true;
+    if (String(node.attrs.alt ?? "") !== insertion.alt) return true;
+    if (String(node.attrs.src ?? "") !== insertion.src) return true;
+
+    const distance = Math.abs(position - preferredPosition);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestPosition = position;
+    }
+
+    return true;
+  });
+
+  return bestPosition;
+}
+
+function focusInsertedImageSource(view: EditorView, insertion: MarkdownImageInsertion) {
+  const source = view.dom.querySelector<HTMLInputElement>(".markra-image-node-source");
+  if (!source) {
+    view.focus();
+    return;
+  }
+
+  source.focus();
+  source.setSelectionRange(insertion.selectionFromOffset, insertion.selectionToOffset);
 }
 
 export function readAiSelectionContextFromView(view: EditorView): AiSelectionContext {
@@ -655,6 +717,7 @@ export function useEditorController() {
       const view = editorRef.current?.action((ctx) => ctx.get(editorViewCtx));
       if (!view) return;
 
+      if (options.suppressEditorChrome) clearFinalizedImageSourceEditing(view);
       updateSearchDecorations(view, matches, activeIndex, options);
     } catch {
       // Search decoration is a transient affordance; failing to draw it should not interrupt editing.
@@ -726,6 +789,32 @@ export function useEditorController() {
 
     view.dispatch(tr);
     view.focus();
+  }, []);
+
+  const insertMarkdownImage = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      const image = imageSchema.type(ctx);
+      const parseMarkdown = ctx.get(parserCtx);
+      const { from, to } = view.state.selection;
+      const selectedText = view.state.doc.textBetween(from, to, " ");
+      const insertion = markdownImageInsertionForSelection(selectedText);
+      const parsedDocument = parseMarkdown(insertion.insertedText);
+      const tr = view.state.tr.replaceRange(from, to, new Slice(parsedDocument.content, 0, 0));
+      const imagePosition = findInsertedImageNodePosition(tr.doc, image, insertion, from);
+
+      if (imagePosition !== null) {
+        tr.setSelection(NodeSelection.create(tr.doc, imagePosition)).scrollIntoView();
+      } else {
+        tr.scrollIntoView();
+      }
+
+      view.dispatch(tr);
+      focusInsertedImageSource(view, insertion);
+    });
   }, []);
 
   const insertMarkdownLink = useCallback(() => {
@@ -982,6 +1071,7 @@ export function useEditorController() {
     getTableAnchors,
     handleEditorReady,
     holdAiSelection,
+    insertMarkdownImage,
     insertMarkdownLink,
     insertMarkdownSnippet,
     insertMarkdownTable,

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -4,6 +4,7 @@ import { useApplicationShortcuts, useNativeMenuHandlers } from "./useNativeBindi
 
 describe("useNativeMenuHandlers", () => {
   const baseOptions = {
+    insertMarkdownImage: vi.fn(),
     insertMarkdownLink: vi.fn(),
     insertMarkdownSnippet: vi.fn(),
     insertMarkdownTable: vi.fn(),
@@ -16,10 +17,12 @@ describe("useNativeMenuHandlers", () => {
 
   it("routes the insert table menu command to the editor table insertion", () => {
     const insertMarkdownLink = vi.fn();
+    const insertMarkdownImage = vi.fn();
     const insertMarkdownSnippet = vi.fn();
     const insertMarkdownTable = vi.fn();
     const { result } = renderHook(() =>
       useNativeMenuHandlers({
+        insertMarkdownImage,
         insertMarkdownLink,
         insertMarkdownSnippet,
         insertMarkdownTable,
@@ -34,7 +37,25 @@ describe("useNativeMenuHandlers", () => {
     result.current.insertTable?.();
 
     expect(insertMarkdownTable).toHaveBeenCalledTimes(1);
+    expect(insertMarkdownImage).not.toHaveBeenCalled();
     expect(insertMarkdownLink).not.toHaveBeenCalled();
+    expect(insertMarkdownSnippet).not.toHaveBeenCalled();
+  });
+
+  it("routes the insert image menu command to the editor image insertion", () => {
+    const insertMarkdownImage = vi.fn();
+    const insertMarkdownSnippet = vi.fn();
+    const { result } = renderHook(() =>
+      useNativeMenuHandlers({
+        ...baseOptions,
+        insertMarkdownImage,
+        insertMarkdownSnippet
+      })
+    );
+
+    result.current.insertImage?.();
+
+    expect(insertMarkdownImage).toHaveBeenCalledTimes(1);
     expect(insertMarkdownSnippet).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -34,6 +34,7 @@ type NativeMenuHandlerOptions = {
   exportHtml?: () => unknown | Promise<unknown>;
   exportLatex?: () => unknown | Promise<unknown>;
   exportPdf?: () => unknown | Promise<unknown>;
+  insertMarkdownImage: () => unknown;
   insertMarkdownLink: () => unknown;
   insertMarkdownSnippet: (open: string, close: string, placeholder: string) => unknown;
   insertMarkdownTable: () => unknown;
@@ -108,6 +109,7 @@ export function useNativeMenuHandlers({
   exportHtml,
   exportLatex,
   exportPdf,
+  insertMarkdownImage,
   insertMarkdownLink,
   insertMarkdownSnippet,
   insertMarkdownTable,
@@ -142,6 +144,7 @@ export function useNativeMenuHandlers({
     exportLatex,
     exportPdf,
     closeDocument,
+    insertMarkdownImage,
     insertMarkdownLink,
     insertMarkdownSnippet,
     insertMarkdownTable,
@@ -172,6 +175,7 @@ export function useNativeMenuHandlers({
     exportLatex,
     exportPdf,
     closeDocument,
+    insertMarkdownImage,
     insertMarkdownLink,
     insertMarkdownSnippet,
     insertMarkdownTable,
@@ -224,7 +228,7 @@ export function useNativeMenuHandlers({
         formatQuote: () => runMarkdownShortcut("quote"),
         formatCodeBlock: () => runMarkdownShortcut("codeBlock"),
         insertLink: () => latestOptionsRef.current.insertMarkdownLink(),
-        insertImage: () => latestOptionsRef.current.insertMarkdownSnippet("![", "](https://)", "alt"),
+        insertImage: () => latestOptionsRef.current.insertMarkdownImage(),
         insertTable: () => latestOptionsRef.current.insertMarkdownTable(),
         toggleAllFolds: () => runMarkdownShortcut("toggleAllFolds")
       };

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2390,6 +2390,14 @@
     background: color-mix(in srgb, var(--accent) 28%, transparent);
   }
 
+  .markdown-paper .ProseMirror-hideselection .markra-image-node-source {
+    caret-color: var(--text-primary) !important;
+  }
+
+  .markdown-paper .ProseMirror-hideselection .markra-image-node-source::selection {
+    background: color-mix(in srgb, var(--accent) 28%, transparent) !important;
+  }
+
   .markdown-paper .markra-image-node-source-invalid .markra-image-node-source {
     @apply text-red-600;
   }

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -211,6 +211,19 @@ describe("editor stylesheet", () => {
     expect(imageSelectionStyles).not.toContain("outline-none");
   });
 
+  it("keeps finalized image source text selection visible while the image block is selected", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const sourceSelectionStart = styles.indexOf(".markdown-paper .ProseMirror-hideselection .markra-image-node-source");
+    const sourceSelectionEnd = styles.indexOf(".markdown-paper .markra-image-node-source-invalid", sourceSelectionStart);
+    const sourceSelectionStyles = styles.slice(sourceSelectionStart, sourceSelectionEnd);
+
+    expect(sourceSelectionStart).toBeGreaterThanOrEqual(0);
+    expect(sourceSelectionEnd).toBeGreaterThan(sourceSelectionStart);
+    expect(sourceSelectionStyles).toContain("caret-color: var(--text-primary) !important");
+    expect(sourceSelectionStyles).toContain(".markdown-paper .ProseMirror-hideselection .markra-image-node-source::selection");
+    expect(sourceSelectionStyles).toContain("background: color-mix(in srgb, var(--accent) 28%, transparent)");
+  });
+
   it("gives horizontal rules a forgiving hit target without heavy selected-node feedback", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const ruleStart = styles.indexOf(".markdown-paper hr {");

--- a/packages/editor/src/link-image-rules.ts
+++ b/packages/editor/src/link-image-rules.ts
@@ -1,4 +1,5 @@
 export { markraLinkImageLivePlugin } from "./link-image/plugin.ts";
+export { clearFinalizedImageSourceEditing } from "./link-image/images.ts";
 export {
   normalizeLinkImageLiveMarkdownDocument,
   serializeLinkImageLiveMarkdown

--- a/packages/editor/src/link-image/images.ts
+++ b/packages/editor/src/link-image/images.ts
@@ -1,7 +1,13 @@
 import type { Node as ProseNode } from "@milkdown/kit/prose/model";
-import { TextSelection } from "@milkdown/kit/prose/state";
+import { NodeSelection, Selection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView, ViewMutationRecord } from "@milkdown/kit/prose/view";
 import type { RawImageRange, ResolveMarkdownImageSrc } from "./types.ts";
+
+const clearFinalizedImageSourceEditingEvent = "markra-clear-finalized-image-source-editing";
+
+export function clearFinalizedImageSourceEditing(view: EditorView) {
+  view.dom.dispatchEvent(new Event(clearFinalizedImageSourceEditingEvent));
+}
 
 export function createImagePreview(range: RawImageRange, resolveImageSrc: ResolveMarkdownImageSrc | undefined) {
   const image = document.createElement("img");
@@ -75,14 +81,6 @@ function parseImageMarkdownSource(source: string) {
   };
 }
 
-function focusImageSource(source: HTMLInputElement, node: ProseNode) {
-  window.setTimeout(() => {
-    source.focus();
-    const alt = String(node.attrs.alt ?? "");
-    source.setSelectionRange(2, 2 + alt.length);
-  });
-}
-
 function createImageSourceIcon(ownerDocument: Document) {
   const svg = ownerDocument.createElementNS("http://www.w3.org/2000/svg", "svg");
   const rect = ownerDocument.createElementNS("http://www.w3.org/2000/svg", "rect");
@@ -122,6 +120,9 @@ export function createFinalizedImageNodeView(
   resolveImageSrc: ResolveMarkdownImageSrc | undefined
 ) {
   let currentNode = node;
+  let sourceEditing = false;
+  let suppressNextSelectNodeSource = false;
+  let imageSelectedForKeyboard = false;
   const dom = document.createElement("span");
   const sourceRow = document.createElement("span");
   const sourceIcon = createImageSourceIcon(document);
@@ -131,38 +132,91 @@ export function createFinalizedImageNodeView(
     if (!sourceRow.isConnected) return;
     if (event.target instanceof Node && dom.contains(event.target)) return;
 
-    hideSource();
+    hideSource({ force: true });
   };
 
   dom.className = "markra-image-node";
   dom.contentEditable = "false";
   dom.draggable = false;
   sourceRow.className = "markra-image-node-source-row";
+  sourceRow.setAttribute("contenteditable", "true");
   source.className = "markra-image-node-source";
+  source.setAttribute("contenteditable", "true");
   source.type = "text";
   source.ariaLabel = "Image markdown source";
   source.spellcheck = false;
   sourceRow.append(sourceIcon, source);
   dom.append(image);
 
-  const showSource = () => {
+  const showSource = (options: { preserveInput?: boolean } = {}) => {
     if (!view.editable) {
-      hideSource();
+      hideSource({ force: true });
       return false;
     }
 
-    source.value = imageMarkdownSource(currentNode);
+    if (!options.preserveInput || !sourceRow.isConnected) {
+      source.value = imageMarkdownSource(currentNode);
+    }
     if (!sourceRow.isConnected) dom.insertBefore(sourceRow, image);
     dom.classList.add("markra-image-node-selected");
+    imageSelectedForKeyboard = true;
     dom.ownerDocument.addEventListener("mousedown", hideSourceOnOutsidePress, true);
     return true;
   };
 
-  const hideSource = () => {
+  const selectSourceContainer = () => {
+    if (!view.editable) {
+      hideSource({ force: true });
+      return false;
+    }
+
+    dom.classList.add("markra-image-node-selected");
+    imageSelectedForKeyboard = true;
+    return true;
+  };
+
+  const hideSource = (options: { force?: boolean } = {}) => {
+    if (sourceEditing && !options.force) return;
+    if (imageSelectedForKeyboard && !options.force) return;
+
+    suppressNextSelectNodeSource = false;
+    sourceEditing = false;
+    if (options.force) imageSelectedForKeyboard = false;
     sourceRow.remove();
     dom.classList.remove("markra-image-node-selected");
     dom.classList.remove("markra-image-node-source-invalid");
     dom.ownerDocument.removeEventListener("mousedown", hideSourceOnOutsidePress, true);
+  };
+
+  const imageNodePosition = () => {
+    const position = typeof getPos === "function" ? getPos() : undefined;
+    if (typeof position !== "number") return null;
+
+    const imageNode = view.state.doc.nodeAt(position);
+    if (!imageNode || imageNode.type.name !== "image") return null;
+
+    return position;
+  };
+
+  const selectImageBlock = () => {
+    const position = imageNodePosition();
+    if (position === null) return false;
+
+    view.focus();
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, position)).scrollIntoView());
+    clearNativeSelection();
+    window.setTimeout(clearNativeSelection);
+    imageSelectedForKeyboard = true;
+    return true;
+  };
+
+  const clearNativeSelection = () => {
+    if (dom.ownerDocument.activeElement === source) return;
+
+    const selection = dom.ownerDocument.getSelection();
+    if (!selection) return;
+
+    selection.removeAllRanges();
   };
 
   const syncSource = () => {
@@ -172,7 +226,13 @@ export function createFinalizedImageNodeView(
     if (source.value.trim().length === 0) {
       if (typeof position !== "number") return false;
 
-      view.dispatch(view.state.tr.delete(position, position + currentNode.nodeSize).scrollIntoView());
+      const transaction = view.state.tr.delete(position, position + currentNode.nodeSize);
+      const selectionPosition = Math.min(position, transaction.doc.content.size);
+      view.dispatch(
+        transaction
+          .setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), -1))
+          .scrollIntoView()
+      );
       return false;
     }
 
@@ -219,7 +279,7 @@ export function createFinalizedImageNodeView(
       view.dispatch(transaction.setSelection(TextSelection.create(transaction.doc, imageEnd + 1)).scrollIntoView());
     }
 
-    hideSource();
+    hideSource({ force: true });
     view.focus();
   };
 
@@ -228,30 +288,114 @@ export function createFinalizedImageNodeView(
     event.stopPropagation();
 
     if (!view.editable) {
-      hideSource();
+      hideSource({ force: true });
       return;
     }
 
+    sourceEditing = false;
+    clearNativeSelection();
+
+    if (event.type === "mousedown") {
+      suppressNextSelectNodeSource = true;
+      if (!selectImageBlock()) suppressNextSelectNodeSource = false;
+      return;
+    }
+
+    suppressNextSelectNodeSource = false;
+    selectImageBlock();
     showSource();
-    focusImageSource(source, currentNode);
+  };
+
+  const selectSourceInput = (event: MouseEvent) => {
+    event.stopPropagation();
+    if (!view.editable) return;
+
+    sourceEditing = true;
+    showSource({ preserveInput: true });
+    source.focus();
+    if (event.target !== source) {
+      source.setSelectionRange(source.value.length, source.value.length);
+    }
+  };
+  const deleteSelectedImageOnKeyDown = (event: KeyboardEvent) => {
+    const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
+    if (hasModifier || (event.key !== "Backspace" && event.key !== "Delete")) return;
+    if (event.target instanceof Node && sourceRow.contains(event.target)) return;
+
+    const position = imageNodePosition();
+    const { selection } = view.state;
+    const imageIsSelected =
+      selection instanceof NodeSelection
+        ? selection.from === position
+        : imageSelectedForKeyboard;
+    if (position === null || !imageIsSelected) return;
+
+    const imageNode = view.state.doc.nodeAt(position);
+    if (!imageNode || imageNode.type.name !== "image") return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const transaction = view.state.tr.delete(position, position + imageNode.nodeSize);
+    const selectionPosition = Math.min(position, transaction.doc.content.size);
+    view.dispatch(
+      transaction
+        .setSelection(Selection.near(transaction.doc.resolve(selectionPosition), -1))
+        .scrollIntoView()
+    );
+    imageSelectedForKeyboard = false;
+    hideSource({ force: true });
+    view.focus();
+  };
+  const hideSourceOnClear = () => hideSource({ force: true });
+  const hideSourceOnBlur = () => {
+    window.setTimeout(() => {
+      if (document.activeElement === source) return;
+
+      hideSource({ force: true });
+    });
   };
 
   updateImageNodeDom(image, currentNode, resolveImageSrc);
+  dom.addEventListener("mousedown", selectImage);
+  dom.addEventListener("click", selectImage);
   image.addEventListener("mousedown", selectImage);
   image.addEventListener("click", selectImage);
+  view.dom.addEventListener(clearFinalizedImageSourceEditingEvent, hideSourceOnClear);
+  view.dom.addEventListener("keydown", deleteSelectedImageOnKeyDown, true);
+  sourceRow.addEventListener("mousedown", selectSourceInput);
+  sourceRow.addEventListener("click", selectSourceInput);
+  source.addEventListener("mousedown", selectSourceInput);
+  source.addEventListener("click", selectSourceInput);
   source.addEventListener("input", syncSource);
   source.addEventListener("change", syncSource);
   source.addEventListener("keydown", moveToParagraphAfterImage);
-  source.addEventListener("blur", hideSource);
+  source.addEventListener("blur", hideSourceOnBlur);
+
+  const editableObserver = dom.ownerDocument.defaultView
+    ? new dom.ownerDocument.defaultView.MutationObserver(() => {
+        if (!view.editable) hideSource({ force: true });
+      })
+    : null;
+  editableObserver?.observe(view.dom, {
+    attributeFilter: ["aria-readonly", "contenteditable"],
+    attributes: true
+  });
 
   return {
     dom,
-    selectNode: showSource,
+    selectNode() {
+      if (!suppressNextSelectNodeSource) return showSource();
+
+      suppressNextSelectNodeSource = false;
+      return selectSourceContainer();
+    },
     deselectNode: hideSource,
     update(nextNode: ProseNode) {
       if (nextNode.type.name !== "image") return false;
 
       currentNode = nextNode;
+      if (!view.editable) hideSource({ force: true });
       updateImageNodeDom(image, currentNode, resolveImageSrc);
       if (source.isConnected && document.activeElement !== source) source.value = imageMarkdownSource(currentNode);
       return true;
@@ -263,13 +407,22 @@ export function createFinalizedImageNodeView(
       return mutation.target === source;
     },
     destroy() {
-      hideSource();
+      hideSource({ force: true });
+      dom.removeEventListener("mousedown", selectImage);
+      dom.removeEventListener("click", selectImage);
       image.removeEventListener("mousedown", selectImage);
       image.removeEventListener("click", selectImage);
+      view.dom.removeEventListener(clearFinalizedImageSourceEditingEvent, hideSourceOnClear);
+      view.dom.removeEventListener("keydown", deleteSelectedImageOnKeyDown, true);
+      sourceRow.removeEventListener("mousedown", selectSourceInput);
+      sourceRow.removeEventListener("click", selectSourceInput);
+      source.removeEventListener("mousedown", selectSourceInput);
+      source.removeEventListener("click", selectSourceInput);
       source.removeEventListener("input", syncSource);
       source.removeEventListener("change", syncSource);
       source.removeEventListener("keydown", moveToParagraphAfterImage);
-      source.removeEventListener("blur", hideSource);
+      source.removeEventListener("blur", hideSourceOnBlur);
+      editableObserver?.disconnect();
     }
   };
 }

--- a/packages/editor/src/link-image/plugin.ts
+++ b/packages/editor/src/link-image/plugin.ts
@@ -51,6 +51,17 @@ function pastedExternalUrl(event: ClipboardEvent) {
   return normalizedExternalAutolinkUrl(text);
 }
 
+function selectionIsInsideActiveRawImageSource(state: EditorState) {
+  const range = findActiveRawMarkdownRange(state);
+  if (range?.kind !== "image") return false;
+
+  const { from, to } = state.selection;
+  const sourceFrom = range.from + range.alt.length + 4;
+  const sourceTo = sourceFrom + range.src.length;
+
+  return sourceFrom <= from && to <= sourceTo;
+}
+
 export function markraLinkImageLivePlugin(resolveImageSrc?: ResolveMarkdownImageSrc) {
   return $prose((ctx) => {
     const link = linkSchema.type(ctx);
@@ -150,6 +161,11 @@ export function markraLinkImageLivePlugin(resolveImageSrc?: ResolveMarkdownImage
           if (!href) return false;
 
           const { from, to } = view.state.selection;
+          if (selectionIsInsideActiveRawImageSource(view.state)) {
+            view.dispatch(view.state.tr.insertText(href, from, to).scrollIntoView());
+            return true;
+          }
+
           const selectedText = view.state.selection.empty ? "" : view.state.doc.textBetween(from, to, " ");
           const pastedText = event.clipboardData?.getData("text/plain") ?? "";
           const label = selectedText.trim() || pastedText.trim() || href;


### PR DESCRIPTION
## Summary

- Stabilize finalized image block selection so clicking an image selects the whole block and reveals the source row without placing the caret in nearby text.
- Make the source row/input explicitly editable only when clicked, keep URL paste inside image source as plain text, and allow Backspace/Delete to remove a selected image block.
- Route native/menu image insertion through parsed image-node insertion so newly inserted images are immediately interactive.
- Cover edge cases for source editing, search chrome hiding, mode switching, raw image markdown finalization, and escaped image alt text.

## Why

Newly inserted or recently edited images could stop responding to clicks after text selection, place the caret in adjacent text, or lose focus before the source input could be edited. Menu-inserted images also started as raw markdown text that was not immediately clickable.

## Validation

- `pnpm --filter @markra/app exec vitest run src/lib/selection-formatting.test.tsx -t "detects bold formatting at the current selection"` passed
- `pnpm test` passed
- `pnpm build` passed

## Risk

- Low to medium: this changes Milkdown image node view event handling and keyboard deletion behavior, but the affected paths are covered by focused interaction tests and the full workspace test/build.

Closes #365
