### PR TITLE
feat(ai): add workspace change actions

### DIFF
--- a/packages/ai/src/agent/document-tools.test.ts
+++ b/packages/ai/src/agent/document-tools.test.ts
@@ -78,6 +78,41 @@ describe("documentAgentTools", () => {
     });
   });
 
+  it("lists workspace image files even when the current document does not reference them", async () => {
+    const tools = createDocumentAgentTools({
+      documentContent: "# Current",
+      documentEndPosition: 9,
+      documentPath: "/vault/current.md",
+      selection: null,
+      workspaceFiles: [
+        {
+          kind: "asset",
+          name: "diagram.png",
+          path: "/vault/assets/diagram.png",
+          relativePath: "assets/diagram.png"
+        },
+        {
+          name: "notes.md",
+          path: "/vault/notes.md",
+          relativePath: "notes.md"
+        }
+      ]
+    });
+    const listTool = tools.find((item) => item.name === "list_assets");
+
+    expect(listTool).toBeTruthy();
+    expect(tools.map((tool) => tool.name)).not.toContain("view_asset");
+
+    const result = await listTool?.execute("tool_list_assets", {});
+
+    expect(toolText(result)).toContain("Workspace image files:");
+    expect(toolText(result)).toContain("assets/diagram.png");
+    expect(result?.details).toEqual(expect.objectContaining({
+      count: 1,
+      workspaceImageCount: 1
+    }));
+  });
+
   it("rejects document image reads that are not referenced by the current document", async () => {
     const readDocumentImage = vi.fn(async () => ({
       dataUrl: "data:image/png;base64,aGVsbG8=",
@@ -206,6 +241,32 @@ describe("documentAgentTools", () => {
     expect(readWorkspaceFile).not.toHaveBeenCalled();
   });
 
+  it("rejects workspace file reads for non-Markdown assets", async () => {
+    const readWorkspaceFile = vi.fn(async () => "image bytes");
+    const tool = createDocumentAgentTools({
+      documentContent: "# Current",
+      documentEndPosition: 9,
+      documentPath: "/vault/current.md",
+      readWorkspaceFile,
+      selection: null,
+      workspaceFiles: [
+        {
+          kind: "asset",
+          name: "diagram.png",
+          path: "/vault/assets/diagram.png",
+          relativePath: "assets/diagram.png"
+        }
+      ]
+    }).find((item) => item.name === "read_workspace_file");
+
+    await expect(tool?.execute("tool_read_workspace_file", {
+      relativePath: "assets/diagram.png"
+    })).rejects.toThrow(
+      "Cannot read that file because it is not in the current Markdown workspace."
+    );
+    expect(readWorkspaceFile).not.toHaveBeenCalled();
+  });
+
   it("searches nearby workspace Markdown files by path and content", async () => {
     const readWorkspaceFile = vi.fn(async (path: string) =>
       path.endsWith("install.md") ? "# Install\n\nUse pnpm install." : "# Notes\n\nOther content."
@@ -243,7 +304,48 @@ describe("documentAgentTools", () => {
     }));
   });
 
-  it("rejects workspace searches with an empty normalized query", async () => {
+  it("does not search workspace image file contents", async () => {
+    const readWorkspaceFile = vi.fn(async (path: string) =>
+      path.endsWith("diagram.png") ? "pnpm install screenshot" : "# Install\n\nUse pnpm install."
+    );
+    const tool = createDocumentAgentTools({
+      documentContent: "# Current",
+      documentEndPosition: 9,
+      documentPath: "/vault/current.md",
+      readWorkspaceFile,
+      selection: null,
+      workspaceFiles: [
+        {
+          kind: "asset",
+          name: "diagram.png",
+          path: "/vault/assets/diagram.png",
+          relativePath: "assets/diagram.png"
+        },
+        {
+          name: "install.md",
+          path: "/vault/docs/install.md",
+          relativePath: "docs/install.md"
+        }
+      ]
+    }).find((item) => item.name === "search_workspace");
+
+    const result = await tool?.execute("tool_search_workspace", {
+      query: "pnpm install"
+    });
+
+    expect(readWorkspaceFile).toHaveBeenCalledWith("/vault/docs/install.md");
+    expect(readWorkspaceFile).not.toHaveBeenCalledWith("/vault/assets/diagram.png");
+    expect(result?.details).toEqual(expect.objectContaining({
+      count: 1,
+      matches: [
+        expect.objectContaining({
+          relativePath: "docs/install.md"
+        })
+      ]
+    }));
+  });
+
+  it("lists workspace Markdown files when the workspace search query is empty", async () => {
     const readWorkspaceFile = vi.fn(async () => "# Alpha");
     const tool = createDocumentAgentTools({
       documentContent: "# Current",
@@ -256,14 +358,118 @@ describe("documentAgentTools", () => {
           name: "alpha.md",
           path: "/vault/alpha.md",
           relativePath: "alpha.md"
+        },
+        {
+          name: "diagram.png",
+          path: "/vault/assets/diagram.png",
+          relativePath: "assets/diagram.png",
+          kind: "asset"
+        },
+        {
+          name: "docs",
+          path: "/vault/docs",
+          relativePath: "docs",
+          kind: "folder"
         }
       ]
     }).find((item) => item.name === "search_workspace");
 
-    await expect(tool?.execute("tool_search_workspace", {
+    const result = await tool?.execute("tool_search_workspace", {
       query: "!!!"
-    })).rejects.toThrow("Cannot search workspace because the query is empty.");
+    });
+
+    expect(toolText(result)).toContain("Workspace has 1 Markdown file:");
+    expect(toolText(result)).toContain("alpha.md");
+    expect(result?.details).toEqual(expect.objectContaining({
+      count: 1,
+      files: [
+        expect.objectContaining({
+          relativePath: "alpha.md"
+        })
+      ],
+      query: ""
+    }));
     expect(readWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it("prepares a workspace change plan without applying file changes", async () => {
+    const tool = createDocumentAgentTools({
+      documentContent: "# Current",
+      documentEndPosition: 9,
+      documentPath: "/vault/current.md",
+      selection: null,
+      workspaceFiles: [
+        {
+          name: "current.md",
+          path: "/vault/current.md",
+          relativePath: "current.md"
+        }
+      ]
+    }).find((item) => item.name === "prepare_workspace_change_plan");
+
+    const result = await tool?.execute("tool_prepare_workspace_change_plan", {
+      changes: [
+        {
+          content: "# Alpha\n\nSynthetic note.",
+          path: "topics/alpha.md",
+          reason: "Split a reusable topic into its own note.",
+          type: "create_note"
+        },
+        {
+          path: "current.md",
+          reason: "Add topic metadata.",
+          tags: ["alpha", "planning"],
+          type: "add_tags"
+        }
+      ],
+      summary: "Organize the current note into the workspace."
+    });
+
+    expect(toolText(result)).toContain("Prepared workspace change plan: Organize the current note into the workspace.");
+    expect(toolText(result)).toContain("1. Create note: topics/alpha.md");
+    expect(toolText(result)).toContain("2. Add tags: current.md");
+    expect(toolText(result)).toContain("No files were changed.");
+    expect(result?.details).toEqual(expect.objectContaining({
+      changes: [
+        expect.objectContaining({
+          path: "topics/alpha.md",
+          type: "create_note"
+        }),
+        expect.objectContaining({
+          path: "current.md",
+          tags: ["alpha", "planning"],
+          type: "add_tags"
+        })
+      ],
+      count: 2,
+      summary: "Organize the current note into the workspace."
+    }));
+  });
+
+  it("rejects workspace change plans with unsafe paths", async () => {
+    const tool = createDocumentAgentTools({
+      documentContent: "# Current",
+      documentEndPosition: 9,
+      documentPath: "/vault/current.md",
+      selection: null,
+      workspaceFiles: [
+        {
+          name: "current.md",
+          path: "/vault/current.md",
+          relativePath: "current.md"
+        }
+      ]
+    }).find((item) => item.name === "prepare_workspace_change_plan");
+
+    await expect(tool?.execute("tool_prepare_workspace_change_plan", {
+      changes: [
+        {
+          content: "# Unsafe",
+          path: "../outside.md",
+          type: "create_note"
+        }
+      ]
+    })).rejects.toThrow("Workspace change path must stay inside the workspace.");
   });
 
   it("returns the current heading outline with editor anchors", async () => {
@@ -1728,7 +1934,7 @@ describe("documentAgentTools", () => {
     }));
   });
 
-  it("exposes the consolidated document tool surface", () => {
+  it("exposes the consolidated core document tool surface", () => {
     const toolNames = createDocumentAgentTools({
       documentContent: "# Title",
       documentEndPosition: 7,
@@ -1778,11 +1984,83 @@ describe("documentAgentTools", () => {
       "delete_content",
       "move_content",
       "batch_edit",
-      "search_workspace",
-      "read_workspace_file",
-      "list_assets",
-      "view_asset",
       "validate_edit"
     ]);
+  });
+
+  it("exposes optional workspace, asset, and web tools only when their capabilities are available", () => {
+    const baseContext = {
+      documentContent: "# Title",
+      documentEndPosition: 7,
+      documentPath: "/vault/README.md",
+      selection: null,
+      workspaceFiles: []
+    };
+    const baseToolNames = createDocumentAgentTools(baseContext).map((tool) => tool.name);
+
+    expect(baseToolNames).not.toContain("search_workspace");
+    expect(baseToolNames).not.toContain("read_workspace_file");
+    expect(baseToolNames).not.toContain("list_assets");
+    expect(baseToolNames).not.toContain("view_asset");
+    expect(baseToolNames).not.toContain("web_search");
+
+    const workspaceAssetToolNames = createDocumentAgentTools({
+      ...baseContext,
+      workspaceFiles: [
+        {
+          kind: "asset",
+          name: "diagram.png",
+          path: "/vault/assets/diagram.png",
+          relativePath: "assets/diagram.png"
+        }
+      ]
+    }).map((tool) => tool.name);
+
+    expect(workspaceAssetToolNames).toContain("list_assets");
+    expect(workspaceAssetToolNames).not.toContain("view_asset");
+
+    const workspaceSearchToolNames = createDocumentAgentTools({
+      ...baseContext,
+      workspaceFiles: [
+        {
+          name: "notes.md",
+          path: "/vault/notes.md",
+          relativePath: "notes.md"
+        }
+      ]
+    }).map((tool) => tool.name);
+
+    expect(workspaceSearchToolNames).toContain("search_workspace");
+    expect(workspaceSearchToolNames).not.toContain("read_workspace_file");
+
+    const fullToolNames = createDocumentAgentTools({
+      ...baseContext,
+      documentContent: "# Title\n\n![Diagram](assets/diagram.png)",
+      documentEndPosition: 38,
+      readDocumentImage: vi.fn(),
+      readWorkspaceFile: vi.fn(),
+      webSearch: {
+        settings: {
+          contentMaxChars: 12000,
+          enabled: true,
+          maxResults: 5,
+          providerId: "local-bing",
+          searxngApiHost: ""
+        }
+      },
+      workspaceFiles: [
+        {
+          name: "notes.md",
+          path: "/vault/notes.md",
+          relativePath: "notes.md"
+        }
+      ]
+    }).map((tool) => tool.name);
+
+    expect(fullToolNames).toContain("search_workspace");
+    expect(fullToolNames).toContain("read_workspace_file");
+    expect(fullToolNames).toContain("list_assets");
+    expect(fullToolNames).toContain("view_asset");
+    expect(fullToolNames).toContain("web_search");
   });
 });

--- a/packages/ai/src/agent/read-only-tools.ts
+++ b/packages/ai/src/agent/read-only-tools.ts
@@ -1,4 +1,5 @@
 export type AgentWorkspaceFile = {
+  kind?: "asset" | "folder";
   name: string;
   path: string;
   relativePath: string;

--- a/packages/ai/src/agent/tools/change-plan.ts
+++ b/packages/ai/src/agent/tools/change-plan.ts
@@ -1,0 +1,68 @@
+import { Type } from "@earendil-works/pi-ai";
+import { prepareWorkspaceChangePlanChanges } from "../workspace-change-plan";
+import { DocumentAgentToolFactory } from "./base";
+import { typedWorkspaceChangePlanArgs } from "./params";
+import { toolErrorResult } from "./results";
+
+export class PrepareWorkspaceChangePlanToolFactory extends DocumentAgentToolFactory<ReturnType<typeof typedWorkspaceChangePlanArgs>> {
+  protected readonly description = [
+    "Prepare a reviewable workspace change plan for organizing Markdown notes.",
+    "Use this for note creation, note updates, renames, moves, links, or tags.",
+    "This tool validates and summarizes the plan only; it never writes files. The user must review and apply changes separately."
+  ].join(" ");
+  protected readonly label = "Prepare workspace change plan";
+  protected readonly name = "prepare_workspace_change_plan";
+  protected readonly parameters = Type.Object({
+    changes: Type.Array(Type.Object({
+      content: Type.Optional(Type.String()),
+      from: Type.Optional(Type.String({ minLength: 1 })),
+      links: Type.Optional(Type.Array(Type.String())),
+      path: Type.Optional(Type.String({ minLength: 1 })),
+      reason: Type.Optional(Type.String()),
+      summary: Type.Optional(Type.String()),
+      tags: Type.Optional(Type.Array(Type.String())),
+      to: Type.Optional(Type.String({ minLength: 1 })),
+      type: Type.Union([
+        Type.Literal("add_links"),
+        Type.Literal("add_tags"),
+        Type.Literal("create_note"),
+        Type.Literal("move_note"),
+        Type.Literal("rename_note"),
+        Type.Literal("update_note")
+      ])
+    })),
+    summary: Type.Optional(Type.String())
+  });
+
+  protected parseParams(params: unknown) {
+    return typedWorkspaceChangePlanArgs(params);
+  }
+
+  protected executeTool(_toolCallId: string, params: ReturnType<typeof typedWorkspaceChangePlanArgs>) {
+    if (!params.changes.length) {
+      return toolErrorResult("Cannot prepare a workspace change plan because no changes were provided.");
+    }
+
+    const preparedChanges = prepareWorkspaceChangePlanChanges(params.changes, this.context.workspaceFiles);
+    const summary = params.summary ?? "Review suggested workspace note changes.";
+
+    return {
+      content: [
+        {
+          text: [
+            `Prepared workspace change plan: ${summary}`,
+            ...preparedChanges.map((change, index) => `${index + 1}. ${change.label}${change.reason ? ` - ${change.reason}` : ""}`),
+            "No files were changed. The user still needs to review and apply this plan."
+          ].join("\n"),
+          type: "text" as const
+        }
+      ],
+      details: {
+        changes: preparedChanges,
+        count: preparedChanges.length,
+        summary
+      },
+      terminate: false
+    };
+  }
+}

--- a/packages/ai/src/agent/tools/format.ts
+++ b/packages/ai/src/agent/tools/format.ts
@@ -5,7 +5,7 @@ import {
   formatSelectionSourceContext,
   resolveMarkdownSourceContext
 } from "../selection";
-import type { MarkdownImageReference } from "./images";
+import type { MarkdownImageReference, WorkspaceImageFile } from "./images";
 import type { LocatedMarkdownRegion, LocatedSection } from "./locate";
 
 export function formatHeadingOutlineText(headingAnchors: AiHeadingAnchor[]) {
@@ -88,6 +88,33 @@ export function formatDocumentImageReferencesText(references: MarkdownImageRefer
       `   file: ${reference.fileName || "(unknown)"}`,
       `   alt: ${reference.alt || "(empty)"}`
     ].join("\n"))
+  ].join("\n");
+}
+
+export function formatAssetInventoryText(
+  references: MarkdownImageReference[],
+  workspaceImages: WorkspaceImageFile[]
+) {
+  if (!references.length && !workspaceImages.length) return "No document image references or workspace image files are available.";
+
+  return [
+    ...(references.length
+      ? [
+          "Current document image references:",
+          ...references.map((reference, index) => [
+            `${index + 1}. src: ${reference.src}`,
+            `   file: ${reference.fileName || "(unknown)"}`,
+            `   alt: ${reference.alt || "(empty)"}`
+          ].join("\n"))
+        ]
+      : ["Current document image references: none"]),
+    "",
+    ...(workspaceImages.length
+      ? [
+          "Workspace image files:",
+          ...workspaceImages.map((file, index) => `${index + 1}. ${file.relativePath || file.name}`)
+        ]
+      : ["Workspace image files: none"])
   ].join("\n");
 }
 

--- a/packages/ai/src/agent/tools/images.ts
+++ b/packages/ai/src/agent/tools/images.ts
@@ -4,6 +4,14 @@ export type MarkdownImageReference = {
   src: string;
 };
 
+export type WorkspaceImageFile = {
+  name: string;
+  path: string;
+  relativePath: string;
+};
+
+const imageFileExtensionPattern = /\.(?:avif|gif|jpe?g|png|svg|webp)$/iu;
+
 export function extractMarkdownImageReferences(markdown: string): MarkdownImageReference[] {
   const references: MarkdownImageReference[] = [];
   const imagePattern = /!\[([^\]]*)\]\(([^)]+)\)/gu;
@@ -22,6 +30,10 @@ export function extractMarkdownImageReferences(markdown: string): MarkdownImageR
   }
 
   return references;
+}
+
+export function workspaceImageFiles(files: readonly WorkspaceImageFile[]) {
+  return files.filter((file) => imageFileExtensionPattern.test(file.name) || imageFileExtensionPattern.test(file.relativePath));
 }
 
 export function resolveMarkdownImageReference(references: MarkdownImageReference[], src: string) {

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -1,5 +1,6 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { BatchEditToolFactory } from "./batch-edit";
+import { PrepareWorkspaceChangePlanToolFactory } from "./change-plan";
 import { DeleteContentToolFactory } from "./delete-content";
 import { GetEditorContextToolFactory } from "./get-editor-context";
 import { InspectDocumentStructureToolFactory } from "./inspect-document-structure";
@@ -14,6 +15,7 @@ import { SearchDocumentToolFactory } from "./search-document";
 import { SearchWorkspaceToolFactory } from "./search-workspace";
 import { ValidateEditToolFactory } from "./validate-edit";
 import type { DocumentAgentToolContext, DocumentAgentToolState } from "./context";
+import { extractMarkdownImageReferences, workspaceImageFiles } from "./images";
 import { ViewAssetToolFactory } from "./view-asset";
 import { WebSearchToolFactory } from "./web-search-tool";
 
@@ -21,6 +23,12 @@ export function createDocumentAgentTools(context: DocumentAgentToolContext): Age
   const state: DocumentAgentToolState = {
     preparedInsertions: []
   };
+  const hasWorkspaceFiles = context.workspaceFiles.length > 0;
+  const hasReadableWorkspaceFiles = hasWorkspaceFiles && Boolean(context.readWorkspaceFile);
+  const hasDocumentAssets = extractMarkdownImageReferences(context.documentContent).length > 0;
+  const hasWorkspaceAssets = workspaceImageFiles(context.workspaceFiles).length > 0;
+  const hasVisibleAssets = hasDocumentAssets || hasWorkspaceAssets;
+  const hasReadableDocumentAssets = hasDocumentAssets && Boolean(context.readDocumentImage);
   const tools = [
     ...(context.webSearch ? [new WebSearchToolFactory(context, state)] : []),
     new GetEditorContextToolFactory(context, state),
@@ -33,10 +41,11 @@ export function createDocumentAgentTools(context: DocumentAgentToolContext): Age
     new DeleteContentToolFactory(context, state),
     new MoveContentToolFactory(context, state),
     new BatchEditToolFactory(context, state),
-    new SearchWorkspaceToolFactory(context, state),
-    new ReadWorkspaceFileToolFactory(context, state),
-    new ListAssetsToolFactory(context, state),
-    new ViewAssetToolFactory(context, state),
+    ...(hasWorkspaceFiles ? [new SearchWorkspaceToolFactory(context, state)] : []),
+    ...(hasReadableWorkspaceFiles ? [new ReadWorkspaceFileToolFactory(context, state)] : []),
+    ...(hasWorkspaceFiles ? [new PrepareWorkspaceChangePlanToolFactory(context, state)] : []),
+    ...(hasVisibleAssets ? [new ListAssetsToolFactory(context, state)] : []),
+    ...(hasReadableDocumentAssets ? [new ViewAssetToolFactory(context, state)] : []),
     new ValidateEditToolFactory(context, state)
   ];
 

--- a/packages/ai/src/agent/tools/list-assets.ts
+++ b/packages/ai/src/agent/tools/list-assets.ts
@@ -1,12 +1,12 @@
 import { Type } from "@earendil-works/pi-ai";
 import { DocumentAgentToolFactory } from "./base";
-import { formatDocumentImageReferencesText } from "./format";
-import { extractMarkdownImageReferences } from "./images";
+import { formatAssetInventoryText } from "./format";
+import { extractMarkdownImageReferences, workspaceImageFiles } from "./images";
 
 export class ListAssetsToolFactory extends DocumentAgentToolFactory {
   protected readonly description = [
-    "List assets referenced by the current Markdown document, including local image references.",
-    "Use this before view_asset when the user asks about screenshots, figures, diagrams, photos, or other referenced visual content."
+    "List image assets available to this turn, including current document image references and workspace image files.",
+    "Use this before view_asset when the user asks about screenshots, figures, diagrams, photos, or referenced visual content."
   ].join(" ");
   protected readonly label = "List assets";
   protected readonly name = "list_assets";
@@ -14,21 +14,29 @@ export class ListAssetsToolFactory extends DocumentAgentToolFactory {
 
   protected executeTool() {
     const images = extractMarkdownImageReferences(this.context.documentContent);
+    const workspaceImages = workspaceImageFiles(this.context.workspaceFiles);
 
     return {
       content: [
         {
-          text: formatDocumentImageReferencesText(images),
+          text: formatAssetInventoryText(images, workspaceImages),
           type: "text" as const
         }
       ],
       details: {
-        assets: images.map((image) => ({
-          ...image,
-          kind: "image"
-        })),
-        count: images.length,
-        imageCount: images.length
+        assets: [
+          ...images.map((image) => ({
+            ...image,
+            kind: "document-image-reference"
+          })),
+          ...workspaceImages.map((file) => ({
+            ...file,
+            kind: "workspace-image-file"
+          }))
+        ],
+        count: images.length + workspaceImages.length,
+        documentImageReferenceCount: images.length,
+        workspaceImageCount: workspaceImages.length
       },
       terminate: false
     };

--- a/packages/ai/src/agent/tools/params.ts
+++ b/packages/ai/src/agent/tools/params.ts
@@ -78,7 +78,32 @@ export type SearchDocumentArgs = {
 
 export type SearchWorkspaceArgs = {
   maxResults?: number;
-  query: string;
+  query?: string;
+};
+
+export type WorkspaceChangeKind =
+  | "add_links"
+  | "add_tags"
+  | "create_note"
+  | "move_note"
+  | "rename_note"
+  | "update_note";
+
+export type WorkspaceChangePlanChange = {
+  content?: string;
+  from?: string;
+  links?: string[];
+  path?: string;
+  reason?: string;
+  summary?: string;
+  tags?: string[];
+  to?: string;
+  type: WorkspaceChangeKind;
+};
+
+export type WorkspaceChangePlanArgs = {
+  changes: WorkspaceChangePlanChange[];
+  summary?: string;
 };
 
 export type ValidateEditArgs = {
@@ -209,7 +234,18 @@ export function typedSearchWorkspaceArgs(params: unknown): SearchWorkspaceArgs {
 
   return {
     maxResults: typeof args.maxResults === "number" ? args.maxResults : undefined,
-    query: args.query.trim()
+    query: args.query?.trim() ?? ""
+  };
+}
+
+export function typedWorkspaceChangePlanArgs(params: unknown): WorkspaceChangePlanArgs {
+  const args = params as { changes?: WorkspaceChangePlanChange[]; summary?: string };
+
+  return {
+    changes: Array.isArray(args.changes)
+      ? args.changes.map((change) => typedWorkspaceChangePlanChange(change))
+      : [],
+    summary: args.summary?.trim() || undefined
   };
 }
 
@@ -219,6 +255,39 @@ export function typedValidateEditArgs(params: unknown): ValidateEditArgs {
   return {
     content: args.content
   };
+}
+
+function typedWorkspaceChangePlanChange(change: WorkspaceChangePlanChange): WorkspaceChangePlanChange {
+  return {
+    content: change.content,
+    from: change.from?.trim() || undefined,
+    links: Array.isArray(change.links)
+      ? change.links.map((link) => String(link).trim()).filter(Boolean)
+      : undefined,
+    path: change.path?.trim() || undefined,
+    reason: change.reason?.trim() || undefined,
+    summary: change.summary?.trim() || undefined,
+    tags: Array.isArray(change.tags)
+      ? change.tags.map((tag) => String(tag).trim()).filter(Boolean)
+      : undefined,
+    to: change.to?.trim() || undefined,
+    type: typedWorkspaceChangeKind(change.type)
+  };
+}
+
+function typedWorkspaceChangeKind(value: unknown): WorkspaceChangeKind {
+  if (
+    value === "add_links" ||
+    value === "add_tags" ||
+    value === "create_note" ||
+    value === "move_note" ||
+    value === "rename_note" ||
+    value === "update_note"
+  ) {
+    return value;
+  }
+
+  return "update_note";
 }
 
 export function typedViewAssetArgs(params: unknown): ViewAssetArgs {

--- a/packages/ai/src/agent/tools/search-workspace.ts
+++ b/packages/ai/src/agent/tools/search-workspace.ts
@@ -1,17 +1,16 @@
 import { Type } from "@earendil-works/pi-ai";
 import { DocumentAgentToolFactory } from "./base";
 import { typedSearchWorkspaceArgs } from "./params";
-import { toolErrorResult } from "./results";
 import { normalizeText } from "./text";
-import { truncateWorkspaceFileContent } from "./workspace";
+import { truncateWorkspaceFileContent, workspaceMarkdownFiles } from "./workspace";
 
 export class SearchWorkspaceToolFactory extends DocumentAgentToolFactory<ReturnType<typeof typedSearchWorkspaceArgs>> {
-  protected readonly description = "Search nearby Markdown workspace files by filename, relative path, and readable content snippets when file reading is available.";
+  protected readonly description = "Inspect nearby Markdown workspace files. Omit query to list files, or pass query to search filenames, relative paths, and readable content snippets when file reading is available.";
   protected readonly label = "Search workspace";
   protected readonly name = "search_workspace";
   protected readonly parameters = Type.Object({
     maxResults: Type.Optional(Type.Number({ maximum: 100, minimum: 1 })),
-    query: Type.String({ minLength: 1 })
+    query: Type.Optional(Type.String())
   });
 
   protected parseParams(params: unknown) {
@@ -19,14 +18,13 @@ export class SearchWorkspaceToolFactory extends DocumentAgentToolFactory<ReturnT
   }
 
   protected async executeTool(_toolCallId: string, params: ReturnType<typeof typedSearchWorkspaceArgs>) {
-    const query = normalizeText(params.query);
-    if (!query) {
-      return toolErrorResult("Cannot search workspace because the query is empty.");
-    }
+    const rawQuery = params.query ?? "";
+    const query = normalizeText(rawQuery);
+    if (!query) return listWorkspaceMarkdownFiles(workspaceMarkdownFiles(this.context.workspaceFiles), params.maxResults);
 
     const matches = [];
 
-    for (const file of this.context.workspaceFiles) {
+    for (const file of workspaceMarkdownFiles(this.context.workspaceFiles)) {
       const pathText = normalizeText(`${file.relativePath} ${file.name}`);
       let contentSnippet: string | undefined;
       let score = pathText.includes(query) ? 4 : 0;
@@ -37,7 +35,7 @@ export class SearchWorkspaceToolFactory extends DocumentAgentToolFactory<ReturnT
           const readableContent = truncateWorkspaceFileContent(content).text;
           if (normalizeText(readableContent).includes(query)) {
             score += 8;
-            contentSnippet = snippetAround(readableContent, params.query);
+            contentSnippet = snippetAround(readableContent, rawQuery);
           }
         } catch {
           // Ignore unreadable workspace files during search; read_workspace_file reports exact read errors.
@@ -63,24 +61,56 @@ export class SearchWorkspaceToolFactory extends DocumentAgentToolFactory<ReturnT
         {
           text: limitedMatches.length
             ? [
-                `Found ${limitedMatches.length} workspace match${limitedMatches.length === 1 ? "" : "es"} for "${params.query}":`,
+                `Found ${limitedMatches.length} workspace match${limitedMatches.length === 1 ? "" : "es"} for "${rawQuery}":`,
                 ...limitedMatches.map((match, index) => [
                   `${index + 1}. ${match.relativePath}`,
                   match.snippet
                 ].filter(Boolean).join("\n"))
               ].join("\n")
-            : `No workspace matches found for "${params.query}".`,
+            : `No workspace matches found for "${rawQuery}".`,
           type: "text" as const
         }
       ],
       details: {
         count: limitedMatches.length,
         matches: limitedMatches,
-        query: params.query
+        query: rawQuery
       },
       terminate: false
     };
   }
+}
+
+function listWorkspaceMarkdownFiles(
+  files: ReturnType<typeof workspaceMarkdownFiles>,
+  maxResults: number | undefined
+) {
+  const sortedFiles = [...files].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  const limitedFiles = sortedFiles.slice(0, maxResults ?? 50);
+
+  return {
+    content: [
+      {
+        text: limitedFiles.length
+          ? [
+              `Workspace has ${limitedFiles.length} Markdown file${limitedFiles.length === 1 ? "" : "s"}:`,
+              ...limitedFiles.map((file, index) => `${index + 1}. ${file.relativePath}`)
+            ].join("\n")
+          : "No Markdown workspace files are available.",
+        type: "text" as const
+      }
+    ],
+    details: {
+      count: limitedFiles.length,
+      files: limitedFiles.map((file) => ({
+        name: file.name,
+        path: file.path,
+        relativePath: file.relativePath
+      })),
+      query: ""
+    },
+    terminate: false
+  };
 }
 
 function snippetAround(content: string, query: string) {

--- a/packages/ai/src/agent/tools/workspace.ts
+++ b/packages/ai/src/agent/tools/workspace.ts
@@ -2,6 +2,7 @@ import type { AgentWorkspaceFile } from "../read-only-tools";
 import type { ReadWorkspaceFileArgs } from "./params";
 
 const workspaceFileReadMaxChars = 24_000;
+const markdownDocumentExtensionPattern = /\.(md|markdown)$/iu;
 
 export function truncateWorkspaceFileContent(content: string) {
   if (content.length <= workspaceFileReadMaxChars) {
@@ -30,9 +31,20 @@ export function resolveWorkspaceFile(
 
   if (!requestedRelativePath && !requestedPath) return null;
 
-  return workspaceFiles.find((file) => {
+  return workspaceMarkdownFiles(workspaceFiles).find((file) => {
     if (requestedRelativePath) return file.relativePath === requestedRelativePath;
 
     return file.path === requestedPath || file.relativePath === requestedPath;
   }) ?? null;
+}
+
+export function isWorkspaceMarkdownFile(file: AgentWorkspaceFile) {
+  return file.kind !== "asset" && file.kind !== "folder" && (
+    markdownDocumentExtensionPattern.test(file.name) ||
+    markdownDocumentExtensionPattern.test(file.relativePath)
+  );
+}
+
+export function workspaceMarkdownFiles(workspaceFiles: readonly AgentWorkspaceFile[]) {
+  return workspaceFiles.filter(isWorkspaceMarkdownFile);
 }

--- a/packages/ai/src/agent/workspace-change-plan.test.ts
+++ b/packages/ai/src/agent/workspace-change-plan.test.ts
@@ -1,0 +1,360 @@
+import { applyWorkspaceChangePlan, type WorkspacePlanVisualEvent } from "./workspace-change-plan";
+import type { AgentWorkspaceFile } from "./read-only-tools";
+
+const workspaceFiles: AgentWorkspaceFile[] = [
+  {
+    name: "current.md",
+    path: "/vault/current.md",
+    relativePath: "current.md"
+  },
+  {
+    name: "guide.md",
+    path: "/vault/docs/guide.md",
+    relativePath: "docs/guide.md"
+  }
+];
+
+describe("workspace change plan executor", () => {
+  it("creates notes and writes full-note updates through confirmed operations", async () => {
+    const createFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => "# Current\n\nOld body.");
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    const result = await applyWorkspaceChangePlan({
+      changes: [
+        {
+          content: "# Alpha\n\nSynthetic note.",
+          path: "topics/alpha.md",
+          type: "create_note"
+        },
+        {
+          content: "# Current\n\nUpdated body.",
+          path: "current.md",
+          type: "update_note"
+        }
+      ],
+      summary: "Apply a confirmed organization plan."
+    }, {
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      workspaceFiles
+    });
+
+    expect(createFile).toHaveBeenCalledWith("topics/alpha.md", "# Alpha\n\nSynthetic note.");
+    expect(readFile).toHaveBeenCalledWith(workspaceFiles[0]);
+    expect(writeFile).toHaveBeenCalledWith(workspaceFiles[0], "# Current\n\nUpdated body.");
+    expect(moveFile).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({
+      count: 2,
+      summary: "Apply a confirmed organization plan."
+    }));
+    expect(result.journal.changes).toEqual([
+      expect.objectContaining({
+        afterContent: "# Alpha\n\nSynthetic note.",
+        path: "topics/alpha.md",
+        type: "create_note"
+      }),
+      expect.objectContaining({
+        afterContent: "# Current\n\nUpdated body.",
+        beforeContent: "# Current\n\nOld body.",
+        path: "current.md",
+        type: "update_note"
+      })
+    ]);
+  });
+
+  it("emits visual events that can drive an AI operation overlay", async () => {
+    const events: WorkspacePlanVisualEvent[] = [];
+    const createFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => "# Current\n\nOld body.");
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    await applyWorkspaceChangePlan({
+      changes: [
+        {
+          content: "# Alpha",
+          path: "topics/alpha.md",
+          type: "create_note"
+        },
+        {
+          content: "# Current\n\nUpdated body.",
+          path: "current.md",
+          type: "update_note"
+        }
+      ]
+    }, {
+      onVisualEvent: (event) => events.push(event),
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      workspaceFiles
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      "plan_validating",
+      "step_started",
+      "step_previewed",
+      "step_applied",
+      "step_started",
+      "step_previewed",
+      "step_applied",
+      "plan_completed"
+    ]);
+    expect(events[1]).toEqual(expect.objectContaining({
+      action: "create_note",
+      index: 0,
+      path: "topics/alpha.md",
+      target: "file_tree"
+    }));
+    expect(events[2]).toEqual(expect.objectContaining({
+      afterContent: "# Alpha",
+      action: "create_note",
+      index: 0,
+      path: "topics/alpha.md"
+    }));
+    expect(events[4]).toEqual(expect.objectContaining({
+      action: "update_note",
+      index: 1,
+      path: "current.md",
+      target: "editor"
+    }));
+    expect(events[5]).toEqual(expect.objectContaining({
+      afterContent: "# Current\n\nUpdated body.",
+      beforeContent: "# Current\n\nOld body.",
+      path: "current.md"
+    }));
+  });
+
+  it("emits a failed visual event before rethrowing apply errors", async () => {
+    const events: WorkspacePlanVisualEvent[] = [];
+    const createFile = vi.fn(async () => {
+      throw new Error("Disk unavailable");
+    });
+    const readFile = vi.fn(async () => "");
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    await expect(applyWorkspaceChangePlan({
+      changes: [
+        {
+          content: "# Alpha",
+          path: "topics/alpha.md",
+          type: "create_note"
+        }
+      ]
+    }, {
+      onVisualEvent: (event) => events.push(event),
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      workspaceFiles
+    })).rejects.toThrow("Disk unavailable");
+
+    expect(events.map((event) => event.type)).toEqual([
+      "plan_validating",
+      "step_started",
+      "step_previewed",
+      "step_failed"
+    ]);
+    expect(events[3]).toEqual(expect.objectContaining({
+      action: "create_note",
+      error: "Disk unavailable",
+      index: 0,
+      path: "topics/alpha.md"
+    }));
+  });
+
+  it("does not let visual event observers block file execution", async () => {
+    const createFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => "");
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    await expect(applyWorkspaceChangePlan({
+      changes: [
+        {
+          content: "# Alpha",
+          path: "topics/alpha.md",
+          type: "create_note"
+        }
+      ]
+    }, {
+      onVisualEvent: () => {
+        throw new Error("Overlay unavailable");
+      },
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      workspaceFiles
+    })).resolves.toEqual(expect.objectContaining({
+      count: 1
+    }));
+
+    expect(createFile).toHaveBeenCalledWith("topics/alpha.md", "# Alpha");
+  });
+
+  it("adds missing tags and related links without duplicating existing values", async () => {
+    const createFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => [
+      "---",
+      "title: Current",
+      "tags:",
+      "  - existing",
+      "---",
+      "",
+      "# Current",
+      "",
+      "Body with [[Alpha]] already linked."
+    ].join("\n"));
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    await applyWorkspaceChangePlan({
+      changes: [
+        {
+          path: "current.md",
+          tags: ["existing", "alpha"],
+          type: "add_tags"
+        },
+        {
+          links: ["[[Alpha]]", "[Guide](./docs/guide.md)"],
+          path: "current.md",
+          type: "add_links"
+        }
+      ]
+    }, {
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      workspaceFiles
+    });
+
+    expect(writeFile).toHaveBeenNthCalledWith(1, workspaceFiles[0], [
+      "---",
+      "title: Current",
+      "tags:",
+      "  - existing",
+      "  - alpha",
+      "---",
+      "",
+      "# Current",
+      "",
+      "Body with [[Alpha]] already linked."
+    ].join("\n"));
+    expect(writeFile).toHaveBeenNthCalledWith(2, workspaceFiles[0], [
+      "---",
+      "title: Current",
+      "tags:",
+      "  - existing",
+      "  - alpha",
+      "---",
+      "",
+      "# Current",
+      "",
+      "Body with [[Alpha]] already linked.",
+      "",
+      "## Related",
+      "",
+      "- [Guide](./docs/guide.md)"
+    ].join("\n"));
+    expect(createFile).not.toHaveBeenCalled();
+    expect(moveFile).not.toHaveBeenCalled();
+  });
+
+  it("moves notes only after validating selected plan entries", async () => {
+    const createFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => "");
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    const result = await applyWorkspaceChangePlan({
+      changes: [
+        {
+          from: "docs/guide.md",
+          to: "archive/guide.md",
+          type: "move_note"
+        },
+        {
+          from: "current.md",
+          to: "docs/current-renamed.md",
+          type: "rename_note"
+        }
+      ]
+    }, {
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      selectedChangeIndexes: [1],
+      workspaceFiles
+    });
+
+    expect(moveFile).toHaveBeenCalledTimes(1);
+    expect(moveFile).toHaveBeenCalledWith(workspaceFiles[0], "docs/current-renamed.md");
+    expect(createFile).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(result.journal.changes).toEqual([
+      expect.objectContaining({
+        from: "current.md",
+        to: "docs/current-renamed.md",
+        type: "rename_note"
+      })
+    ]);
+  });
+
+  it("rejects duplicate target paths before touching files", async () => {
+    const createFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => "");
+    const writeFile = vi.fn(async () => {});
+    const moveFile = vi.fn(async () => {});
+
+    await expect(applyWorkspaceChangePlan({
+      changes: [
+        {
+          content: "# Alpha",
+          path: "topics/alpha.md",
+          type: "create_note"
+        },
+        {
+          from: "current.md",
+          to: "topics/alpha.md",
+          type: "move_note"
+        }
+      ]
+    }, {
+      operations: {
+        createFile,
+        moveFile,
+        readFile,
+        writeFile
+      },
+      workspaceFiles
+    })).rejects.toThrow("Workspace change path \"topics/alpha.md\" is targeted by more than one change.");
+
+    expect(createFile).not.toHaveBeenCalled();
+    expect(moveFile).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai/src/agent/workspace-change-plan.ts
+++ b/packages/ai/src/agent/workspace-change-plan.ts
@@ -1,0 +1,555 @@
+import type { AgentWorkspaceFile } from "./read-only-tools";
+import type {
+  WorkspaceChangeKind,
+  WorkspaceChangePlanArgs,
+  WorkspaceChangePlanChange
+} from "./tools/params";
+import { workspaceMarkdownFiles } from "./tools/workspace";
+
+export type PreparedWorkspaceChange = WorkspaceChangePlanChange & {
+  label: string;
+};
+
+export type WorkspaceChangePlanOperations = {
+  createFile: (relativePath: string, content: string) => Promise<unknown> | unknown;
+  moveFile: (file: AgentWorkspaceFile, toRelativePath: string) => Promise<unknown> | unknown;
+  readFile: (file: AgentWorkspaceFile) => Promise<string> | string;
+  writeFile: (file: AgentWorkspaceFile, content: string) => Promise<unknown> | unknown;
+};
+
+export type ApplyWorkspaceChangePlanOptions = {
+  onVisualEvent?: (event: WorkspacePlanVisualEvent) => unknown;
+  operations: WorkspaceChangePlanOperations;
+  selectedChangeIndexes?: readonly number[];
+  workspaceFiles: readonly AgentWorkspaceFile[];
+};
+
+export type WorkspaceChangeJournalEntry = {
+  afterContent?: string;
+  beforeContent?: string;
+  from?: string;
+  path?: string;
+  to?: string;
+  type: WorkspaceChangeKind;
+};
+
+export type ApplyWorkspaceChangePlanResult = {
+  count: number;
+  journal: {
+    changes: WorkspaceChangeJournalEntry[];
+  };
+  summary: string;
+};
+
+export type WorkspacePlanVisualTarget = "editor" | "file_tree";
+
+export type WorkspacePlanVisualEvent =
+  | {
+      totalSteps: number;
+      type: "plan_validating";
+    }
+  | WorkspacePlanVisualStepEvent
+  | {
+      count: number;
+      journal: WorkspaceChangeJournalEntry[];
+      type: "plan_completed";
+    };
+
+export type WorkspacePlanVisualStepEvent = {
+  action: WorkspaceChangeKind;
+  afterContent?: string;
+  beforeContent?: string;
+  error?: string;
+  from?: string;
+  index: number;
+  label: string;
+  path?: string;
+  target: WorkspacePlanVisualTarget;
+  to?: string;
+  type: "step_applied" | "step_failed" | "step_previewed" | "step_started";
+};
+
+const markdownDocumentExtensionPattern = /\.(md|markdown)$/iu;
+
+export async function applyWorkspaceChangePlan(
+  plan: WorkspaceChangePlanArgs,
+  options: ApplyWorkspaceChangePlanOptions
+): Promise<ApplyWorkspaceChangePlanResult> {
+  const selectedEntries = selectedWorkspaceChangeEntries(plan.changes, options.selectedChangeIndexes);
+  const selectedChanges = selectedEntries.map((entry) => entry.change);
+  if (!selectedChanges.length) {
+    throw new Error("Cannot apply a workspace change plan because no changes were selected.");
+  }
+
+  emitWorkspacePlanVisualEvent(options, {
+    totalSteps: selectedChanges.length,
+    type: "plan_validating"
+  });
+
+  const preparedChanges = prepareWorkspaceChangePlanChanges(selectedChanges, options.workspaceFiles);
+  const contentCache = new Map<string, string>();
+  const journalChanges: WorkspaceChangeJournalEntry[] = [];
+
+  const readCurrentContent = async (file: AgentWorkspaceFile) => {
+    const key = normalizeWorkspaceRelativePath(file.relativePath);
+    if (contentCache.has(key)) return contentCache.get(key) ?? "";
+
+    const content = await options.operations.readFile(file);
+    contentCache.set(key, content);
+    return content;
+  };
+
+  const writeCurrentContent = async (file: AgentWorkspaceFile, content: string) => {
+    contentCache.set(normalizeWorkspaceRelativePath(file.relativePath), content);
+    await options.operations.writeFile(file, content);
+  };
+
+  for (const [stepIndex, change] of preparedChanges.entries()) {
+    const index = selectedEntries[stepIndex]?.index ?? stepIndex;
+    emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_started"));
+
+    try {
+      if (change.type === "create_note") {
+        const path = requiredPath(change.path);
+        const content = requiredContent(change.content, "create_note");
+        emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_previewed", {
+          afterContent: content,
+          path
+        }));
+        await options.operations.createFile(path, content);
+
+        const journalEntry = {
+          afterContent: content,
+          path,
+          type: change.type
+        } satisfies WorkspaceChangeJournalEntry;
+        journalChanges.push(journalEntry);
+        emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_applied", {
+          afterContent: content,
+          path
+        }));
+        continue;
+      }
+
+      if (change.type === "rename_note" || change.type === "move_note") {
+        const from = requiredPath(change.from);
+        const to = requiredPath(change.to);
+        const file = existingPreparedChangeFile(options.workspaceFiles, from);
+        emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_previewed", {
+          from,
+          to
+        }));
+        await options.operations.moveFile(file, to);
+
+        const journalEntry = {
+          from,
+          to,
+          type: change.type
+        } satisfies WorkspaceChangeJournalEntry;
+        journalChanges.push(journalEntry);
+        emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_applied", {
+          from,
+          to
+        }));
+        continue;
+      }
+
+      const path = requiredPath(change.path);
+      const file = existingPreparedChangeFile(options.workspaceFiles, path);
+      const beforeContent = await readCurrentContent(file);
+      const afterContent = appliedMarkdownContent(change, beforeContent);
+      emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_previewed", {
+        afterContent,
+        beforeContent,
+        path
+      }));
+      await writeCurrentContent(file, afterContent);
+
+      const journalEntry = {
+        afterContent,
+        beforeContent,
+        path,
+        type: change.type
+      } satisfies WorkspaceChangeJournalEntry;
+      journalChanges.push(journalEntry);
+      emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_applied", {
+        afterContent,
+        beforeContent,
+        path
+      }));
+    } catch (error) {
+      emitWorkspacePlanVisualEvent(options, visualStepEvent(change, index, "step_failed", {
+        error: error instanceof Error ? error.message : "Failed to apply workspace change."
+      }));
+      throw error;
+    }
+  }
+
+  const result = {
+    count: journalChanges.length,
+    journal: {
+      changes: journalChanges
+    },
+    summary: plan.summary ?? "Apply workspace note changes."
+  };
+
+  emitWorkspacePlanVisualEvent(options, {
+    count: result.count,
+    journal: result.journal.changes,
+    type: "plan_completed"
+  });
+
+  return result;
+}
+
+export function prepareWorkspaceChangePlanChanges(
+  changes: readonly WorkspaceChangePlanChange[],
+  workspaceFiles: readonly AgentWorkspaceFile[]
+): PreparedWorkspaceChange[] {
+  const existingMarkdownFiles = workspaceMarkdownFiles(workspaceFiles);
+  const existingRelativePaths = new Set(existingMarkdownFiles.map((file) => normalizeWorkspaceRelativePath(file.relativePath)));
+  const plannedTargetPaths = new Set<string>();
+
+  return changes.map((change) => prepareWorkspaceChange(change, existingMarkdownFiles, existingRelativePaths, plannedTargetPaths));
+}
+
+export function normalizeWorkspaceRelativePath(path: string) {
+  return path.trim().replace(/\\/gu, "/").replace(/^\.\/+/u, "").replace(/\/{2,}/gu, "/");
+}
+
+function prepareWorkspaceChange(
+  change: WorkspaceChangePlanChange,
+  existingMarkdownFiles: AgentWorkspaceFile[],
+  existingRelativePaths: Set<string>,
+  plannedTargetPaths: Set<string>
+): PreparedWorkspaceChange {
+  if (change.type === "create_note") {
+    const path = validateNewMarkdownPath(change.path, existingRelativePaths, plannedTargetPaths);
+    return {
+      ...change,
+      path,
+      label: `Create note: ${path}`
+    };
+  }
+
+  if (change.type === "rename_note" || change.type === "move_note") {
+    const from = validateExistingMarkdownPath(change.from, existingMarkdownFiles);
+    const to = validateNewMarkdownPath(change.to, existingRelativePaths, plannedTargetPaths);
+    return {
+      ...change,
+      from,
+      to,
+      label: `${change.type === "rename_note" ? "Rename note" : "Move note"}: ${from} -> ${to}`
+    };
+  }
+
+  const path = validateExistingMarkdownPath(change.path, existingMarkdownFiles);
+  const label = change.type === "add_links"
+    ? `Add links: ${path}`
+    : change.type === "add_tags"
+      ? `Add tags: ${path}`
+      : `Update note: ${path}`;
+
+  return {
+    ...change,
+    path,
+    label
+  };
+}
+
+function validateExistingMarkdownPath(path: string | undefined, existingMarkdownFiles: AgentWorkspaceFile[]) {
+  const normalizedPath = validateWorkspaceMarkdownPath(path);
+  const file = existingMarkdownFiles.find((candidate) =>
+    normalizeWorkspaceRelativePath(candidate.relativePath) === normalizedPath ||
+    normalizeWorkspaceRelativePath(candidate.path) === normalizedPath
+  );
+  if (!file) {
+    throw new Error(`Workspace change path "${path ?? ""}" does not match an existing Markdown note.`);
+  }
+
+  return normalizeWorkspaceRelativePath(file.relativePath);
+}
+
+function validateNewMarkdownPath(
+  path: string | undefined,
+  existingRelativePaths: Set<string>,
+  plannedTargetPaths: Set<string>
+) {
+  const normalizedPath = validateWorkspaceMarkdownPath(path);
+  if (plannedTargetPaths.has(normalizedPath)) {
+    throw new Error(`Workspace change path "${normalizedPath}" is targeted by more than one change.`);
+  }
+  if (existingRelativePaths.has(normalizedPath)) {
+    throw new Error(`Workspace change path "${normalizedPath}" already exists.`);
+  }
+
+  plannedTargetPaths.add(normalizedPath);
+  return normalizedPath;
+}
+
+function validateWorkspaceMarkdownPath(path: string | undefined) {
+  const normalizedPath = normalizeWorkspaceRelativePath(path ?? "");
+  if (!normalizedPath || normalizedPath.startsWith("/") || /^[a-z]:\//iu.test(normalizedPath)) {
+    throw new Error("Workspace change path must be a relative Markdown path.");
+  }
+  if (normalizedPath.split("/").includes("..")) {
+    throw new Error("Workspace change path must stay inside the workspace.");
+  }
+  if (!markdownDocumentExtensionPattern.test(normalizedPath)) {
+    throw new Error("Workspace change path must target a Markdown note.");
+  }
+
+  return normalizedPath;
+}
+
+function selectedWorkspaceChangeEntries(
+  changes: readonly WorkspaceChangePlanChange[],
+  selectedChangeIndexes: readonly number[] | undefined
+) {
+  if (!selectedChangeIndexes) {
+    return changes.map((change, index) => ({ change, index }));
+  }
+
+  const selectedIndexes = new Set<number>();
+  selectedChangeIndexes.forEach((index) => {
+    if (!Number.isInteger(index) || index < 0 || index >= changes.length) {
+      throw new Error(`Workspace change selection index "${index}" is outside the plan.`);
+    }
+    selectedIndexes.add(index);
+  });
+
+  return changes
+    .map((change, index) => ({ change, index }))
+    .filter((entry) => selectedIndexes.has(entry.index));
+}
+
+function requiredPath(path: string | undefined) {
+  if (!path) throw new Error("Workspace change is missing a path.");
+
+  return path;
+}
+
+function requiredContent(content: string | undefined, type: WorkspaceChangeKind) {
+  if (typeof content !== "string") {
+    throw new Error(`Workspace change "${type}" requires content.`);
+  }
+
+  return content;
+}
+
+function existingPreparedChangeFile(workspaceFiles: readonly AgentWorkspaceFile[], relativePath: string) {
+  const normalizedPath = normalizeWorkspaceRelativePath(relativePath);
+  const file = workspaceMarkdownFiles(workspaceFiles).find((candidate) =>
+    normalizeWorkspaceRelativePath(candidate.relativePath) === normalizedPath
+  );
+  if (!file) {
+    throw new Error(`Workspace change path "${relativePath}" does not match an existing Markdown note.`);
+  }
+
+  return file;
+}
+
+function appliedMarkdownContent(change: PreparedWorkspaceChange, beforeContent: string) {
+  if (change.type === "update_note") {
+    return requiredContent(change.content, change.type);
+  }
+
+  if (change.type === "add_tags") {
+    if (!change.tags?.length) throw new Error("Workspace change \"add_tags\" requires at least one tag.");
+
+    return addMarkdownTags(beforeContent, change.tags);
+  }
+
+  if (change.type === "add_links") {
+    if (!change.links?.length) throw new Error("Workspace change \"add_links\" requires at least one link.");
+
+    return addMarkdownLinks(beforeContent, change.links);
+  }
+
+  return beforeContent;
+}
+
+function addMarkdownTags(markdown: string, tags: readonly string[]) {
+  const uniqueTags = uniqueTrimmedValues(tags);
+  if (!uniqueTags.length) return markdown;
+
+  const frontmatter = leadingYamlFrontmatter(markdown);
+  if (!frontmatter) {
+    return [
+      "---",
+      ...formatYamlTags([], uniqueTags),
+      "---",
+      "",
+      markdown
+    ].join("\n");
+  }
+
+  const nextBody = addTagsToYamlFrontmatterBody(frontmatter.body, uniqueTags);
+  return `${markdown.slice(0, frontmatter.bodyFrom)}${nextBody}${markdown.slice(frontmatter.bodyTo)}`;
+}
+
+function addMarkdownLinks(markdown: string, links: readonly string[]) {
+  const missingLinks = uniqueTrimmedValues(links).filter((link) => !markdown.includes(link));
+  if (!missingLinks.length) return markdown;
+
+  const relatedSection = [
+    "## Related",
+    "",
+    ...missingLinks.map((link) => `- ${link}`)
+  ].join("\n");
+
+  return markdown.trimEnd()
+    ? [markdown.trimEnd(), "", relatedSection].join("\n")
+    : relatedSection;
+}
+
+function addTagsToYamlFrontmatterBody(body: string, tags: readonly string[]) {
+  const lines = body.split(/\r?\n/u);
+  const tagLineIndex = lines.findIndex((line) => /^tags\s*:/iu.test(line));
+  if (tagLineIndex < 0) {
+    return [...lines.filter((line, index) => index < lines.length - 1 || line), ...formatYamlTags([], tags)].join("\n");
+  }
+
+  const tagLine = lines[tagLineIndex] ?? "";
+  const inlineTagValue = tagLine.replace(/^tags\s*:/iu, "").trim();
+  const listEndIndex = inlineTagValue ? tagLineIndex + 1 : yamlListEndIndex(lines, tagLineIndex + 1);
+  const existingTags = inlineTagValue
+    ? parseInlineYamlTags(inlineTagValue)
+    : lines.slice(tagLineIndex + 1, listEndIndex).map(parseYamlListTag).filter((tag): tag is string => Boolean(tag));
+  const replacement = formatYamlTags(existingTags, tags);
+
+  return [
+    ...lines.slice(0, tagLineIndex),
+    ...replacement,
+    ...lines.slice(listEndIndex)
+  ].join("\n");
+}
+
+function leadingYamlFrontmatter(markdown: string) {
+  const match = /^(---\r?\n)([\s\S]*?)(\r?\n---)(\r?\n|$)/u.exec(markdown);
+  if (!match) return null;
+
+  const opening = match[1] ?? "";
+  const body = match[2] ?? "";
+
+  return {
+    body,
+    bodyFrom: opening.length,
+    bodyTo: opening.length + body.length
+  };
+}
+
+function yamlListEndIndex(lines: readonly string[], startIndex: number) {
+  let index = startIndex;
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+    if (!/^\s*-\s+/u.test(line)) break;
+
+    index += 1;
+  }
+
+  return index;
+}
+
+function parseYamlListTag(line: string) {
+  const match = /^\s*-\s+(.+?)\s*$/u.exec(line);
+  return match ? cleanYamlTagValue(match[1] ?? "") : null;
+}
+
+function parseInlineYamlTags(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map(cleanYamlTagValue)
+      .filter(Boolean);
+  }
+
+  return [cleanYamlTagValue(trimmed)].filter(Boolean);
+}
+
+function cleanYamlTagValue(value: string) {
+  return value.trim().replace(/^["']|["']$/gu, "");
+}
+
+function formatYamlTags(existingTags: readonly string[], nextTags: readonly string[]) {
+  const tags = uniqueTrimmedValues([...existingTags, ...nextTags]);
+  return [
+    "tags:",
+    ...tags.map((tag) => `  - ${tag}`)
+  ];
+}
+
+function uniqueTrimmedValues(values: readonly string[]) {
+  const seen = new Set<string>();
+  const uniqueValues: string[] = [];
+
+  values.forEach((value) => {
+    const trimmed = value.trim();
+    const key = trimmed.toLocaleLowerCase();
+    if (!trimmed || seen.has(key)) return;
+
+    seen.add(key);
+    uniqueValues.push(trimmed);
+  });
+
+  return uniqueValues;
+}
+
+function emitWorkspacePlanVisualEvent(
+  options: ApplyWorkspaceChangePlanOptions,
+  event: WorkspacePlanVisualEvent
+) {
+  try {
+    const result = options.onVisualEvent?.(event);
+    if (isPromiseLike(result)) {
+      result.catch(() => {});
+    }
+  } catch {
+    // Visual observers must not block confirmed workspace file operations.
+  }
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    "catch" in value &&
+    typeof (value as { catch?: unknown }).catch === "function"
+  );
+}
+
+function visualStepEvent(
+  change: PreparedWorkspaceChange,
+  index: number,
+  type: WorkspacePlanVisualStepEvent["type"],
+  overrides: Partial<WorkspacePlanVisualStepEvent> = {}
+): WorkspacePlanVisualStepEvent {
+  const path = change.path ?? overrides.path;
+  const from = change.from ?? overrides.from;
+  const to = change.to ?? overrides.to;
+
+  return {
+    action: change.type,
+    index,
+    label: change.label,
+    target: visualTargetForWorkspaceChange(change.type),
+    type,
+    ...(path ? { path } : {}),
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+    ...overrides
+  };
+}
+
+function visualTargetForWorkspaceChange(type: WorkspaceChangeKind): WorkspacePlanVisualTarget {
+  if (type === "create_note" || type === "move_note" || type === "rename_note") return "file_tree";
+
+  return "editor";
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -11,4 +11,6 @@ export * from "./agent/runtime.ts";
 export * from "./agent/session-state.ts";
 export * from "./agent/session-title.ts";
 export * from "./agent/tools/web-search.ts";
+export type { WorkspaceChangePlanArgs } from "./agent/tools/params.ts";
 export * from "./agent/web-search-availability.ts";
+export * from "./agent/workspace-change-plan.ts";

--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -101,6 +101,7 @@ describe("Markra AI workspace", () => {
   it("moves structurally complex inline prompts into the Markra AI panel", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -191,6 +192,7 @@ describe("Markra AI workspace", () => {
   it("hides the complex inline prompt panel suggestion when the experimental setting is off", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -272,7 +274,7 @@ describe("Markra AI workspace", () => {
     expect(screen.queryByRole("button", { name: "Use Markra AI" })).not.toBeInTheDocument();
   });
 
-  it("does not allow agent messages until a markdown document is open", async () => {
+  it("allows agent messages when a workspace is open without a markdown document", async () => {
     mockedOpenNativeMarkdownPath.mockResolvedValue({
       kind: "folder",
       folder: {
@@ -293,10 +295,14 @@ describe("Markra AI workspace", () => {
     const sendButton = within(agentPanel).getByRole("button", { name: "Send message" });
     const suggestion = within(agentPanel).getByRole("button", { name: "Summarize this document" });
 
-    expect(within(agentPanel).getByText("Open a Markdown document to chat")).toBeInTheDocument();
-    expect(input).toBeDisabled();
-    expect(sendButton).toBeDisabled();
+    expect(within(agentPanel).getByText("Ready when you are")).toBeInTheDocument();
+    expect(input).toHaveAttribute("placeholder", "Ask Markra AI...");
+    expect(input).toBeEnabled();
     expect(suggestion).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "List markdown files in this workspace" } });
+
+    expect(sendButton).toBeEnabled();
   });
 
   it("restores the pending AI suggestion without reopening the command input when an applied suggestion is undone", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -320,6 +320,7 @@ function createStoredEditorPreferences(
     ],
     showWordCount: true,
     ...overrides,
+    aiWorkspaceAnimationEnabled: overrides.aiWorkspaceAnimationEnabled ?? false,
     wrapCodeBlocks: overrides.wrapCodeBlocks ?? true
   };
 }
@@ -781,6 +782,7 @@ describe("Markra workspace", () => {
   it("persists titlebar action order changes by holding and dragging", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -836,6 +838,7 @@ describe("Markra workspace", () => {
     await waitFor(() =>
       expect(mockedSaveStoredEditorPreferences).toHaveBeenCalledWith({
         aiQuickActionPrompts: defaultAiQuickActionPrompts,
+        aiWorkspaceAnimationEnabled: false,
         autoRevealActiveFile: true,
         autoSaveEnabled: true,
         autoSaveIntervalMinutes: 10,
@@ -879,6 +882,7 @@ describe("Markra workspace", () => {
     await waitFor(() =>
       expect(mockedNotifyAppEditorPreferencesChanged).toHaveBeenCalledWith({
         aiQuickActionPrompts: defaultAiQuickActionPrompts,
+        aiWorkspaceAnimationEnabled: false,
         autoRevealActiveFile: true,
         autoSaveEnabled: true,
         autoSaveIntervalMinutes: 10,
@@ -1538,6 +1542,7 @@ describe("Markra workspace", () => {
     });
     const initialPreferences = {
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -1665,6 +1670,7 @@ describe("Markra workspace", () => {
   it("updates markdown shortcuts from the dedicated settings tab", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -4343,6 +4349,7 @@ describe("Markra workspace", () => {
   it("does not expose side-open file tree actions when document tabs are hidden", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -4486,6 +4493,7 @@ describe("Markra workspace", () => {
   it("keeps dirty editor content when opening another markdown file is cancelled", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -38,6 +38,7 @@ import { QuickOpenPanel } from "./components/QuickOpenPanel";
 import { SideDocumentPane } from "./components/SideDocumentPane";
 import { SettingsWindow } from "./components/SettingsWindow";
 import { WorkspaceLayout } from "./components/WorkspaceLayout";
+import { WorkspaceOperationOverlay } from "./components/WorkspaceOperationOverlay";
 import { useAppLanguage } from "./hooks/useAppLanguage";
 import { useAppTheme } from "./hooks/useAppTheme";
 import { useAiCommandUi } from "./hooks/useAiCommandUi";
@@ -96,6 +97,11 @@ import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath
 import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
 import { saveEditorImage, saveLocalEditorImage } from "./lib/image-upload";
 import { aiCommandSelection, automaticAiSelection } from "./lib/ai-selection";
+import { createWorkspaceChangePlanOperations } from "./lib/workspace-plan-apply";
+import {
+  workspaceOperationEventsFromPlanEvents,
+  workspaceOperationRevealPaths as revealPathsForWorkspaceOperation
+} from "./lib/workspace-operation-animation";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
 import { replaceMovedPath, sameNativePath } from "./lib/path-move";
@@ -122,7 +128,15 @@ import {
   toggleNativeWindowFullscreen,
   toggleNativeWindowMaximized
 } from "./lib/tauri";
-import { aiAgentWebSearchAvailable, type AiDiffResult, type AiEditIntent, type AiSelectionContext } from "@markra/ai";
+import {
+  aiAgentWebSearchAvailable,
+  applyWorkspaceChangePlan,
+  type AiDiffResult,
+  type AiEditIntent,
+  type AiSelectionContext,
+  type WorkspaceChangePlanArgs,
+  type WorkspacePlanVisualEvent
+} from "@markra/ai";
 import {
   AI_EDITOR_PREVIEW_APPLIED_EVENT,
   AI_EDITOR_PREVIEW_ACTION_EVENT,
@@ -166,6 +180,7 @@ import {
   readNativeMarkdownFile,
   readNativeMarkdownTemplateFile,
   saveNativeHtmlFile,
+  saveNativeMarkdownFile,
   saveNativePandocFile,
   saveNativePdfFile,
   showNativePandocSetup,
@@ -829,6 +844,44 @@ function WorkspaceApp() {
     restoreWorkspaceOnStartup: editorPreferences.preferences.restoreWorkspaceOnStartup,
     titlebarTabs
   });
+  const applyRenamedTreeFile = useCallback((previousPath: string, renamedFile: NativeMarkdownFolderFile) => {
+    replaceOpenDocumentFile(previousPath, renamedFile);
+    persistSideDocumentGroupPathUpdate({
+      nextPath: renamedFile.path,
+      previousPath
+    });
+    setImageTabs((currentTabs) => currentTabs.map((tab) =>
+      tab.path === previousPath ? createImageDocumentTab(renamedFile) : tab
+    ));
+    setActiveImageFile((currentFile) => currentFile?.path === previousPath ? renamedFile : currentFile);
+  }, [persistSideDocumentGroupPathUpdate, replaceOpenDocumentFile]);
+  const applyMovedTreeFile = useCallback((
+    previousFile: NativeMarkdownFolderFile,
+    movedFile: NativeMarkdownFolderFile
+  ) => {
+    const moveFolderFile = (file: NativeMarkdownFolderFile): NativeMarkdownFolderFile => {
+      const nextPath = replaceMovedPath(file.path, previousFile.path, movedFile.path);
+      if (nextPath === file.path) return file;
+
+      return {
+        ...file,
+        name: file.path === previousFile.path ? movedFile.name : file.name,
+        path: nextPath,
+        relativePath: replaceMovedPath(file.relativePath, previousFile.relativePath, movedFile.relativePath)
+      };
+    };
+
+    replaceMovedOpenDocumentFile(previousFile.path, movedFile);
+    persistSideDocumentGroupPathUpdate({
+      nextPath: movedFile.path,
+      previousPath: previousFile.path
+    });
+    setImageTabs((currentTabs) => currentTabs.map((tab) => {
+      const movedTab = moveFolderFile(tab);
+      return movedTab === tab ? tab : createImageDocumentTab(movedTab);
+    }));
+    setActiveImageFile((currentFile) => currentFile ? moveFolderFile(currentFile) : currentFile);
+  }, [persistSideDocumentGroupPathUpdate, replaceMovedOpenDocumentFile]);
   const getAiDocumentContent = useCallback(
     () => (document.open ? readCurrentMarkdownForDocument(document.content) : document.content),
     [document.content, document.open, readCurrentMarkdownForDocument]
@@ -846,6 +899,65 @@ function WorkspaceApp() {
       src
     });
   }, [document.path]);
+  const applyAiWorkspacePlan = useCallback(async (
+    plan: WorkspaceChangePlanArgs,
+    options: { onVisualEvent: (event: WorkspacePlanVisualEvent) => unknown }
+  ) => {
+    if (!fileTreeSourcePath) {
+      throw new Error("Open a folder workspace before applying workspace changes.");
+    }
+
+    await saveDirtyMarkdownFiles();
+
+    const result = await applyWorkspaceChangePlan(plan, {
+      onVisualEvent: options.onVisualEvent,
+      operations: createWorkspaceChangePlanOperations({
+        createFile: createMarkdownTreeFile,
+        createFolder: createMarkdownTreeFolder,
+        moveFile: async (file, targetParentPath) => {
+          const movedFile = await moveMarkdownTreeFile(file, targetParentPath);
+          if (movedFile) applyMovedTreeFile(file, movedFile);
+
+          return movedFile;
+        },
+        readFile: readAiWorkspaceFile,
+        renameFile: async (file, fileName) => {
+          const renamedFile = await renameMarkdownTreeFile(file, fileName);
+          if (renamedFile) applyRenamedTreeFile(file.path, renamedFile);
+
+          return renamedFile;
+        },
+        workspaceFiles: fileTreeFiles,
+        writeFile: async (file, content) => {
+          const savedFile = await saveNativeMarkdownFile({
+            contents: content,
+            path: file.path,
+            suggestedName: file.name
+          });
+          if (!savedFile) {
+            throw new Error(`Workspace change could not write "${file.relativePath}".`);
+          }
+        }
+      }),
+      workspaceFiles: fileTreeFiles
+    });
+
+    await refreshMarkdownFileTree(document.path);
+    return result;
+  }, [
+    applyMovedTreeFile,
+    applyRenamedTreeFile,
+    createMarkdownTreeFile,
+    createMarkdownTreeFolder,
+    document.path,
+    fileTreeFiles,
+    fileTreeSourcePath,
+    moveMarkdownTreeFile,
+    readAiWorkspaceFile,
+    refreshMarkdownFileTree,
+    renameMarkdownTreeFile,
+    saveDirtyMarkdownFiles
+  ]);
   const saveDocumentTabViewState = useCallback((tabId: string | null | undefined, patch: DocumentTabViewState) => {
     if (!tabId) return;
 
@@ -1006,6 +1118,7 @@ function WorkspaceApp() {
       : "transition-[grid-template-columns] duration-220 ease-out motion-reduce:transition-none"
   }`;
   const aiAgent = useAiAgentSession({
+    applyWorkspacePlan: applyAiWorkspacePlan,
     documentPath: document.path,
     getDocumentContent: getAiDocumentContent,
     getDocumentEndPosition: editor.getDocumentEndPosition,
@@ -1856,44 +1969,6 @@ function WorkspaceApp() {
     );
     setActiveImageFile(file);
   }, []);
-  const applyRenamedTreeFile = useCallback((previousPath: string, renamedFile: NativeMarkdownFolderFile) => {
-    replaceOpenDocumentFile(previousPath, renamedFile);
-    persistSideDocumentGroupPathUpdate({
-      nextPath: renamedFile.path,
-      previousPath
-    });
-    setImageTabs((currentTabs) => currentTabs.map((tab) =>
-      tab.path === previousPath ? createImageDocumentTab(renamedFile) : tab
-    ));
-    setActiveImageFile((currentFile) => currentFile?.path === previousPath ? renamedFile : currentFile);
-  }, [persistSideDocumentGroupPathUpdate, replaceOpenDocumentFile]);
-  const applyMovedTreeFile = useCallback((
-    previousFile: NativeMarkdownFolderFile,
-    movedFile: NativeMarkdownFolderFile
-  ) => {
-    const moveFolderFile = (file: NativeMarkdownFolderFile): NativeMarkdownFolderFile => {
-      const nextPath = replaceMovedPath(file.path, previousFile.path, movedFile.path);
-      if (nextPath === file.path) return file;
-
-      return {
-        ...file,
-        name: file.path === previousFile.path ? movedFile.name : file.name,
-        path: nextPath,
-        relativePath: replaceMovedPath(file.relativePath, previousFile.relativePath, movedFile.relativePath)
-      };
-    };
-
-    replaceMovedOpenDocumentFile(previousFile.path, movedFile);
-    persistSideDocumentGroupPathUpdate({
-      nextPath: movedFile.path,
-      previousPath: previousFile.path
-    });
-    setImageTabs((currentTabs) => currentTabs.map((tab) => {
-      const movedTab = moveFolderFile(tab);
-      return movedTab === tab ? tab : createImageDocumentTab(movedTab);
-    }));
-    setActiveImageFile((currentFile) => currentFile ? moveFolderFile(currentFile) : currentFile);
-  }, [persistSideDocumentGroupPathUpdate, replaceMovedOpenDocumentFile]);
   const handleCreateMarkdownTreeFolder = useCallback(async (folderName: string, parentPath: string | null = null) => {
     try {
       await createMarkdownTreeFolder(folderName, parentPath);
@@ -3550,11 +3625,18 @@ function WorkspaceApp() {
       thinkingEnabled={aiAgent.thinkingEnabled}
       webSearchAvailable={webSearchAvailable}
       webSearchEnabled={aiAgent.webSearchEnabled}
+      workspaceAvailable={Boolean(fileTree.sourcePath)}
+      workspacePlanApplyError={aiAgent.workspacePlanApplyError}
+      workspacePlanApplyStatus={aiAgent.workspacePlanApplyStatus}
+      workspacePlanEvents={aiAgent.workspacePlanEvents}
       maxWidth={aiAgentPanelMaxWidth}
       minWidth={aiAgentPanelMinWidth}
       width={aiAgentPanelWidth}
       onArchiveSession={(sessionId, archived) => {
         handleArchiveAiAgentSession(sessionId, archived).catch(() => {});
+      }}
+      onApplyWorkspacePlan={() => {
+        aiAgent.applyWorkspacePlan().catch(() => {});
       }}
       onClose={closeAiAgentPanel}
       onCreateSession={handleCreateAiAgentSession}
@@ -3577,6 +3659,30 @@ function WorkspaceApp() {
       onSubmitEditedMessage={aiAgent.submitEditedMessage}
       onToggleThinking={() => aiAgent.setThinkingEnabled((enabled) => !enabled)}
       onToggleWebSearch={() => aiAgent.setWebSearchEnabled((enabled) => !enabled)}
+    />
+  ) : null;
+  const workspaceOperationEvents = useMemo(
+    () => workspaceOperationEventsFromPlanEvents(aiAgent.workspacePlanEvents),
+    [aiAgent.workspacePlanEvents]
+  );
+  const workspaceOperationRevealPaths = useMemo(
+    () => (
+      aiFeatureEnabled && editorPreferences.preferences.aiWorkspaceAnimationEnabled
+        ? revealPathsForWorkspaceOperation(workspaceOperationEvents, aiAgent.workspacePlanApplyStatus)
+        : []
+    ),
+    [
+      aiAgent.workspacePlanApplyStatus,
+      aiFeatureEnabled,
+      editorPreferences.preferences.aiWorkspaceAnimationEnabled,
+      workspaceOperationEvents
+    ]
+  );
+  const workspaceOperationOverlay = aiFeatureEnabled ? (
+    <WorkspaceOperationOverlay
+      enabled={editorPreferences.preferences.aiWorkspaceAnimationEnabled}
+      events={workspaceOperationEvents}
+      status={aiAgent.workspacePlanApplyStatus}
     />
   ) : null;
 
@@ -3660,6 +3766,7 @@ function WorkspaceApp() {
             maxWidth: fileTreeMaxWidth,
             minWidth: fileTreeMinWidth,
             open: fileTreeOpen,
+            operationRevealPaths: workspaceOperationRevealPaths,
             outlineItems,
             recentFolders: recentMarkdownFolders,
             recentFoldersOpen: recentMarkdownFoldersOpen,
@@ -3695,6 +3802,7 @@ function WorkspaceApp() {
             onToggleMarkdownFiles: handleFileTreeToggle
           }}
           windowsSelfDrawnChrome={windowsSelfDrawnChromeEnabled}
+          workspaceOperationOverlay={workspaceOperationOverlay}
           workspaceLayoutClassName={workspaceLayoutClassName}
           workspaceLayoutStyle={workspaceLayoutStyle}
           onEditorContentDragLeave={handleEditorContentDragLeave}

--- a/packages/app/src/components/AiAgentPanel.test.tsx
+++ b/packages/app/src/components/AiAgentPanel.test.tsx
@@ -58,6 +58,112 @@ describe("AiAgentPanel", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a compact workspace plan confirmation above the composer without the runner panel", () => {
+    renderAgentPanel({
+      workspacePlanEvents: [
+        {
+          totalSteps: 1,
+          type: "plan_validating"
+        },
+        {
+          action: "create_note",
+          afterContent: "# Alpha",
+          index: 0,
+          label: "Create note: topics/alpha.md",
+          path: "topics/alpha.md",
+          target: "file_tree",
+          type: "step_previewed"
+        }
+      ]
+    });
+
+    const confirmation = screen.getByRole("region", { name: "Workspace plan confirmation" });
+
+    expect(confirmation).toBeInTheDocument();
+    expect(confirmation.closest("form")).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "AI workspace actions" })).not.toBeInTheDocument();
+    expect(screen.queryByText("AI cursor")).not.toBeInTheDocument();
+    expect(confirmation).toHaveTextContent("Create note: topics/alpha.md");
+  });
+
+  it("offers a confirmed apply action for prepared workspace plans", () => {
+    const applyWorkspacePlan = vi.fn();
+
+    renderAgentPanel({
+      workspacePlanApplyStatus: "idle",
+      workspacePlanEvents: [
+        {
+          totalSteps: 1,
+          type: "plan_validating"
+        },
+        {
+          action: "create_note",
+          afterContent: "# Alpha",
+          index: 0,
+          label: "Create note: topics/alpha.md",
+          path: "topics/alpha.md",
+          target: "file_tree",
+          type: "step_previewed"
+        }
+      ],
+      onApplyWorkspacePlan: applyWorkspacePlan
+    } as Partial<AiAgentPanelProps>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply workspace plan" }));
+
+    expect(applyWorkspacePlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables workspace plan apply while execution is running", () => {
+    renderAgentPanel({
+      workspacePlanApplyStatus: "applying",
+      workspacePlanEvents: [
+        {
+          totalSteps: 1,
+          type: "plan_validating"
+        },
+        {
+          action: "update_note",
+          index: 0,
+          label: "Update note: alpha.md",
+          path: "alpha.md",
+          target: "editor",
+          type: "step_started"
+        }
+      ],
+      onApplyWorkspacePlan: () => {}
+    } as Partial<AiAgentPanelProps>);
+
+    expect(screen.getByRole("button", { name: "Apply workspace plan" })).toBeDisabled();
+    expect(screen.getByText("Applying")).toBeInTheDocument();
+  });
+
+  it("lets users dismiss the completed workspace plan confirmation", () => {
+    renderAgentPanel({
+      workspacePlanApplyStatus: "applied",
+      workspacePlanEvents: [
+        {
+          totalSteps: 1,
+          type: "plan_validating"
+        },
+        {
+          action: "move_note",
+          index: 0,
+          label: "Move note: drafts/example.md -> notes/example.md",
+          target: "file_tree",
+          type: "step_applied"
+        }
+      ]
+    });
+
+    expect(screen.getByRole("region", { name: "Workspace plan confirmation" })).toHaveTextContent("Applied");
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss workspace plan confirmation" }));
+
+    expect(screen.queryByRole("region", { name: "Workspace plan confirmation" })).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Markra AI message" })).toBeInTheDocument();
+  });
+
   it("shows the current turn context in a collapsible panel", () => {
     renderAgentPanel({
       context: {
@@ -389,6 +495,35 @@ describe("AiAgentPanel", () => {
 
     expect(updateDraft).not.toHaveBeenCalled();
     expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("allows freeform AI chat when only a workspace is available", () => {
+    const submit = vi.fn();
+    const updateDraft = vi.fn();
+
+    renderAgentPanel({
+      documentAvailable: false,
+      draft: "List workspace notes",
+      onDraftChange: updateDraft,
+      onSubmit: submit,
+      workspaceAvailable: true
+    });
+
+    const input = screen.getByRole("textbox", { name: "Markra AI message" });
+    const sendButton = screen.getByRole("button", { name: "Send message" });
+    const suggestion = screen.getByRole("button", { name: "Summarize this document" });
+
+    expect(screen.getByText("Ready when you are")).toBeInTheDocument();
+    expect(input).toHaveAttribute("placeholder", "Ask Markra AI...");
+    expect(input).toBeEnabled();
+    expect(sendButton).toBeEnabled();
+    expect(suggestion).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Show markdown files" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(updateDraft).toHaveBeenCalledWith("Show markdown files");
+    expect(submit).toHaveBeenCalledTimes(1);
   });
 
   it("does not send when Enter confirms an IME composition", () => {

--- a/packages/app/src/components/AiAgentPanel.tsx
+++ b/packages/app/src/components/AiAgentPanel.tsx
@@ -28,7 +28,8 @@ import { AiAgentProcessList } from "./AiAgentProcessList";
 import { useImeInputGuard } from "../hooks/useImeInputGuard";
 import { clampNumber, t, type AppLanguage, type I18nKey } from "@markra/shared";
 import type { AiModelCapability, AiProviderApiStyle, StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
-import type { AiAgentPanelMessage } from "../hooks/useAiAgentSession";
+import type { AiAgentPanelMessage, WorkspacePlanApplyStatus } from "../hooks/useAiAgentSession";
+import type { WorkspacePlanVisualEvent } from "@markra/ai";
 import { IconButton, RoundIconButton, ToggleButton } from "@markra/ui";
 
 type AiAgentModelOption = AiModelPickerOption & { capabilities: AiModelCapability[] };
@@ -60,11 +61,16 @@ type AiAgentPanelProps = {
   thinkingEnabled?: boolean;
   webSearchAvailable?: boolean;
   webSearchEnabled?: boolean;
+  workspaceAvailable?: boolean;
+  workspacePlanApplyError?: string | null;
+  workspacePlanApplyStatus?: WorkspacePlanApplyStatus;
+  workspacePlanEvents?: WorkspacePlanVisualEvent[];
   maxWidth?: number;
   minWidth?: number;
   width?: number;
   sessions?: StoredAiAgentSessionSummary[];
   onArchiveSession?: (sessionId: string, archived: boolean) => unknown;
+  onApplyWorkspacePlan?: () => unknown;
   onClose: () => unknown;
   onCreateSession?: () => unknown;
   onDeleteSession?: (sessionId: string) => unknown;
@@ -105,11 +111,16 @@ export function AiAgentPanel({
   thinkingEnabled = false,
   webSearchAvailable = false,
   webSearchEnabled = false,
+  workspaceAvailable = false,
+  workspacePlanApplyError = null,
+  workspacePlanApplyStatus = "idle",
+  workspacePlanEvents = [],
   maxWidth = defaultMaxWidth,
   minWidth = defaultMinWidth,
   sessions = [],
   width,
   onArchiveSession,
+  onApplyWorkspacePlan,
   onClose,
   onCreateSession,
   onDeleteSession,
@@ -136,6 +147,7 @@ export function AiAgentPanel({
   const transcriptShouldFollowRef = useRef(true);
   const [contextOpen, setContextOpen] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<number | null>(null);
+  const [dismissedAppliedWorkspacePlanKey, setDismissedAppliedWorkspacePlanKey] = useState<string | null>(null);
   const [editingMessageId, setEditingMessageId] = useState<number | null>(null);
   const [collapsedThinkingMessageIds, setCollapsedThinkingMessageIds] = useState<Set<string>>(() =>
     collectCompletedThinkingMessageKeys(messages, status, activeSessionId)
@@ -177,10 +189,15 @@ export function AiAgentPanel({
     }
   ];
   const submitting = status === "thinking" || status === "streaming";
-  const canSend = documentAvailable && draft.trim().length > 0 && !submitting;
-  const emptyTitle = documentAvailable ? label("app.aiAgentEmptyTitle") : label("app.aiAgentUnavailableTitle");
-  const emptyBody = documentAvailable ? label("app.aiAgentEmptyBody") : label("app.aiAgentUnavailableBody");
-  const composerPlaceholder = documentAvailable ? label("app.aiAgentPlaceholder") : label("app.aiAgentUnavailablePlaceholder");
+  const agentAvailable = documentAvailable || workspaceAvailable;
+  const canSend = agentAvailable && draft.trim().length > 0 && !submitting;
+  const emptyTitle = agentAvailable ? label("app.aiAgentEmptyTitle") : label("app.aiAgentUnavailableTitle");
+  const emptyBody = agentAvailable ? label("app.aiAgentEmptyBody") : label("app.aiAgentUnavailableBody");
+  const composerPlaceholder = agentAvailable ? label("app.aiAgentPlaceholder") : label("app.aiAgentUnavailablePlaceholder");
+  const workspacePlanConfirmationKey = workspacePlanKey(workspacePlanEvents);
+  const workspacePlanConfirmationDismissed =
+    workspacePlanApplyStatus === "applied" &&
+    dismissedAppliedWorkspacePlanKey === workspacePlanConfirmationKey;
   const contextDocumentName = context?.documentName?.trim() || "Untitled.md";
   const contextSelection =
     (context?.selectionChars ?? 0) > 0
@@ -197,6 +214,12 @@ export function AiAgentPanel({
     if (!supportsThinking && thinkingEnabled) onDisableThinking?.();
     if (!supportsWebSearch && webSearchEnabled) onToggleWebSearch?.();
   }, [onDisableThinking, onToggleWebSearch, supportsThinking, supportsWebSearch, thinkingEnabled, webSearchEnabled]);
+
+  useEffect(() => {
+    if (workspacePlanApplyStatus === "applied" || dismissedAppliedWorkspacePlanKey === null) return;
+
+    setDismissedAppliedWorkspacePlanKey(null);
+  }, [dismissedAppliedWorkspacePlanKey, workspacePlanApplyStatus]);
 
   useEffect(() => {
     return () => {
@@ -716,6 +739,17 @@ export function AiAgentPanel({
         </div>
 
         <form className="shrink-0 border-t border-(--border-default) p-3" onSubmit={handleSubmit}>
+          {workspacePlanEvents.length > 0 && !workspacePlanConfirmationDismissed ? (
+            <WorkspacePlanConfirmationBar
+              applyError={workspacePlanApplyError}
+              applyStatus={workspacePlanApplyStatus}
+              events={workspacePlanEvents}
+              onApply={onApplyWorkspacePlan}
+              onDismiss={workspacePlanApplyStatus === "applied" ? () => {
+                setDismissedAppliedWorkspacePlanKey(workspacePlanConfirmationKey);
+              } : undefined}
+            />
+          ) : null}
           <div
             className={`ai-agent-composer relative overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) px-3 pt-3 pb-2 transition-[border-color,box-shadow] duration-150 ease-out focus-within:border-(--accent) focus-within:shadow-(--ai-command-shadow) ${
               submitting ? "ai-agent-composer-running" : ""
@@ -732,10 +766,10 @@ export function AiAgentPanel({
               placeholder={composerPlaceholder}
               rows={2}
               aria-label={label("app.aiAgentMessage")}
-              disabled={!documentAvailable}
+              disabled={!agentAvailable}
               readOnly={submitting}
               onChange={(event) => {
-                if (!documentAvailable) return;
+                if (!agentAvailable) return;
                 onDraftChange?.(event.target.value);
               }}
               onCompositionEnd={handleCompositionEnd}
@@ -780,6 +814,114 @@ export function AiAgentPanel({
       </div>
     </aside>
   );
+}
+
+type WorkspacePlanConfirmationBarProps = {
+  applyError?: string | null;
+  applyStatus: WorkspacePlanApplyStatus;
+  events: WorkspacePlanVisualEvent[];
+  onApply?: () => unknown;
+  onDismiss?: () => unknown;
+};
+
+function WorkspacePlanConfirmationBar({
+  applyError = null,
+  applyStatus,
+  events,
+  onApply,
+  onDismiss
+}: WorkspacePlanConfirmationBarProps) {
+  const latestStep = latestWorkspacePlanStep(events);
+  const stepCount = workspacePlanStepCount(events);
+  const applied = applyStatus === "applied";
+  const disabled = applyStatus === "applying" || applied || !onApply;
+  const labelText = latestStep?.label ?? "Workspace changes";
+  const detailText = applyError ?? (stepCount > 0 ? `${stepCount} workspace ${stepCount === 1 ? "action" : "actions"}` : "Workspace changes");
+
+  return (
+    <section
+      aria-label="Workspace plan confirmation"
+      className="mb-2 flex min-w-0 items-center gap-2 rounded-md border border-(--border-default) bg-(--bg-primary) px-2.5 py-2 shadow-(--ai-command-shadow)"
+    >
+      <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--accent)_10%,transparent)] text-(--accent)">
+        <WorkspacePlanConfirmationIcon status={applyStatus} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="m-0 truncate text-[12px] leading-4 font-[620] text-(--text-heading)">{labelText}</p>
+        <p
+          className={`m-0 truncate text-[11px] leading-4 ${applyError ? "text-(--danger)" : "text-(--text-secondary)"}`}
+          title={detailText}
+        >
+          {detailText}
+        </p>
+      </div>
+      {applied ? (
+        <span className="inline-flex h-7 shrink-0 items-center rounded-md bg-(--bg-active) px-2 text-[11px] leading-4 font-[620] text-(--text-heading)">
+          {workspacePlanApplyLabel(applyStatus)}
+        </span>
+      ) : (
+        <button
+          aria-label="Apply workspace plan"
+          className="inline-flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-(--accent) bg-(--accent) px-2 text-[11px] leading-4 font-[620] text-(--bg-primary) transition-[background-color,border-color,color,opacity] duration-150 ease-out hover:border-(--accent-hover) hover:bg-(--accent-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 disabled:hover:border-(--accent) disabled:hover:bg-(--accent)"
+          disabled={disabled}
+          type="button"
+          onClick={onApply}
+        >
+          <span>{workspacePlanApplyLabel(applyStatus)}</span>
+        </button>
+      )}
+      {applied && onDismiss ? (
+        <button
+          aria-label="Dismiss workspace plan confirmation"
+          className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent bg-transparent text-(--text-secondary) transition-[background-color,color] duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+          title="Dismiss workspace plan confirmation"
+          type="button"
+          onClick={onDismiss}
+        >
+          <X aria-hidden="true" size={13} />
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+function WorkspacePlanConfirmationIcon({ status }: { status: WorkspacePlanApplyStatus }) {
+  if (status === "applied") return <Check aria-hidden="true" size={13} />;
+  if (status === "error") return <X aria-hidden="true" size={13} />;
+
+  return <PencilLine aria-hidden="true" size={13} />;
+}
+
+function workspacePlanApplyLabel(status: WorkspacePlanApplyStatus) {
+  if (status === "applying") return "Applying";
+  if (status === "applied") return "Applied";
+  if (status === "error") return "Retry";
+
+  return "Apply";
+}
+
+function latestWorkspacePlanStep(events: WorkspacePlanVisualEvent[]) {
+  return [...events].reverse().find(isWorkspacePlanStepEvent) ?? null;
+}
+
+function workspacePlanStepCount(events: WorkspacePlanVisualEvent[]) {
+  const planEvent = [...events].reverse().find((event) => event.type === "plan_validating");
+  if (planEvent?.type === "plan_validating") return planEvent.totalSteps;
+
+  return new Set(events.filter(isWorkspacePlanStepEvent).map((event) => event.index)).size;
+}
+
+function workspacePlanKey(events: WorkspacePlanVisualEvent[]) {
+  return JSON.stringify(events);
+}
+
+function isWorkspacePlanStepEvent(
+  event: WorkspacePlanVisualEvent
+): event is Extract<WorkspacePlanVisualEvent, { index: number }> {
+  return event.type === "step_applied" ||
+    event.type === "step_failed" ||
+    event.type === "step_previewed" ||
+    event.type === "step_started";
 }
 
 function messageThinkingSections(message: AiAgentPanelMessage) {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -173,6 +173,50 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(container.querySelector(".markdown-file-tree-content")).toHaveClass("opacity-0");
   });
 
+  it("marks file rows as AI workspace operation targets", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const awsFileRow = screen.getByRole("button", { name: "AWS.md" });
+    const awsFileLabel = within(awsFileRow).getByText("AWS.md");
+
+    expect(awsFileRow).toHaveAttribute("data-ai-workspace-file-path", "/vault/AWS.md");
+    expect(awsFileRow).toHaveAttribute("data-ai-workspace-file-relative-path", "AWS.md");
+    expect(awsFileLabel).toHaveAttribute("data-ai-workspace-file-label-path", "/vault/AWS.md");
+    expect(awsFileLabel).toHaveAttribute("data-ai-workspace-file-label-relative-path", "AWS.md");
+  });
+
+  it("marks folder rows as AI workspace operation fallback targets", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const deployFolderRow = screen.getByRole("button", { name: "deploy" });
+    const deployFolderLabel = within(deployFolderRow).getByText("deploy");
+
+    expect(deployFolderRow).toHaveAttribute("data-ai-workspace-folder-path", "deploy");
+    expect(deployFolderRow).toHaveAttribute("data-ai-workspace-folder-relative-path", "deploy");
+    expect(deployFolderLabel).toHaveAttribute("data-ai-workspace-folder-label-path", "deploy");
+    expect(deployFolderLabel).toHaveAttribute("data-ai-workspace-folder-label-relative-path", "deploy");
+  });
+
   it("shows file and outline panels together", () => {
     const { container } = render(
       <MarkdownFileTreeDrawer
@@ -1424,6 +1468,64 @@ describe("MarkdownFileTreeDrawer", () => {
 
     expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("temporarily expands parent folders for workspace operation targets", () => {
+    const renderDrawer = (operationRevealPaths: readonly string[]) => (
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        operationRevealPaths={operationRevealPaths}
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+    const { rerender } = render(renderDrawer([]));
+
+    expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: "deploy/deploy.md" })).not.toBeInTheDocument();
+
+    rerender(renderDrawer(["/vault/deploy/new-note.md"]));
+
+    expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toBeInTheDocument();
+
+    rerender(renderDrawer([]));
+
+    expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: "deploy/deploy.md" })).not.toBeInTheDocument();
+  });
+
+  it("does not collapse folders the user opened before a workspace operation", () => {
+    const renderDrawer = (operationRevealPaths: readonly string[]) => (
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        operationRevealPaths={operationRevealPaths}
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+    const { rerender } = render(renderDrawer([]));
+    const deployFolder = screen.getByRole("button", { name: "deploy" });
+
+    fireEvent.click(deployFolder);
+
+    expect(deployFolder).toHaveAttribute("aria-expanded", "true");
+
+    rerender(renderDrawer(["/vault/deploy/new-note.md"]));
+    rerender(renderDrawer([]));
+
+    expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toBeInTheDocument();
   });
 
   it("toggles all folders from the root file row", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -94,6 +94,7 @@ import {
   collectMarkdownFolderTargetPaths,
   creatingAtFileTreeParentPath,
   defaultFileTreeSort,
+  expandedFolderPathsForFileTreeTarget,
   expandedFolderPathsForFileTreePath,
   fallbackFileTreeViewportHeight,
   fileTreeRowHeight,
@@ -144,6 +145,7 @@ type MarkdownFileTreeDrawerProps = {
   minWidth?: number;
   folderOpen?: boolean;
   open: boolean;
+  operationRevealPaths?: readonly string[];
   outlineItems: MarkdownOutlineItem[];
   platform?: DesktopPlatform;
   recentFolders?: readonly RecentMarkdownFolder[];
@@ -440,6 +442,7 @@ export function MarkdownFileTreeDrawer({
   minWidth = 220,
   folderOpen = true,
   open,
+  operationRevealPaths = [],
   outlineItems,
   platform = resolveDesktopPlatform(),
   recentFolders = [],
@@ -524,6 +527,7 @@ export function MarkdownFileTreeDrawer({
   const [fileTreeSelectionAnchorPath, setFileTreeSelectionAnchorPath] = useState<string | null>(null);
   const lastRevealRequestIdRef = useRef<number | null>(null);
   const lastAutoRevealedPathRef = useRef<string | null>(null);
+  const operationOpenedFolderPathsRef = useRef<Set<string>>(new Set());
   renamingPathRef.current = renamingPath;
   const fileTreeDndSensors = useSensors(
     useSensor(MouseSensor, {
@@ -692,6 +696,10 @@ export function MarkdownFileTreeDrawer({
   const outlineExpansionAvailable = collapsibleOutlineKeys.length > 0;
   const allOutlineItemsCollapsed = outlineExpansionAvailable &&
     collapsibleOutlineKeys.every((outlineKey) => collapsedOutlineKeys.has(outlineKey));
+  const operationRevealPathKey = operationRevealPaths
+    .map((path) => path.trim())
+    .filter(Boolean)
+    .join("\n");
   const visibleOutlineItems = useMemo(
     () => visibleOutlineRenderItems(outlineRenderItems, collapsedOutlineKeys),
     [collapsedOutlineKeys, outlineRenderItems]
@@ -915,6 +923,7 @@ export function MarkdownFileTreeDrawer({
   }, [clearImageAssetDragTracking]);
 
   const toggleFolder = (relativePath: string) => {
+    operationOpenedFolderPathsRef.current.delete(relativePath);
     setExpandedFolders((current) => {
       const next = new Set(current);
       if (next.has(relativePath)) {
@@ -929,6 +938,7 @@ export function MarkdownFileTreeDrawer({
   const toggleAllFolders = () => {
     if (!folderExpansionAvailable) return;
 
+    operationOpenedFolderPathsRef.current.clear();
     setExpandedFolders((current) => {
       const currentAllFoldersExpanded = folderPaths.every((folderPath) => current.has(folderPath));
       return currentAllFoldersExpanded ? new Set() : new Set(folderPaths);
@@ -979,6 +989,56 @@ export function MarkdownFileTreeDrawer({
       lastAutoRevealedPathRef.current = currentPath;
     }
   }, [autoRevealActiveFile, currentPath, open, revealFileTreePath]);
+
+  useEffect(() => {
+    const requestedPaths = operationRevealPathKey.split("\n").filter(Boolean);
+
+    if (requestedPaths.length === 0) {
+      const folderPathsToRestore = operationOpenedFolderPathsRef.current;
+      if (folderPathsToRestore.size === 0) return;
+
+      operationOpenedFolderPathsRef.current = new Set();
+      setExpandedFolders((current) => {
+        let changed = false;
+        const next = new Set(current);
+
+        for (const folderPath of folderPathsToRestore) {
+          if (!next.has(folderPath)) continue;
+
+          next.delete(folderPath);
+          changed = true;
+        }
+
+        return changed ? next : current;
+      });
+      return;
+    }
+
+    const revealFolderPaths = Array.from(new Set(requestedPaths.flatMap((path) =>
+      expandedFolderPathsForFileTreeTarget(assetFilteredTree, path) ?? []
+    )));
+    if (revealFolderPaths.length === 0) return;
+
+    setActiveSidebarPanel("files");
+    setSearchQuery("");
+    setFileTreeSortMenuOpen(false);
+    setCreateMenuOpen(false);
+    setOutlineLevelMenuOpen(false);
+    setExpandedFolders((current) => {
+      let changed = false;
+      const next = new Set(current);
+
+      for (const folderPath of revealFolderPaths) {
+        if (next.has(folderPath)) continue;
+
+        next.add(folderPath);
+        operationOpenedFolderPathsRef.current.add(folderPath);
+        changed = true;
+      }
+
+      return changed ? next : current;
+    });
+  }, [assetFilteredTree, operationRevealPathKey]);
 
   useEffect(() => {
     if (!pendingRevealPath || !filePanelVisible) return;
@@ -1898,6 +1958,8 @@ export function MarkdownFileTreeDrawer({
                 style={rowIndentStyle}
                 type="button"
                 aria-expanded={expanded}
+                data-ai-workspace-folder-path={folderFile.path}
+                data-ai-workspace-folder-relative-path={node.relativePath}
                 onContextMenu={(event) => openContextMenu(event, folderFile, node.path)}
                 onClick={() => {
                   finishFileTreeInputsBeforeRowNavigation();
@@ -1913,7 +1975,13 @@ export function MarkdownFileTreeDrawer({
                   <ChevronRight aria-hidden="true" className="shrink-0" size={13} />
                 )}
                 <Folder aria-hidden="true" className="shrink-0" size={16} />
-                <span className="min-w-0 truncate leading-5">{node.name}</span>
+                <span
+                  className="min-w-0 truncate leading-5"
+                  data-ai-workspace-folder-label-path={folderFile.path}
+                  data-ai-workspace-folder-label-relative-path={node.relativePath}
+                >
+                  {node.name}
+                </span>
               </button>
             )}
           </FileTreeDragSource>
@@ -2076,6 +2144,8 @@ export function MarkdownFileTreeDrawer({
             aria-selected={selected ? "true" : undefined}
             aria-label={node.relativePath}
             data-active-file-tree-row={active ? "true" : undefined}
+            data-ai-workspace-file-path={node.file.path}
+            data-ai-workspace-file-relative-path={node.relativePath}
             data-file-tree-path={node.file.path}
             data-reveal-file-tree-row={
               pendingRevealPath && sameNativePath(node.file.path, pendingRevealPath) ? "true" : undefined
@@ -2089,7 +2159,13 @@ export function MarkdownFileTreeDrawer({
             onDragStart={(event) => handleFileRowDragStart(event, node.file)}
           >
             <FileIcon aria-hidden="true" className="shrink-0" size={15} />
-            <span className="min-w-0 truncate leading-5">{node.name}</span>
+            <span
+              className="min-w-0 truncate leading-5"
+              data-ai-workspace-file-label-path={node.file.path}
+              data-ai-workspace-file-label-relative-path={node.relativePath}
+            >
+              {node.name}
+            </span>
           </button>
         )}
       </FileTreeDragSource>
@@ -2558,6 +2634,7 @@ export function MarkdownFileTreeDrawer({
           {filePanelVisible ? (
             <section
               className={`markdown-file-tree-files flex min-h-0 flex-col ${filePanelClassName}`}
+              data-ai-workspace-file-tree="true"
               style={filePanelStyle}
             >
               <DndContext

--- a/packages/app/src/components/WorkspaceLayout.tsx
+++ b/packages/app/src/components/WorkspaceLayout.tsx
@@ -18,6 +18,7 @@ type WorkspaceLayoutProps = {
   editorDropTargetActive: boolean;
   fileTree: MarkdownFileTreeDrawerProps;
   windowsSelfDrawnChrome: boolean;
+  workspaceOperationOverlay?: ReactNode;
   workspaceLayoutClassName: string;
   workspaceLayoutStyle: CSSProperties;
   onEditorContentDragLeave: () => unknown;
@@ -35,6 +36,7 @@ export function WorkspaceLayout({
   editorDropTargetActive,
   fileTree,
   windowsSelfDrawnChrome,
+  workspaceOperationOverlay = null,
   workspaceLayoutClassName,
   workspaceLayoutStyle,
   onEditorContentDragLeave,
@@ -61,6 +63,7 @@ export function WorkspaceLayout({
           data-document-search-open={documentSearchOpen && documentSearchAvailable ? "true" : undefined}
           data-document-tab-editor-drop-target="true"
           data-document-tab-drop-target={editorDropTargetActive ? "true" : undefined}
+          data-ai-workspace-editor="true"
           onDragLeave={onEditorContentDragLeave}
           onDragOver={onEditorContentDragOver}
           onDrop={onEditorContentDrop}
@@ -72,6 +75,8 @@ export function WorkspaceLayout({
           {aiAgentPanel}
         </div>
       </div>
+
+      {workspaceOperationOverlay}
     </div>
   );
 }

--- a/packages/app/src/components/WorkspaceOperationOverlay.test.tsx
+++ b/packages/app/src/components/WorkspaceOperationOverlay.test.tsx
@@ -1,0 +1,589 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { WorkspaceOperationAnimationEvent } from "../lib/workspace-operation-animation";
+import { WorkspaceOperationOverlay } from "./WorkspaceOperationOverlay";
+
+const appliedEvents: WorkspaceOperationAnimationEvent[] = [
+  {
+    totalSteps: 2,
+    type: "operation_started"
+  },
+  {
+    action: "create_note",
+    index: 0,
+    label: "Create note: topics/alpha.md",
+    path: "topics/alpha.md",
+    target: "file_tree",
+    type: "step_started"
+  },
+  {
+    action: "create_note",
+    afterContent: "# Alpha",
+    index: 0,
+    label: "Create note: topics/alpha.md",
+    path: "topics/alpha.md",
+    target: "file_tree",
+    type: "step_previewed"
+  },
+  {
+    action: "create_note",
+    afterContent: "# Alpha",
+    index: 0,
+    label: "Create note: topics/alpha.md",
+    path: "topics/alpha.md",
+    target: "file_tree",
+    type: "step_applied"
+  },
+  {
+    action: "add_tags",
+    index: 1,
+    label: "Add tags: current.md",
+    path: "current.md",
+    target: "editor",
+    type: "step_started"
+  },
+  {
+    action: "add_tags",
+    afterContent: "Tags: alpha",
+    index: 1,
+    label: "Add tags: current.md",
+    path: "current.md",
+    target: "editor",
+    type: "step_previewed"
+  },
+  {
+    action: "add_tags",
+    afterContent: "Tags: alpha",
+    index: 1,
+    label: "Add tags: current.md",
+    path: "current.md",
+    target: "editor",
+    type: "step_applied"
+  },
+  {
+    count: 2,
+    type: "operation_completed"
+  }
+];
+const liveFileTreeEvents: WorkspaceOperationAnimationEvent[] = [
+  {
+    totalSteps: 1,
+    type: "operation_started"
+  },
+  {
+    action: "create_note",
+    index: 0,
+    label: "Create note: topics/beta.md",
+    path: "topics/beta.md",
+    target: "file_tree",
+    type: "step_started"
+  }
+];
+const hiddenFileEvents: WorkspaceOperationAnimationEvent[] = [
+  {
+    totalSteps: 1,
+    type: "operation_started"
+  },
+  {
+    action: "update_note",
+    index: 0,
+    label: "Update note: docs/hidden.md",
+    path: "docs/hidden.md",
+    target: "file_tree",
+    type: "step_started"
+  }
+];
+const hiddenRootFileEvents: WorkspaceOperationAnimationEvent[] = [
+  {
+    totalSteps: 1,
+    type: "operation_started"
+  },
+  {
+    action: "create_note",
+    index: 0,
+    label: "Create note: TODO.md",
+    path: "TODO.md",
+    target: "file_tree",
+    type: "step_started"
+  }
+];
+
+function setRect(element: Element | null, rect: Partial<DOMRect>) {
+  if (!element) throw new Error("Missing test element");
+
+  const normalizedRect = {
+    bottom: rect.bottom ?? (rect.top ?? 0) + (rect.height ?? 0),
+    height: rect.height ?? 0,
+    left: rect.left ?? 0,
+    right: rect.right ?? (rect.left ?? 0) + (rect.width ?? 0),
+    top: rect.top ?? 0,
+    width: rect.width ?? 0,
+    x: rect.left ?? 0,
+    y: rect.top ?? 0,
+    toJSON: () => ({})
+  } satisfies DOMRect;
+
+  element.getBoundingClientRect = vi.fn(() => normalizedRect);
+}
+
+function renderWorkspaceOverlay(events: WorkspaceOperationAnimationEvent[] = appliedEvents) {
+  return render(
+    <>
+      <aside className="markdown-file-tree-slot">
+        <button
+          data-ai-workspace-file-path="/vault/topics/alpha.md"
+          data-ai-workspace-file-relative-path="topics/alpha.md"
+          type="button"
+        >
+          <span
+            data-ai-workspace-file-label-path="/vault/topics/alpha.md"
+            data-ai-workspace-file-label-relative-path="topics/alpha.md"
+          >
+            alpha.md
+          </span>
+        </button>
+      </aside>
+      <main
+        className="editor-content-slot"
+        data-ai-workspace-editor="true"
+      >
+        <div className="markdown-paper">Editor</div>
+      </main>
+      <WorkspaceOperationOverlay
+        events={events}
+        playbackDelayMs={100}
+        status="applied"
+      />
+    </>
+  );
+}
+
+describe("WorkspaceOperationOverlay", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("anchors the AI cursor to the real workspace file row during file-tree steps", () => {
+    vi.useFakeTimers();
+    const { container } = renderWorkspaceOverlay();
+    setRect(container.querySelector("[data-ai-workspace-file-relative-path='topics/alpha.md']"), {
+      height: 32,
+      left: 40,
+      top: 72,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-label-relative-path='topics/alpha.md']"), {
+      height: 20,
+      left: 82,
+      top: 78,
+      width: 88
+    });
+    setRect(container.querySelector("[data-ai-workspace-editor='true']"), {
+      height: 520,
+      left: 320,
+      top: 50,
+      width: 620
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const cursor = screen.getByTestId("workspace-operation-cursor");
+
+    expect(cursor).toHaveAttribute("data-ai-workspace-target", "file_tree");
+    expect(cursor).toHaveStyle({
+      transform: "translate3d(84px, 88px, 0)"
+    });
+    expect(cursor.style.left).toBe("");
+    expect(cursor.style.top).toBe("");
+  });
+
+  it("keeps workspace operation details out of the workspace overlay", () => {
+    const previewEvents: WorkspaceOperationAnimationEvent[] = [
+      {
+        totalSteps: 1,
+        type: "operation_started"
+      },
+      {
+        action: "create_note",
+        afterContent: "# Alpha\n\nSynthetic detail",
+        index: 0,
+        label: "Create note: topics/alpha.md",
+        path: "topics/alpha.md",
+        target: "file_tree",
+        type: "step_previewed"
+      }
+    ];
+    const { container } = render(
+      <>
+        <aside className="markdown-file-tree-slot">
+          <button
+            data-ai-workspace-file-relative-path="topics/alpha.md"
+            type="button"
+          >
+            <span data-ai-workspace-file-label-relative-path="topics/alpha.md">alpha.md</span>
+          </button>
+        </aside>
+        <WorkspaceOperationOverlay
+          events={previewEvents}
+          status="applying"
+        />
+      </>
+    );
+    setRect(container.querySelector("[data-ai-workspace-file-relative-path='topics/alpha.md']"), {
+      height: 32,
+      left: 40,
+      top: 72,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-label-relative-path='topics/alpha.md']"), {
+      height: 20,
+      left: 82,
+      top: 78,
+      width: 88
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(screen.queryByTestId("workspace-operation-step-panel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-operation-step-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-operation-cursor")).toHaveStyle({
+      transform: "translate3d(84px, 88px, 0)"
+    });
+    expect(screen.getByTestId("workspace-operation-target")).toHaveStyle({
+      transform: "translate3d(40px, 72px, 0)"
+    });
+  });
+
+  it("keeps the cursor tip on the target while offsetting its label bubble", () => {
+    vi.useFakeTimers();
+    const { container } = renderWorkspaceOverlay();
+    setRect(container.querySelector("[data-ai-workspace-file-relative-path='topics/alpha.md']"), {
+      height: 32,
+      left: 40,
+      top: 72,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-label-relative-path='topics/alpha.md']"), {
+      height: 20,
+      left: 82,
+      top: 78,
+      width: 88
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(screen.getByTestId("workspace-operation-cursor")).toHaveStyle({
+      transform: "translate3d(84px, 88px, 0)"
+    });
+    expect(screen.getByTestId("workspace-operation-cursor-pointer")).toHaveAttribute("data-ai-workspace-cursor-tip", "true");
+    expect(screen.getByTestId("workspace-operation-cursor-bubble")).toHaveStyle({
+      transform: "translate3d(18px, 9px, 0)"
+    });
+  });
+
+  it("moves the AI cursor onto the real editor area as playback advances", () => {
+    vi.useFakeTimers();
+    const { container } = renderWorkspaceOverlay();
+    setRect(container.querySelector("[data-ai-workspace-file-relative-path='topics/alpha.md']"), {
+      height: 32,
+      left: 40,
+      top: 72,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-label-relative-path='topics/alpha.md']"), {
+      height: 20,
+      left: 82,
+      top: 78,
+      width: 88
+    });
+    setRect(container.querySelector("[data-ai-workspace-editor='true']"), {
+      height: 500,
+      left: 300,
+      top: 80,
+      width: 600
+    });
+    setRect(container.querySelector(".markdown-paper"), {
+      height: 360,
+      left: 380,
+      top: 118,
+      width: 520
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    for (let frame = 0; frame < 6; frame += 1) {
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+    }
+
+    const cursor = screen.getByTestId("workspace-operation-cursor");
+
+    expect(cursor).toHaveAttribute("data-ai-workspace-target", "editor");
+    expect(cursor).toHaveStyle({
+      transform: "translate3d(442px, 183px, 0)"
+    });
+  });
+
+  it("dismisses the workspace overlay shortly after completed playback", () => {
+    vi.useFakeTimers();
+    const { container } = renderWorkspaceOverlay();
+    setRect(container.querySelector("[data-ai-workspace-file-relative-path='topics/alpha.md']"), {
+      height: 32,
+      left: 40,
+      top: 72,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-label-relative-path='topics/alpha.md']"), {
+      height: 20,
+      left: 82,
+      top: 78,
+      width: 88
+    });
+    setRect(container.querySelector("[data-ai-workspace-editor='true']"), {
+      height: 500,
+      left: 300,
+      top: 80,
+      width: 600
+    });
+    setRect(container.querySelector(".markdown-paper"), {
+      height: 360,
+      left: 380,
+      top: 118,
+      width: 520
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    for (let frame = 0; frame < 8; frame += 1) {
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+    }
+
+    expect(screen.queryByTestId("workspace-operation-step-panel")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-operation-cursor")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(screen.queryByTestId("workspace-operation-step-panel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-operation-cursor")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-operation-target")).not.toBeInTheDocument();
+  });
+
+  it("uses transform transitions instead of left and top layout animation", () => {
+    vi.useFakeTimers();
+    const { container } = renderWorkspaceOverlay();
+    setRect(container.querySelector("[data-ai-workspace-file-relative-path='topics/alpha.md']"), {
+      height: 32,
+      left: 40,
+      top: 72,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-label-relative-path='topics/alpha.md']"), {
+      height: 20,
+      left: 82,
+      top: 78,
+      width: 88
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const cursor = screen.getByTestId("workspace-operation-cursor");
+    const target = screen.getByTestId("workspace-operation-target");
+
+    expect(cursor.className).toContain("transition-[transform,opacity]");
+    expect(target.className).toContain("transition-[transform,width,height,opacity]");
+    expect(target).toHaveStyle({
+      transform: "translate3d(40px, 72px, 0)"
+    });
+  });
+
+  it("does not render over the workspace while the plan is only a preview", () => {
+    const { container } = render(
+      <WorkspaceOperationOverlay
+        events={appliedEvents}
+        status="idle"
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not render when the workspace operation animation is disabled", () => {
+    const { container } = render(
+      <WorkspaceOperationOverlay
+        enabled={false}
+        events={liveFileTreeEvents}
+        status="applying"
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("anchors to a visible parent folder when the target file is not visible", () => {
+    const { container } = render(
+      <>
+        <aside className="markdown-file-tree-slot">
+          <section
+            className="markdown-file-tree-files"
+            data-ai-workspace-file-tree="true"
+          >
+            <button
+              data-ai-workspace-folder-relative-path="docs"
+              type="button"
+            >
+              <span data-ai-workspace-folder-label-relative-path="docs">docs</span>
+            </button>
+          </section>
+        </aside>
+        <WorkspaceOperationOverlay
+          events={hiddenFileEvents}
+          status="applying"
+        />
+      </>
+    );
+    setRect(container.querySelector(".markdown-file-tree-slot"), {
+      height: 500,
+      left: 0,
+      top: 0,
+      width: 240
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-tree='true']"), {
+      height: 320,
+      left: 0,
+      top: 240,
+      width: 240
+    });
+    setRect(container.querySelector("[data-ai-workspace-folder-relative-path='docs']"), {
+      height: 32,
+      left: 24,
+      top: 300,
+      width: 180
+    });
+    setRect(container.querySelector("[data-ai-workspace-folder-label-relative-path='docs']"), {
+      height: 20,
+      left: 88,
+      top: 306,
+      width: 64
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(screen.getByTestId("workspace-operation-cursor")).toHaveStyle({
+      transform: "translate3d(90px, 316px, 0)"
+    });
+    expect(screen.getByTestId("workspace-operation-target")).toHaveStyle({
+      transform: "translate3d(24px, 300px, 0)"
+    });
+  });
+
+  it("falls back to the file list area instead of the sidebar top for root files", () => {
+    const { container } = render(
+      <>
+        <aside className="markdown-file-tree-slot">Sidebar chrome</aside>
+        <section
+          className="markdown-file-tree-files"
+          data-ai-workspace-file-tree="true"
+        >
+          File list
+        </section>
+        <WorkspaceOperationOverlay
+          events={hiddenRootFileEvents}
+          status="applying"
+        />
+      </>
+    );
+    setRect(container.querySelector(".markdown-file-tree-slot"), {
+      height: 500,
+      left: 0,
+      top: 0,
+      width: 240
+    });
+    setRect(container.querySelector("[data-ai-workspace-file-tree='true']"), {
+      height: 320,
+      left: 0,
+      top: 240,
+      width: 240
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(screen.getByTestId("workspace-operation-cursor")).toHaveStyle({
+      transform: "translate3d(24px, 288px, 0)"
+    });
+  });
+
+  it("reattaches to a real file row when the row appears after execution starts", async () => {
+    const { container } = render(
+      <>
+        <aside className="markdown-file-tree-slot">Workspace</aside>
+        <WorkspaceOperationOverlay
+          events={liveFileTreeEvents}
+          status="applying"
+        />
+      </>
+    );
+    const fileTree = container.querySelector(".markdown-file-tree-slot");
+    setRect(fileTree, {
+      height: 240,
+      left: 10,
+      top: 20,
+      width: 220
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(screen.getByTestId("workspace-operation-cursor")).toHaveStyle({
+      transform: "translate3d(34px, 68px, 0)"
+    });
+
+    const fileRow = document.createElement("button");
+    fileRow.dataset.aiWorkspaceFileRelativePath = "topics/beta.md";
+    fileRow.type = "button";
+    setRect(fileRow, {
+      height: 32,
+      left: 44,
+      top: 76,
+      width: 180
+    });
+    const fileLabel = document.createElement("span");
+    fileLabel.dataset.aiWorkspaceFileLabelRelativePath = "topics/beta.md";
+    fileLabel.textContent = "beta.md";
+    setRect(fileLabel, {
+      height: 20,
+      left: 88,
+      top: 82,
+      width: 74
+    });
+    fileRow.appendChild(fileLabel);
+
+    act(() => {
+      fileTree?.appendChild(fileRow);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-operation-cursor")).toHaveStyle({
+        transform: "translate3d(90px, 92px, 0)"
+      });
+    });
+  });
+});

--- a/packages/app/src/components/WorkspaceOperationOverlay.tsx
+++ b/packages/app/src/components/WorkspaceOperationOverlay.tsx
@@ -1,0 +1,436 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Check, MousePointer2 } from "lucide-react";
+import {
+  activeWorkspaceOperationStep,
+  hasTerminalWorkspaceOperationStep,
+  workspaceOperationEventSignature,
+  workspaceOperationPlaybackEvents,
+  workspaceOperationPlaybackStartCount,
+  workspaceOperationSteps,
+  type WorkspaceOperationAnimationEvent,
+  type WorkspaceOperationAnimationStatus,
+  type WorkspaceOperationStepView,
+  type WorkspaceOperationTarget
+} from "../lib/workspace-operation-animation";
+
+type WorkspaceOperationOverlayProps = {
+  enabled?: boolean;
+  events: readonly WorkspaceOperationAnimationEvent[];
+  playbackDelayMs?: number;
+  status?: WorkspaceOperationAnimationStatus;
+};
+
+type WorkspaceOperationPosition = {
+  height: number;
+  left: number;
+  status: WorkspaceOperationStepView["type"];
+  target: WorkspaceOperationTarget;
+  targetLeft: number;
+  targetTop: number;
+  top: number;
+  width: number;
+};
+
+const defaultPlaybackDelayMs = 420;
+const completedPlaybackDismissDelayMs = 1000;
+const editorTargetSelector = "[data-ai-workspace-editor='true'], .editor-content-slot";
+const editorSurfaceSelector = ".markdown-paper, .markdown-source-paper, .markdown-source-editor, [role='textbox']";
+const fileTreeFallbackSelectors = [
+  "[data-ai-workspace-file-tree='true']",
+  ".markdown-file-tree-files",
+  ".markdown-file-tree-body",
+  ".markdown-file-tree-slot"
+] as const;
+
+export function WorkspaceOperationOverlay({
+  enabled = true,
+  events,
+  playbackDelayMs = defaultPlaybackDelayMs,
+  status = "idle"
+}: WorkspaceOperationOverlayProps) {
+  const [playbackState, setPlaybackState] = useState({
+    signature: "",
+    visibleEventCount: 0
+  });
+  const [dismissedPlaybackSignature, setDismissedPlaybackSignature] = useState("");
+  const [position, setPosition] = useState<WorkspaceOperationPosition | null>(null);
+  const playbackEvents = workspaceOperationPlaybackEvents(events);
+  const playbackEnabled =
+    enabled &&
+    (status === "applied" || status === "error") &&
+    hasTerminalWorkspaceOperationStep(playbackEvents);
+  const playbackSignature = workspaceOperationEventSignature(playbackEvents);
+  const playbackStartCount = workspaceOperationPlaybackStartCount(playbackEvents);
+  const currentPlaybackCount =
+    playbackEnabled && playbackState.signature === playbackSignature
+      ? playbackState.visibleEventCount
+      : playbackStartCount;
+  const visibleEvents = playbackEnabled
+    ? playbackEvents.slice(0, Math.min(currentPlaybackCount, playbackEvents.length))
+    : events;
+  const visibleEventSignature = workspaceOperationEventSignature(visibleEvents);
+  const visibleSteps = useMemo(
+    () => workspaceOperationSteps(visibleEvents),
+    [visibleEventSignature]
+  );
+  const activeStep = useMemo(
+    () => activeWorkspaceOperationStep(visibleSteps),
+    [visibleSteps]
+  );
+  const activeStepPositionKey = activeStep ? workspaceStepPositionKey(activeStep) : "";
+  const completedPlayback =
+    playbackEnabled &&
+    status === "applied" &&
+    playbackState.signature === playbackSignature &&
+    playbackState.visibleEventCount >= playbackEvents.length &&
+    playbackEvents.length > 0;
+  const playbackDismissed =
+    playbackEnabled &&
+    dismissedPlaybackSignature === playbackSignature;
+
+  useEffect(() => {
+    if (!enabled || !playbackEnabled) return;
+
+    if (playbackState.signature !== playbackSignature) {
+      setPlaybackState({
+        signature: playbackSignature,
+        visibleEventCount: playbackStartCount
+      });
+      return;
+    }
+
+    if (playbackState.visibleEventCount >= playbackEvents.length) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setPlaybackState((currentState) => {
+        if (currentState.signature !== playbackSignature) return currentState;
+
+        return {
+          ...currentState,
+          visibleEventCount: Math.min(currentState.visibleEventCount + 1, playbackEvents.length)
+        };
+      });
+    }, playbackDelayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    playbackDelayMs,
+    enabled,
+    playbackEnabled,
+    playbackEvents.length,
+    playbackSignature,
+    playbackStartCount,
+    playbackState.signature,
+    playbackState.visibleEventCount
+  ]);
+
+  useEffect(() => {
+    if (!completedPlayback || playbackDismissed) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setDismissedPlaybackSignature(playbackSignature);
+    }, completedPlaybackDismissDelayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    completedPlayback,
+    playbackDismissed,
+    playbackSignature
+  ]);
+
+  useEffect(() => {
+    if (!enabled || status === "idle" || !activeStep) {
+      setPosition(null);
+      return;
+    }
+
+    const updatePosition = () => {
+      setPosition(positionForWorkspaceStep(activeStep));
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    const observer = typeof MutationObserver === "undefined"
+      ? null
+      : new MutationObserver(updatePosition);
+    observer?.observe(document.body, {
+      attributeFilter: [
+        "data-ai-workspace-editor",
+        "data-ai-workspace-file-path",
+        "data-ai-workspace-file-label-path",
+        "data-ai-workspace-file-label-relative-path",
+        "data-ai-workspace-file-relative-path",
+        "data-ai-workspace-file-tree",
+        "data-ai-workspace-folder-label-path",
+        "data-ai-workspace-folder-label-relative-path",
+        "data-ai-workspace-folder-path",
+        "data-ai-workspace-folder-relative-path",
+        "data-file-tree-path"
+      ],
+      attributes: true,
+      childList: true,
+      subtree: true
+    });
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+      observer?.disconnect();
+    };
+  }, [activeStep, activeStepPositionKey, enabled, status]);
+
+  if (!enabled || status === "idle" || !position || playbackDismissed) return null;
+
+  const targetStyle: CSSProperties = {
+    height: `${position.height}px`,
+    transform: translate3d(position.targetLeft, position.targetTop),
+    width: `${position.width}px`
+  };
+  const cursorStyle: CSSProperties = {
+    transform: translate3d(position.left, position.top)
+  };
+
+  return (
+    <div
+      aria-hidden="true"
+      className="workspace-operation-overlay pointer-events-none fixed inset-0 z-[60]"
+      data-ai-workspace-operation-overlay="true"
+    >
+      <div
+        className="absolute left-0 top-0 rounded-md border border-[color-mix(in_srgb,var(--accent)_42%,transparent)] bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] opacity-90 shadow-[0_0_0_1px_color-mix(in_srgb,var(--accent)_18%,transparent),0_10px_32px_color-mix(in_srgb,var(--accent)_12%,transparent)] transition-[transform,width,height,opacity] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transition-none"
+        data-testid="workspace-operation-target"
+        style={targetStyle}
+      />
+      <div
+        className="absolute left-0 top-0 size-0 transition-[transform,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform motion-reduce:transition-none"
+        data-ai-workspace-target={position.target}
+        data-testid="workspace-operation-cursor"
+        style={cursorStyle}
+      >
+        <MousePointer2
+          aria-hidden="true"
+          className="absolute -left-0.5 -top-0.5 text-(--accent) drop-shadow-[0_1px_1px_color-mix(in_srgb,var(--bg-primary)_90%,transparent)]"
+          data-ai-workspace-cursor-tip="true"
+          data-testid="workspace-operation-cursor-pointer"
+          size={16}
+        />
+        <div
+          className="absolute left-0 top-0 inline-flex items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--accent)_38%,var(--border-default))] bg-(--bg-primary)/95 px-2 py-1 text-[10px] leading-4 font-[620] text-(--text-heading) shadow-(--ai-command-popover-shadow) backdrop-blur"
+          data-testid="workspace-operation-cursor-bubble"
+          style={{ transform: translate3d(18, 9) }}
+        >
+          {position.status === "step_applied" ? (
+            <Check aria-hidden="true" className="text-(--accent)" size={12} />
+          ) : (
+            <MousePointer2 aria-hidden="true" className="text-(--accent)" size={12} />
+          )}
+          <span className="max-w-40 truncate">{operationCursorLabel(position)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function positionForWorkspaceStep(step: WorkspaceOperationStepView) {
+  const elements = elementsForWorkspaceStep(step);
+  if (!elements) return null;
+
+  const targetRect = elements.target.getBoundingClientRect();
+  const cursorRect = (elements.cursor ?? elements.target).getBoundingClientRect();
+  const cursorPoint = cursorPointForWorkspaceStep(step, cursorRect, elements.cursor !== undefined);
+
+  return {
+    height: Math.round(targetRect.height),
+    left: Math.round(cursorPoint.left),
+    status: step.type,
+    target: step.target,
+    targetLeft: Math.round(targetRect.left),
+    targetTop: Math.round(targetRect.top),
+    top: Math.round(cursorPoint.top),
+    width: Math.round(targetRect.width)
+  } satisfies WorkspaceOperationPosition;
+}
+
+function elementsForWorkspaceStep(step: WorkspaceOperationStepView) {
+  if (step.target === "editor") {
+    const editor = document.querySelector<HTMLElement>(editorTargetSelector);
+    if (!editor) return null;
+
+    const editorSurface = editor.querySelector<HTMLElement>(editorSurfaceSelector);
+    return {
+      target: editorSurface ?? editor
+    };
+  }
+
+  const fileElement = fileElementForWorkspaceStep(step);
+  if (fileElement) {
+    return {
+      cursor: fileLabelElementForWorkspaceStep(step) ?? fileElement,
+      target: fileElement
+    };
+  }
+
+  const folderElement = folderElementForWorkspaceStep(step);
+  if (folderElement) {
+    return {
+      cursor: folderLabelElementForWorkspaceStep(step) ?? folderElement,
+      target: folderElement
+    };
+  }
+
+  const fallback = fileTreeFallbackElement();
+  return fallback ? { target: fallback } : null;
+}
+
+function fileElementForWorkspaceStep(step: WorkspaceOperationStepView) {
+  for (const path of workspaceStepPaths(step)) {
+    const target = document.querySelector<HTMLElement>(
+      [
+        attributeSelector("data-ai-workspace-file-relative-path", path),
+        attributeSelector("data-ai-workspace-file-path", path),
+        attributeSelector("data-file-tree-path", path)
+      ].join(", ")
+    );
+    if (target) return target;
+  }
+
+  return null;
+}
+
+function fileLabelElementForWorkspaceStep(step: WorkspaceOperationStepView) {
+  for (const path of workspaceStepPaths(step)) {
+    const target = document.querySelector<HTMLElement>(
+      [
+        attributeSelector("data-ai-workspace-file-label-relative-path", path),
+        attributeSelector("data-ai-workspace-file-label-path", path)
+      ].join(", ")
+    );
+    if (target) return target;
+  }
+
+  return null;
+}
+
+function folderElementForWorkspaceStep(step: WorkspaceOperationStepView) {
+  for (const path of workspaceStepParentFolderPaths(step)) {
+    const target = document.querySelector<HTMLElement>(
+      [
+        attributeSelector("data-ai-workspace-folder-relative-path", path),
+        attributeSelector("data-ai-workspace-folder-path", path)
+      ].join(", ")
+    );
+    if (target) return target;
+  }
+
+  return null;
+}
+
+function folderLabelElementForWorkspaceStep(step: WorkspaceOperationStepView) {
+  for (const path of workspaceStepParentFolderPaths(step)) {
+    const target = document.querySelector<HTMLElement>(
+      [
+        attributeSelector("data-ai-workspace-folder-label-relative-path", path),
+        attributeSelector("data-ai-workspace-folder-label-path", path)
+      ].join(", ")
+    );
+    if (target) return target;
+  }
+
+  return null;
+}
+
+function fileTreeFallbackElement() {
+  for (const selector of fileTreeFallbackSelectors) {
+    const target = document.querySelector<HTMLElement>(selector);
+    if (target) return target;
+  }
+
+  return null;
+}
+
+function cursorPointForWorkspaceStep(
+  step: WorkspaceOperationStepView,
+  rect: DOMRect,
+  preciseFileLabel: boolean
+) {
+  if (step.target === "file_tree") {
+    return {
+      left: rect.left + (preciseFileLabel ? 2 : 24),
+      top: rect.top + (preciseFileLabel ? rect.height / 2 : Math.min(48, Math.max(24, rect.height * 0.2)))
+    };
+  }
+
+  return {
+    left: rect.left + Math.min(96, Math.max(32, rect.width * 0.12)),
+    top: rect.top + Math.min(96, Math.max(48, rect.height * 0.18))
+  };
+}
+
+function workspaceStepPaths(step: WorkspaceOperationStepView) {
+  return [step.path, step.to, step.from].filter((path): path is string => Boolean(path));
+}
+
+function workspaceStepParentFolderPaths(step: WorkspaceOperationStepView) {
+  const parentPaths: string[] = [];
+
+  for (const path of workspaceStepPaths(step)) {
+    parentPaths.push(...parentFolderPathCandidates(path));
+  }
+
+  return uniqueStrings(parentPaths);
+}
+
+function parentFolderPathCandidates(path: string) {
+  const normalizedPath = path.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  const parts = normalizedPath.split("/").filter(Boolean);
+  const absolutePrefix = normalizedPath.startsWith("/") ? "/" : "";
+  if (parts.length <= 1) return [];
+
+  const folders: string[] = [];
+  for (let count = parts.length - 1; count > 0; count -= 1) {
+    folders.push(`${absolutePrefix}${parts.slice(0, count).join("/")}`);
+  }
+
+  return folders;
+}
+
+function uniqueStrings(values: string[]) {
+  return Array.from(new Set(values));
+}
+
+function attributeSelector(attribute: string, value: string) {
+  return `[${attribute}="${cssAttributeValue(value)}"]`;
+}
+
+function cssAttributeValue(value: string) {
+  return value.replace(/\\/gu, "\\\\").replace(/"/gu, "\\\"");
+}
+
+function translate3d(left: number, top: number) {
+  return `translate3d(${left}px, ${top}px, 0)`;
+}
+
+function operationCursorLabel(position: WorkspaceOperationPosition) {
+  if (position.status === "step_applied") return "Done";
+  if (position.status === "step_failed") return "Failed";
+  if (position.status === "step_previewed") return "Preview";
+
+  return "Working";
+}
+
+function workspaceStepPositionKey(step: WorkspaceOperationStepView) {
+  return [
+    step.type,
+    step.index,
+    step.target,
+    step.path ?? "",
+    step.from ?? "",
+    step.to ?? "",
+    step.label
+  ].join(":");
+}

--- a/packages/app/src/components/file-tree/file-tree-model.ts
+++ b/packages/app/src/components/file-tree/file-tree-model.ts
@@ -284,6 +284,39 @@ export function expandedFolderPathsForFileTreePath(nodes: TreeNode[], path: stri
   return findPath(nodes, []);
 }
 
+export function expandedFolderPathsForFileTreeTarget(
+  nodes: TreeNode[],
+  path: string | null | undefined
+) {
+  const filePathFolders = expandedFolderPathsForFileTreePath(nodes, path);
+  if (filePathFolders !== null) return filePathFolders;
+  if (!path?.trim()) return null;
+
+  const parentCandidates = parentFolderPathCandidates(path);
+  if (parentCandidates.length === 0) return [];
+
+  const findDeepestFolder = (treeNodes: TreeNode[], parents: string[]): string[] | null => {
+    let deepest: string[] | null = null;
+
+    for (const node of treeNodes) {
+      if (node.type !== "folder") continue;
+
+      const folderParents = [...parents, node.relativePath];
+      const folderMatches = parentCandidates.some((candidate) =>
+        sameNativePath(node.relativePath, candidate) || sameNativePath(node.path, candidate)
+      );
+      if (folderMatches) deepest = folderParents;
+
+      const childMatch = findDeepestFolder(node.children, folderParents);
+      if (childMatch) deepest = childMatch;
+    }
+
+    return deepest;
+  };
+
+  return findDeepestFolder(nodes, []);
+}
+
 export function folderNodeAsFile(node: FolderNode): NativeMarkdownFolderFile {
   return {
     createdAt: node.createdAt,
@@ -446,4 +479,18 @@ export function fileTreeRowIndentStyle(depth: number, mode: FileTreeRowRenderMod
 
 export function fileTreeRowIndentClass(mode: FileTreeRowRenderMode) {
   return mode === "virtual" ? "" : "pl-8";
+}
+
+function parentFolderPathCandidates(path: string) {
+  const normalizedPath = path.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  const parts = normalizedPath.split("/").filter(Boolean);
+  const absolutePrefix = normalizedPath.startsWith("/") ? "/" : "";
+  if (parts.length <= 1) return [];
+
+  const folders: string[] = [];
+  for (let count = parts.length - 1; count > 0; count -= 1) {
+    folders.push(`${absolutePrefix}${parts.slice(0, count).join("/")}`);
+  }
+
+  return folders;
 }

--- a/packages/app/src/components/settings/AiSettings.test.tsx
+++ b/packages/app/src/components/settings/AiSettings.test.tsx
@@ -22,6 +22,12 @@ describe("AiSettings", () => {
 
     expect(screen.getByRole("switch", { name: "Show AI quick input" })).toHaveAttribute("aria-checked", "true");
     expect(screen.getByRole("switch", { name: "Show floating toolbar" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("switch", { name: "AI workspace animation" })).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByText(
+        "Experimental. Shows an AI cursor and highlights in the workspace while file changes are being applied."
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "Experimental. Suggest Markra AI for complex inline requests based on local input structure. Turn it off if the prompt feels too eager."
@@ -49,6 +55,14 @@ describe("AiSettings", () => {
     expect(onUpdatePreferences).toHaveBeenCalledWith({
       ...defaultEditorPreferences,
       suggestAiPanelForComplexInlinePrompts: false
+    });
+
+    fireEvent.click(screen.getByRole("switch", { name: "AI workspace animation" }));
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      suggestAiPanelForComplexInlinePrompts: true,
+      aiWorkspaceAnimationEnabled: true
     });
   });
 

--- a/packages/app/src/components/settings/AiSettings.tsx
+++ b/packages/app/src/components/settings/AiSettings.tsx
@@ -101,6 +101,22 @@ export function AiSettings({
           }
         />
         <SettingsRow
+          title={translate("settings.editor.aiWorkspaceAnimation")}
+          description={translate("settings.editor.aiWorkspaceAnimationDescription")}
+          action={
+            <SettingsSwitch
+              checked={preferences.aiWorkspaceAnimationEnabled}
+              label={translate("settings.editor.aiWorkspaceAnimation")}
+              onChange={() =>
+                onUpdatePreferences({
+                  ...preferences,
+                  aiWorkspaceAnimationEnabled: !preferences.aiWorkspaceAnimationEnabled
+                })
+              }
+            />
+          }
+        />
+        <SettingsRow
           title={translate("settings.editor.suggestAiPanelForComplexInlinePrompts")}
           description={translate("settings.editor.suggestAiPanelForComplexInlinePromptsDescription")}
           action={

--- a/packages/app/src/hooks/useAiAgentSession.test.tsx
+++ b/packages/app/src/hooks/useAiAgentSession.test.tsx
@@ -81,6 +81,10 @@ describe("useAiAgentSession", () => {
     mockedSaveStoredAiAgentSessionTitle.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("streams an assistant reply into the transcript", async () => {
     mockedRunDocumentAiAgent.mockImplementation(async ({ onTextDelta }) => {
       onTextDelta?.("Hello");
@@ -856,6 +860,175 @@ describe("useAiAgentSession", () => {
       role: "assistant",
       text: "Done"
     });
+  });
+
+  it("exposes prepared workspace plan events from agent tool results", async () => {
+    mockedRunDocumentAiAgent.mockImplementation(async ({ onEvent, onTextDelta }) => {
+      onEvent?.({
+        isError: false,
+        result: {
+          details: {
+            changes: [
+              {
+                content: "# Alpha",
+                label: "Create note: topics/alpha.md",
+                path: "topics/alpha.md",
+                type: "create_note"
+              }
+            ],
+            count: 1,
+            summary: "Organize synthetic notes."
+          }
+        },
+        toolCallId: "tool-plan",
+        toolName: "prepare_workspace_change_plan",
+        type: "tool_execution_end"
+      });
+      onTextDelta?.("Prepared plan.");
+
+      return {
+        content: "Prepared plan.",
+        finishReason: "stop"
+      };
+    });
+
+    const { result } = renderAiAgentSession({
+      documentPath: "/vault/README.md",
+      sessionId: "session-a"
+    });
+
+    await act(async () => {
+      await result.current.submit("Organize this workspace");
+    });
+
+    expect(result.current.workspacePlanEvents.map((event) => event.type)).toEqual([
+      "plan_validating",
+      "step_started",
+      "step_previewed"
+    ]);
+    expect(result.current.workspacePlanEvents[1]).toEqual(expect.objectContaining({
+      action: "create_note",
+      path: "topics/alpha.md",
+      target: "file_tree"
+    }));
+  });
+
+  it("applies the latest prepared workspace plan through a confirmed delayed executor", async () => {
+    vi.useFakeTimers();
+    mockedRunDocumentAiAgent.mockImplementation(async ({ onEvent, onTextDelta }) => {
+      onEvent?.({
+        isError: false,
+        result: {
+          details: {
+            changes: [
+              {
+                content: "# Alpha",
+                label: "Create note: topics/alpha.md",
+                path: "topics/alpha.md",
+                type: "create_note"
+              }
+            ],
+            count: 1,
+            summary: "Organize synthetic notes."
+          }
+        },
+        toolCallId: "tool-plan",
+        toolName: "prepare_workspace_change_plan",
+        type: "tool_execution_end"
+      });
+      onTextDelta?.("Prepared plan.");
+
+      return {
+        content: "Prepared plan.",
+        finishReason: "stop"
+      };
+    });
+    const applyWorkspacePlan = vi.fn(async (plan, options) => {
+      expect(plan).toEqual({
+        changes: [
+          {
+            content: "# Alpha",
+            label: "Create note: topics/alpha.md",
+            path: "topics/alpha.md",
+            type: "create_note"
+          }
+        ],
+        summary: "Organize synthetic notes."
+      });
+
+      options.onVisualEvent({
+        totalSteps: 1,
+        type: "plan_validating"
+      });
+      options.onVisualEvent({
+        action: "create_note",
+        afterContent: "# Alpha",
+        index: 0,
+        label: "Create note: topics/alpha.md",
+        path: "topics/alpha.md",
+        target: "file_tree",
+        type: "step_applied"
+      });
+
+      return {
+        count: 1,
+        journal: {
+          changes: [
+            {
+              afterContent: "# Alpha",
+              path: "topics/alpha.md",
+              type: "create_note" as const
+            }
+          ]
+        },
+        summary: "Organize synthetic notes."
+      };
+    });
+
+    const { result } = renderAiAgentSession({
+      applyWorkspacePlan,
+      documentPath: "/vault/README.md",
+      sessionId: "session-a"
+    });
+
+    await act(async () => {
+      await result.current.submit("Organize this workspace");
+    });
+
+    expect(result.current.workspacePlanApplyStatus).toBe("idle");
+
+    let applyPromise: Promise<unknown> | null = null;
+    act(() => {
+      applyPromise = result.current.applyWorkspacePlan();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(applyWorkspacePlan).toHaveBeenCalledTimes(1);
+    expect(result.current.workspacePlanApplyStatus).toBe("applying");
+    expect(result.current.workspacePlanEvents.map((event) => event.type)).toEqual(["plan_validating"]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(420);
+      await Promise.resolve();
+    });
+
+    expect(result.current.workspacePlanEvents.map((event) => event.type)).toEqual([
+      "plan_validating",
+      "step_applied"
+    ]);
+
+    await act(async () => {
+      await applyPromise;
+    });
+
+    expect(result.current.workspacePlanApplyStatus).toBe("applied");
+    expect(result.current.workspacePlanApplyError).toBeNull();
+    expect(result.current.workspacePlanEvents.at(-1)).toEqual(expect.objectContaining({
+      path: "topics/alpha.md",
+      type: "step_applied"
+    }));
   });
 
   it("restores and persists a stored session for the active document", async () => {

--- a/packages/app/src/hooks/useAiAgentSession.ts
+++ b/packages/app/src/hooks/useAiAgentSession.ts
@@ -9,6 +9,7 @@ import {
   finalizeAgentProcesses,
   generateAiAgentSessionTitle,
   runDocumentAiAgent,
+  type ApplyWorkspaceChangePlanResult,
   type AgentWorkspaceFile,
   type AiDiffResult,
   type AiDocumentAnchor,
@@ -19,7 +20,9 @@ import {
   type DocumentAiHistoryMessage,
   type DocumentAiImage,
   type WebSearchSettings,
-  type StoredAiAgentSessionState
+  type StoredAiAgentSessionState,
+  type WorkspaceChangePlanArgs,
+  type WorkspacePlanVisualEvent
 } from "@markra/ai";
 import { getProviderCapabilities, type AiProviderConfig } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
@@ -32,10 +35,18 @@ import {
   saveStoredAiAgentSession,
   saveStoredAiAgentSessionTitle
 } from "../lib/settings/app-settings";
+import {
+  workspaceChangePlanFromToolResult,
+  workspacePlanEventsFromToolResult
+} from "../lib/workspace-plan-events";
 
 export type AiAgentPanelMessage = AiAgentSessionMessage;
 
 type AiAgentSessionContext = {
+  applyWorkspacePlan?: (
+    plan: WorkspaceChangePlanArgs,
+    options: { onVisualEvent: (event: WorkspacePlanVisualEvent) => unknown }
+  ) => Promise<ApplyWorkspaceChangePlanResult>;
   documentPath?: string | null;
   getDocumentContent: () => string;
   getDocumentEndPosition?: () => number;
@@ -63,6 +74,10 @@ type AiAgentSessionContext = {
   workspaceFiles?: AgentWorkspaceFile[];
 };
 
+export type WorkspacePlanApplyStatus = "applied" | "applying" | "error" | "idle";
+
+const workspacePlanVisualEventDelayMs = 420;
+
 type RunningAiAgentRequest = {
   assistantMessageId: number;
   draft: string;
@@ -80,6 +95,10 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
   const [webSearchEnabled, setWebSearchEnabledState] = useState(false);
   const [status, setStatus] = useState<"idle" | "thinking" | "streaming" | "error">("idle");
   const [titleVersion, setTitleVersion] = useState(0);
+  const [workspacePlanEvents, setWorkspacePlanEvents] = useState<WorkspacePlanVisualEvent[]>([]);
+  const [workspacePlanApplyStatus, setWorkspacePlanApplyStatus] = useState<WorkspacePlanApplyStatus>("idle");
+  const [workspacePlanApplyError, setWorkspacePlanApplyError] = useState<string | null>(null);
+  const [latestWorkspacePlan, setLatestWorkspacePlan] = useState<WorkspaceChangePlanArgs | null>(null);
   const requestIdRef = useRef(0);
   const hydrationRequestIdRef = useRef(0);
   const activeSessionKeyRef = useRef<string | null>(null);
@@ -171,6 +190,10 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
     const runningRequest = runningRequestsRef.current.get(sessionKey);
     hydratedSessionKeyRef.current = null;
     skipNextPersistRef.current = false;
+    setWorkspacePlanEvents([]);
+    setLatestWorkspacePlan(null);
+    setWorkspacePlanApplyError(null);
+    setWorkspacePlanApplyStatus("idle");
     sessionTitleSourceRef.current = null;
     titleGenerationSignatureRef.current = null;
     setStatus(runningRequest?.status ?? "idle");
@@ -488,6 +511,10 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
       webSearchEnabled: runWebSearchEnabled
     });
     setDraft("");
+    setWorkspacePlanEvents([]);
+    setLatestWorkspacePlan(null);
+    setWorkspacePlanApplyError(null);
+    setWorkspacePlanApplyStatus("idle");
     setStatus("thinking");
     let preparedEditorPreview = false;
     const latestPreparedEditorPreview: { current: { previewId?: string; result: AiDiffResult } | null } = {
@@ -533,6 +560,21 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
             ...currentMessage,
             activities: applyAgentEventToProcesses(currentMessage.activities ?? [], event, message)
           }));
+
+          if (
+            event.type === "tool_execution_end" &&
+            !event.isError &&
+            event.toolName === "prepare_workspace_change_plan"
+          ) {
+            const nextWorkspacePlanEvents = workspacePlanEventsFromToolResult(event.result);
+            const nextWorkspacePlan = workspaceChangePlanFromToolResult(event.result);
+            if (nextWorkspacePlanEvents.length > 0 && activeSessionKeyRef.current === runSessionKey) {
+              setLatestWorkspacePlan(nextWorkspacePlan);
+              setWorkspacePlanApplyError(null);
+              setWorkspacePlanApplyStatus("idle");
+              setWorkspacePlanEvents(nextWorkspacePlanEvents);
+            }
+          }
 
           if (event.type === "message_end" && event.message.role === "assistant") {
             const completedThinking = assistantThinkingFromAgentMessageContent(event.message.content);
@@ -685,7 +727,57 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
     });
   }, [draft, messages, status, submit]);
 
+  const applyWorkspacePlan = useCallback(async () => {
+    if (!latestWorkspacePlan || !ctx.applyWorkspacePlan) return null;
+
+    const runSessionKey = sessionKey;
+    let queuedVisualEventCount = 0;
+    let visualEventQueue = Promise.resolve();
+    const queueVisualEvent = (event: WorkspacePlanVisualEvent) => {
+      const queuedIndex = queuedVisualEventCount;
+      queuedVisualEventCount += 1;
+      visualEventQueue = visualEventQueue.then(async () => {
+        if (queuedIndex > 0) {
+          await delayWorkspacePlanVisualEvent();
+        }
+        if (activeSessionKeyRef.current !== runSessionKey) return;
+
+        setWorkspacePlanEvents((currentEvents) =>
+          event.type === "plan_validating" ? [event] : [...currentEvents, event]
+        );
+      });
+
+      return visualEventQueue;
+    };
+
+    setWorkspacePlanApplyError(null);
+    setWorkspacePlanApplyStatus("applying");
+
+    try {
+      const result = await ctx.applyWorkspacePlan(latestWorkspacePlan, {
+        onVisualEvent: queueVisualEvent
+      });
+      await visualEventQueue;
+
+      if (activeSessionKeyRef.current === runSessionKey) {
+        setWorkspacePlanApplyStatus("applied");
+      }
+
+      return result;
+    } catch (error) {
+      await visualEventQueue.catch(() => {});
+
+      if (activeSessionKeyRef.current === runSessionKey) {
+        setWorkspacePlanApplyError(error instanceof Error ? error.message : "Workspace plan execution failed.");
+        setWorkspacePlanApplyStatus("error");
+      }
+
+      return null;
+    }
+  }, [ctx.applyWorkspacePlan, latestWorkspacePlan, sessionKey]);
+
   return {
+    applyWorkspacePlan,
     draft,
     interrupt,
     messages,
@@ -699,8 +791,17 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
     submitEditedMessage,
     thinkingEnabled,
     titleVersion,
-    webSearchEnabled
+    webSearchEnabled,
+    workspacePlanApplyError,
+    workspacePlanApplyStatus,
+    workspacePlanEvents
   };
+}
+
+function delayWorkspacePlanVisualEvent() {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, workspacePlanVisualEventDelayMs);
+  });
 }
 
 function assistantThinkingFromAgentMessageContent(content: unknown) {

--- a/packages/app/src/hooks/useEditorPreferences.test.tsx
+++ b/packages/app/src/hooks/useEditorPreferences.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../lib/settings/app-settings", () => ({
       summarize: "",
       translate: ""
     },
+    aiWorkspaceAnimationEnabled: false,
     autoSaveEnabled: true,
     autoSaveIntervalMinutes: 10,
     autoUpdateEnabled: true,
@@ -112,6 +113,7 @@ describe("useEditorPreferences", () => {
     let onPreferencesChanged: Parameters<typeof listenAppEditorPreferencesChanged>[0] | null = null;
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -216,6 +218,7 @@ describe("useEditorPreferences", () => {
     act(() => {
       onPreferencesChanged?.({
         aiQuickActionPrompts: defaultAiQuickActionPrompts,
+        aiWorkspaceAnimationEnabled: false,
         autoRevealActiveFile: true,
         autoSaveEnabled: true,
         autoSaveIntervalMinutes: 10,
@@ -317,7 +320,7 @@ describe("useEditorPreferences", () => {
 
   it("keeps a live preference update when the initial stored preferences resolve later", async () => {
     let onPreferencesChanged: Parameters<typeof listenAppEditorPreferencesChanged>[0] | null = null;
-    let resolveStoredPreferences: (preferences: Awaited<ReturnType<typeof getStoredEditorPreferences>>) => void = () => {};
+    let resolveStoredPreferences: (preferences: Awaited<ReturnType<typeof getStoredEditorPreferences>>) => unknown = () => {};
     mockedGetStoredEditorPreferences.mockReturnValue(new Promise((resolve) => {
       resolveStoredPreferences = resolve;
     }));

--- a/packages/app/src/lib/selection-formatting.test.tsx
+++ b/packages/app/src/lib/selection-formatting.test.tsx
@@ -37,7 +37,7 @@ async function renderEditor(initialContent: string) {
     />
   );
 
-  await waitFor(() => expect(editor).not.toBeNull());
+  await waitFor(() => expect(editor).not.toBeNull(), { timeout: 5000 });
 
   return {
     ...result,

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -337,6 +337,7 @@ export type ExtendedSyntaxPreferences = {
 };
 export type EditorPreferences = {
   aiQuickActionPrompts: AiQuickActionPrompts;
+  aiWorkspaceAnimationEnabled: boolean;
   autoRevealActiveFile: boolean;
   autoSaveEnabled: boolean;
   autoSaveIntervalMinutes: number;
@@ -457,6 +458,7 @@ export const defaultExtendedSyntaxPreferences: ExtendedSyntaxPreferences = {
 
 export const defaultEditorPreferences: EditorPreferences = {
   aiQuickActionPrompts: { ...defaultAiQuickActionPrompts },
+  aiWorkspaceAnimationEnabled: false,
   autoRevealActiveFile: false,
   autoSaveEnabled: true,
   autoSaveIntervalMinutes: defaultAutoSaveIntervalMinutes,
@@ -1462,6 +1464,10 @@ export function normalizeEditorPreferences(value: unknown): EditorPreferences {
 
   return {
     aiQuickActionPrompts: normalizeAiQuickActionPrompts(preferences.aiQuickActionPrompts),
+    aiWorkspaceAnimationEnabled:
+      typeof preferences.aiWorkspaceAnimationEnabled === "boolean"
+        ? preferences.aiWorkspaceAnimationEnabled
+        : defaultEditorPreferences.aiWorkspaceAnimationEnabled,
     autoRevealActiveFile:
       typeof preferences.autoRevealActiveFile === "boolean"
         ? preferences.autoRevealActiveFile

--- a/packages/app/src/lib/settings/editor-preferences.test.ts
+++ b/packages/app/src/lib/settings/editor-preferences.test.ts
@@ -26,6 +26,7 @@ describe("editor preferences", () => {
 
     await expect(getStoredEditorPreferences()).resolves.toEqual({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: false,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -143,6 +144,7 @@ describe("editor preferences", () => {
 
     await expect(getStoredEditorPreferences()).resolves.toEqual({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: false,
       autoSaveEnabled: false,
       autoSaveIntervalMinutes: 30,
@@ -242,6 +244,13 @@ describe("editor preferences", () => {
     expect(normalizeEditorPreferences({}).autoUpdateEnabled).toBe(true);
     expect(normalizeEditorPreferences({ autoUpdateEnabled: false }).autoUpdateEnabled).toBe(false);
     expect(normalizeEditorPreferences({ autoUpdateEnabled: "no" }).autoUpdateEnabled).toBe(true);
+  });
+
+  it("normalizes the experimental AI workspace animation preference", () => {
+    expect(defaultEditorPreferences.aiWorkspaceAnimationEnabled).toBe(false);
+    expect(normalizeEditorPreferences({}).aiWorkspaceAnimationEnabled).toBe(false);
+    expect(normalizeEditorPreferences({ aiWorkspaceAnimationEnabled: true }).aiWorkspaceAnimationEnabled).toBe(true);
+    expect(normalizeEditorPreferences({ aiWorkspaceAnimationEnabled: "yes" }).aiWorkspaceAnimationEnabled).toBe(false);
   });
 
   it("normalizes the automatic save preferences", () => {
@@ -588,6 +597,7 @@ describe("editor preferences", () => {
 
     await expect(getStoredEditorPreferences()).resolves.toEqual({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: false,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -656,6 +666,7 @@ describe("editor preferences", () => {
   it("persists editor preferences", async () => {
     await saveStoredEditorPreferences({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,
@@ -732,6 +743,7 @@ describe("editor preferences", () => {
 
     expect(store.set).toHaveBeenCalledWith("editorPreferences", {
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,

--- a/packages/app/src/lib/settings/settings-events.test.ts
+++ b/packages/app/src/lib/settings/settings-events.test.ts
@@ -152,6 +152,7 @@ describe("settings events", () => {
 
     const preferences: EditorPreferences = {
       aiQuickActionPrompts: defaultAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: true,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,

--- a/packages/app/src/lib/workspace-operation-animation.test.ts
+++ b/packages/app/src/lib/workspace-operation-animation.test.ts
@@ -1,0 +1,45 @@
+import {
+  workspaceOperationRevealPaths,
+  type WorkspaceOperationAnimationEvent
+} from "./workspace-operation-animation";
+
+describe("workspaceOperationRevealPaths", () => {
+  it("returns active file-tree target paths while a workspace operation is applying", () => {
+    const events: WorkspaceOperationAnimationEvent[] = [
+      {
+        totalSteps: 1,
+        type: "operation_started"
+      },
+      {
+        action: "create_note",
+        index: 0,
+        label: "Create note: notes/new.md",
+        path: "notes/new.md",
+        target: "file_tree",
+        type: "step_started"
+      }
+    ];
+
+    expect(workspaceOperationRevealPaths(events, "applying")).toEqual(["notes/new.md"]);
+  });
+
+  it("does not keep file-tree reveal paths after the operation leaves the applying state", () => {
+    const events: WorkspaceOperationAnimationEvent[] = [
+      {
+        totalSteps: 1,
+        type: "operation_started"
+      },
+      {
+        action: "move_note",
+        from: "drafts/example.md",
+        index: 0,
+        label: "Move note: drafts/example.md -> notes/example.md",
+        target: "file_tree",
+        to: "notes/example.md",
+        type: "step_applied"
+      }
+    ];
+
+    expect(workspaceOperationRevealPaths(events, "applied")).toEqual([]);
+  });
+});

--- a/packages/app/src/lib/workspace-operation-animation.ts
+++ b/packages/app/src/lib/workspace-operation-animation.ts
@@ -1,0 +1,194 @@
+import type {
+  WorkspacePlanVisualEvent,
+  WorkspacePlanVisualStepEvent
+} from "@markra/ai";
+
+export type WorkspaceOperationAnimationStatus = "applied" | "applying" | "error" | "idle";
+export type WorkspaceOperationTarget = "editor" | "file_tree";
+
+export type WorkspaceOperationAnimationEvent =
+  | {
+      totalSteps: number;
+      type: "operation_started";
+    }
+  | WorkspaceOperationStepEvent
+  | {
+      count: number;
+      type: "operation_completed";
+    };
+
+export type WorkspaceOperationStepEvent = {
+  action: string;
+  afterContent?: string;
+  beforeContent?: string;
+  error?: string;
+  from?: string;
+  index: number;
+  label: string;
+  path?: string;
+  target: WorkspaceOperationTarget;
+  to?: string;
+  type: "step_applied" | "step_failed" | "step_previewed" | "step_started";
+};
+
+export type WorkspaceOperationStepView = WorkspaceOperationStepEvent & {
+  statusLabel: string;
+};
+
+export function workspaceOperationEventsFromPlanEvents(
+  events: readonly WorkspacePlanVisualEvent[]
+): WorkspaceOperationAnimationEvent[] {
+  return events.map((event) => {
+    if (event.type === "plan_validating") {
+      return {
+        totalSteps: event.totalSteps,
+        type: "operation_started"
+      };
+    }
+
+    if (event.type === "plan_completed") {
+      return {
+        count: event.count,
+        type: "operation_completed"
+      };
+    }
+
+    return workspaceOperationStepFromPlanStep(event);
+  });
+}
+
+export function workspaceOperationSteps(
+  events: readonly WorkspaceOperationAnimationEvent[]
+): WorkspaceOperationStepView[] {
+  const steps = new Map<number, WorkspaceOperationStepEvent>();
+
+  for (const event of events) {
+    if (!isWorkspaceOperationStepEvent(event)) continue;
+    steps.set(event.index, event);
+  }
+
+  return [...steps.values()]
+    .sort((left, right) => left.index - right.index)
+    .map((step) => ({
+      ...step,
+      statusLabel: workspaceOperationStatusLabel(step)
+    }));
+}
+
+export function activeWorkspaceOperationStep(steps: readonly WorkspaceOperationStepView[]) {
+  return [...steps].reverse().find((step) => step.type !== "step_applied") ?? steps.at(-1) ?? null;
+}
+
+export function workspaceOperationRevealPaths(
+  events: readonly WorkspaceOperationAnimationEvent[],
+  status: WorkspaceOperationAnimationStatus
+) {
+  if (status !== "applying") return [];
+
+  const activeStep = activeWorkspaceOperationStep(workspaceOperationSteps(events));
+  if (!activeStep || activeStep.target !== "file_tree") return [];
+
+  return uniqueStrings(
+    [activeStep.path, activeStep.to, activeStep.from].filter((path): path is string => Boolean(path))
+  );
+}
+
+export function workspaceOperationPlaybackEvents(
+  events: readonly WorkspaceOperationAnimationEvent[]
+) {
+  const startIndex = latestWorkspaceOperationStartIndex(events);
+
+  return startIndex >= 0 ? events.slice(startIndex) : events;
+}
+
+export function hasTerminalWorkspaceOperationStep(
+  events: readonly WorkspaceOperationAnimationEvent[]
+) {
+  return events.some(isTerminalWorkspaceOperationStep);
+}
+
+export function workspaceOperationPlaybackStartCount(
+  events: readonly WorkspaceOperationAnimationEvent[]
+) {
+  const firstStepIndex = events.findIndex(isWorkspaceOperationStepEvent);
+  if (firstStepIndex < 0) return events.length;
+
+  return Math.min(events.length, firstStepIndex + 1);
+}
+
+export function workspaceOperationEventSignature(
+  events: readonly WorkspaceOperationAnimationEvent[]
+) {
+  return events.map((event) => {
+    if (isWorkspaceOperationStepEvent(event)) {
+      return [
+        event.type,
+        event.index,
+        event.action,
+        event.target,
+        event.path ?? "",
+        event.from ?? "",
+        event.to ?? "",
+        event.error ?? "",
+        event.afterContent ?? ""
+      ].join(":");
+    }
+
+    if (event.type === "operation_started") return `started:${event.totalSteps}`;
+
+    return `completed:${event.count}`;
+  }).join("|");
+}
+
+export function isWorkspaceOperationStepEvent(
+  event: WorkspaceOperationAnimationEvent
+): event is WorkspaceOperationStepEvent {
+  return event.type === "step_applied" ||
+    event.type === "step_failed" ||
+    event.type === "step_previewed" ||
+    event.type === "step_started";
+}
+
+function workspaceOperationStepFromPlanStep(
+  event: WorkspacePlanVisualStepEvent
+): WorkspaceOperationStepEvent {
+  return {
+    action: event.action,
+    index: event.index,
+    label: event.label,
+    target: event.target,
+    type: event.type,
+    ...(event.afterContent ? { afterContent: event.afterContent } : {}),
+    ...(event.beforeContent ? { beforeContent: event.beforeContent } : {}),
+    ...(event.error ? { error: event.error } : {}),
+    ...(event.from ? { from: event.from } : {}),
+    ...(event.path ? { path: event.path } : {}),
+    ...(event.to ? { to: event.to } : {})
+  };
+}
+
+function latestWorkspaceOperationStartIndex(events: readonly WorkspaceOperationAnimationEvent[]) {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.type !== "operation_started") continue;
+    if (events.slice(index).some(isTerminalWorkspaceOperationStep)) return index;
+  }
+
+  return -1;
+}
+
+function isTerminalWorkspaceOperationStep(event: WorkspaceOperationAnimationEvent) {
+  return event.type === "step_applied" || event.type === "step_failed";
+}
+
+function workspaceOperationStatusLabel(step: WorkspaceOperationStepEvent) {
+  if (step.type === "step_applied") return "Done";
+  if (step.type === "step_failed") return "Failed";
+  if (step.type === "step_started") return "Working";
+
+  return "Previewing";
+}
+
+function uniqueStrings(values: readonly string[]) {
+  return Array.from(new Set(values));
+}

--- a/packages/app/src/lib/workspace-plan-apply.test.ts
+++ b/packages/app/src/lib/workspace-plan-apply.test.ts
@@ -1,0 +1,94 @@
+import type { AgentWorkspaceFile } from "@markra/ai";
+import { createWorkspaceChangePlanOperations } from "./workspace-plan-apply";
+
+const rootFile = {
+  name: "alpha.md",
+  path: "/mock-vault/alpha.md",
+  relativePath: "alpha.md"
+} satisfies AgentWorkspaceFile;
+
+describe("createWorkspaceChangePlanOperations", () => {
+  it("creates missing parent folders before creating a planned note", async () => {
+    const createFolder = vi.fn(async (folderName: string, parentPath: string | null) => ({
+      kind: "folder" as const,
+      name: folderName,
+      path: parentPath ? `${parentPath}/${folderName}` : `/mock-vault/${folderName}`,
+      relativePath: parentPath ? `topics/${folderName}` : folderName
+    }));
+    const createFile = vi.fn(async (fileName: string, parentPath: string | null, contents: string) => ({
+      name: fileName,
+      path: `${parentPath}/${fileName}`,
+      relativePath: `topics/${fileName}`,
+      contents
+    }));
+    const operations = createWorkspaceChangePlanOperations({
+      createFile,
+      createFolder,
+      moveFile: vi.fn(),
+      readFile: vi.fn(),
+      renameFile: vi.fn(),
+      workspaceFiles: [rootFile],
+      writeFile: vi.fn()
+    });
+
+    await operations.createFile("topics/beta.md", "# Beta");
+
+    expect(createFolder).toHaveBeenCalledWith("topics", null);
+    expect(createFile).toHaveBeenCalledWith("beta.md", "/mock-vault/topics", "# Beta");
+  });
+
+  it("moves a note to the target folder and renames it when the target path changes both", async () => {
+    const docsFolder = {
+      kind: "folder" as const,
+      name: "docs",
+      path: "/mock-vault/docs",
+      relativePath: "docs"
+    };
+    const movedFile = {
+      name: "alpha.md",
+      path: "/mock-vault/docs/alpha.md",
+      relativePath: "docs/alpha.md"
+    };
+    const renamedFile = {
+      name: "beta.md",
+      path: "/mock-vault/docs/beta.md",
+      relativePath: "docs/beta.md"
+    };
+    const moveFile = vi.fn(async () => movedFile);
+    const renameFile = vi.fn(async () => renamedFile);
+    const operations = createWorkspaceChangePlanOperations({
+      createFile: vi.fn(),
+      createFolder: vi.fn(),
+      moveFile,
+      readFile: vi.fn(),
+      renameFile,
+      workspaceFiles: [rootFile, docsFolder],
+      writeFile: vi.fn()
+    });
+
+    await operations.moveFile(rootFile, "docs/beta.md");
+
+    expect(moveFile).toHaveBeenCalledWith(rootFile, "/mock-vault/docs");
+    expect(renameFile).toHaveBeenCalledWith(movedFile, "beta.md");
+  });
+
+  it("writes through the native markdown save operation for existing notes", async () => {
+    const readFile = vi.fn(async () => "# Alpha");
+    const writeFile = vi.fn(async () => {});
+    const operations = createWorkspaceChangePlanOperations({
+      createFile: vi.fn(),
+      createFolder: vi.fn(),
+      moveFile: vi.fn(),
+      readFile,
+      renameFile: vi.fn(),
+      workspaceFiles: [rootFile],
+      writeFile
+    });
+
+    await expect(operations.readFile(rootFile)).resolves.toBe("# Alpha");
+    await operations.writeFile(rootFile, "# Updated");
+
+    expect(readFile).toHaveBeenCalledWith("/mock-vault/alpha.md");
+    expect(writeFile).toHaveBeenCalledWith(rootFile, "# Updated");
+  });
+});

--- a/packages/app/src/lib/workspace-plan-apply.ts
+++ b/packages/app/src/lib/workspace-plan-apply.ts
@@ -1,0 +1,126 @@
+import type {
+  AgentWorkspaceFile,
+  WorkspaceChangePlanOperations
+} from "@markra/ai";
+import { normalizeWorkspaceRelativePath } from "@markra/ai";
+import { parentPathFromPath, pathNameFromPath } from "@markra/shared";
+import type { NativeMarkdownFolderFile } from "./tauri";
+
+export type WorkspacePlanNativeOperations = {
+  createFile: (
+    fileName: string,
+    parentPath: string | null,
+    contents: string
+  ) => Promise<NativeMarkdownFolderFile | null> | NativeMarkdownFolderFile | null;
+  createFolder: (
+    folderName: string,
+    parentPath: string | null
+  ) => Promise<NativeMarkdownFolderFile | null> | NativeMarkdownFolderFile | null;
+  moveFile: (
+    file: NativeMarkdownFolderFile,
+    targetParentPath: string | null
+  ) => Promise<NativeMarkdownFolderFile | null> | NativeMarkdownFolderFile | null;
+  readFile: (path: string) => Promise<string> | string;
+  renameFile: (
+    file: NativeMarkdownFolderFile,
+    fileName: string
+  ) => Promise<NativeMarkdownFolderFile | null> | NativeMarkdownFolderFile | null;
+  workspaceFiles: readonly AgentWorkspaceFile[];
+  writeFile: (file: NativeMarkdownFolderFile, content: string) => Promise<unknown> | unknown;
+};
+
+export function createWorkspaceChangePlanOperations(
+  options: WorkspacePlanNativeOperations
+): WorkspaceChangePlanOperations {
+  const foldersByRelativePath = new Map<string, NativeMarkdownFolderFile>();
+
+  options.workspaceFiles.forEach((file) => {
+    if (file.kind !== "folder") return;
+    foldersByRelativePath.set(normalizeWorkspaceRelativePath(file.relativePath), nativeFileFromWorkspaceFile(file));
+  });
+
+  const ensureParentPath = async (relativePath: string) => {
+    const parentRelativePath = parentPathFromPath(normalizeWorkspaceRelativePath(relativePath));
+    if (!parentRelativePath) return null;
+
+    return ensureFolderPath(parentRelativePath, foldersByRelativePath, options);
+  };
+
+  return {
+    createFile: async (relativePath, content) => {
+      const parentPath = await ensureParentPath(relativePath);
+      const fileName = pathNameFromPath(relativePath);
+      const createdFile = await options.createFile(fileName, parentPath, content);
+      if (!createdFile) {
+        throw new Error(`Workspace change could not create "${relativePath}".`);
+      }
+    },
+    moveFile: async (file, toRelativePath) => {
+      const targetParentPath = await ensureParentPath(toRelativePath);
+      const targetFileName = pathNameFromPath(toRelativePath);
+      const currentParentRelativePath = parentPathFromPath(normalizeWorkspaceRelativePath(file.relativePath));
+      const targetParentRelativePath = parentPathFromPath(normalizeWorkspaceRelativePath(toRelativePath));
+      const nativeFile = nativeFileFromWorkspaceFile(file);
+      const parentChanged = (currentParentRelativePath ?? "") !== (targetParentRelativePath ?? "");
+      const movedFile = parentChanged
+        ? await options.moveFile(nativeFile, targetParentPath)
+        : nativeFile;
+      if (!movedFile) {
+        throw new Error(`Workspace change could not move "${file.relativePath}".`);
+      }
+
+      if (movedFile.name === targetFileName) return;
+
+      const renamedFile = await options.renameFile(movedFile, targetFileName);
+      if (!renamedFile) {
+        throw new Error(`Workspace change could not rename "${movedFile.relativePath}".`);
+      }
+    },
+    readFile: (file) => options.readFile(file.path),
+    writeFile: (file, content) => options.writeFile(nativeFileFromWorkspaceFile(file), content)
+  };
+}
+
+async function ensureFolderPath(
+  relativePath: string,
+  foldersByRelativePath: Map<string, NativeMarkdownFolderFile>,
+  operations: Pick<WorkspacePlanNativeOperations, "createFolder">
+) {
+  const segments = normalizeWorkspaceRelativePath(relativePath).split("/").filter(Boolean);
+  let currentRelativePath = "";
+  let currentParentPath: string | null = null;
+
+  for (const segment of segments) {
+    currentRelativePath = currentRelativePath ? `${currentRelativePath}/${segment}` : segment;
+    const existingFolder = foldersByRelativePath.get(currentRelativePath);
+    if (existingFolder) {
+      currentParentPath = existingFolder.path;
+      continue;
+    }
+
+    const createdFolder = await operations.createFolder(segment, currentParentPath);
+    if (!createdFolder) {
+      throw new Error(`Workspace change could not create folder "${currentRelativePath}".`);
+    }
+
+    const normalizedCreatedPath = normalizeWorkspaceRelativePath(createdFolder.relativePath || currentRelativePath);
+    foldersByRelativePath.set(normalizedCreatedPath, createdFolder);
+    currentParentPath = createdFolder.path;
+  }
+
+  return currentParentPath;
+}
+
+function nativeFileFromWorkspaceFile(file: AgentWorkspaceFile): NativeMarkdownFolderFile {
+  const nativeFile: NativeMarkdownFolderFile = {
+    name: file.name,
+    path: file.path,
+    relativePath: file.relativePath
+  };
+
+  if (file.kind) {
+    nativeFile.kind = file.kind;
+  }
+
+  return nativeFile;
+}

--- a/packages/app/src/lib/workspace-plan-events.test.ts
+++ b/packages/app/src/lib/workspace-plan-events.test.ts
@@ -1,0 +1,113 @@
+import {
+  workspaceChangePlanFromToolResult,
+  workspacePlanEventsFromToolResult
+} from "./workspace-plan-events";
+
+describe("workspace plan visual events", () => {
+  it("converts prepared workspace change details into runner events", () => {
+    const events = workspacePlanEventsFromToolResult({
+      details: {
+        changes: [
+          {
+            content: "# Alpha",
+            label: "Create note: topics/alpha.md",
+            path: "topics/alpha.md",
+            type: "create_note"
+          },
+          {
+            label: "Move note: docs/guide.md -> archive/guide.md",
+            from: "docs/guide.md",
+            to: "archive/guide.md",
+            type: "move_note"
+          },
+          {
+            label: "Add tags: current.md",
+            path: "current.md",
+            tags: ["alpha", "planning"],
+            type: "add_tags"
+          }
+        ],
+        count: 3,
+        summary: "Organize synthetic notes."
+      }
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      "plan_validating",
+      "step_started",
+      "step_previewed",
+      "step_started",
+      "step_previewed",
+      "step_started",
+      "step_previewed"
+    ]);
+    expect(events[1]).toEqual(expect.objectContaining({
+      action: "create_note",
+      index: 0,
+      path: "topics/alpha.md",
+      target: "file_tree"
+    }));
+    expect(events[2]).toEqual(expect.objectContaining({
+      afterContent: "# Alpha",
+      label: "Create note: topics/alpha.md"
+    }));
+    expect(events[4]).toEqual(expect.objectContaining({
+      from: "docs/guide.md",
+      to: "archive/guide.md",
+      target: "file_tree"
+    }));
+    expect(events[6]).toEqual(expect.objectContaining({
+      afterContent: "Tags: alpha, planning",
+      path: "current.md",
+      target: "editor"
+    }));
+  });
+
+  it("ignores non-plan tool results", () => {
+    expect(workspacePlanEventsFromToolResult({
+      details: {
+        count: 2
+      }
+    })).toEqual([]);
+  });
+
+  it("extracts an executable workspace change plan from prepared tool details", () => {
+    expect(workspaceChangePlanFromToolResult({
+      details: {
+        changes: [
+          {
+            content: "",
+            label: "Create note: topics/empty.md",
+            path: "topics/empty.md",
+            reason: "Synthetic empty note.",
+            type: "create_note"
+          },
+          {
+            label: "Add links: current.md",
+            links: ["[[topics/empty]]"],
+            path: "current.md",
+            type: "add_links"
+          }
+        ],
+        summary: "Organize synthetic notes."
+      }
+    })).toEqual({
+      changes: [
+        {
+          content: "",
+          label: "Create note: topics/empty.md",
+          path: "topics/empty.md",
+          reason: "Synthetic empty note.",
+          type: "create_note"
+        },
+        {
+          label: "Add links: current.md",
+          links: ["[[topics/empty]]"],
+          path: "current.md",
+          type: "add_links"
+        }
+      ],
+      summary: "Organize synthetic notes."
+    });
+  });
+});

--- a/packages/app/src/lib/workspace-plan-events.ts
+++ b/packages/app/src/lib/workspace-plan-events.ts
@@ -1,0 +1,190 @@
+import type {
+  WorkspaceChangePlanArgs,
+  WorkspacePlanVisualEvent,
+  WorkspacePlanVisualStepEvent,
+  WorkspacePlanVisualTarget
+} from "@markra/ai";
+
+type PreparedWorkspacePlanChange = {
+  content?: string;
+  from?: string;
+  label?: string;
+  links?: string[];
+  path?: string;
+  reason?: string;
+  summary?: string;
+  tags?: string[];
+  to?: string;
+  type?: unknown;
+};
+
+type WorkspacePlanAction = WorkspacePlanVisualStepEvent["action"];
+type WorkspacePlanChangeForApply = WorkspaceChangePlanArgs["changes"][number] & {
+  label?: string;
+};
+
+export function workspacePlanEventsFromToolResult(result: unknown): WorkspacePlanVisualEvent[] {
+  const changes = preparedWorkspacePlanChanges(result);
+  if (!changes.length) return [];
+
+  return [
+    {
+      totalSteps: changes.length,
+      type: "plan_validating" as const
+    },
+    ...changes.flatMap((change, index) => {
+      const action = workspacePlanAction(change.type);
+      if (!action) return [];
+
+      const base = workspacePlanStepEvent(change, index, action, "step_started");
+      return [
+        base,
+        workspacePlanStepEvent(change, index, action, "step_previewed")
+      ];
+    })
+  ];
+}
+
+export function workspaceChangePlanFromToolResult(result: unknown): WorkspaceChangePlanArgs | null {
+  const changes = preparedWorkspacePlanChanges(result)
+    .map(workspacePlanChangeForApply)
+    .filter((change): change is WorkspacePlanChangeForApply => Boolean(change));
+  if (!changes.length) return null;
+
+  const summary = trimmedValue(workspacePlanDetails(result)?.summary);
+  return {
+    changes,
+    ...(summary ? { summary } : {})
+  };
+}
+
+function preparedWorkspacePlanChanges(result: unknown) {
+  const details = workspacePlanDetails(result);
+  if (!details) return [];
+  const changes = (details as { changes?: unknown }).changes;
+
+  return Array.isArray(changes) ? changes.filter(isPreparedWorkspacePlanChange) : [];
+}
+
+function workspacePlanDetails(result: unknown) {
+  if (!result || typeof result !== "object") return null;
+  const details = (result as { details?: unknown }).details;
+  if (!details || typeof details !== "object") return null;
+
+  return details as { changes?: unknown; summary?: unknown };
+}
+
+function isPreparedWorkspacePlanChange(value: unknown): value is PreparedWorkspacePlanChange {
+  if (!value || typeof value !== "object") return false;
+
+  return Boolean(workspacePlanAction((value as PreparedWorkspacePlanChange).type));
+}
+
+function workspacePlanStepEvent(
+  change: PreparedWorkspacePlanChange,
+  index: number,
+  action: WorkspacePlanAction,
+  type: WorkspacePlanVisualStepEvent["type"]
+): WorkspacePlanVisualStepEvent {
+  const path = trimmedValue(change.path);
+  const from = trimmedValue(change.from);
+  const to = trimmedValue(change.to);
+  const afterContent = type === "step_previewed" ? previewContentForChange(change, action) : undefined;
+
+  return {
+    action,
+    index,
+    label: trimmedValue(change.label) ?? fallbackLabelForChange(action, path, from, to),
+    target: workspacePlanTarget(action),
+    type,
+    ...(afterContent ? { afterContent } : {}),
+    ...(from ? { from } : {}),
+    ...(path ? { path } : {}),
+    ...(to ? { to } : {})
+  };
+}
+
+function workspacePlanChangeForApply(change: PreparedWorkspacePlanChange): WorkspacePlanChangeForApply | null {
+  const action = workspacePlanAction(change.type);
+  if (!action) return null;
+
+  const nextChange: WorkspacePlanChangeForApply = {
+    type: action
+  };
+  const path = trimmedValue(change.path);
+  const from = trimmedValue(change.from);
+  const to = trimmedValue(change.to);
+  const reason = trimmedValue(change.reason);
+  const summary = trimmedValue(change.summary);
+  const label = trimmedValue(change.label);
+  const tags = stringArray(change.tags);
+  const links = stringArray(change.links);
+
+  if (typeof change.content === "string") nextChange.content = change.content;
+  if (from) nextChange.from = from;
+  if (label) nextChange.label = label;
+  if (links.length > 0) nextChange.links = links;
+  if (path) nextChange.path = path;
+  if (reason) nextChange.reason = reason;
+  if (summary) nextChange.summary = summary;
+  if (tags.length > 0) nextChange.tags = tags;
+  if (to) nextChange.to = to;
+
+  return nextChange;
+}
+
+function workspacePlanAction(value: unknown): WorkspacePlanAction | null {
+  if (
+    value === "add_links" ||
+    value === "add_tags" ||
+    value === "create_note" ||
+    value === "move_note" ||
+    value === "rename_note" ||
+    value === "update_note"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function workspacePlanTarget(action: WorkspacePlanAction): WorkspacePlanVisualTarget {
+  if (action === "create_note" || action === "move_note" || action === "rename_note") return "file_tree";
+
+  return "editor";
+}
+
+function previewContentForChange(change: PreparedWorkspacePlanChange, action: WorkspacePlanAction) {
+  if (action === "add_tags" && change.tags?.length) return `Tags: ${change.tags.join(", ")}`;
+  if (action === "add_links" && change.links?.length) return change.links.join("\n");
+  if (typeof change.content === "string") return change.content;
+
+  return undefined;
+}
+
+function fallbackLabelForChange(
+  action: WorkspacePlanAction,
+  path: string | undefined,
+  from: string | undefined,
+  to: string | undefined
+) {
+  const target = path ?? (from && to ? `${from} -> ${to}` : "workspace note");
+
+  if (action === "add_links") return `Add links: ${target}`;
+  if (action === "add_tags") return `Add tags: ${target}`;
+  if (action === "create_note") return `Create note: ${target}`;
+  if (action === "move_note") return `Move note: ${target}`;
+  if (action === "rename_note") return `Rename note: ${target}`;
+
+  return `Update note: ${target}`;
+}
+
+function trimmedValue(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -245,6 +245,7 @@ vi.mock("../lib/settings/app-settings", () => ({
   splitVisualPanePercentMax: 75,
   defaultEditorPreferences: {
     aiQuickActionPrompts: testAiQuickActionPrompts,
+    aiWorkspaceAnimationEnabled: false,
     autoUpdateEnabled: true,
     bodyFontSize: 16,
     clipboardImageFolder: "assets",
@@ -512,6 +513,7 @@ vi.mock("../lib/settings/app-settings", () => ({
   listStoredAiAgentSessions: vi.fn(),
   normalizeEditorPreferences: vi.fn((preferences) => ({
     aiQuickActionPrompts: testAiQuickActionPrompts,
+    aiWorkspaceAnimationEnabled: false,
     autoUpdateEnabled: true,
     bodyFontSize: 16,
     clipboardImageFolder: "assets",
@@ -1220,6 +1222,7 @@ export function installAppTestHarness() {
     mockedGetStoredAiAgentSessionSummary.mockResolvedValue(null);
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: testAiQuickActionPrompts,
+      aiWorkspaceAnimationEnabled: false,
       autoRevealActiveFile: true,
       autoSaveEnabled: true,
       autoSaveIntervalMinutes: 10,

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "Min.",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Inline-KI beim Öffnen von Markra AI schließen",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Blendet die untere KI-Befehlseingabe aus, wenn das rechte KI-Panel geöffnet wird.",
+  "settings.editor.aiWorkspaceAnimation": "KI-Arbeitsbereichsanimation",
+  "settings.editor.aiWorkspaceAnimationDescription": "Experimentell. Zeigt einen KI-Cursor und Hervorhebungen im Arbeitsbereich, während Dateiänderungen angewendet werden.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Markra AI für komplexe Inline-Anfragen vorschlagen",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Experimentell. Schlägt Markra AI für komplexe Inline-Anfragen anhand lokaler Eingabestruktur vor. Deaktivieren, wenn der Hinweis zu häufig erscheint.",
   "settings.ai.addProvider": "Anbieter hinzufügen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -298,6 +298,8 @@ const messages: BaseLocaleMessages = {
   "settings.editor.aiSelectionDisplayMode.useToolbar": "Show floating toolbar",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Close inline AI when opening Markra AI",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Hide the bottom AI command input when the right-side AI panel opens.",
+  "settings.editor.aiWorkspaceAnimation": "AI workspace animation",
+  "settings.editor.aiWorkspaceAnimationDescription": "Experimental. Shows an AI cursor and highlights in the workspace while file changes are being applied.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Suggest Markra AI for complex inline requests",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Experimental. Suggest Markra AI for complex inline requests based on local input structure. Turn it off if the prompt feels too eager.",
   "settings.editor.fontFamily": "Editor font",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "min",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Cerrar IA en línea al abrir Markra AI",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Oculta la entrada de comandos de IA inferior cuando se abre el panel de IA derecho.",
+  "settings.editor.aiWorkspaceAnimation": "Animación de IA en el espacio de trabajo",
+  "settings.editor.aiWorkspaceAnimationDescription": "Experimental. Muestra un cursor de IA y resaltados en el espacio de trabajo mientras se aplican cambios de archivos.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Sugerir Markra AI para solicitudes en línea complejas",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Experimental. Sugiere Markra AI para solicitudes en línea complejas según la estructura local de la entrada. Desactívalo si la sugerencia aparece demasiado.",
   "settings.ai.addProvider": "Añadir proveedor",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "min",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Fermer l’IA intégrée à l’ouverture de Markra AI",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Masque la saisie de commande IA du bas quand le panneau IA de droite s’ouvre.",
+  "settings.editor.aiWorkspaceAnimation": "Animation IA de l’espace de travail",
+  "settings.editor.aiWorkspaceAnimationDescription": "Expérimental. Affiche un curseur IA et des surbrillances dans l’espace de travail pendant l’application des changements de fichiers.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Suggérer Markra AI pour les demandes intégrées complexes",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Expérimental. Suggère Markra AI pour les demandes intégrées complexes d’après la structure locale de la saisie. Désactivez-le si l’invite apparaît trop souvent.",
   "settings.ai.addProvider": "Ajouter un fournisseur",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "min",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Chiudi AI in linea all’apertura di Markra AI",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Nasconde l’input comandi AI in basso quando si apre il pannello AI a destra.",
+  "settings.editor.aiWorkspaceAnimation": "Animazione AI nell’area di lavoro",
+  "settings.editor.aiWorkspaceAnimationDescription": "Sperimentale. Mostra un cursore AI ed evidenziazioni nell’area di lavoro mentre vengono applicate modifiche ai file.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Suggerisci Markra AI per richieste inline complesse",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Sperimentale. Suggerisce Markra AI per richieste inline complesse in base alla struttura locale dell’input. Disattivalo se il suggerimento è troppo frequente.",
   "settings.ai.addProvider": "Aggiungi provider",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -110,6 +110,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "分",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Markra AI を開くときにインライン AI を閉じる",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "右側の AI パネルを開くと、下部の AI コマンド入力を隠します。",
+  "settings.editor.aiWorkspaceAnimation": "AI ワークスペースアニメーション",
+  "settings.editor.aiWorkspaceAnimationDescription": "実験的機能。AI がファイル変更を適用している間、ワークスペースに AI カーソルとハイライトを表示します。",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "複雑なインライン依頼に Markra AI を提案",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "実験的機能。入力の長さ、改行、リストなどローカルの構造シグナルから Markra AI を提案します。提案が多すぎる場合はオフにできます。",
   "settings.ai.addProvider": "プロバイダーを追加",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "분",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Markra AI를 열 때 인라인 AI 닫기",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "오른쪽 AI 패널을 열면 하단 AI 명령 입력창을 숨깁니다.",
+  "settings.editor.aiWorkspaceAnimation": "AI 작업 공간 애니메이션",
+  "settings.editor.aiWorkspaceAnimationDescription": "실험적 기능입니다. AI가 파일 변경을 적용하는 동안 작업 공간에 AI 커서와 강조 표시를 보여 줍니다.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "복잡한 인라인 요청에 Markra AI 제안",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "실험적 기능입니다. 입력 길이, 줄바꿈, 목록 같은 로컬 구조 신호로 Markra AI를 제안합니다. 제안이 너무 적극적이면 끌 수 있습니다.",
   "settings.ai.addProvider": "제공자 추가",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "min",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Fechar IA embutida ao abrir o Markra AI",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Oculta a entrada de comando de IA inferior quando o painel de IA à direita é aberto.",
+  "settings.editor.aiWorkspaceAnimation": "Animação de IA no workspace",
+  "settings.editor.aiWorkspaceAnimationDescription": "Experimental. Mostra um cursor de IA e destaques no workspace enquanto alterações de arquivos são aplicadas.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Sugerir Markra AI para pedidos embutidos complexos",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Experimental. Sugere Markra AI para pedidos embutidos complexos com base na estrutura local da entrada. Desative se o aviso parecer insistente.",
   "settings.ai.addProvider": "Adicionar provedor",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -102,6 +102,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoSaveIntervalUnit": "мин",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "Закрывать встроенный ИИ при открытии Markra AI",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "Скрывает нижнее поле команды ИИ, когда открывается правая панель ИИ.",
+  "settings.editor.aiWorkspaceAnimation": "Анимация ИИ в рабочей области",
+  "settings.editor.aiWorkspaceAnimationDescription": "Экспериментально. Показывает курсор ИИ и подсветку в рабочей области во время применения изменений файлов.",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "Предлагать Markra AI для сложных встроенных запросов",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "Экспериментально. Предлагает Markra AI для сложных встроенных запросов по локальной структуре ввода. Отключите, если подсказка слишком настойчива.",
   "settings.ai.addProvider": "Добавить провайдера",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -139,6 +139,8 @@ export type I18nKey =
   | "settings.editor.aiSelectionDisplayMode.useToolbar"
   | "settings.editor.closeAiCommandOnAgentPanelOpen"
   | "settings.editor.closeAiCommandOnAgentPanelOpenDescription"
+  | "settings.editor.aiWorkspaceAnimation"
+  | "settings.editor.aiWorkspaceAnimationDescription"
   | "settings.editor.suggestAiPanelForComplexInlinePrompts"
   | "settings.editor.suggestAiPanelForComplexInlinePromptsDescription"
   | "settings.editor.fontFamily"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -298,6 +298,8 @@ const messages: LocaleMessages = {
   "settings.editor.aiSelectionDisplayMode.useToolbar": "显示选区浮动框",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "打开 Markra AI 时关闭快捷输入框",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "打开右侧 AI 面板时隐藏底部 AI 命令输入框。",
+  "settings.editor.aiWorkspaceAnimation": "AI 工作区动画",
+  "settings.editor.aiWorkspaceAnimationDescription": "实验性功能。AI 执行文件变更时，在工作区显示 AI 光标和高亮动画。",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "复杂快捷 AI 请求时建议转到 Markra AI",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "实验性功能。根据输入长度、换行、列表等本地结构信号建议改用 Markra AI；如果提示过于积极，可以关闭。",
   "settings.editor.fontFamily": "编辑器字体",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -110,6 +110,8 @@ const messages: LocaleMessages = {
   "settings.editor.autoOpenAiOnSelectionDescription": "選中文本後自動開啟 AI 快捷輸入框。",
   "settings.editor.closeAiCommandOnAgentPanelOpen": "開啟 Markra AI 時關閉快捷輸入框",
   "settings.editor.closeAiCommandOnAgentPanelOpenDescription": "開啟右側 AI 面板時隱藏底部 AI 命令輸入框。",
+  "settings.editor.aiWorkspaceAnimation": "AI 工作區動畫",
+  "settings.editor.aiWorkspaceAnimationDescription": "實驗性功能。AI 執行檔案變更時，在工作區顯示 AI 游標和高亮動畫。",
   "settings.editor.suggestAiPanelForComplexInlinePrompts": "複雜快捷 AI 請求時建議轉到 Markra AI",
   "settings.editor.suggestAiPanelForComplexInlinePromptsDescription": "實驗性功能。根據輸入長度、換行、列表等本地結構訊號建議改用 Markra AI；如果提示過於積極，可以關閉。",
   "settings.ai.addProvider": "新增服務商",


### PR DESCRIPTION
## Summary
- Add workspace-aware AI tools for Markdown search/read, asset listing, and preparing confirmed workspace change plans.
- Add workspace change plan execution with serial visual events and app-side apply handling.
- Render AI workspace operation animation on the real workspace, with an experimental settings toggle that defaults off.
- Allow Markra AI chat when a workspace is open even if no Markdown document is active.

## Validation
- `pnpm --dir packages/ai exec vitest run --globals src/agent/document-tools.test.ts src/agent/workspace-change-plan.test.ts` passed, 68 tests.
- `pnpm --filter @markra/ai build` passed.
- `pnpm --dir packages/app exec vitest run src/App.ai.test.tsx src/components/AiAgentPanel.test.tsx src/components/MarkdownFileTreeDrawer.test.tsx src/components/WorkspaceOperationOverlay.test.tsx src/hooks/useAiAgentSession.test.tsx src/hooks/useEditorPreferences.test.tsx src/lib/settings/editor-preferences.test.ts src/lib/settings/settings-events.test.ts src/lib/workspace-plan-apply.test.ts src/lib/workspace-plan-events.test.ts` passed, 216 tests.
- `pnpm --filter @markra/app build` passed.
- `git diff --cached --check` passed.

## Risk
- Touches AI tool selection, workspace file operations, and the AI panel workflow. The workspace operation animation remains experimental and defaults off.

## Screenshots
- Not included; UI behavior is covered by focused component tests.