### PR TITLE
fix(app): repair file tree input context menu edit actions

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -2162,13 +2162,101 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.getByRole("menuitem", { name: /Paste/ })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /Select All/ })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("menuitem", { name: /Paste/ }));
+    const pasteItem = screen.getByRole("menuitem", { name: /Paste/ });
+    fireEvent.pointerDown(pasteItem);
+
+    expect(screen.getByRole("textbox", { name: "New file name" })).toBeInTheDocument();
+
+    fireEvent.click(pasteItem);
 
     await waitFor(() => expect(newFileInput).toHaveValue("Pasted note"));
 
     fireEvent.keyDown(newFileInput, { key: "Enter" });
 
     expect(createFile).toHaveBeenCalledWith("Pasted note");
+  });
+
+  it("uses native text insertion for right-click paste so input undo remains available", async () => {
+    const originalExecCommand = document.execCommand;
+    const execCommand = vi.fn(() => true);
+    mockedReadNativeClipboardText.mockResolvedValue("Undoable note");
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+
+    try {
+      render(
+        <MarkdownFileTreeDrawer
+          currentPath="/vault/Untitled.md"
+          files={markdownFiles}
+          open
+          outlineItems={[]}
+          rootName="Obsidian Vault"
+          onCreateFile={vi.fn()}
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+
+      const newFileInput = screen.getByRole("textbox", { name: "New file name" }) as HTMLInputElement;
+      fireEvent.contextMenu(newFileInput, { clientX: 24, clientY: 36 });
+      fireEvent.click(screen.getByRole("menuitem", { name: /Paste/ }));
+
+      await waitFor(() => {
+        expect(execCommand).toHaveBeenCalledWith("insertText", false, "Undoable note");
+      });
+    } finally {
+      Object.defineProperty(document, "execCommand", {
+        configurable: true,
+        value: originalExecCommand
+      });
+    }
+  });
+
+  it("uses native cut for right-click cut so input undo remains available", async () => {
+    const originalExecCommand = document.execCommand;
+    const execCommand = vi.fn((command: string) => command === "cut");
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+
+    try {
+      render(
+        <MarkdownFileTreeDrawer
+          currentPath="/vault/Untitled.md"
+          files={markdownFiles}
+          open
+          outlineItems={[]}
+          rootName="Obsidian Vault"
+          onCreateFile={vi.fn()}
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "New file" }));
+
+      const newFileInput = screen.getByRole("textbox", { name: "New file name" }) as HTMLInputElement;
+      fireEvent.change(newFileInput, { target: { value: "Draft note" } });
+      newFileInput.setSelectionRange(0, "Draft".length);
+      fireEvent.contextMenu(newFileInput, { clientX: 24, clientY: 36 });
+      fireEvent.click(screen.getByRole("menuitem", { name: /Cut/ }));
+
+      await waitFor(() => {
+        expect(execCommand).toHaveBeenCalledWith("cut");
+      });
+    } finally {
+      Object.defineProperty(document, "execCommand", {
+        configurable: true,
+        value: originalExecCommand
+      });
+    }
   });
 
   it("keeps the rename input visible until an async rename finishes", async () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -332,13 +332,15 @@ async function writeBrowserClipboardText(input: EditableTextInput, text: string)
   }
 }
 
-function runTextInputDocumentCommand(input: EditableTextInput, command: string) {
+function runTextInputDocumentCommand(input: EditableTextInput, command: string, value?: string) {
   const documentTarget = input.ownerDocument;
   const execCommand = (documentTarget as unknown as Record<string, unknown>)["execCommand"];
   if (typeof execCommand !== "function") return false;
 
   try {
     input.focus({ preventScroll: true });
+    if (value !== undefined) return Boolean(execCommand.call(documentTarget, command, false, value));
+
     return Boolean(execCommand.call(documentTarget, command));
   } catch {
     return false;
@@ -360,6 +362,18 @@ function fileNameSelectionEndBeforeExtension(fileName: string) {
   return extensionSeparatorIndex > 0 && extensionSeparatorIndex < fileName.length - 1
     ? extensionSeparatorIndex
     : fileName.length;
+}
+
+function closestElementFromNode(node: Node | null) {
+  if (node instanceof Element) return node;
+
+  return node?.parentElement ?? null;
+}
+
+function isSelfDrawnContextMenuTarget(node: Node | null) {
+  return Boolean(
+    closestElementFromNode(node)?.closest("[data-markra-context-menu-root], [data-markra-context-menu]")
+  );
 }
 
 function replaceTextInputSelection(
@@ -389,6 +403,7 @@ async function cutTextInputSelection(input: EditableTextInput, setValue: TextInp
   if (input.readOnly || input.disabled) return false;
   const selectedText = selectedTextInputText(input);
   if (!selectedText) return false;
+  if (runTextInputDocumentCommand(input, "cut")) return true;
 
   const copied = await copyTextInputSelection(input);
   if (!copied) return false;
@@ -402,6 +417,8 @@ async function pasteTextInputSelection(input: EditableTextInput, setValue: TextI
 
   const clipboardText = await readNativeClipboardText();
   if (!clipboardText) return false;
+
+  if (runTextInputDocumentCommand(input, "insertText", clipboardText)) return true;
 
   replaceTextInputSelection(input, setValue, clipboardText);
   return true;
@@ -841,7 +858,7 @@ export function MarkdownFileTreeDrawer({
           ? eventTarget.parentElement
           : null;
       if (!target) return;
-      if (target.closest("[data-file-tree-path], [data-markra-context-menu-root], [data-markra-context-menu]")) return;
+      if (target.closest("[data-file-tree-path]") || isSelfDrawnContextMenuTarget(target)) return;
 
       clearFileTreeMultiSelection();
     };
@@ -1226,6 +1243,7 @@ export function MarkdownFileTreeDrawer({
 
       const fileTreeRoot = fileTreeBodyRef.current?.closest(".markdown-file-tree");
       if (fileTreeRoot?.contains(target)) return;
+      if (isSelfDrawnContextMenuTarget(target)) return;
 
       const renamingFile = renamingFileRef.current;
       if (!renamingFile) return;
@@ -1249,6 +1267,7 @@ export function MarkdownFileTreeDrawer({
 
       const fileTreeRoot = fileTreeBodyRef.current?.closest(".markdown-file-tree");
       if (fileTreeRoot?.contains(target)) return;
+      if (isSelfDrawnContextMenuTarget(target)) return;
 
       cancelFileTreeInputs();
     };


### PR DESCRIPTION
## Summary
- Keep file tree create and rename inputs active when interacting with Markra's self-drawn context menu.
- Route right-click Paste through native `insertText` when available so the input's undo stack can handle `Ctrl/Cmd+Z`.
- Route right-click Cut through native `cut` when available for the same undo-stack behavior.
- Add regression coverage for the context-menu pointer path and undo-friendly Cut/Paste paths.

## Why
- On Windows, clicking the input context menu was treated as an outside pointer down and cancelled the pending file input before paste could run.
- The fallback edit path directly updates React state, which bypasses the browser/WebView input undo stack; native edit commands preserve the same undo behavior as keyboard shortcuts.

## Similar-Issue Audit
- Checked other self-drawn menus and text-edit paths. The editor/native menu paths already use `execCommand`/`insertText`; ordinary text inputs keep the system context menu.
- The same undo-stack issue was found in the file tree input Cut action and fixed here.

## Validation
- `node_modules\.bin\vitest.cmd run src\components\MarkdownFileTreeDrawer.test.tsx` passed from `packages/app`.
- `node_modules\.bin\tsc.cmd -p tsconfig.test.json --noEmit` passed from `packages/app`.

Closes #394