### PR TITLE
fix(app): keep editor content above quiet status

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -503,6 +503,22 @@ describe("Markra workspace", () => {
     expect(container.querySelector(".quiet-status")).not.toHaveTextContent("75 words");
   });
 
+  it("keeps the active writing surface clear of the quiet status line", async () => {
+    const { container } = renderApp();
+
+    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(container.querySelector(".markdown-paper")?.getAttribute("style")).toContain("padding-bottom: 56px");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to source mode" }));
+    await waitFor(() => {
+      expect(container.querySelector(".markdown-source-paper")?.getAttribute("style")).toContain(
+        "padding-bottom: 56px"
+      );
+    });
+  });
+
   it("restores a selected history version into the current document", async () => {
     mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
     mockOpenMarkdownFile({

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -198,9 +198,14 @@ const sideDocumentPaneKeyboardStepPercent = 5;
 const sideDocumentMainPanePercentMin = 35;
 const sideDocumentMainPanePercentMax = 70;
 const defaultSideDocumentMainPanePercent = 50;
+const quietStatusOverlayInset = 56;
 
 function persistSideDocumentGroup(group: StoredWorkspaceSideBySideGroup | null) {
   saveStoredWorkspaceState({ sideBySideGroup: group }).catch(() => {});
+}
+
+function editorBottomOverlayInset(aiCommandActive: boolean, aiCommandInset: number) {
+  return Math.max(quietStatusOverlayInset, aiCommandActive ? aiCommandInset : 0);
 }
 
 type AiQuickActionIntent = Exclude<AiEditIntent, "custom">;
@@ -3395,11 +3400,11 @@ function WorkspaceApp() {
                 (splitMode ? activeEditorSurface === "visual" : shouldFocusEditorOnReady(tab.content))
               }
               bottomOverlayInset={
-                tabActive &&
-                !sourceMode &&
-                aiCommandVisible &&
-                (!splitMode || activeEditorSurface === "visual")
-                  ? aiCommandOverlayInset
+                tabActive && !sourceMode
+                  ? editorBottomOverlayInset(
+                      aiCommandVisible && (!splitMode || activeEditorSurface === "visual"),
+                      aiCommandOverlayInset
+                    )
                   : 0
               }
               bodyFontSize={editorPreferences.preferences.bodyFontSize}
@@ -3704,6 +3709,10 @@ function WorkspaceApp() {
                       <div className="min-h-0 overflow-hidden" onFocusCapture={handleSourcePaneFocus}>
                         <LazyMarkdownSourceEditor
                           autoFocus={activeEditorSurface === "source"}
+                          bottomOverlayInset={editorBottomOverlayInset(
+                            aiCommandVisible && activeEditorSurface === "source",
+                            aiCommandOverlayInset
+                          )}
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
                           contentWidth={activeEditorContentWidth}
@@ -3733,6 +3742,7 @@ function WorkspaceApp() {
                       {sourceMode ? (
                         <LazyMarkdownSourceEditor
                           autoFocus
+                          bottomOverlayInset={editorBottomOverlayInset(aiCommandVisible, aiCommandOverlayInset)}
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
                           contentWidth={activeEditorContentWidth}

--- a/packages/app/src/components/LazyMarkdownSourceEditor.tsx
+++ b/packages/app/src/components/LazyMarkdownSourceEditor.tsx
@@ -29,6 +29,7 @@ function markdownSourceContentWidth(contentWidth: EditorContentWidth | undefined
 
 function MarkdownSourceEditorFallback({
   bodyFontSize = 16,
+  bottomOverlayInset = 0,
   contentWidth,
   contentWidthPx,
   editorFontFamily = { family: null, source: "theme" },
@@ -41,7 +42,8 @@ function MarkdownSourceEditorFallback({
     ...(editorFontFamilyCss ? { "--source-editor-font-family": editorFontFamilyCss } : {}),
     fontSize: `${bodyFontSize}px`,
     lineHeight,
-    maxWidth: `${markdownSourceContentWidth(contentWidth, contentWidthPx)}px`
+    maxWidth: `${markdownSourceContentWidth(contentWidth, contentWidthPx)}px`,
+    paddingBottom: bottomOverlayInset > 0 ? `${bottomOverlayInset}px` : 0
   } satisfies MarkdownSourceFallbackStyle;
 
   return (

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -19,6 +19,7 @@ import { EditorWidthResizer } from "./EditorWidthResizer";
 
 export type MarkdownSourceEditorProps = {
   autoFocus?: boolean;
+  bottomOverlayInset?: number;
   bodyFontSize?: number;
   content: string;
   contentWidth?: EditorContentWidth;
@@ -172,6 +173,7 @@ function markdownSourceTheme(): Extension {
 
 export function MarkdownSourceEditor({
   autoFocus = false,
+  bottomOverlayInset = 0,
   bodyFontSize = 16,
   content,
   contentWidth = "default",
@@ -212,7 +214,8 @@ export function MarkdownSourceEditor({
     ...(editorFontFamilyCss ? { "--source-editor-font-family": editorFontFamilyCss } : {}),
     fontSize: `${bodyFontSize}px`,
     lineHeight,
-    maxWidth: `${resolvedContentWidth}px`
+    maxWidth: `${resolvedContentWidth}px`,
+    paddingBottom: bottomOverlayInset > 0 ? `${bottomOverlayInset}px` : 0
   } satisfies MarkdownSourcePaperStyle;
   const topInsetClassName =
     topInset === "tabs"


### PR DESCRIPTION
## Summary
- Add a 56px bottom safe area for the main visual and source editor surfaces so content clears the quiet status line.
- Keep the AI command overlay inset as the larger bottom inset when it is visible.
- Cover the visual and source editor spacing with an app-level regression test.

## Validation
- `pnpm --filter @markra/app test -- App.test.tsx -t "keeps the active writing surface clear of the quiet status line"` passed
- `pnpm --filter @markra/app build` passed