### PR TITLE
fix(editor): restore horizontal rule selection

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -274,6 +274,23 @@ function findNodeStartPosition(view: EditorView, typeName: string) {
   return position;
 }
 
+function findTopLevelEmptyParagraphPosition(view: EditorView) {
+  let position: number | null = null;
+
+  view.state.doc.forEach((node, offset) => {
+    if (position !== null) return;
+    if (node.type.name !== "paragraph" || node.content.size > 0) return;
+
+    position = offset;
+  });
+
+  if (position === null) {
+    throw new Error("Could not find top-level empty paragraph in editor.");
+  }
+
+  return position;
+}
+
 function pressEnter(view: EditorView) {
   const event = new KeyboardEvent("keydown", {
     key: "Enter",
@@ -3011,7 +3028,82 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
-  it("ignores clicks above the visual line inside a horizontal rule hit target", async () => {
+  it("selects a horizontal rule from a line click", async () => {
+    const { container, view } = await renderEditor("First\n\n---\n\nSecond");
+    const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const rule = surface?.querySelector<HTMLElement>("hr");
+    expect(rule).toBeInTheDocument();
+
+    moveCursor(view, findTextPosition(view, "Second"));
+    const lineResult = fireEvent.mouseDown(rule!, {
+      button: 0,
+      clientX: 200,
+      clientY: 140
+    });
+
+    expect(lineResult).toBe(false);
+    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "hr"));
+    restoreLayout();
+  });
+
+  it("selects a horizontal rule between an image and another horizontal rule", async () => {
+    const markdown = [
+      "![First](assets/first.png)",
+      "",
+      "***",
+      "",
+      "![Second](assets/second.png)",
+      "",
+      "***",
+      "",
+      "***"
+    ].join("\n");
+    const { container, view } = await renderEditor(markdown);
+    const rules = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror hr"));
+    const rulePositions = nodePositionsByType(view, "hr");
+
+    expect(rules).toHaveLength(3);
+    expect(rulePositions).toHaveLength(3);
+    moveCursor(view, findNodeStartPosition(view, "image"));
+
+    fireEvent.mouseDown(rules[1]);
+
+    await waitFor(() => expect(view.state.selection).toBeInstanceOf(NodeSelection));
+    expect(view.state.selection.from).toBe(rulePositions[1]);
+  });
+
+  it("selects a horizontal rule below an image from its forgiving hit target", async () => {
+    const { container, view } = await renderEditor("![Screenshot](assets/image.png)\n\n---\n\nSecond");
+    const surface = container.querySelector<HTMLElement>(".ProseMirror");
+    const rule = surface?.querySelector<HTMLElement>("hr");
+    expect(rule).toBeInTheDocument();
+
+    rule!.getBoundingClientRect = vi.fn(() => ({
+      bottom: 146,
+      height: 12,
+      left: 160,
+      right: 640,
+      top: 134,
+      width: 480,
+      x: 160,
+      y: 134,
+      toJSON: () => ({})
+    } as DOMRect));
+
+    moveCursor(view, findTextPosition(view, "Second"));
+    fireEvent.mouseDown(rule!, {
+      button: 0,
+      clientX: 200,
+      clientY: 136
+    });
+
+    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "hr"));
+  });
+
+  it("ignores clicks above the visual line outside a horizontal rule element", async () => {
     const { container, view } = await renderEditor("First\n\n---\n\nSecond");
     const restoreLayout = mockThinHorizontalRuleBlockDragLayout(view, container);
     const surface = container.querySelector<HTMLElement>(".ProseMirror");
@@ -3032,7 +3124,7 @@ describe("MarkdownPaper editing", () => {
 
     const secondCursor = findTextPosition(view, "Second");
     moveCursor(view, secondCursor);
-    const upperHitTargetResult = fireEvent.mouseDown(rule!, {
+    const upperHitTargetResult = fireEvent.mouseDown(surface!, {
       button: 0,
       clientX: 200,
       clientY: 136
@@ -3057,6 +3149,36 @@ describe("MarkdownPaper editing", () => {
     expect(editedDocument.child(0).type.name).toBe("paragraph");
     expect(editedDocument.child(0).textContent).toContain("Inserted");
     expect(editedDocument.child(1).type.name).toBe("hr");
+  });
+
+  it("removes an empty paragraph below a horizontal rule on Backspace", async () => {
+    const { editor, view } = await renderEditor("First\n\n---\n\n\n\nSecond");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const emptyParagraphPosition = findTopLevelEmptyParagraphPosition(view);
+
+    expect(view.state.doc.child(2).type.name).toBe("paragraph");
+    expect(view.state.doc.child(2).content.size).toBe(0);
+    moveCursor(view, emptyParagraphPosition + 1);
+
+    expect(pressBackspace(view)).toBe(true);
+    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "hr"));
+    expect(serializeMarkdown(view.state.doc)).toBe("First\n\n***\n\nSecond\n");
+  });
+
+  it("removes an empty paragraph above a horizontal rule on Delete", async () => {
+    const { editor, view } = await renderEditor("First\n\n\n\n---\n\nSecond");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const emptyParagraphPosition = findTopLevelEmptyParagraphPosition(view);
+
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+    moveCursor(view, emptyParagraphPosition + 1);
+
+    expect(pressShortcut(view, "Delete")).toBe(true);
+    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+    expect(view.state.selection.from).toBe(findNodeStartPosition(view, "hr"));
+    expect(serializeMarkdown(view.state.doc)).toBe("First\n\n***\n\nSecond\n");
   });
 
   it("reorders blocks below a table drop target", async () => {

--- a/packages/editor/src/block-gap.ts
+++ b/packages/editor/src/block-gap.ts
@@ -1,9 +1,15 @@
-import { Plugin } from "@milkdown/kit/prose/state";
+import { NodeSelection, Plugin } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
 const gapGuardedBlockNames = new Set(["hr"]);
 const fallbackGuardedGapPadding = 20;
+const guardedBlockVisualLineHeight = 2;
+
+type GuardedBlockTarget = {
+  kind: "guard" | "line";
+  position: number;
+};
 
 function isPlainLeftMouseDown(event: MouseEvent) {
   return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
@@ -56,6 +62,13 @@ function verticalPointIsInsideBlockHitTarget(top: number, rect: DOMRect) {
   return top >= rect.top && top <= rect.bottom;
 }
 
+function verticalPointIsInsideBlockVisualLine(top: number, rect: DOMRect) {
+  const center = rect.top + rect.height / 2;
+  const halfHeight = Math.min(Math.max(guardedBlockVisualLineHeight / 2, 0.5), Math.max(rect.height / 2, 0.5));
+
+  return top >= center - halfHeight && top <= center + halfHeight;
+}
+
 function verticalPointIsInsideGuardedBlockZone(top: number, rect: DOMRect, gap: { bottom: number; top: number }) {
   return verticalPointIsInsideBlockGap(top, rect, gap) || verticalPointIsInsideBlockHitTarget(top, rect);
 }
@@ -65,8 +78,27 @@ function eventTargetsEditorContent(view: EditorView, target: EventTarget | null)
   return Boolean(element && (element === view.dom || view.dom.contains(element)));
 }
 
-function pointIsInGuardedBlockGap(view: EditorView, left: number, top: number) {
-  let isInGap = false;
+function guardedBlockElementTarget(view: EditorView, target: EventTarget | null): GuardedBlockTarget | null {
+  const element = eventTargetElement(target)?.closest("hr");
+  if (!element || !view.dom.contains(element)) return null;
+
+  let blockTarget: GuardedBlockTarget | null = null;
+  view.state.doc.descendants((node, position) => {
+    if (!gapGuardedBlockNames.has(node.type.name)) return true;
+    if (view.nodeDOM(position) !== element) return true;
+
+    blockTarget = {
+      kind: "line",
+      position
+    };
+    return false;
+  });
+
+  return blockTarget;
+}
+
+function guardedBlockTargetAtPoint(view: EditorView, left: number, top: number): GuardedBlockTarget | null {
+  let target: GuardedBlockTarget | null = null;
 
   view.state.doc.descendants((node, position) => {
     if (!gapGuardedBlockNames.has(node.type.name)) return true;
@@ -74,18 +106,44 @@ function pointIsInGuardedBlockGap(view: EditorView, left: number, top: number) {
     const dom = view.nodeDOM(position);
     const element = eventTargetElement(dom);
     const rect = element?.getBoundingClientRect();
-    if (!element || !rect || !horizontalPointIsInsideRect(left, rect)) return false;
+    if (!element || !rect || !horizontalPointIsInsideRect(left, rect)) return true;
 
     const gap = blockGapExtents(element);
-    if (verticalPointIsInsideGuardedBlockZone(top, rect, gap)) {
-      isInGap = true;
+    if (verticalPointIsInsideBlockHitTarget(top, rect) && verticalPointIsInsideBlockVisualLine(top, rect)) {
+      target = {
+        kind: "line",
+        position
+      };
       return false;
     }
 
-    return false;
+    if (verticalPointIsInsideGuardedBlockZone(top, rect, gap)) {
+      target = {
+        kind: "guard",
+        position
+      };
+    }
+
+    return true;
   });
 
-  return isInGap;
+  return target;
+}
+
+function guardedBlockTargetFromEvent(view: EditorView, event: MouseEvent): GuardedBlockTarget | null {
+  const elementTarget = guardedBlockElementTarget(view, event.target);
+  if (!elementTarget) return guardedBlockTargetAtPoint(view, event.clientX, event.clientY);
+
+  return elementTarget;
+}
+
+function selectGuardedBlock(view: EditorView, position: number) {
+  view.dispatch(
+    view.state.tr
+      .setSelection(NodeSelection.create(view.state.doc, position))
+      .scrollIntoView()
+  );
+  view.focus();
 }
 
 export function createBlockGapPlugin() {
@@ -95,10 +153,12 @@ export function createBlockGapPlugin() {
         mousedown(view, event) {
           if (!view.editable || !isPlainLeftMouseDown(event)) return false;
           if (!eventTargetsEditorContent(view, event.target)) return false;
-          if (!pointIsInGuardedBlockGap(view, event.clientX, event.clientY)) return false;
+          const target = guardedBlockTargetFromEvent(view, event);
+          if (!target) return false;
 
           event.preventDefault();
           event.stopPropagation();
+          if (target.kind === "line") selectGuardedBlock(view, target.position);
           return true;
         }
       }

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -560,6 +560,65 @@ function moveBackToImageFromEmptyParagraph(view: EditorView, paragraph: NodeType
   return true;
 }
 
+function emptyTopLevelParagraphAdjacentToHorizontalRule(
+  view: EditorView,
+  paragraph: NodeType,
+  direction: "backward" | "forward"
+) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return null;
+
+  const { $from } = selection;
+  if ($from.depth !== 1) return null;
+  if ($from.parent.type !== paragraph || $from.parent.content.size > 0 || $from.parentOffset !== 0) return null;
+
+  const index = $from.index(0);
+  const paragraphFrom = $from.before(1);
+  const paragraphTo = $from.after(1);
+
+  if (direction === "backward") {
+    if (index <= 0) return null;
+
+    const previousNode = view.state.doc.child(index - 1);
+    if (previousNode.type.name !== "hr") return null;
+
+    return {
+      blockPosition: paragraphFrom - previousNode.nodeSize,
+      paragraphFrom,
+      paragraphTo
+    };
+  }
+
+  if (index >= view.state.doc.childCount - 1) return null;
+
+  const nextNode = view.state.doc.child(index + 1);
+  if (nextNode.type.name !== "hr") return null;
+
+  return {
+    blockPosition: paragraphTo,
+    paragraphFrom,
+    paragraphTo
+  };
+}
+
+function moveToHorizontalRuleFromEmptyParagraph(
+  view: EditorView,
+  paragraph: NodeType,
+  direction: "backward" | "forward"
+) {
+  const target = emptyTopLevelParagraphAdjacentToHorizontalRule(view, paragraph, direction);
+  if (!target) return false;
+
+  const transaction = view.state.tr.delete(target.paragraphFrom, target.paragraphTo);
+  view.dispatch(
+    transaction
+      .setSelection(NodeSelection.create(transaction.doc, transaction.mapping.map(target.blockPosition, -1)))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
 const plainTextIndentation = "  ";
 
 function insertPlainTextIndentation(view: EditorView) {
@@ -659,10 +718,12 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
 
           event.preventDefault();
           return true;
-        } else if (event.key === "Backspace" && !hasModifier) {
-          const handled =
-            moveBackIntoTableFromEmptyParagraph(view, paragraph) ||
-            moveBackToImageFromEmptyParagraph(view, paragraph);
+        } else if ((event.key === "Backspace" || event.key === "Delete") && !hasModifier) {
+          const handled = event.key === "Backspace"
+            ? moveBackIntoTableFromEmptyParagraph(view, paragraph) ||
+              moveBackToImageFromEmptyParagraph(view, paragraph) ||
+              moveToHorizontalRuleFromEmptyParagraph(view, paragraph, "backward")
+            : moveToHorizontalRuleFromEmptyParagraph(view, paragraph, "forward");
           if (!handled) return false;
 
           event.preventDefault();


### PR DESCRIPTION
## Summary
- Make horizontal rule clicks select the rule node directly, including rules below images and adjacent rules.
- Preserve surrounding-gap click protection while allowing the full rule hit target to select.
- Allow Backspace/Delete from empty paragraphs around horizontal rules to remove the blank paragraph and select the rule.

## Why
Horizontal rules could lose their selectable hit target when adjacent to images or blank paragraphs, which also made nearby empty lines feel impossible to delete.

## Validation
- `pnpm vitest run src/components/MarkdownPaper.test.tsx`
- `pnpm --filter @markra/app typecheck:test`
- `git diff --check`

## Risk
- Low; scoped to horizontal-rule click handling and adjacent empty-paragraph keyboard behavior.
