### PR TITLE
fix(app): collapse editor view mode controls

### DIFF
--- a/packages/app/src/App.document-history.test.tsx
+++ b/packages/app/src/App.document-history.test.tsx
@@ -30,12 +30,27 @@ vi.mock("./hooks/useEditorController", async (importOriginal) => {
 installAppTestHarness();
 
 async function selectEditorViewMode(optionName: "Preview" | "Source code" | "Preview + Source") {
-  const targetLabel = `Editor view mode: ${optionName}`;
-  const targetButton = screen.getByRole("button", { name: targetLabel });
-  if (targetButton.getAttribute("aria-pressed") === "true") return;
+  const modeOrder = ["Preview", "Source code", "Preview + Source"] as const;
+  const currentMode = () => {
+    if (screen.queryByRole("button", { name: "Editor view mode: Preview" })) return "Preview";
+    if (screen.queryByRole("button", { name: "Editor view mode: Source code" })) return "Source code";
+    if (screen.queryByRole("button", { name: "Editor view mode: Preview + Source" })) return "Preview + Source";
 
-  fireEvent.click(targetButton);
-  await waitFor(() => expect(screen.getByRole("button", { name: targetLabel })).toHaveAttribute("aria-pressed", "true"));
+    throw new Error("Editor view mode button was not found.");
+  };
+
+  for (let attempts = 0; attempts < modeOrder.length; attempts += 1) {
+    const mode = currentMode();
+    if (mode === optionName) return;
+
+    const nextMode = modeOrder[(modeOrder.indexOf(mode) + 1) % modeOrder.length]!;
+    fireEvent.click(screen.getByRole("button", { name: `Editor view mode: ${mode}` }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: `Editor view mode: ${nextMode}` })).toBeInTheDocument()
+    );
+  }
+
+  throw new Error(`Editor view mode did not cycle to ${optionName}.`);
 }
 
 function replaceMarkdownSource(sourceEditor: HTMLElement, value: string) {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -97,12 +97,46 @@ import { configureAppRuntime, createDefaultAppRuntime, resetAppRuntimeForTests }
 installAppTestHarness();
 
 async function selectEditorViewMode(optionName: "Preview" | "Source code" | "Preview + Source") {
-  const targetLabel = `Editor view mode: ${optionName}`;
-  const targetButton = screen.getByRole("button", { name: targetLabel });
-  if (targetButton.getAttribute("aria-pressed") === "true") return;
+  const modeOrder = ["Preview", "Source code", "Preview + Source"] as const;
+  const currentMode = () => {
+    if (screen.queryByRole("button", { name: "Editor view mode: Preview" })) return "Preview";
+    if (screen.queryByRole("button", { name: "Editor view mode: Source code" })) return "Source code";
+    if (screen.queryByRole("button", { name: "Editor view mode: Preview + Source" })) return "Preview + Source";
 
-  fireEvent.click(targetButton);
-  await waitFor(() => expect(screen.getByRole("button", { name: targetLabel })).toHaveAttribute("aria-pressed", "true"));
+    throw new Error("Editor view mode button was not found.");
+  };
+  const switchSourcePreviewDirectly = async () => {
+    const mode = currentMode();
+    if (
+      !((mode === "Preview" && optionName === "Source code") || (mode === "Source code" && optionName === "Preview"))
+    ) return false;
+
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls.at(-1)?.[0] as NativeMenuHandlers | undefined;
+    if (!menuHandlers?.toggleSourceMode) return false;
+
+    await act(async () => {
+      await menuHandlers.toggleSourceMode?.();
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: `Editor view mode: ${optionName}` })).toBeInTheDocument()
+    );
+    return true;
+  };
+
+  if (await switchSourcePreviewDirectly()) return;
+
+  for (let attempts = 0; attempts < modeOrder.length; attempts += 1) {
+    const mode = currentMode();
+    if (mode === optionName) return;
+
+    const nextMode = modeOrder[(modeOrder.indexOf(mode) + 1) % modeOrder.length]!;
+    fireEvent.click(screen.getByRole("button", { name: `Editor view mode: ${mode}` }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: `Editor view mode: ${nextMode}` })).toBeInTheDocument()
+    );
+  }
+
+  throw new Error(`Editor view mode did not cycle to ${optionName}.`);
 }
 
 const defaultImageUpload = {
@@ -279,7 +313,6 @@ function createStoredEditorPreferences(
     titlebarActions: [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "save", visible: true },
       { id: "theme", visible: true }
     ],
@@ -777,7 +810,6 @@ describe("Markra workspace", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
@@ -789,7 +821,7 @@ describe("Markra workspace", () => {
     await screen.findByText("Welcome to Markra");
 
     const aiButton = screen.getByRole("button", { name: "Toggle Markra AI" });
-    mockTitlebarActionRects(["aiAgent", "sourceMode", "splitMode", "save", "theme"]);
+    mockTitlebarActionRects(["aiAgent", "sourceMode", "save", "theme"]);
 
     fireEvent.mouseDown(aiButton, { button: 0, clientX: 10, clientY: 10 });
     fireEvent.mouseMove(document, { buttons: 1, clientX: 20, clientY: 10 });
@@ -830,10 +862,9 @@ describe("Markra workspace", () => {
         spellcheckLanguage: "en",
         titlebarActions: [
           { id: "sourceMode", visible: true },
-          { id: "splitMode", visible: true },
           { id: "save", visible: true },
-          { id: "aiAgent", visible: true },
-          { id: "theme", visible: true }
+          { id: "theme", visible: true },
+          { id: "aiAgent", visible: true }
         ],
         showWordCount: true,
         wrapCodeBlocks: true
@@ -872,10 +903,9 @@ describe("Markra workspace", () => {
         spellcheckLanguage: "en",
         titlebarActions: [
           { id: "sourceMode", visible: true },
-          { id: "splitMode", visible: true },
           { id: "save", visible: true },
-          { id: "aiAgent", visible: true },
-          { id: "theme", visible: true }
+          { id: "theme", visible: true },
+          { id: "aiAgent", visible: true }
         ],
         showWordCount: true,
         wrapCodeBlocks: true
@@ -1531,7 +1561,6 @@ describe("Markra workspace", () => {
       titlebarActions: [
         { id: "aiAgent" as const, visible: true },
         { id: "sourceMode" as const, visible: true },
-        { id: "splitMode" as const, visible: true },
         { id: "save" as const, visible: true },
         { id: "theme" as const, visible: true }
       ],
@@ -1549,7 +1578,6 @@ describe("Markra workspace", () => {
     expect(within(toolbarGroup).getAllByRole("button").map((button) => button.getAttribute("aria-label"))).toEqual([
       "Toggle Markra AI",
       "Editor view mode",
-      "Switch to preview and source split",
       "Save Markdown",
       "Switch to dark theme",
       "Reset toolbar buttons"
@@ -1560,7 +1588,6 @@ describe("Markra workspace", () => {
         ...initialPreferences,
         titlebarActions: [
           { id: "sourceMode", visible: true },
-          { id: "splitMode", visible: true },
           { id: "save", visible: true },
           { id: "aiAgent", visible: true },
           { id: "theme", visible: true }
@@ -1570,7 +1597,6 @@ describe("Markra workspace", () => {
 
     expect(within(toolbarGroup).getAllByRole("button").map((button) => button.getAttribute("aria-label"))).toEqual([
       "Editor view mode",
-      "Switch to preview and source split",
       "Save Markdown",
       "Toggle Markra AI",
       "Switch to dark theme",
@@ -1663,7 +1689,6 @@ describe("Markra workspace", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
@@ -4337,7 +4362,6 @@ describe("Markra workspace", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],
@@ -4479,7 +4503,6 @@ describe("Markra workspace", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
       ],

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -393,7 +393,7 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".windows-titlebar-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
     expect(container.querySelector(".windows-app-chrome .windows-window-controls")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Editor view mode: Source code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Editor view mode: Preview" }));
 
     expect(toggleSourceMode).toHaveBeenCalledTimes(1);
   });
@@ -796,7 +796,7 @@ describe("NativeTitleBar", () => {
     expect(showHistory).toHaveBeenCalledTimes(1);
   });
 
-  it("selects editor view modes directly from the titlebar action", () => {
+  it("cycles editor view modes from the titlebar action", () => {
     const selectEditorMode = vi.fn();
     const visualModeCase = render(
       <NativeTitleBar
@@ -815,16 +815,13 @@ describe("NativeTitleBar", () => {
       />
     );
 
-    const previewModeButton = screen.getByRole("button", { name: "Editor view mode: Preview" });
-    const sourceModeButton = screen.getByRole("button", { name: "Editor view mode: Source code" });
-    const splitModeButton = screen.getByRole("button", { name: "Editor view mode: Preview + Source" });
-    expect(previewModeButton).toContainElement(visualModeCase.container.querySelector(".lucide-eye"));
-    expect(sourceModeButton).toContainElement(visualModeCase.container.querySelector(".lucide-code-xml"));
-    expect(splitModeButton.querySelector(".lucide-panel-right")).toBeInTheDocument();
-    expect(previewModeButton).toHaveAttribute("aria-pressed", "true");
-    expect(sourceModeButton).toHaveAttribute("aria-pressed", "false");
-    expect(splitModeButton).toHaveAttribute("aria-pressed", "false");
-    expect(previewModeButton).not.toHaveAttribute("aria-haspopup");
+    const sourceModeButton = screen.getByRole("button", { name: "Editor view mode: Preview" });
+    expect(sourceModeButton).toContainElement(visualModeCase.container.querySelector(".lucide-eye"));
+    expect(sourceModeButton).not.toHaveAttribute("aria-pressed");
+    expect(sourceModeButton).not.toHaveAttribute("aria-haspopup");
+    expect(screen.queryByRole("button", { name: "Editor view mode: Source code" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Editor view mode: Preview + Source" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitemradio", { name: "Preview" })).not.toBeInTheDocument();
 
     fireEvent.click(sourceModeButton);
 
@@ -852,9 +849,8 @@ describe("NativeTitleBar", () => {
 
     const sourceViewModeButton = screen.getByRole("button", { name: "Editor view mode: Source code" });
     expect(sourceViewModeButton).toContainElement(sourceModeCase.container.querySelector(".lucide-code-xml"));
-    expect(sourceViewModeButton).toHaveAttribute("aria-pressed", "true");
 
-    fireEvent.click(screen.getByRole("button", { name: "Editor view mode: Preview + Source" }));
+    fireEvent.click(sourceViewModeButton);
 
     expect(selectEditorMode).toHaveBeenLastCalledWith("split");
 
@@ -880,9 +876,8 @@ describe("NativeTitleBar", () => {
 
     const splitViewModeButton = screen.getByRole("button", { name: "Editor view mode: Preview + Source" });
     expect(splitViewModeButton.querySelector(".lucide-panel-right")).toBeInTheDocument();
-    expect(splitViewModeButton).toHaveAttribute("aria-pressed", "true");
 
-    fireEvent.click(screen.getByRole("button", { name: "Editor view mode: Preview" }));
+    fireEvent.click(splitViewModeButton);
 
     expect(selectEditorMode).toHaveBeenLastCalledWith("visual");
   });
@@ -901,7 +896,7 @@ describe("NativeTitleBar", () => {
           { id: "splitMode", visible: true },
           { id: "aiAgent", visible: true },
           { id: "sourceMode", visible: true }
-        ]}
+        ] as any}
         onToggleAiAgent={() => {}}
         onOpenMarkdown={() => {}}
         onSaveMarkdown={() => {}}
@@ -918,11 +913,8 @@ describe("NativeTitleBar", () => {
 
     expect(actionLabels).toEqual([
       "Switch to dark theme",
-      "Switch to preview and source split",
       "Toggle Markra AI",
       "Editor view mode: Preview",
-      "Editor view mode: Source code",
-      "Editor view mode: Preview + Source",
       "Show history"
     ]);
     expect(screen.getByRole("button", { name: "Open Markdown or Folder" }).closest(".titlebar-spacer")).toBeInTheDocument();
@@ -955,7 +947,7 @@ describe("NativeTitleBar", () => {
     );
 
     const aiButton = screen.getByRole("button", { name: "Toggle Markra AI" });
-    mockTitlebarActionRects(["aiAgent", "sourceMode", "save", "theme", "splitMode", "history"]);
+    mockTitlebarActionRects(["aiAgent", "sourceMode", "save", "theme", "history"]);
 
     fireEvent.mouseDown(aiButton, { button: 0, clientX: 10, clientY: 10 });
     fireEvent.mouseMove(document, { buttons: 1, clientX: 20, clientY: 10 });
@@ -968,7 +960,6 @@ describe("NativeTitleBar", () => {
       { id: "save", visible: true },
       { id: "aiAgent", visible: true },
       { id: "theme", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true }
     ]);
   });
@@ -999,7 +990,7 @@ describe("NativeTitleBar", () => {
     );
 
     const saveButton = screen.getByRole("button", { name: "Save Markdown" });
-    mockTitlebarActionRects(["aiAgent", "sourceMode", "save", "theme", "splitMode", "history"]);
+    mockTitlebarActionRects(["aiAgent", "sourceMode", "save", "theme", "history"]);
 
     fireEvent.mouseDown(saveButton, { button: 0, clientX: 80, clientY: 10 });
     fireEvent.mouseMove(document, { buttons: 1, clientX: 70, clientY: 10 });
@@ -1012,7 +1003,6 @@ describe("NativeTitleBar", () => {
       { id: "save", visible: true },
       { id: "sourceMode", visible: true },
       { id: "theme", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true }
     ]);
   });

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -366,68 +366,33 @@ export function NativeTitleBar({
     }
 
     if (id === "sourceMode") {
-      if (!onSelectEditorMode && !onToggleSourceMode) return null;
+      if (!onSelectEditorMode && !onToggleSourceMode && !onToggleSplitMode) return null;
 
       const editorViewModeOptions = [
         { Icon: Eye, label: label("app.editorViewPreview"), mode: "visual" as const },
         { Icon: Code2, label: label("app.editorViewSource"), mode: "source" as const },
         { Icon: PanelRight, label: label("app.editorViewSplit"), mode: "split" as const }
       ];
-
-      return (
-        <div
-          aria-label={label("app.editorViewMode")}
-          className={mergeClassNames(
-            "inline-flex h-7 items-center overflow-hidden rounded-lg border border-transparent bg-transparent",
-            sourceModeDisabled ? "opacity-35" : "",
-            sortable.actionClassName
-          )}
-          role="group"
-        >
-          {editorViewModeOptions.map(({ Icon, label: optionLabel, mode }) => {
-            const selected = editorViewMode === mode;
-
-            return (
-              <button
-                key={mode}
-                aria-label={`${label("app.editorViewMode")}: ${optionLabel}`}
-                aria-pressed={selected}
-                className={mergeClassNames(
-                  "inline-flex size-7 shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-(--text-secondary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)",
-                  selected ? "bg-(--bg-active) text-(--text-heading) opacity-100" : ""
-                )}
-                disabled={sourceModeDisabled}
-                type="button"
-                onClick={(event) => handleTitlebarActionClick("sourceMode", event, () => selectEditorViewMode(mode))}
-                {...sortable.actionAttributes}
-                {...sortable.actionListeners}
-              >
-                <Icon aria-hidden="true" size={15} />
-              </button>
-            );
-          })}
-        </div>
-      );
-    }
-
-    if (id === "splitMode") {
-      if (!onToggleSplitMode) return null;
-
+      const currentEditorViewModeOption =
+        editorViewModeOptions.find((option) => option.mode === editorViewMode) ?? editorViewModeOptions[0]!;
+      const CurrentIcon = currentEditorViewModeOption.Icon;
+      const nextEditorViewMode = editorViewMode === "visual" ? "source" : editorViewMode === "source" ? "split" : "visual";
       return (
         <IconButton
           className={mergeClassNames(
-            splitMode ? "bg-(--bg-active) text-(--text-heading) opacity-100" : "",
+            editorViewMode === "visual" ? "" : "bg-(--bg-active) text-(--text-heading) opacity-100",
             "disabled:opacity-35",
             sortable.actionClassName
           )}
           disabled={sourceModeDisabled}
-          label={splitMode ? label("app.closeSplitMode") : label("app.switchToSplitMode")}
-          pressed={splitMode}
-          onClick={(event) => handleTitlebarActionClick("splitMode", event, onToggleSplitMode)}
+          label={`${label("app.editorViewMode")}: ${currentEditorViewModeOption.label}`}
+          onClick={(event) => {
+            handleTitlebarActionClick("sourceMode", event, () => selectEditorViewMode(nextEditorViewMode));
+          }}
           {...sortable.actionAttributes}
           {...sortable.actionListeners}
         >
-          <PanelRight aria-hidden="true" size={15} />
+          <CurrentIcon aria-hidden="true" size={15} />
         </IconButton>
       );
     }

--- a/packages/app/src/components/settings/EditorSettings.test.tsx
+++ b/packages/app/src/components/settings/EditorSettings.test.tsx
@@ -485,7 +485,6 @@ describe("EditorSettings", () => {
       titlebarActions: [
         { id: "theme", visible: true },
         { id: "save", visible: false },
-        { id: "splitMode", visible: true },
         { id: "sourceMode", visible: true },
         { id: "aiAgent", visible: true }
       ]
@@ -505,7 +504,6 @@ describe("EditorSettings", () => {
     expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
       "Switch to dark theme",
       "Save Markdown",
-      "Switch to preview and source split",
       "Editor view mode",
       "Toggle Markra AI"
     ]);
@@ -525,14 +523,13 @@ describe("EditorSettings", () => {
       titlebarActions: [
         { id: "theme", visible: true },
         { id: "save", visible: true },
-        { id: "splitMode", visible: true },
         { id: "sourceMode", visible: true },
         { id: "aiAgent", visible: true }
       ]
     });
 
     const themeButton = screen.getByRole("button", { name: "Switch to dark theme" });
-    mockTitlebarActionRects(["theme", "save", "splitMode", "sourceMode", "aiAgent"]);
+    mockTitlebarActionRects(["theme", "save", "sourceMode", "aiAgent"]);
 
     fireEvent.mouseDown(themeButton, { button: 0, clientX: 10, clientY: 10 });
     fireEvent.mouseMove(document, { buttons: 1, clientX: 20, clientY: 10 });
@@ -545,7 +542,6 @@ describe("EditorSettings", () => {
       titlebarActions: [
         { id: "save", visible: false },
         { id: "theme", visible: true },
-        { id: "splitMode", visible: true },
         { id: "sourceMode", visible: true },
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
@@ -568,9 +564,8 @@ describe("EditorSettings", () => {
       ...preferences,
       titlebarActions: [
         { id: "theme", visible: true },
-        { id: "save", visible: false },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
+        { id: "save", visible: false },
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ]
@@ -583,7 +578,6 @@ describe("EditorSettings", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "history", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }

--- a/packages/app/src/components/settings/EditorSettings.tsx
+++ b/packages/app/src/components/settings/EditorSettings.tsx
@@ -3,7 +3,6 @@ import {
   Code2,
   History,
   Moon,
-  PanelRight,
   RotateCcw,
   Save,
   Search,
@@ -79,11 +78,6 @@ const titlebarActionOptions: Array<{
     icon: Code2,
     id: "sourceMode",
     labelKey: "app.editorViewMode"
-  },
-  {
-    icon: PanelRight,
-    id: "splitMode",
-    labelKey: "app.switchToSplitMode"
   },
   {
     icon: History,

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -270,7 +270,7 @@ export const defaultAppThemePreferences: AppThemePreferences = {
   darkTheme: "dark",
   lightTheme: "light"
 };
-export type TitlebarActionId = "aiAgent" | "sourceMode" | "splitMode" | "history" | "save" | "theme";
+export type TitlebarActionId = "aiAgent" | "sourceMode" | "history" | "save" | "theme";
 export type TitlebarActionPreference = {
   id: TitlebarActionId;
   visible: boolean;
@@ -388,7 +388,6 @@ export const defaultCustomThemeCssValues: CustomThemeCssValues = {
 export const defaultTitlebarActions: readonly TitlebarActionPreference[] = [
   { id: "aiAgent", visible: true },
   { id: "sourceMode", visible: true },
-  { id: "splitMode", visible: true },
   { id: "history", visible: true },
   { id: "save", visible: true },
   { id: "theme", visible: true }

--- a/packages/app/src/lib/settings/editor-preferences.test.ts
+++ b/packages/app/src/lib/settings/editor-preferences.test.ts
@@ -80,7 +80,6 @@ describe("editor preferences", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "history", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
@@ -206,7 +205,6 @@ describe("editor preferences", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "history", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
@@ -222,6 +220,7 @@ describe("editor preferences", () => {
         { id: "save", visible: false },
         { id: "theme", visible: true },
         { id: "save", visible: true },
+        { id: "splitMode", visible: true },
         { id: "unknown", visible: true },
         { id: "aiAgent", visible: "yes" },
         { id: "open", visible: true }
@@ -231,7 +230,6 @@ describe("editor preferences", () => {
       { id: "theme", visible: true },
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true }
     ]);
   });
@@ -362,7 +360,6 @@ describe("editor preferences", () => {
     const actions = [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true },
       { id: "save", visible: true },
       { id: "theme", visible: true }
@@ -370,7 +367,6 @@ describe("editor preferences", () => {
 
     expect(reorderTitlebarActions(actions, "aiAgent", "save")).toEqual([
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true },
       { id: "save", visible: true },
       { id: "aiAgent", visible: true },
@@ -380,7 +376,6 @@ describe("editor preferences", () => {
       { id: "aiAgent", visible: true },
       { id: "save", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true },
       { id: "theme", visible: true }
     ]);
@@ -643,7 +638,6 @@ describe("editor preferences", () => {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "history", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
@@ -721,7 +715,6 @@ describe("editor preferences", () => {
         { id: "theme", visible: true },
         { id: "save", visible: false },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ],
@@ -796,7 +789,6 @@ describe("editor preferences", () => {
         { id: "theme", visible: true },
         { id: "save", visible: false },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ],

--- a/packages/app/src/lib/settings/settings-events.test.ts
+++ b/packages/app/src/lib/settings/settings-events.test.ts
@@ -210,7 +210,6 @@ describe("settings events", () => {
         { id: "theme", visible: true },
         { id: "save", visible: false },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "aiAgent", visible: true },
         { id: "history", visible: true }
       ],

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -303,7 +303,6 @@ vi.mock("../lib/settings/app-settings", () => ({
     titlebarActions: [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true },
       { id: "save", visible: true },
       { id: "theme", visible: true }
@@ -455,7 +454,6 @@ vi.mock("../lib/settings/app-settings", () => ({
   defaultTitlebarActions: [
     { id: "aiAgent", visible: true },
     { id: "sourceMode", visible: true },
-    { id: "splitMode", visible: true },
     { id: "history", visible: true },
     { id: "save", visible: true },
     { id: "theme", visible: true }
@@ -570,7 +568,6 @@ vi.mock("../lib/settings/app-settings", () => ({
     titlebarActions: [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "history", visible: true },
       { id: "save", visible: true },
       { id: "theme", visible: true }
@@ -591,7 +588,6 @@ vi.mock("../lib/settings/app-settings", () => ({
   normalizeTitlebarActions: vi.fn((actions) => Array.isArray(actions) ? actions : [
     { id: "aiAgent", visible: true },
     { id: "sourceMode", visible: true },
-    { id: "splitMode", visible: true },
     { id: "save", visible: true },
     { id: "theme", visible: true }
   ]),
@@ -603,7 +599,6 @@ vi.mock("../lib/settings/app-settings", () => ({
     const normalized = Array.isArray(actions) ? actions : [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
-      { id: "splitMode", visible: true },
       { id: "save", visible: true },
       { id: "theme", visible: true }
     ];
@@ -1277,7 +1272,6 @@ export function installAppTestHarness() {
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
-        { id: "splitMode", visible: true },
         { id: "history", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }


### PR DESCRIPTION
## Summary
- Collapse the titlebar editor view controls into one current-mode button.
- Make each click cycle Preview -> Source code -> Preview + Source -> Preview; there is no dropdown/list for this control.
- Remove the legacy splitMode titlebar action from defaults, settings, and preference normalization while preserving split editor mode support.
- Update app, document history, titlebar, settings, and preference tests for the single-button cycle behavior and legacy splitMode pruning.

## Why
- The intended UI is one merged editor view control that switches mode on each click, not separate buttons and not a dropdown selector.

## Validation
- `pnpm test` passed.
- `pnpm run typecheck:test` passed.
- `pnpm build` passed.
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check` passed.
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --locked` passed.

## Risk
- Low. This changes the titlebar view mode affordance and drops the old configurable splitMode action; old persisted splitMode entries are normalized away.

## Related Issues
- Refs #385