### PR TITLE
fix(markdown): resolve pasted images from Windows paths

### DIFF
--- a/packages/markdown/src/local-images.test.ts
+++ b/packages/markdown/src/local-images.test.ts
@@ -9,6 +9,26 @@ describe("local markdown image paths", () => {
     expect(resolveImageSrc("assets/pasted%20image.png")).toBe("asset:///Users/me/notes/assets/pasted image.png");
   });
 
+  it("resolves relative image paths beside Windows verbatim document paths", () => {
+    const resolveImageSrc = createMarkdownImageSrcResolver(String.raw`\\?\C:\mock-vault\notes\today.md`, {
+      convertFileSrc: (path) => `asset://${path}`
+    });
+
+    expect(resolveImageSrc("assets/pasted-image.png")).toBe(
+      String.raw`asset://C:\mock-vault\notes\assets\pasted-image.png`
+    );
+  });
+
+  it("preserves Windows UNC roots when resolving relative image paths", () => {
+    const resolveImageSrc = createMarkdownImageSrcResolver(String.raw`\\mock-server\share\notes\today.md`, {
+      convertFileSrc: (path) => `asset://${path}`
+    });
+
+    expect(resolveImageSrc("assets/pasted-image.png")).toBe(
+      String.raw`asset://\\mock-server\share\notes\assets\pasted-image.png`
+    );
+  });
+
   it("leaves remote and data image URLs unchanged", () => {
     const resolveImageSrc = createMarkdownImageSrcResolver("/Users/me/notes/today.md", {
       convertFileSrc: (path) => `asset://${path}`

--- a/packages/markdown/src/local-images.ts
+++ b/packages/markdown/src/local-images.ts
@@ -20,6 +20,13 @@ function documentSeparator(path: string) {
   return path.includes("\\") && !path.includes("/") ? "\\" : "/";
 }
 
+function normalizeWindowsVerbatimPath(path: string) {
+  if (/^\\\\\?\\UNC[\\/]/iu.test(path)) return `\\\\${path.slice(8)}`;
+  if (/^\\\\\?\\[a-zA-Z]:[\\/]/u.test(path)) return path.slice(4);
+
+  return path;
+}
+
 function decodeMarkdownImagePath(src: string) {
   try {
     return decodeURI(src.split(/[?#]/u)[0] ?? src);
@@ -28,15 +35,69 @@ function decodeMarkdownImagePath(src: string) {
   }
 }
 
+function splitLocalPathRoot(path: string, separator: string) {
+  const driveRoot = /^[a-zA-Z]:[\\/]/u.exec(path)?.[0];
+  if (driveRoot) {
+    return {
+      root: driveRoot.replace(/[\\/]$/u, separator),
+      rest: path.slice(driveRoot.length)
+    };
+  }
+
+  if (path.startsWith("\\\\") || path.startsWith("//")) {
+    const [, , server = "", share = "", ...rest] = path.split(/[\\/]/u);
+    if (server && share) {
+      return {
+        root: `${separator}${separator}${server}${separator}${share}${separator}`,
+        rest: rest.join(separator)
+      };
+    }
+  }
+
+  if (path.startsWith("/")) {
+    return {
+      root: "/",
+      rest: path.slice(1)
+    };
+  }
+
+  if (path.startsWith("\\")) {
+    return {
+      root: "\\",
+      rest: path.slice(1)
+    };
+  }
+
+  return {
+    root: "",
+    rest: path
+  };
+}
+
+function joinLocalPath(root: string, parts: string[], separator: string) {
+  const path = parts.join(separator);
+  if (!root) return path;
+  if (!path) return root;
+
+  return root.endsWith("/") || root.endsWith("\\") ? `${root}${path}` : `${root}${separator}${path}`;
+}
+
+function localPathIsAbsolute(path: string) {
+  return path.startsWith("/") || path.startsWith("\\\\") || /^[a-zA-Z]:[\\/]/u.test(path);
+}
+
 function resolveLocalPath(src: string, documentPath: string) {
-  const decodedSrc = decodeMarkdownImagePath(src);
+  const normalizedDocumentPath = normalizeWindowsVerbatimPath(documentPath);
+  const decodedSrc = normalizeWindowsVerbatimPath(decodeMarkdownImagePath(src));
   const separator = documentSeparator(documentPath);
 
-  if (decodedSrc.startsWith("/") || /^[a-zA-Z]:[\\/]/u.test(decodedSrc)) {
+  if (localPathIsAbsolute(decodedSrc)) {
     return decodedSrc;
   }
 
-  const parts = [...documentDirectory(documentPath).split(/[\\/]/u), ...decodedSrc.split(/[\\/]/u)];
+  const directory = documentDirectory(normalizedDocumentPath);
+  const { root, rest } = splitLocalPathRoot(directory, separator);
+  const parts = [...rest.split(/[\\/]/u), ...decodedSrc.split(/[\\/]/u)];
   const resolvedParts: string[] = [];
 
   for (const part of parts) {
@@ -48,9 +109,7 @@ function resolveLocalPath(src: string, documentPath: string) {
     resolvedParts.push(part);
   }
 
-  if (documentPath.startsWith("/")) return `/${resolvedParts.join("/")}`;
-
-  return resolvedParts.join(separator);
+  return joinLocalPath(root, resolvedParts, separator);
 }
 
 export function createMarkdownImageSrcResolver(


### PR DESCRIPTION
## Summary
- Normalize Windows verbatim paths before resolving local markdown image sources.
- Preserve Windows drive and UNC roots when joining relative pasted-image paths.
- Add regression coverage for Windows verbatim document paths and UNC paths.

## Why
- On Windows, pasted images from a `\\?\C:\...` document path could resolve to `?\C:\...`, which Tauri encoded as `%3F%5C...` under `asset.localhost`, causing the image preview to break.

## Validation
- `packages\markdown\node_modules\.bin\vitest.cmd run --environment jsdom --globals packages\markdown\src\local-images.test.ts` passed
- `packages\markdown\node_modules\.bin\tsc.cmd -p packages\markdown\tsconfig.test.json --noEmit` passed
- `packages\markdown\node_modules\.bin\tsc.cmd -p packages\markdown\tsconfig.build.json --noEmit` passed
- `node_modules\.bin\vitest.cmd run src\components\MarkdownPaper.test.tsx --testNamePattern "renders local image markdown with resolved preview sources"` passed from `packages/app`
- `node_modules\.bin\vitest.cmd run src\components\MarkdownPaper.test.tsx --testNamePattern "saves pasted clipboard images and inserts markdown image references"` passed from `packages/app`
- `node_modules\.bin\tsc.cmd -p tsconfig.test.json --noEmit` passed from `packages/app`

## Risk
- Low; change is scoped to local markdown image path resolution and adds Windows-specific regression coverage.

## Related Issues
Closes #396
