### PR TITLE
fix(app): keep split resizer line below tabs

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3792,7 +3792,7 @@ function WorkspaceApp() {
                         onKeyDown={handleSplitPaneResizeKeyDown}
                         onPointerDown={handleSplitPaneResizePointerDown}
                       >
-                        <span className="pointer-events-none absolute inset-y-5 left-1/2 w-px -translate-x-1/2 bg-(--border-default) transition-colors duration-150 ease-out group-hover/split-resizer:bg-(--accent) group-focus/split-resizer:bg-(--accent)" />
+                        <span className="pointer-events-none absolute top-10 bottom-5 left-1/2 w-px -translate-x-1/2 bg-(--border-default) transition-colors duration-150 ease-out group-hover/split-resizer:bg-(--accent) group-focus/split-resizer:bg-(--accent)" />
                       </div>
                       <div className="min-h-0 overflow-hidden" onFocusCapture={handleSourcePaneFocus}>
                         <LazyMarkdownSourceEditor
@@ -3880,7 +3880,7 @@ function WorkspaceApp() {
                         onKeyDown={handleSideDocumentPaneResizeKeyDown}
                         onPointerDown={handleSideDocumentPaneResizePointerDown}
                       >
-                        <span className="pointer-events-none absolute inset-y-5 left-1/2 w-px -translate-x-1/2 bg-(--border-default) transition-colors duration-150 ease-out group-hover/side-resizer:bg-(--accent) group-focus/side-resizer:bg-(--accent)" />
+                        <span className="pointer-events-none absolute top-10 bottom-5 left-1/2 w-px -translate-x-1/2 bg-(--border-default) transition-colors duration-150 ease-out group-hover/side-resizer:bg-(--accent) group-focus/side-resizer:bg-(--accent)" />
                       </div>
                       <SideDocumentPane
                         bodyFontSize={editorPreferences.preferences.bodyFontSize}


### PR DESCRIPTION
## Summary
- Limit split-view and side-by-side resizer indicator lines to start below the document tabs/titlebar area.
- Prevent the hover/focus divider highlight from extending into the tab strip while resizing panes.

## Why
- The latest reply on #385 reports that in 0.14.0 the preview+source split divider highlight appears longer than the normal divider and intrudes into the file tabs while dragging.

## Validation
- `pnpm --filter @markra/app build` passed.
- `git diff --cached --check` passed before commit.

## Risk
- Low; this is a visual-only Tailwind class adjustment.
- Not run: manual drag/screenshot QA.

Refs #385