### PR TITLE
fix(app): dismiss transient state across panes

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1391,6 +1391,10 @@ function WorkspaceApp() {
     layoutSignature: aiSelectionToolbarLayoutSignature,
     refresh: refreshAiSelectionToolbarAnchor
   });
+  const handleAiSelectionToolbarDismiss = useCallback(() => {
+    setAiSelectionToolbarAnchor(null);
+    clearAiSelectionToolbarCopySuccess();
+  }, [clearAiSelectionToolbarCopySuccess]);
   const handleAiSelectionToolbarOpenCommand = useCallback(() => {
     setAiSelectionToolbarAnchor(null);
     if (aiCommandVisible) return;
@@ -3863,6 +3867,7 @@ function WorkspaceApp() {
             open={aiSelectionToolbarVisible}
             quickActionPrompts={editorPreferences.preferences.aiQuickActionPrompts}
             onCopySelection={handleAiSelectionToolbarCopySelection}
+            onDismiss={handleAiSelectionToolbarDismiss}
             onInsertLink={handleAiSelectionToolbarInsertLink}
             onOpenCommand={handleAiSelectionToolbarOpenCommand}
             onRunFormattingAction={handleAiSelectionToolbarFormattingAction}

--- a/packages/app/src/components/AiSelectionToolbar.test.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.test.tsx
@@ -362,6 +362,31 @@ describe("AiSelectionToolbar", () => {
     expect(onOpenCommand).toHaveBeenCalledTimes(1);
   });
 
+  it("dismisses when a pointer starts outside the toolbar", () => {
+    const onDismiss = vi.fn();
+
+    render(
+      <AiSelectionToolbar
+        anchor={anchor}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onDismiss={onDismiss}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={vi.fn()}
+        onRunAction={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Polish" }));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
   it("does not render when there is no selected text anchor", () => {
     render(
       <AiSelectionToolbar

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -83,6 +83,7 @@ type AiSelectionToolbarProps = {
   activeHeadingLevel?: SelectionHeadingLevel | null;
   quickActionPrompts?: AiQuickActionPrompts;
   onCopySelection: () => unknown;
+  onDismiss?: () => unknown;
   onInsertLink: () => unknown;
   onOpenCommand: () => unknown;
   onRunFormattingAction: (action: SelectionFormattingToolbarAction) => unknown;
@@ -197,6 +198,7 @@ export function AiSelectionToolbar({
   activeHeadingLevel = null,
   quickActionPrompts = defaultAiQuickActionPrompts,
   onCopySelection,
+  onDismiss,
   onInsertLink,
   onOpenCommand,
   onRunFormattingAction,
@@ -205,6 +207,7 @@ export function AiSelectionToolbar({
 }: AiSelectionToolbarProps) {
   const [headingLevelMenuOpen, setHeadingLevelMenuOpen] = useState(false);
   const [headingLevelMenuStyle, setHeadingLevelMenuStyle] = useState<CSSProperties | null>(null);
+  const toolbarRef = useRef<HTMLElement | null>(null);
   const headingLevelButtonRef = useRef<HTMLButtonElement | null>(null);
   const headingLevelMenuRef = useRef<HTMLDivElement | null>(null);
 
@@ -271,6 +274,25 @@ export function AiSelectionToolbar({
       window.removeEventListener("scroll", handleLayoutChange, true);
     };
   }, [headingLevelMenuOpen]);
+
+  useEffect(() => {
+    if (!open || !anchor || !onDismiss) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+
+      if (toolbarRef.current?.contains(target) || headingLevelMenuRef.current?.contains(target)) return;
+
+      onDismiss();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [anchor, onDismiss, open]);
 
   if (!open || !anchor) return null;
 
@@ -340,6 +362,7 @@ export function AiSelectionToolbar({
   return (
     <section
       className="ai-selection-toolbar pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full animate-[markra-ai-float-in_160ms_ease-out_both] motion-reduce:animate-none"
+      ref={toolbarRef}
       style={style}
       role="toolbar"
       aria-label={label("app.aiQuickActions")}

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -2180,6 +2180,32 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(renameFile).not.toHaveBeenCalled();
   });
 
+  it("cancels create inputs when a pointer starts outside the file tree", () => {
+    const createFile = vi.fn();
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onCreateFile={createFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+    expect(screen.getByRole("textbox", { name: "New file name" })).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole("textbox", { name: "New file name" })).not.toBeInTheDocument();
+    expect(createFile).not.toHaveBeenCalled();
+  });
+
   it("finishes active file tree inputs when another file row is clicked", async () => {
     const openFile = vi.fn();
     const createFile = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -1174,6 +1174,26 @@ export function MarkdownFileTreeDrawer({
     };
   }, [renamingPath, commitRenameFile]);
 
+  useEffect(() => {
+    if (!creatingFile && !creatingFolder) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+
+      const fileTreeRoot = fileTreeBodyRef.current?.closest(".markdown-file-tree");
+      if (fileTreeRoot?.contains(target)) return;
+
+      cancelFileTreeInputs();
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [creatingFile, creatingFolder, cancelFileTreeInputs]);
+
   const creatingAtParentPath = (parentPath: string | null | undefined, depth = 0) => {
     return creatingAtFileTreeParentPath(parentPath, depth, creatingParentPath);
   };


### PR DESCRIPTION
## Summary
- Dismiss the AI selection floating toolbar when a pointer starts outside the toolbar or its heading menu.
- Wire the app to hide that toolbar on outside clicks, including sidebars.
- Cancel file-tree create inputs when pointer focus leaves the file tree.

## Why
- Issue #379 reports that editor, left sidebar, and right/sidebar transient states do not consistently refresh each other.
- PR #380 already covers row navigation finishing file-tree naming inputs; this PR adds the remaining cross-pane outside-click behavior.

## Validation
- `pnpm --filter @markra/app test -- src/components/AiSelectionToolbar.test.tsx -t "dismisses when a pointer starts outside the toolbar"` passed
- `pnpm --filter @markra/app test -- src/components/MarkdownFileTreeDrawer.test.tsx -t "cancels create inputs when a pointer starts outside the file tree"` passed
- `pnpm --filter @markra/app test -- src/components/AiSelectionToolbar.test.tsx src/components/MarkdownFileTreeDrawer.test.tsx` passed on rerun
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed

## Related Issues
- Closes #379