### PR TITLE
fix(markdown): preserve math source escapes

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2460,6 +2460,14 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("Where $A$ is the final amount.");
   });
 
+  it("preserves escaped underscore math source in inline formulas", async () => {
+    const source = String.raw`> **Synthetic material Si$\\\_3$N$\\\_4$ remains stable.**`;
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(source);
+  });
+
   it("renders Hugo-style inline and display math formulas while preserving markdown source", async () => {
     const inlineFormula = String.raw`\(a^2 + b^2 = c^2\)`;
     const displayFormula = [

--- a/packages/editor/src/math.ts
+++ b/packages/editor/src/math.ts
@@ -196,6 +196,7 @@ type MarkdownSerializerInfo = {
 type MarkdownSerializerState = {
   containerPhrasing: (node: MarkdownNode, info: MarkdownSerializerInfo) => string;
   enter: (name: string) => () => unknown;
+  safe: (value: string, info: MarkdownSerializerInfo) => string;
 };
 
 type RemarkProcessorData = {
@@ -300,29 +301,34 @@ function isDisplayMathSource(source: string) {
   return ranges.length === 1 && ranges[0]?.kind === "display" && ranges[0].from === 0 && ranges[0].to === source.length;
 }
 
-function isHugoMathRange(range: MathRange) {
-  return range.source.startsWith("\\(") || range.source.startsWith("\\[");
-}
-
 function serializeMarkdownSourceSegment(source: string, state: MarkdownSerializerState, info: MarkdownSerializerInfo) {
   if (!source) return "";
 
-  return state.containerPhrasing(
+  const leadingSpace = source.match(/^[ \t]+/u)?.[0] ?? "";
+  const trailingSpace = source.match(/[ \t]+$/u)?.[0] ?? "";
+  const contentStart = leadingSpace.length;
+  const contentEnd = source.length - trailingSpace.length;
+
+  if (contentStart >= contentEnd) return source;
+
+  const serialized = state.containerPhrasing(
     {
-      children: sourceToInlineMarkdownNodes(source),
+      children: sourceToInlineMarkdownNodes(source.slice(contentStart, contentEnd)),
       type: "paragraph"
     },
     info
   );
+
+  return `${leadingSpace}${serialized}${trailingSpace}`;
 }
 
-function serializeHugoMathAwareParagraphSource(
+function serializeMathAwareParagraphSource(
   source: string,
   state: MarkdownSerializerState,
   info: MarkdownSerializerInfo
 ) {
   const ranges = getMathRanges(source);
-  if (!ranges.some(isHugoMathRange)) return null;
+  if (ranges.length === 0) return null;
 
   let cursor = 0;
   let value = "";
@@ -334,6 +340,75 @@ function serializeHugoMathAwareParagraphSource(
 
   value += serializeMarkdownSourceSegment(source.slice(cursor), state, info);
   return value;
+}
+
+function serializePhrasingNodesAsSegment(
+  children: MarkdownNode[],
+  state: MarkdownSerializerState,
+  info: MarkdownSerializerInfo
+) {
+  return state.containerPhrasing(
+    {
+      children,
+      type: "paragraph"
+    },
+    info
+  );
+}
+
+function serializeMathAwarePhrasingNodes(
+  children: MarkdownNode[] | undefined,
+  state: MarkdownSerializerState,
+  info: MarkdownSerializerInfo
+) {
+  if (!children) return null;
+
+  let changed = false;
+  let value = "";
+  let textBuffer: MarkdownNode[] = [];
+
+  const flushTextBuffer = () => {
+    if (textBuffer.length === 0) return;
+
+    const source = markdownSourceFromInlineNodes(textBuffer);
+    if (source !== null) {
+      const serialized = serializeMathAwareParagraphSource(source, state, info);
+      if (serialized !== null) {
+        value += serialized;
+        changed = true;
+        textBuffer = [];
+        return;
+      }
+    }
+
+    value += serializePhrasingNodesAsSegment(textBuffer, state, info);
+    textBuffer = [];
+  };
+
+  for (const child of children) {
+    if (child.type === "text" || child.type === "break") {
+      textBuffer.push(child);
+      continue;
+    }
+
+    flushTextBuffer();
+
+    if ((child.type === "strong" || child.type === "emphasis") && Array.isArray(child.children)) {
+      const serialized = serializeMathAwarePhrasingNodes(child.children, state, info);
+      if (serialized !== null) {
+        const marker = child.type === "strong" ? "**" : "*";
+        value += `${marker}${serialized}${marker}`;
+        changed = true;
+        continue;
+      }
+    }
+
+    value += serializePhrasingNodesAsSegment([child], state, info);
+  }
+
+  flushTextBuffer();
+
+  return changed ? value : null;
 }
 
 function serializeMathAwareParagraph(
@@ -349,11 +424,46 @@ function serializeMathAwareParagraph(
   const subexit = state.enter("phrasing");
   const value =
     source === null
-      ? state.containerPhrasing(node, info)
-      : serializeHugoMathAwareParagraphSource(source, state, info) ?? state.containerPhrasing(node, info);
+      ? serializeMathAwarePhrasingNodes(node.children, state, info) ?? state.containerPhrasing(node, info)
+      : serializeMathAwareParagraphSource(source, state, info) ?? state.containerPhrasing(node, info);
   subexit();
   exit();
   return value;
+}
+
+function serializeMathAwareText(
+  node: MarkdownNode,
+  _parent: MarkdownNode | undefined,
+  state: MarkdownSerializerState,
+  info: MarkdownSerializerInfo
+) {
+  const value = typeof node.value === "string" ? node.value : "";
+  return serializeMathAwareParagraphSource(value, state, info) ?? state.safe(value, info);
+}
+
+function serializeMathAwareHeading(
+  node: MarkdownNode,
+  _parent: MarkdownNode | undefined,
+  state: MarkdownSerializerState
+) {
+  const headingNode = node as MarkdownNode & { depth?: number };
+  const rank = Math.max(Math.min(6, headingNode.depth || 1), 1);
+  const sequence = "#".repeat(rank);
+  const exit = state.enter("headingAtx");
+  const subexit = state.enter("phrasing");
+  const value =
+    serializeMathAwarePhrasingNodes(node.children, state, {
+      after: "\n",
+      before: "# "
+    }) ?? state.containerPhrasing(node, {
+      after: "\n",
+      before: "# "
+    });
+
+  subexit();
+  exit();
+
+  return value ? `${sequence} ${value}` : sequence;
 }
 
 function remarkMathParseOnly(this: { data: () => RemarkProcessorData }) {
@@ -371,7 +481,9 @@ function remarkMathParseOnly(this: { data: () => RemarkProcessorData }) {
   dataAfterMath.toMarkdownExtensions.splice(toMarkdownExtensionCount);
   dataAfterMath.toMarkdownExtensions.push({
     handlers: {
-      paragraph: serializeMathAwareParagraph
+      heading: serializeMathAwareHeading,
+      paragraph: serializeMathAwareParagraph,
+      text: serializeMathAwareText
     }
   });
 }


### PR DESCRIPTION
## Summary
- Preserve raw math source ranges when serializing inline math in paragraphs, nested emphasis/strong text, and headings.
- Add a regression test for escaped underscore math inside formatted text.

## Why
- Files with escaped underscore math such as `Si$\\\_3$N$\\\_4$` were reserialized with extra backslashes after opening in the visual editor, which made unchanged files look dirty on close.

## Validation
- `corepack pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx --testNamePattern math --reporter dot`
- `corepack pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx --reporter dot --silent`
- `corepack pnpm --filter @markra/editor build`
- `corepack pnpm --filter @markra/app build`
- `git diff --check`

## Related Issues
- Refs #308