### PR TITLE
fix(app): restore tabs from current workspace state

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1667,6 +1667,73 @@ describe("useMarkdownDocument", () => {
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
   });
 
+  it("prefers the current window tabs over a stale update-restart snapshot", async () => {
+    const guidePath = "/mock-files/vault/guide.md";
+    const notesPath = "/mock-files/vault/notes.md";
+    const stalePath = "/mock-files/vault/stale.md";
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-current-tabs",
+      filePath: notesPath,
+      fileTreeOpen: false,
+      folderName: null,
+      folderPath: null,
+      openFilePaths: [guidePath, notesPath],
+      openWindows: [
+        {
+          filePath: stalePath,
+          label: "main",
+          openFilePaths: [stalePath]
+        }
+      ]
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === guidePath) {
+        return {
+          content: "# Guide",
+          name: "guide.md",
+          path
+        };
+      }
+      if (path === notesPath) {
+        return {
+          content: "# Notes",
+          name: "notes.md",
+          path
+        };
+      }
+
+      return {
+        content: "# Stale",
+        name: "stale.md",
+        path
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.tabs.map((tab) => tab.name)).toEqual(["guide.md", "notes.md"]));
+
+    expect(result.current.document).toMatchObject({
+      content: "# Notes",
+      dirty: false,
+      name: "notes.md",
+      path: notesPath
+    });
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(notesPath);
+    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalledWith(stalePath);
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({ openWindows: [] });
+  });
+
   it("keeps the saved folder root when restoring tabs with the file tree collapsed", async () => {
     const guidePath = "/mock-files/vault/docs/guide.md";
     const onTreeRootFromFilePath = vi.fn();

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -11,7 +11,9 @@ import {
   saveStoredRecentMarkdownFile,
   saveStoredWorkspaceState,
   type RecentMarkdownFile,
-  type StoredWorkspaceDraftTab
+  type StoredWorkspaceDraftTab,
+  type StoredWorkspaceState,
+  type StoredWorkspaceWindow
 } from "../lib/settings/app-settings";
 import { getMarkdownOutline, getWordCount, type MarkdownOutlineItem } from "@markra/markdown";
 import {
@@ -189,6 +191,24 @@ function workspaceRootForSource(sourcePath: string | null | undefined, currentFi
 
   const normalizedCurrentFilePath = normalizeComparablePath(currentFilePath);
   return normalizedCurrentFilePath ? parentPathFromPath(normalizedCurrentFilePath) : null;
+}
+
+function workspaceHasCurrentWindowRestoreState(workspace: StoredWorkspaceState) {
+  return Boolean(
+    workspace.filePath ||
+    workspace.folderPath ||
+    workspace.openFilePaths.length > 0 ||
+    workspace.draftTabs?.length
+  );
+}
+
+function additionalEditorWindowsForRestore(
+  restoreWindows: readonly StoredWorkspaceWindow[],
+  currentWindowHasRestoreState: boolean
+) {
+  return currentWindowHasRestoreState
+    ? restoreWindows.filter((window) => window.label !== "main")
+    : restoreWindows.slice(1);
 }
 
 export function useMarkdownDocument({
@@ -1679,7 +1699,8 @@ export function useMarkdownDocument({
           const workspace = await getStoredWorkspaceState();
           const sessionId = workspace.aiAgentSessionId ?? createAiAgentSessionId();
           const restoreWindows = workspace.openWindows ?? [];
-          const primaryRestoreWindow = restoreWindows[0] ?? null;
+          const currentWindowHasRestoreState = workspaceHasCurrentWindowRestoreState(workspace);
+          const primaryRestoreWindow = currentWindowHasRestoreState ? null : restoreWindows[0] ?? null;
           const primaryRestoreWindowFilePath = primaryRestoreWindow
             ? activeFilePathFromWindowRestore(primaryRestoreWindow)
             : null;
@@ -1696,8 +1717,7 @@ export function useMarkdownDocument({
             );
           const activeRestoreFilePath = primaryRestoreWindow ? primaryRestoreWindowFilePath : workspace.filePath;
           const additionalRestoreWindowFilePaths = normalizeOpenFilePaths(
-            restoreWindows
-              .slice(1)
+            additionalEditorWindowsForRestore(restoreWindows, currentWindowHasRestoreState)
               .map(activeFilePathFromWindowRestore)
           ).filter((path) => !restoreFilePaths.includes(path));
 

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -1113,6 +1113,8 @@ export async function saveStoredWorkspaceState(
   }
 
   if (workspacePatchHasWindowState(patch)) {
+    current.openWindows = [];
+
     const windowLabel = await resolveStoredWorkspaceWindowLabel(options);
     const targetLabel = windowLabel === settingsWorkspaceWindowLabel ? mainWorkspaceWindowLabel : windowLabel;
     const currentWindowState = workspaceStateForWindowLabel(current, targetLabel);

--- a/packages/app/src/lib/settings/workspace-state.test.ts
+++ b/packages/app/src/lib/settings/workspace-state.test.ts
@@ -179,6 +179,54 @@ describe("workspace state settings", () => {
     expect(store.save).toHaveBeenCalledTimes(1);
   });
 
+  it("clears a transient open window snapshot when persisting current window state", async () => {
+    store.get.mockResolvedValue({
+      openWindows: [
+        {
+          filePath: "/mock-files/stale.md",
+          label: "main",
+          openFilePaths: ["/mock-files/stale.md"]
+        }
+      ],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/current.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: ["/mock-files/current.md"]
+        }
+      }
+    });
+
+    await saveStoredWorkspaceState({
+      filePath: "/mock-files/current.md",
+      openFilePaths: [
+        "/mock-files/current.md",
+        "/mock-files/notes.md"
+      ]
+    });
+
+    expect(store.set).toHaveBeenCalledWith("workspace", {
+      openWindows: [],
+      windowStates: {
+        main: {
+          aiAgentSessionId: "session-main",
+          filePath: "/mock-files/current.md",
+          fileTreeOpen: false,
+          folderName: null,
+          folderPath: null,
+          openFilePaths: [
+            "/mock-files/current.md",
+            "/mock-files/notes.md"
+          ]
+        }
+      }
+    });
+    expect(store.save).toHaveBeenCalledTimes(1);
+  });
+
   it("loads normalized file tree sort preferences by workspace path", async () => {
     store.get.mockResolvedValue({
       "/mock-workspaces/notes": {


### PR DESCRIPTION
## Summary
- Prefer the current window workspace state over stale update-restart snapshots when restoring document tabs.
- Clear transient `openWindows` snapshots whenever the current window state is persisted.
- Add regression coverage for stale snapshot restore and snapshot cleanup.

## Why
A leftover update-restart snapshot could outlive the relaunch flow and override the newer per-window tab state on the next startup, making document tabs restore from stale data.

## Validation
- `pnpm --filter @markra/app exec vitest run src/lib/settings/workspace-state.test.ts src/hooks/useMarkdownDocument.test.tsx` passed: 2 files, 63 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app exec vitest run` passed: 90 files, 1322 tests.