### PR TITLE
feat(app): add file tree multi-selection

### DIFF
--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -34,6 +34,7 @@ export type NativeMarkdownFileTreeContextMenuHandlers = {
   deleteFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   openContainingFolder?: (file?: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   openFileToSide?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
+  multiSelect?: boolean;
   renameFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   saveFileAsTemplate?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
 };

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2279,6 +2279,48 @@ describe("Markra workspace", () => {
     await waitFor(() => expect(mockedDeleteNativeMarkdownTreeFile).toHaveBeenCalledWith(mockFolderPath, docsPath));
   });
 
+  it("uses plural confirmation copy when deleting selected sidebar files", async () => {
+    const alphaFile = { name: "alpha.md", path: `${mockFolderPath}/alpha.md`, relativePath: "alpha.md" };
+    const betaFile = { name: "beta.md", path: `${mockFolderPath}/beta.md`, relativePath: "beta.md" };
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([alphaFile, betaFile]);
+    mockedConfirmNativeMarkdownFileDelete.mockResolvedValue(true);
+    mockedDeleteNativeMarkdownTreeFile.mockResolvedValue(undefined);
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    const alphaButton = await screen.findByRole("button", { name: "alpha.md" });
+    const betaButton = await screen.findByRole("button", { name: "beta.md" });
+    fireEvent.click(alphaButton, { metaKey: true });
+    fireEvent.click(betaButton, { metaKey: true });
+    fireEvent.contextMenu(alphaButton);
+    const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls.at(-1)?.[0];
+
+    await act(async () => {
+      await contextHandlers?.deleteFile?.(alphaFile);
+    });
+
+    await waitFor(() =>
+      expect(mockedConfirmNativeMarkdownFileDelete).toHaveBeenCalledWith("2 files", {
+        cancelLabel: "Cancel",
+        message: "Delete these 2 files?",
+        okLabel: "Confirm"
+      })
+    );
+    await waitFor(() => expect(mockedDeleteNativeMarkdownTreeFile).toHaveBeenCalledWith(mockFolderPath, alphaFile.path));
+    await waitFor(() => expect(mockedDeleteNativeMarkdownTreeFile).toHaveBeenCalledWith(mockFolderPath, betaFile.path));
+    expect(mockedConfirmNativeMarkdownFileDelete).toHaveBeenCalledTimes(1);
+  });
+
   it("saves a sidebar markdown file as a custom template", async () => {
     const templatePath = `${mockFolderPath}/standup.md`;
     const templateFile = { name: "standup.md", path: templatePath, relativePath: "standup.md" };

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -95,7 +95,7 @@ import { saveEditorImage } from "./lib/image-upload";
 import { aiCommandSelection, automaticAiSelection } from "./lib/ai-selection";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
-import { replaceMovedPath } from "./lib/path-move";
+import { replaceMovedPath, sameNativePath } from "./lib/path-move";
 import {
   resolveDesktopOsVersion,
   resolveDesktopPlatform,
@@ -1834,20 +1834,34 @@ function WorkspaceApp() {
       // Keep the existing tree state if the native move fails.
     }
   }, [applyMovedTreeFile, moveMarkdownTreeFile]);
-  const handleDeleteMarkdownTreeFile = useCallback(async (file: NativeMarkdownFolderFile) => {
+  const handleDeleteMarkdownTreeFile = useCallback(async (
+    file: NativeMarkdownFolderFile,
+    context?: { files: readonly NativeMarkdownFolderFile[] }
+  ) => {
+    const deleteTargets = context?.files?.length ? context.files : [file];
+    const uniqueDeleteTargets = deleteTargets.filter((target, index, targets) =>
+      targets.findIndex((candidate) => sameNativePath(candidate.path, target.path)) === index
+    );
+    const deletingMultipleFiles = uniqueDeleteTargets.length > 1;
     const fileIsFolder = file.kind === "folder";
-    const confirmed = await confirmNativeMarkdownFileDelete(file.name, {
+    const deleteCount = String(uniqueDeleteTargets.length);
+    const deleteCountLabel = translate("app.workspaceSearch.fileCountPlural").replace("{count}", deleteCount);
+    const confirmed = await confirmNativeMarkdownFileDelete(deletingMultipleFiles ? deleteCountLabel : file.name, {
       cancelLabel: translate(fileIsFolder ? "app.cancelDeleteMarkdownFolder" : "app.cancelDeleteMarkdownFile"),
-      message: translate(fileIsFolder ? "app.confirmDeleteMarkdownFolder" : "app.confirmDeleteMarkdownFile"),
+      message: deletingMultipleFiles
+        ? translate("app.confirmDeleteSelectedMarkdownFiles").replace("{count}", deleteCount)
+        : translate(fileIsFolder ? "app.confirmDeleteMarkdownFolder" : "app.confirmDeleteMarkdownFile"),
       okLabel: translate(fileIsFolder ? "app.confirmDeleteMarkdownFolderAction" : "app.confirmDeleteMarkdownFileAction")
     });
     if (!confirmed) return;
 
-    try {
-      const deleted = await deleteMarkdownTreeFile(file);
-      if (deleted) detachDeletedDocumentFile(file.path);
-    } catch {
-      // Leave the file visible when native deletion fails.
+    for (const targetFile of uniqueDeleteTargets) {
+      try {
+        const deleted = await deleteMarkdownTreeFile(targetFile);
+        if (deleted) detachDeletedDocumentFile(targetFile.path);
+      } catch {
+        // Leave the file visible when native deletion fails.
+      }
     }
   }, [deleteMarkdownTreeFile, detachDeletedDocumentFile, translate]);
   const handleSaveMarkdownFileAsTemplate = useCallback(async (file: NativeMarkdownFolderFile) => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -691,6 +691,171 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(openFile).toHaveBeenCalledWith(markdownFiles[2]);
   });
 
+  it("supports modifier-based multi-selection in the visible file tree", () => {
+    const openFile = vi.fn();
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[
+          ...markdownFiles,
+          { name: "Architecture.md", path: "/vault/Architecture.md", relativePath: "Architecture.md" }
+        ]}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={openFile}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const architecture = screen.getByRole("button", { name: "Architecture.md" });
+    const aws = screen.getByRole("button", { name: "AWS.md" });
+    const untitled = screen.getByRole("button", { name: "Untitled.md" });
+    const folder = screen.getByRole("button", { name: "deploy" });
+
+    fireEvent.click(aws, { metaKey: true });
+
+    expect(openFile).not.toHaveBeenCalled();
+    expect(aws).toHaveAttribute("aria-selected", "true");
+    expect(architecture).not.toHaveAttribute("aria-selected");
+
+    fireEvent.click(architecture, { ctrlKey: true });
+
+    expect(openFile).not.toHaveBeenCalled();
+    expect(architecture).toHaveAttribute("aria-selected", "true");
+    expect(aws).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(untitled, { shiftKey: true });
+
+    expect(openFile).not.toHaveBeenCalled();
+    expect(architecture).toHaveAttribute("aria-selected", "true");
+    expect(aws).toHaveAttribute("aria-selected", "true");
+    expect(untitled).toHaveAttribute("aria-selected", "true");
+    expect(folder).not.toHaveAttribute("aria-selected");
+
+    fireEvent.click(aws, { ctrlKey: true });
+
+    expect(aws).not.toHaveAttribute("aria-selected");
+    expect(architecture).toHaveAttribute("aria-selected", "true");
+    expect(untitled).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.mouseDown(container.querySelector(".file-tree-scroll") as HTMLElement);
+
+    expect(architecture).not.toHaveAttribute("aria-selected");
+    expect(untitled).not.toHaveAttribute("aria-selected");
+
+    fireEvent.click(architecture, { metaKey: true });
+    fireEvent.click(untitled, { metaKey: true });
+
+    expect(architecture).toHaveAttribute("aria-selected", "true");
+    expect(untitled).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(untitled);
+
+    expect(openFile).toHaveBeenCalledWith(markdownFiles[0]);
+    expect(architecture).not.toHaveAttribute("aria-selected");
+    expect(untitled).not.toHaveAttribute("aria-selected");
+  });
+
+  it("clears file multi-selection when clicking outside file rows", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[
+          ...markdownFiles,
+          { name: "Architecture.md", path: "/vault/Architecture.md", relativePath: "Architecture.md" }
+        ]}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const architecture = screen.getByRole("button", { name: "Architecture.md" });
+    const aws = screen.getByRole("button", { name: "AWS.md" });
+
+    fireEvent.click(aws, { metaKey: true });
+    fireEvent.click(architecture, { metaKey: true });
+
+    expect(architecture).toHaveAttribute("aria-selected", "true");
+    expect(aws).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.pointerDown(screen.getByText("Files"));
+
+    expect(architecture).not.toHaveAttribute("aria-selected");
+    expect(aws).not.toHaveAttribute("aria-selected");
+
+    fireEvent.click(aws, { metaKey: true });
+    fireEvent.click(architecture, { metaKey: true });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "deploy" }));
+
+    expect(architecture).not.toHaveAttribute("aria-selected");
+    expect(aws).not.toHaveAttribute("aria-selected");
+  });
+
+  it("uses selected file rows for supported file tree context menu actions", () => {
+    const deleteFile = vi.fn();
+    const openFileToSide = vi.fn();
+    const architectureFile = {
+      name: "Architecture.md",
+      path: "/vault/Architecture.md",
+      relativePath: "Architecture.md"
+    };
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[...markdownFiles, architectureFile]}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onDeleteFile={deleteFile}
+        onOpenFile={() => {}}
+        onOpenFileToSide={openFileToSide}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const architecture = screen.getByRole("button", { name: "Architecture.md" });
+    const aws = screen.getByRole("button", { name: "AWS.md" });
+    const untitled = screen.getByRole("button", { name: "Untitled.md" });
+
+    fireEvent.click(aws, { metaKey: true });
+    fireEvent.click(architecture, { metaKey: true });
+    fireEvent.contextMenu(aws);
+
+    const selectedContextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls.at(-1)?.[0];
+    expect(selectedContextHandlers).toEqual(expect.objectContaining({ multiSelect: true }));
+    selectedContextHandlers?.openFileToSide?.(markdownFiles[1]);
+
+    expect(openFileToSide).toHaveBeenCalledWith(markdownFiles[1]);
+    expect(openFileToSide).toHaveBeenCalledWith(architectureFile);
+    expect(openFileToSide).toHaveBeenCalledTimes(2);
+
+    selectedContextHandlers?.deleteFile?.(markdownFiles[1]);
+
+    expect(deleteFile).toHaveBeenCalledWith(markdownFiles[1], {
+      files: expect.arrayContaining([markdownFiles[1], architectureFile])
+    });
+    expect(deleteFile.mock.calls[0]?.[1]?.files).toHaveLength(2);
+    expect(deleteFile).toHaveBeenCalledTimes(1);
+
+    deleteFile.mockClear();
+    openFileToSide.mockClear();
+    fireEvent.contextMenu(untitled);
+
+    const singleContextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls.at(-1)?.[0];
+    expect(singleContextHandlers).toEqual(expect.objectContaining({ multiSelect: false }));
+    singleContextHandlers?.openFileToSide?.(markdownFiles[0]);
+    singleContextHandlers?.deleteFile?.(markdownFiles[0]);
+
+    expect(openFileToSide).not.toHaveBeenCalled();
+    expect(deleteFile).toHaveBeenCalledWith(markdownFiles[0]);
+    expect(deleteFile).toHaveBeenCalledTimes(1);
+  });
+
   it("reveals a requested file path in the tree", () => {
     const { rerender } = render(
       <MarkdownFileTreeDrawer
@@ -2292,9 +2457,15 @@ describe("MarkdownFileTreeDrawer", () => {
     fireEvent.contextMenu(screen.getByRole("button", { name: "Untitled.md" }));
 
     const contextHandlers = mockedShowNativeMarkdownFileTreeContextMenu.mock.calls[0]?.[0];
-    expect(contextHandlers?.openFileToSide).toBe(openFileToSide);
+    expect(contextHandlers?.openFileToSide).toEqual(expect.any(Function));
     expect(contextHandlers?.canOpenFileToSide?.(markdownFiles[0])).toBe(false);
     expect(contextHandlers?.canOpenFileToSide?.(markdownFiles[1])).toBe(true);
+
+    contextHandlers?.openFileToSide?.(markdownFiles[0]);
+    contextHandlers?.openFileToSide?.(markdownFiles[1]);
+
+    expect(openFileToSide).toHaveBeenCalledWith(markdownFiles[1]);
+    expect(openFileToSide).toHaveBeenCalledTimes(1);
   });
 
   it("keeps file tree context-menu rows from selecting text", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -135,7 +135,10 @@ type MarkdownFileTreeDrawerProps = {
   width?: number;
   onCreateFile?: (fileName: string, parentPath?: string | null, contents?: string) => unknown | Promise<unknown>;
   onCreateFolder?: (folderName: string, parentPath?: string | null) => unknown | Promise<unknown>;
-  onDeleteFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
+  onDeleteFile?: (
+    file: NativeMarkdownFolderFile,
+    context?: { files: readonly NativeMarkdownFolderFile[] }
+  ) => unknown | Promise<unknown>;
   onFileTreeSortChange?: (sort: FileTreeSort) => unknown;
   onOpenFile: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   onOpenContainingFolder?: (path: string) => unknown | Promise<unknown>;
@@ -444,6 +447,8 @@ export function MarkdownFileTreeDrawer({
   const [activeDragFile, setActiveDragFile] = useState<NativeMarkdownFolderFile | null>(null);
   const [collapsedOutlineKeys, setCollapsedOutlineKeys] = useState<Set<string>>(() => new Set());
   const [pendingRevealPath, setPendingRevealPath] = useState<string | null>(null);
+  const [selectedFileTreePaths, setSelectedFileTreePaths] = useState<Set<string>>(() => new Set());
+  const [fileTreeSelectionAnchorPath, setFileTreeSelectionAnchorPath] = useState<string | null>(null);
   const lastRevealRequestIdRef = useRef<number | null>(null);
   const lastAutoRevealedPathRef = useRef<string | null>(null);
   renamingPathRef.current = renamingPath;
@@ -497,6 +502,38 @@ export function MarkdownFileTreeDrawer({
     [fileTreeScrollOffset, fileTreeViewportHeight, getFileTreeRowKey, visibleFileTreeRows]
   );
   const virtualFileTreeHeight = visibleFileTreeRows.length * fileTreeRowHeight;
+  const visibleFileTreeFilePaths = useMemo(
+    () => visibleFileTreeRows.flatMap((row) =>
+      row.type === "node" && row.node.type === "file" ? [row.node.file.path] : []
+    ),
+    [visibleFileTreeRows]
+  );
+  const allFileTreeFilePaths = useMemo(
+    () => files.filter((file) => file.kind !== "folder").map((file) => file.path),
+    [files]
+  );
+  const pathInFileTree = useCallback((path: string | null | undefined, paths: readonly string[]) => (
+    paths.some((candidatePath) => sameNativePath(candidatePath, path))
+  ), []);
+  const fileTreePathSelected = useCallback((path: string) => (
+    Array.from(selectedFileTreePaths).some((selectedPath) => sameNativePath(selectedPath, path))
+  ), [selectedFileTreePaths]);
+  const clearFileTreeSelection = useCallback(() => {
+    setSelectedFileTreePaths((current) => current.size === 0 ? current : new Set());
+  }, []);
+  const clearFileTreeMultiSelection = useCallback(() => {
+    clearFileTreeSelection();
+    setFileTreeSelectionAnchorPath(null);
+  }, [clearFileTreeSelection]);
+  const fileTreeSelectionRange = useCallback((anchorPath: string, targetPath: string) => {
+    const anchorIndex = visibleFileTreeFilePaths.findIndex((path) => sameNativePath(path, anchorPath));
+    const targetIndex = visibleFileTreeFilePaths.findIndex((path) => sameNativePath(path, targetPath));
+    if (anchorIndex < 0 || targetIndex < 0) return [targetPath];
+
+    const startIndex = Math.min(anchorIndex, targetIndex);
+    const endIndex = Math.max(anchorIndex, targetIndex);
+    return visibleFileTreeFilePaths.slice(startIndex, endIndex + 1);
+  }, [visibleFileTreeFilePaths]);
   const setFileTreeScrollRef = useCallback((element: HTMLDivElement | null) => {
     fileTreeScrollNodeRef.current = element;
     if (!element) return undefined;
@@ -655,6 +692,39 @@ export function MarkdownFileTreeDrawer({
       resizeObserver.disconnect();
     };
   }, [fileTreeScrollElement, measureFileTreeViewport]);
+
+  useEffect(() => {
+    setSelectedFileTreePaths((current) => {
+      const next = new Set(Array.from(current).filter((path) => pathInFileTree(path, allFileTreeFilePaths)));
+      return next.size === current.size ? current : next;
+    });
+    setFileTreeSelectionAnchorPath((current) => (
+      pathInFileTree(current, allFileTreeFilePaths) ? current : null
+    ));
+  }, [allFileTreeFilePaths, pathInFileTree]);
+
+  useEffect(() => {
+    if (selectedFileTreePaths.size === 0) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const eventTarget = event.target;
+      const target = eventTarget instanceof Element
+        ? eventTarget
+        : eventTarget instanceof Node
+          ? eventTarget.parentElement
+          : null;
+      if (!target) return;
+      if (target.closest("[data-file-tree-path], [data-markra-context-menu-root], [data-markra-context-menu]")) return;
+
+      clearFileTreeMultiSelection();
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [clearFileTreeMultiSelection, selectedFileTreePaths.size]);
 
   useEffect(() => {
     if (!fileTreeSortMenuOpen && !createMenuOpen && !outlineLevelMenuOpen) return;
@@ -995,6 +1065,7 @@ export function MarkdownFileTreeDrawer({
     if (target?.closest("button, input")) return;
 
     cancelFileTreeInputs();
+    clearFileTreeMultiSelection();
   };
 
   useEffect(() => {
@@ -1029,6 +1100,22 @@ export function MarkdownFileTreeDrawer({
     return file.kind === "folder" ? file.path : parentPathFromPath(file.path);
   };
 
+  const fileTreeContextTargets = (targetFile: NativeMarkdownFolderFile | undefined) => {
+    if (!targetFile) return [];
+    if (targetFile.kind === "folder" || !fileTreePathSelected(targetFile.path)) return [targetFile];
+
+    const selectedTargets = visibleFileTreeFilePaths
+      .filter((path) => fileTreePathSelected(path))
+      .map((path) => files.find((candidate) => candidate.kind !== "folder" && sameNativePath(candidate.path, path)) ?? null)
+      .filter((candidate): candidate is NativeMarkdownFolderFile => candidate !== null);
+
+    return selectedTargets.length > 0 ? selectedTargets : [targetFile];
+  };
+
+  const canOpenFileTreeContextTargetToSide = (targetFile: NativeMarkdownFolderFile) => (
+    targetFile.kind !== "asset" && !sameNativePath(targetFile.path, currentPath)
+  );
+
   const openContextMenu = (
     event: ReactMouseEvent,
     file?: NativeMarkdownFolderFile,
@@ -1039,10 +1126,13 @@ export function MarkdownFileTreeDrawer({
     if (!backgroundContextMenuAvailable && !file) return;
 
     const createTargetFolderPath = normalizeCreateParentPath(targetFolderPath ?? targetFolderPathForFile(file));
+    const contextTargets = fileTreeContextTargets(file);
+    const multiSelect = contextTargets.length > 1;
 
     showNativeMarkdownFileTreeContextMenu(
       {
-        canOpenFileToSide: (targetFile) => targetFile.path !== currentPath,
+        canOpenFileToSide: (targetFile) =>
+          Boolean(onOpenFileToSide && fileTreeContextTargets(targetFile).some(canOpenFileTreeContextTargetToSide)),
         createFile: fileCreationAvailable ? () => startCreatingFile(createTargetFolderPath) : undefined,
         createFileFromTemplates: fileCreationAvailable
           ? availableMarkdownTemplates.map((template) => ({
@@ -1053,7 +1143,10 @@ export function MarkdownFileTreeDrawer({
           : undefined,
         createFolder: folderCreationAvailable ? () => startCreatingFolder(createTargetFolderPath) : undefined,
         deleteFile: (targetFile) => {
-          onDeleteFile?.(targetFile);
+          const targetFiles = fileTreeContextTargets(targetFile);
+          if (targetFiles.length > 1) return onDeleteFile?.(targetFile, { files: targetFiles });
+
+          return onDeleteFile?.(targetFile);
         },
         openContainingFolder: onOpenContainingFolder
           ? (targetFile) => {
@@ -1063,7 +1156,15 @@ export function MarkdownFileTreeDrawer({
             return onOpenContainingFolder(path);
           }
           : undefined,
-        openFileToSide: onOpenFileToSide,
+        openFileToSide: onOpenFileToSide
+          ? (targetFile) =>
+            Promise.all(
+              fileTreeContextTargets(targetFile)
+                .filter(canOpenFileTreeContextTargetToSide)
+                .map((target) => Promise.resolve(onOpenFileToSide(target)))
+            )
+          : undefined,
+        multiSelect,
         renameFile: startRenamingFile,
         saveFileAsTemplate: onSaveFileAsTemplate
       },
@@ -1552,8 +1653,63 @@ export function MarkdownFileTreeDrawer({
     );
   };
 
+  const handleFileRowClick = (
+    event: ReactMouseEvent<HTMLButtonElement>,
+    file: NativeMarkdownFolderFile
+  ) => {
+    const additiveSelection = event.metaKey || event.ctrlKey;
+    const rangeSelection = event.shiftKey;
+
+    setSelectedCreateParentPath(null);
+
+    if (!additiveSelection && !rangeSelection) {
+      clearFileTreeSelection();
+      setFileTreeSelectionAnchorPath(file.path);
+      onOpenFile(file);
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (rangeSelection) {
+      const anchorPath =
+        fileTreeSelectionAnchorPath && pathInFileTree(fileTreeSelectionAnchorPath, visibleFileTreeFilePaths)
+          ? fileTreeSelectionAnchorPath
+          : currentPath && pathInFileTree(currentPath, visibleFileTreeFilePaths)
+            ? currentPath
+            : file.path;
+      const rangePaths = fileTreeSelectionRange(anchorPath, file.path);
+
+      setSelectedFileTreePaths((current) => {
+        if (!additiveSelection) return new Set(rangePaths);
+
+        const next = new Set(current);
+        rangePaths.forEach((path) => next.add(path));
+        return next;
+      });
+      setFileTreeSelectionAnchorPath(anchorPath);
+      return;
+    }
+
+    setSelectedFileTreePaths((current) => {
+      const next = new Set(current);
+      const selectedPath = Array.from(next).find((path) => sameNativePath(path, file.path));
+
+      if (selectedPath) {
+        next.delete(selectedPath);
+      } else {
+        next.add(file.path);
+      }
+
+      return next;
+    });
+    setFileTreeSelectionAnchorPath(file.path);
+  };
+
   const renderFileRowContent = (node: FileNode, depth: number, mode: FileTreeRowRenderMode) => {
     const active = sameNativePath(node.file.path, currentPath);
+    const selected = fileTreePathSelected(node.file.path);
     const renaming = renamingPath === node.file.path;
     const asset = node.file.kind === "asset";
     const FileIcon = asset ? ImageIcon : FileText;
@@ -1568,10 +1724,11 @@ export function MarkdownFileTreeDrawer({
         {(dragSource) => (
           <button
             ref={dragSource.setNodeRef}
-            className={`relative grid h-8 w-full cursor-pointer touch-none grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 border-0 bg-transparent py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-[current=page]:border-l-[3px] aria-[current=page]:border-(--text-secondary) aria-[current=page]:bg-(--bg-active) aria-[current=page]:text-(--text-heading) ${dragSource.isDragging ? "opacity-70" : ""} ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
+            className={`relative grid h-8 w-full cursor-pointer touch-none grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 border-0 bg-transparent py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-[current=page]:border-l-[3px] aria-[current=page]:border-(--text-secondary) aria-[current=page]:bg-(--bg-active) aria-[current=page]:text-(--text-heading) aria-[selected=true]:bg-(--accent-soft) aria-[selected=true]:text-(--text-heading) aria-[selected=true]:shadow-[inset_3px_0_0_var(--accent)] ${dragSource.isDragging ? "opacity-70" : ""} ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
             style={rowIndentStyle}
             type="button"
             aria-current={active ? "page" : undefined}
+            aria-selected={selected ? "true" : undefined}
             aria-label={node.relativePath}
             data-active-file-tree-row={active ? "true" : undefined}
             data-file-tree-path={node.file.path}
@@ -1580,10 +1737,7 @@ export function MarkdownFileTreeDrawer({
             }
             title={node.file.path}
             onContextMenu={(event) => openContextMenu(event, node.file)}
-            onClick={() => {
-              setSelectedCreateParentPath(null);
-              onOpenFile(node.file);
-            }}
+            onClick={(event) => handleFileRowClick(event, node.file)}
             {...dragSource.attributes}
             {...dragSource.listeners}
           >
@@ -1617,6 +1771,7 @@ export function MarkdownFileTreeDrawer({
         className={depth === 0 ? "m-0 list-none p-0" : `ml-5 list-none border-l border-(--border-default) p-0 ${listDropTarget ? fileTreeDropListTargetClassName : ""}`}
         role={depth === 0 ? "tree" : "group"}
         aria-label={treeLabel}
+        aria-multiselectable={depth === 0 ? "true" : undefined}
       >
         {renderCreateRows(parentPath, depth)}
         {nodes.map((node) => {
@@ -1658,6 +1813,7 @@ export function MarkdownFileTreeDrawer({
       className="relative m-0 list-none p-0"
       role="tree"
       aria-label={label("app.markdownFiles")}
+      aria-multiselectable="true"
       style={{ height: `${virtualFileTreeHeight}px` }}
     >
       {virtualFileTreeRows.map((virtualRow) => {

--- a/packages/app/src/lib/tauri/menu.ts
+++ b/packages/app/src/lib/tauri/menu.ts
@@ -21,6 +21,7 @@ export type NativeMarkdownFileTreeContextMenuHandlers = {
   deleteFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   openContainingFolder?: (file?: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   openFileToSide?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
+  multiSelect?: boolean;
   renameFile?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   saveFileAsTemplate?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
 };

--- a/packages/app/src/runtime/context-menu-items.test.ts
+++ b/packages/app/src/runtime/context-menu-items.test.ts
@@ -163,4 +163,31 @@ describe("markdown file tree context menu entries", () => {
     expect(openContainingFolder).toHaveBeenCalledTimes(1);
     expect(openContainingFolder.mock.calls[0]).toEqual([]);
   });
+
+  it("disables single-file actions for a multi-selected markdown file context", () => {
+    const file = {
+      name: "guide.md",
+      path: "/mock-project/docs/guide.md",
+      relativePath: "docs/guide.md"
+    };
+    const entries = createMarkdownFileTreeContextMenuEntries(
+      {
+        canOpenFileToSide: () => true,
+        deleteFile: vi.fn(),
+        multiSelect: true,
+        openContainingFolder: vi.fn(),
+        openFileToSide: vi.fn(),
+        renameFile: vi.fn(),
+        saveFileAsTemplate: vi.fn()
+      },
+      "en",
+      file
+    );
+
+    expect(menuItemById(entries, "markra:file-tree:open-to-side").disabled).toBe(true);
+    expect(menuItemById(entries, "markra:file-tree:delete").disabled).toBe(false);
+    expect(menuItemById(entries, "markra:file-tree:save-as-template").disabled).toBe(true);
+    expect(menuItemById(entries, "markra:file-tree:open-containing-folder").disabled).toBe(true);
+    expect(menuItemById(entries, "markra:file-tree:rename").disabled).toBe(true);
+  });
 });

--- a/packages/app/src/runtime/context-menu-items.ts
+++ b/packages/app/src/runtime/context-menu-items.ts
@@ -283,6 +283,7 @@ export function createMarkdownFileTreeContextMenuEntries(
   const label = (key: I18nKey) => menuLabel(language, key);
   const fileIsFolder = file?.kind === "folder";
   const fileIsAsset = file?.kind === "asset";
+  const multiSelect = Boolean(handlers.multiSelect);
   const templateItems = handlers.createFileFromTemplates?.map((template) =>
     contextMenuItem(fileTreeId(`new-from-template:${template.id}`), template.name, undefined, template.create)
   ) ?? [];
@@ -319,13 +320,14 @@ export function createMarkdownFileTreeContextMenuEntries(
   entries.push(contextMenuSeparator());
   if (!fileIsAsset && handlers.openFileToSide) {
     const canOpenFileToSide = handlers.canOpenFileToSide?.(file) ?? true;
+    const openFileToSideEnabled = canOpenFileToSide && !multiSelect;
     entries.push(
       contextMenuItem(
         fileTreeId("open-to-side"),
         label("app.openDocumentToSide"),
         undefined,
-        canOpenFileToSide ? () => handlers.openFileToSide?.(file) : undefined,
-        !canOpenFileToSide
+        openFileToSideEnabled ? () => handlers.openFileToSide?.(file) : undefined,
+        !openFileToSideEnabled
       )
     );
   }
@@ -335,13 +337,14 @@ export function createMarkdownFileTreeContextMenuEntries(
         fileTreeId("save-as-template"),
         label("app.saveMarkdownFileAsTemplate"),
         undefined,
-        () => handlers.saveFileAsTemplate?.(file)
+        () => handlers.saveFileAsTemplate?.(file),
+        multiSelect
       )
     );
   }
   entries.push(
-    contextMenuItem(fileTreeId("open-containing-folder"), label("app.openContainingFolder"), undefined, () => handlers.openContainingFolder?.(file), !handlers.openContainingFolder),
-    contextMenuItem(fileTreeId("rename"), label("app.renameMarkdownFile"), undefined, () => handlers.renameFile?.(file), !handlers.renameFile),
+    contextMenuItem(fileTreeId("open-containing-folder"), label("app.openContainingFolder"), undefined, () => handlers.openContainingFolder?.(file), multiSelect || !handlers.openContainingFolder),
+    contextMenuItem(fileTreeId("rename"), label("app.renameMarkdownFile"), undefined, () => handlers.renameFile?.(file), multiSelect || !handlers.renameFile),
     contextMenuItem(fileTreeId("delete"), label("app.deleteMarkdownFile"), undefined, () => handlers.deleteFile?.(file), !handlers.deleteFile)
   );
 

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "Ordner umbenennen",
   "app.deleteMarkdownFile": "Datei löschen",
   "app.confirmDeleteMarkdownFile": "Diese Datei löschen?",
+  "app.confirmDeleteSelectedMarkdownFiles": "Diese {count} Dateien löschen?",
   "app.cancelDeleteMarkdownFile": "Abbrechen",
   "app.confirmDeleteMarkdownFileAction": "Bestätigen",
   "app.deleteMarkdownFolder": "Ordner löschen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -551,6 +551,7 @@ const messages: BaseLocaleMessages = {
   "app.renameMarkdownFolder": "Rename folder",
   "app.deleteMarkdownFile": "Delete file",
   "app.confirmDeleteMarkdownFile": "Delete this file?",
+  "app.confirmDeleteSelectedMarkdownFiles": "Delete these {count} files?",
   "app.cancelDeleteMarkdownFile": "Cancel",
   "app.confirmDeleteMarkdownFileAction": "Confirm",
   "app.deleteMarkdownFolder": "Delete folder",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "Renombrar carpeta",
   "app.deleteMarkdownFile": "Eliminar archivo",
   "app.confirmDeleteMarkdownFile": "¿Eliminar este archivo?",
+  "app.confirmDeleteSelectedMarkdownFiles": "¿Eliminar estos {count} archivos?",
   "app.cancelDeleteMarkdownFile": "Cancelar",
   "app.confirmDeleteMarkdownFileAction": "Confirmar",
   "app.deleteMarkdownFolder": "Eliminar carpeta",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "Renommer le dossier",
   "app.deleteMarkdownFile": "Supprimer le fichier",
   "app.confirmDeleteMarkdownFile": "Supprimer ce fichier ?",
+  "app.confirmDeleteSelectedMarkdownFiles": "Supprimer ces {count} fichiers ?",
   "app.cancelDeleteMarkdownFile": "Annuler",
   "app.confirmDeleteMarkdownFileAction": "Confirmer",
   "app.deleteMarkdownFolder": "Supprimer le dossier",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "Rinomina cartella",
   "app.deleteMarkdownFile": "Elimina file",
   "app.confirmDeleteMarkdownFile": "Eliminare questo file?",
+  "app.confirmDeleteSelectedMarkdownFiles": "Eliminare questi {count} file?",
   "app.cancelDeleteMarkdownFile": "Annulla",
   "app.confirmDeleteMarkdownFileAction": "Conferma",
   "app.deleteMarkdownFolder": "Elimina cartella",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -349,6 +349,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "フォルダ名を変更",
   "app.deleteMarkdownFile": "ファイルを削除",
   "app.confirmDeleteMarkdownFile": "このファイルを削除しますか？",
+  "app.confirmDeleteSelectedMarkdownFiles": "選択した {count} 件のファイルを削除しますか？",
   "app.cancelDeleteMarkdownFile": "キャンセル",
   "app.confirmDeleteMarkdownFileAction": "確認",
   "app.deleteMarkdownFolder": "フォルダを削除",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "폴더 이름 변경",
   "app.deleteMarkdownFile": "파일 삭제",
   "app.confirmDeleteMarkdownFile": "이 파일을 삭제할까요?",
+  "app.confirmDeleteSelectedMarkdownFiles": "선택한 {count}개 파일을 삭제할까요?",
   "app.cancelDeleteMarkdownFile": "취소",
   "app.confirmDeleteMarkdownFileAction": "확인",
   "app.deleteMarkdownFolder": "폴더 삭제",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "Renomear pasta",
   "app.deleteMarkdownFile": "Excluir arquivo",
   "app.confirmDeleteMarkdownFile": "Excluir este arquivo?",
+  "app.confirmDeleteSelectedMarkdownFiles": "Excluir estes {count} arquivos?",
   "app.cancelDeleteMarkdownFile": "Cancelar",
   "app.confirmDeleteMarkdownFileAction": "Confirmar",
   "app.deleteMarkdownFolder": "Excluir pasta",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -341,6 +341,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "Переименовать папку",
   "app.deleteMarkdownFile": "Удалить файл",
   "app.confirmDeleteMarkdownFile": "Удалить этот файл?",
+  "app.confirmDeleteSelectedMarkdownFiles": "Удалить выбранные файлы ({count})?",
   "app.cancelDeleteMarkdownFile": "Отмена",
   "app.confirmDeleteMarkdownFileAction": "Подтвердить",
   "app.deleteMarkdownFolder": "Удалить папку",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -562,6 +562,7 @@ export type I18nKey =
   | "app.renameMarkdownFolder"
   | "app.deleteMarkdownFile"
   | "app.confirmDeleteMarkdownFile"
+  | "app.confirmDeleteSelectedMarkdownFiles"
   | "app.cancelDeleteMarkdownFile"
   | "app.confirmDeleteMarkdownFileAction"
   | "app.deleteMarkdownFolder"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -551,6 +551,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "重命名文件夹",
   "app.deleteMarkdownFile": "删除文件",
   "app.confirmDeleteMarkdownFile": "确定删除这个文件吗？",
+  "app.confirmDeleteSelectedMarkdownFiles": "确定删除这 {count} 个文件吗？",
   "app.cancelDeleteMarkdownFile": "取消",
   "app.confirmDeleteMarkdownFileAction": "确认",
   "app.deleteMarkdownFolder": "删除文件夹",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -349,6 +349,7 @@ const messages: LocaleMessages = {
   "app.renameMarkdownFolder": "重新命名資料夾",
   "app.deleteMarkdownFile": "刪除檔案",
   "app.confirmDeleteMarkdownFile": "確定要刪除此檔案嗎？",
+  "app.confirmDeleteSelectedMarkdownFiles": "確定要刪除這 {count} 個檔案嗎？",
   "app.cancelDeleteMarkdownFile": "取消",
   "app.confirmDeleteMarkdownFileAction": "確認",
   "app.deleteMarkdownFolder": "刪除資料夾",


### PR DESCRIPTION
## Summary
- add Cmd/Ctrl and Shift multi-selection for sidebar markdown files
- support selected-file batch delete with plural confirmation copy
- disable single-file-only context menu actions during multi-select
- clear multi-selection when clicking outside file rows

## Validation
- pnpm --filter @markra/app test
- pnpm exec vitest run src/runtime/context-menu-items.test.ts src/components/MarkdownFileTreeDrawer.test.tsx
- pnpm --filter @markra/app build
- pnpm --filter @markra/app typecheck:test
- pnpm --filter @markra/shared test -- i18n
- pnpm --filter @markra/shared build
- pnpm --filter @markra/desktop exec tsc -p tsconfig.app.json --noEmit
- git diff --check

Closes #364