### PR TITLE
fix(app): swap conflicting keyboard shortcuts

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2557,6 +2557,7 @@ function WorkspaceApp() {
 
     handleRunEditorShortcut(shortcut.key, {
       altKey: Boolean(shortcut.altKey),
+      code: shortcut.code,
       shiftKey: Boolean(shortcut.shiftKey)
     });
     syncAiSelectionToolbarFormattingState();

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -340,7 +340,7 @@ function pressArrowDown(view: EditorView) {
 function pressShortcut(
   view: EditorView,
   key: string,
-  modifiers: Pick<KeyboardEventInit, "altKey" | "ctrlKey" | "metaKey" | "shiftKey"> = {}
+  modifiers: Pick<KeyboardEventInit, "altKey" | "code" | "ctrlKey" | "metaKey" | "shiftKey"> = {}
 ) {
   const event = new KeyboardEvent("keydown", {
     key,
@@ -6296,14 +6296,14 @@ describe("MarkdownPaper editing", () => {
     const bullet = await renderEditor();
     typeText(bullet.view, "Bullet");
 
-    expect(pressShortcut(bullet.view, "8", { metaKey: true, shiftKey: true })).toBe(true);
+    expect(pressShortcut(bullet.view, "*", { code: "Digit8", metaKey: true, shiftKey: true })).toBe(true);
 
     expect(bullet.container.querySelector(".ProseMirror ul li")).toHaveTextContent("Bullet");
 
     const ordered = await renderEditor();
     typeText(ordered.view, "Ordered");
 
-    expect(pressShortcut(ordered.view, "7", { metaKey: true, shiftKey: true })).toBe(true);
+    expect(pressShortcut(ordered.view, "&", { code: "Digit7", metaKey: true, shiftKey: true })).toBe(true);
 
     expect(ordered.container.querySelector(".ProseMirror ol li")).toHaveTextContent("Ordered");
 

--- a/packages/app/src/components/settings/KeyboardShortcutsSettings.test.tsx
+++ b/packages/app/src/components/settings/KeyboardShortcutsSettings.test.tsx
@@ -89,6 +89,87 @@ describe("KeyboardShortcutsSettings", () => {
     });
   });
 
+  it("records shifted digit and punctuation shortcuts from physical keys", () => {
+    const onUpdatePreferences = vi.fn();
+    const preferences: EditorPreferences = {
+      ...defaultEditorPreferences,
+      markdownShortcuts: defaultMarkdownShortcuts
+    };
+
+    render(
+      <KeyboardShortcutsSettings
+        preferences={preferences}
+        translate={translate}
+        onUpdatePreferences={onUpdatePreferences}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Bullet List shortcut" }));
+    fireEvent.keyDown(window, {
+      code: "Digit8",
+      key: "*",
+      metaKey: true,
+      shiftKey: true
+    });
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...preferences,
+      markdownShortcuts: {
+        ...defaultMarkdownShortcuts,
+        bulletList: "Mod+Shift+8"
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Link shortcut" }));
+    fireEvent.keyDown(window, {
+      code: "Slash",
+      key: "?",
+      metaKey: true,
+      shiftKey: true
+    });
+
+    expect(onUpdatePreferences).toHaveBeenLastCalledWith({
+      ...preferences,
+      markdownShortcuts: {
+        ...defaultMarkdownShortcuts,
+        link: "Mod+Shift+/"
+      }
+    });
+  });
+
+  it("swaps existing shortcuts when recording a chord already used by another action", () => {
+    const onUpdatePreferences = vi.fn();
+    const preferences: EditorPreferences = {
+      ...defaultEditorPreferences,
+      markdownShortcuts: defaultMarkdownShortcuts
+    };
+
+    render(
+      <KeyboardShortcutsSettings
+        preferences={preferences}
+        translate={translate}
+        onUpdatePreferences={onUpdatePreferences}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Link shortcut" }));
+    fireEvent.keyDown(window, {
+      code: "Digit8",
+      key: "*",
+      metaKey: true,
+      shiftKey: true
+    });
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...preferences,
+      markdownShortcuts: {
+        ...defaultMarkdownShortcuts,
+        bulletList: "Mod+K",
+        link: "Mod+Shift+8"
+      }
+    });
+  });
+
   it("uses Ctrl labels for markdown shortcuts on Windows and Linux", () => {
     render(
       <KeyboardShortcutsSettings

--- a/packages/app/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/packages/app/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -5,7 +5,8 @@ import {
   markdownShortcutFromKeyboardEvent,
   normalizeMarkdownShortcuts,
   parseMarkdownShortcut,
-  type MarkdownShortcutAction
+  type MarkdownShortcutAction,
+  type MarkdownShortcutBindings
 } from "@markra/editor";
 import type { I18nKey } from "@markra/shared";
 import type { EditorPreferences } from "../../lib/settings/app-settings";
@@ -84,6 +85,27 @@ const keyboardShortcutSections: Array<{
 
 function keyboardShortcutActionAvailable(action: MarkdownShortcutAction, aiEnabled: boolean) {
   return aiEnabled || (action !== "toggleAiAgent" && action !== "toggleAiCommand");
+}
+
+function assignKeyboardShortcut(
+  shortcuts: MarkdownShortcutBindings,
+  action: MarkdownShortcutAction,
+  nextShortcut: string
+) {
+  const nextShortcuts: MarkdownShortcutBindings = {
+    ...shortcuts,
+    [action]: nextShortcut
+  };
+  const previousShortcut = shortcuts[action];
+  const conflictingAction = (Object.keys(shortcuts) as MarkdownShortcutAction[]).find(
+    (candidate) => candidate !== action && shortcuts[candidate] === nextShortcut
+  );
+
+  if (conflictingAction) {
+    nextShortcuts[conflictingAction] = previousShortcut;
+  }
+
+  return normalizeMarkdownShortcuts(nextShortcuts);
 }
 
 function formatShortcutForPlatform(shortcut: string, platform: DesktopPlatform) {
@@ -189,10 +211,7 @@ export function KeyboardShortcutsSettings({
       event.stopPropagation();
       onUpdatePreferences({
         ...preferences,
-        markdownShortcuts: normalizeMarkdownShortcuts({
-          ...shortcuts,
-          [activeAction]: nextShortcut
-        })
+        markdownShortcuts: assignKeyboardShortcut(shortcuts, activeAction, nextShortcut)
       });
       setActiveAction(null);
     };

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -731,7 +731,7 @@ export function useEditorController() {
   const runEditorShortcut = useCallback(
     (
       key: string,
-      modifiers: Pick<KeyboardEventInit, "altKey" | "shiftKey"> = {},
+      modifiers: Pick<KeyboardEventInit, "altKey" | "code" | "shiftKey"> = {},
       options: { focusEditor?: boolean } = {}
     ) => {
       const editor = editorRef.current;

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -149,6 +149,24 @@ describe("useNativeMenuHandlers", () => {
     });
   });
 
+  it("routes shifted digit formatting commands through physical key data", () => {
+    const runEditorShortcut = vi.fn();
+    const { result } = renderHook(() =>
+      useNativeMenuHandlers({
+        ...baseOptions,
+        runEditorShortcut
+      })
+    );
+
+    result.current.formatBulletList?.();
+
+    expect(runEditorShortcut).toHaveBeenCalledWith("*", {
+      altKey: false,
+      code: "Digit8",
+      shiftKey: true
+    });
+  });
+
   it("routes native edit history commands through editor shortcuts", () => {
     const runEditorShortcut = vi.fn();
     const { result } = renderHook(() =>

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -46,7 +46,7 @@ type NativeMenuHandlerOptions = {
   openQuickOpen?: () => unknown | Promise<unknown>;
   openRecentFile?: (file: RecentMarkdownFile) => unknown | Promise<unknown>;
   runAiQuickAction?: (intent: NativeAiQuickActionIntent, prompt: string) => unknown | Promise<unknown>;
-  runEditorShortcut: (key: string, modifiers?: Pick<KeyboardEventInit, "altKey" | "shiftKey">) => unknown;
+  runEditorShortcut: (key: string, modifiers?: Pick<KeyboardEventInit, "altKey" | "code" | "shiftKey">) => unknown;
   saveDocument: () => unknown | Promise<unknown>;
   saveDocumentAs: () => unknown | Promise<unknown>;
   toggleAiAgent?: () => unknown | Promise<unknown>;
@@ -276,6 +276,7 @@ export function useNativeMenuHandlers({
 
     latestOptionsRef.current.runEditorShortcut(shortcut.key, {
       altKey: Boolean(shortcut.altKey),
+      code: shortcut.code,
       shiftKey: Boolean(shortcut.shiftKey)
     });
   }

--- a/packages/shared/src/keyboard-shortcuts.test.ts
+++ b/packages/shared/src/keyboard-shortcuts.test.ts
@@ -1,6 +1,10 @@
 import {
   defaultKeyboardShortcuts,
+  formatKeyboardShortcut,
+  keyboardShortcutFromKeyboardEvent,
   keyboardShortcutActions,
+  keyboardShortcutToKeyboardEventInit,
+  matchesKeyboardShortcutEvent,
   normalizeKeyboardShortcuts
 } from "./keyboard-shortcuts";
 
@@ -48,5 +52,45 @@ describe("keyboard shortcuts", () => {
     expect(normalizeKeyboardShortcuts({
       toggleDocumentHistory: "Mod+H"
     }).toggleDocumentHistory).toBe(defaultKeyboardShortcuts.toggleDocumentHistory);
+  });
+
+  it("uses physical digit keys for shifted digit shortcuts", () => {
+    const event = new KeyboardEvent("keydown", {
+      code: "Digit8",
+      key: "*",
+      metaKey: true,
+      shiftKey: true
+    });
+
+    expect(keyboardShortcutFromKeyboardEvent(event)).toBe("Mod+Shift+8");
+    expect(matchesKeyboardShortcutEvent(event, "Mod+Shift+8")).toBe(true);
+  });
+
+  it("records and matches punctuation shortcuts", () => {
+    const event = new KeyboardEvent("keydown", {
+      code: "Slash",
+      ctrlKey: true,
+      key: "?",
+      shiftKey: true
+    });
+
+    expect(formatKeyboardShortcut("Mod+/")).toBe("Mod+/");
+    expect(keyboardShortcutFromKeyboardEvent(event)).toBe("Mod+Shift+/");
+    expect(matchesKeyboardShortcutEvent(event, "Mod+Shift+/")).toBe(true);
+  });
+
+  it("creates realistic keyboard event init values for shifted physical keys", () => {
+    expect(keyboardShortcutToKeyboardEventInit("Mod+Shift+8")).toEqual({
+      altKey: false,
+      code: "Digit8",
+      key: "*",
+      shiftKey: true
+    });
+    expect(keyboardShortcutToKeyboardEventInit("Mod+Shift+/")).toEqual({
+      altKey: false,
+      code: "Slash",
+      key: "?",
+      shiftKey: true
+    });
   });
 });

--- a/packages/shared/src/keyboard-shortcuts.ts
+++ b/packages/shared/src/keyboard-shortcuts.ts
@@ -107,6 +107,10 @@ export type ParsedKeyboardShortcut = {
   shift: boolean;
 };
 
+export type KeyboardShortcutEventInit = Pick<KeyboardEventInit, "altKey" | "code" | "shiftKey"> & {
+  key: string;
+};
+
 export function isKeyboardShortcutModKey(event: Pick<KeyboardEvent, "ctrlKey" | "metaKey">) {
   return event.metaKey || event.ctrlKey;
 }
@@ -124,12 +128,87 @@ export function matchesKeyboardShortcut(
   );
 }
 
+const shortcutKeyByPhysicalCode: Record<string, string> = {
+  Backquote: "`",
+  Backslash: "\\",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Comma: ",",
+  Digit0: "0",
+  Digit1: "1",
+  Digit2: "2",
+  Digit3: "3",
+  Digit4: "4",
+  Digit5: "5",
+  Digit6: "6",
+  Digit7: "7",
+  Digit8: "8",
+  Digit9: "9",
+  Equal: "=",
+  Minus: "-",
+  Period: ".",
+  Quote: "'",
+  Semicolon: ";",
+  Slash: "/"
+};
+
+const shiftedKeyByPhysicalCode: Record<string, string> = {
+  Backquote: "~",
+  Backslash: "|",
+  BracketLeft: "{",
+  BracketRight: "}",
+  Comma: "<",
+  Digit0: ")",
+  Digit1: "!",
+  Digit2: "@",
+  Digit3: "#",
+  Digit4: "$",
+  Digit5: "%",
+  Digit6: "^",
+  Digit7: "&",
+  Digit8: "*",
+  Digit9: "(",
+  Equal: "+",
+  Minus: "_",
+  Period: ">",
+  Quote: "\"",
+  Semicolon: ":",
+  Slash: "?"
+};
+
+const physicalCodeByShortcutKey = Object.fromEntries(
+  Object.entries(shortcutKeyByPhysicalCode).map(([code, key]) => [key, code])
+) as Record<string, string>;
+
+const punctuationShortcutKeys = new Set([
+  "`",
+  "\\",
+  "[",
+  "]",
+  ",",
+  "=",
+  "-",
+  ".",
+  "'",
+  ";",
+  "/"
+]);
+
 function normalizeShortcutKey(key: string) {
   if (/^[a-z]$/iu.test(key)) return key.toUpperCase();
   if (/^[0-9]$/u.test(key)) return key;
-  if (key === ",") return key;
+  if (punctuationShortcutKeys.has(key)) return key;
 
   return null;
+}
+
+function shortcutKeyFromKeyboardEvent(
+  event: Pick<KeyboardEvent, "key"> & Partial<Pick<KeyboardEvent, "code">>
+) {
+  const physicalKey = event.code ? shortcutKeyByPhysicalCode[event.code] : null;
+  if (physicalKey) return physicalKey;
+
+  return normalizeShortcutKey(event.key);
 }
 
 export function parseKeyboardShortcut(shortcut: unknown): ParsedKeyboardShortcut | null {
@@ -192,30 +271,37 @@ export function formatKeyboardShortcut(shortcut: unknown) {
   ].filter((part): part is string => Boolean(part)).join("+");
 }
 
-export function keyboardShortcutToKeyboardEventInit(shortcut: unknown) {
+export function keyboardShortcutToKeyboardEventInit(shortcut: unknown): KeyboardShortcutEventInit | null {
   const parsed = parseKeyboardShortcut(shortcut);
   if (!parsed) return null;
 
-  return {
+  const code = physicalCodeByShortcutKey[parsed.key];
+  const eventInit: KeyboardShortcutEventInit = {
     altKey: parsed.alt,
-    key: parsed.key,
+    key: parsed.shift && code ? shiftedKeyByPhysicalCode[code] ?? parsed.key : parsed.key,
     shiftKey: parsed.shift
-  } satisfies Pick<KeyboardEventInit, "altKey" | "key" | "shiftKey">;
+  };
+  if (code) eventInit.code = code;
+
+  return eventInit;
 }
 
 export function keyboardShortcutFromKeyboardEvent(
-  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey">
+  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey"> & Partial<Pick<KeyboardEvent, "code">>
 ) {
   if (!event.metaKey && !event.ctrlKey) return null;
   if (event.key === "Alt" || event.key === "Control" || event.key === "Meta" || event.key === "Shift") {
     return null;
   }
 
+  const key = shortcutKeyFromKeyboardEvent(event);
+  if (!key) return null;
+
   return formatKeyboardShortcut([
     "Mod",
     event.shiftKey ? "Shift" : null,
     event.altKey ? "Alt" : null,
-    event.key
+    key
   ].filter((part): part is string => Boolean(part)).join("+"));
 }
 
@@ -259,15 +345,17 @@ export function normalizeKeyboardShortcuts(value: unknown): KeyboardShortcutBind
 }
 
 export function matchesKeyboardShortcutEvent(
-  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey">,
+  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey"> & Partial<Pick<KeyboardEvent, "code">>,
   shortcut: string
 ) {
   const parsed = parseKeyboardShortcut(shortcut);
   if (!parsed) return false;
+  const key = shortcutKeyFromKeyboardEvent(event);
+  if (!key) return false;
 
   return (
     isKeyboardShortcutModKey(event) &&
-    event.key.toLowerCase() === parsed.key.toLowerCase() &&
+    key.toLowerCase() === parsed.key.toLowerCase() &&
     event.altKey === parsed.alt &&
     event.shiftKey === parsed.shift
   );


### PR DESCRIPTION
## Summary
- Normalize shortcut capture and matching through physical key codes for shifted digit and punctuation keys.
- Preserve physical key data when menu and toolbar actions synthesize editor shortcuts.
- Swap an existing shortcut when recording a chord already used by another action, avoiding silent rollback on conflicts.

## Why
- Fixes #373.
- `Cmd/Ctrl+Shift+8` can arrive as `key="*"` with `code="Digit8"`, so matching only `event.key` misses the saved `Mod+Shift+8` binding.
- Settings capture previously normalized duplicate shortcuts back to defaults, which made a conflicting shortcut look like it was not recorded.

## Validation
- `pnpm --filter @markra/shared test -- keyboard-shortcuts.test.ts`
- `pnpm --filter @markra/app test -- KeyboardShortcutsSettings.test.tsx useNativeBindings.test.tsx MarkdownPaper.test.tsx`
- `pnpm --filter @markra/app build`
- `pnpm --filter @markra/shared build`
- `pnpm --filter @markra/editor build`
