### PR TITLE
feat(editor): add Mermaid diagram zoom controls

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2154,6 +2154,46 @@ describe("MarkdownPaper editing", () => {
     expect(zoomButton).toHaveFocus();
   });
 
+  it("zooms and pans the enlarged Mermaid diagram", async () => {
+    const source = ["```mermaid", "flowchart LR", "  A --> B --> C --> D", "```"].join("\n");
+    const { container } = await renderEditor(source);
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-mermaid-render svg")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Enlarge Mermaid diagram" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Enlarged Mermaid diagram" });
+    const content = dialog.querySelector<HTMLElement>(".markra-mermaid-zoom-content");
+    const canvas = dialog.querySelector<HTMLElement>(".markra-mermaid-zoom-canvas");
+
+    expect(content).toHaveAttribute("data-zoom", "1");
+    expect(canvas).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Zoom in Mermaid diagram" }));
+
+    expect(content).toHaveAttribute("data-zoom", "1.25");
+    expect(within(dialog).getByText("125%")).toBeInTheDocument();
+    expect(canvas?.style.transform).toBe("translate(0px, 0px) scale(1.25)");
+
+    fireEvent.wheel(content!, { deltaY: -100 });
+
+    expect(Number(content?.dataset.zoom)).toBeGreaterThan(1.25);
+
+    fireEvent.pointerDown(content!, { button: 0, clientX: 100, clientY: 80, pointerId: 9 });
+    fireEvent.pointerMove(content!, { clientX: 132, clientY: 96, pointerId: 9 });
+    fireEvent.pointerUp(content!, { pointerId: 9 });
+
+    expect(canvas?.style.transform).toContain("translate(32px, 16px)");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Reset Mermaid diagram view" }));
+
+    expect(content).toHaveAttribute("data-zoom", "1");
+    expect(within(dialog).getByText("100%")).toBeInTheDocument();
+    expect(canvas?.style.transform).toBe("translate(0px, 0px) scale(1)");
+  });
+
   it("returns a single Mermaid block to preview mode from the source control", async () => {
     const source = ["```mermaid", "flowchart TD", "  A --> B", "```"].join("\n");
     const { container } = await renderEditor(source);

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2973,27 +2973,42 @@
   }
 
   .markra-mermaid-zoom-panel {
-    @apply relative max-h-[88vh] w-full overflow-auto rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-2xl;
+    @apply relative flex max-h-[88vh] w-full flex-col overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-2xl;
     background: var(--editor-paper-bg, var(--bg-primary));
     border-color: color-mix(in srgb, var(--editor-border-strong, var(--border-strong)) 82%, transparent);
     color: var(--editor-text-primary, var(--text-primary));
+    height: min(88vh, 44rem);
     max-width: min(92vw, 80rem);
+    min-height: min(28rem, 88vh);
   }
 
+  .markra-mermaid-zoom-toolbar {
+    @apply relative z-[2] flex items-center justify-end gap-1 border-b border-(--border-default) px-3 py-2;
+    background: color-mix(in srgb, var(--editor-paper-bg, var(--bg-primary)) 94%, transparent);
+    border-color: color-mix(in srgb, var(--editor-border, var(--border-default)) 82%, transparent);
+  }
+
+  .markra-mermaid-zoom-value {
+    @apply min-w-12 px-1 text-center text-[12px] leading-5 font-[650] tabular-nums text-(--text-secondary);
+    color: var(--editor-text-secondary, var(--text-secondary));
+  }
+
+  .markra-mermaid-zoom-control-button,
   .markra-mermaid-zoom-close-button {
-    @apply sticky top-3 ml-auto mr-3 grid size-8 cursor-pointer place-items-center rounded-md border border-(--border-default) bg-(--bg-primary) p-0 text-(--text-secondary) outline-none transition-[color,background-color,border-color,box-shadow] duration-150 ease-out;
+    @apply grid size-8 cursor-pointer place-items-center rounded-md border border-(--border-default) bg-(--bg-primary) p-0 text-(--text-secondary) outline-none transition-[color,background-color,border-color,box-shadow] duration-150 ease-out;
     background: var(--editor-code-control-bg, var(--bg-primary));
     border-color: var(--editor-border, var(--border-default));
     color: var(--editor-text-secondary, var(--text-secondary));
-    z-index: 1;
   }
 
+  .markra-mermaid-zoom-control-button:hover,
   .markra-mermaid-zoom-close-button:hover {
     background: var(--editor-bg-secondary, var(--bg-hover));
     border-color: var(--editor-border-strong, var(--border-strong));
     color: var(--editor-text-heading, var(--text-heading));
   }
 
+  .markra-mermaid-zoom-control-button:focus-visible,
   .markra-mermaid-zoom-close-button:focus-visible {
     background: var(--editor-bg-secondary, var(--bg-hover));
     border-color: var(--editor-border-strong, var(--border-strong));
@@ -3002,11 +3017,33 @@
   }
 
   .markra-mermaid-zoom-content {
-    @apply px-8 pb-8 pt-2;
+    @apply relative min-h-0 flex-1 overflow-hidden px-8 py-8 outline-none;
+    cursor: grab;
+    touch-action: none;
+  }
+
+  .markra-mermaid-zoom-content:focus-visible {
+    box-shadow: inset 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
+  .markra-mermaid-zoom-content[data-dragging="true"] {
+    cursor: grabbing;
+  }
+
+  .markra-mermaid-zoom-canvas {
+    @apply flex min-h-full items-center justify-center;
+    transform-origin: center center;
+    transition: transform 90ms ease-out;
+    will-change: transform;
+  }
+
+  .markra-mermaid-zoom-content[data-dragging="true"] .markra-mermaid-zoom-canvas {
+    transition: none;
   }
 
   .markra-mermaid-zoom-svg {
     display: block;
+    flex: 0 0 auto;
     width: min(100%, 72rem);
     min-width: min(48rem, calc(100vw - 5rem));
     max-width: none;

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -444,6 +444,10 @@ describe("editor stylesheet", () => {
     expect(mermaidZoomCloseHoverStyles).not.toContain(":focus-visible");
     expect(mermaidZoomCloseHoverStyles).not.toContain("box-shadow");
     expect(styles).toContain(".markra-mermaid-zoom-dialog");
+    expect(styles).toContain(".markra-mermaid-zoom-toolbar");
+    expect(styles).toContain(".markra-mermaid-zoom-control-button");
+    expect(styles).toContain(".markra-mermaid-zoom-content[data-dragging=\"true\"]");
+    expect(styles).toContain(".markra-mermaid-zoom-canvas");
     expect(styles).toContain(
       ".markdown-paper .markra-code-block[data-mermaid-mode=\"preview\"] .markra-mermaid-render"
     );

--- a/packages/editor/src/code-block.ts
+++ b/packages/editor/src/code-block.ts
@@ -39,6 +39,14 @@ type SvgChildSpec = {
   tag: "path" | "rect";
 };
 
+type MermaidZoomDragState = {
+  originX: number;
+  originY: number;
+  pointerId: number;
+  startX: number;
+  startY: number;
+};
+
 const codeLanguageOptions = [
   { label: "Plain Text", value: "" },
   { label: "Bash", value: "bash" },
@@ -87,6 +95,11 @@ const codeLanguageOptions = [
 const codeBlockHighlightKey = new PluginKey("markra-code-block-highlight");
 const lowlight = createLowlight(common);
 const codeFencePattern = /^```(?<language>[^\s`]*)$/u;
+const mermaidZoomDefaultScale = 1;
+const mermaidZoomMaxScale = 6;
+const mermaidZoomMinScale = 0.25;
+const mermaidZoomStep = 0.25;
+const mermaidZoomWheelFactor = 1.12;
 const svgNamespace = "http://www.w3.org/2000/svg";
 const copyIconChildren: SvgChildSpec[] = [
   {
@@ -152,6 +165,42 @@ const closeIconChildren: SvgChildSpec[] = [
     tag: "path",
     attributes: {
       d: "m6 6 12 12"
+    }
+  }
+];
+const zoomInIconChildren: SvgChildSpec[] = [
+  {
+    tag: "path",
+    attributes: {
+      d: "M12 5v14"
+    }
+  },
+  {
+    tag: "path",
+    attributes: {
+      d: "M5 12h14"
+    }
+  }
+];
+const zoomOutIconChildren: SvgChildSpec[] = [
+  {
+    tag: "path",
+    attributes: {
+      d: "M5 12h14"
+    }
+  }
+];
+const resetViewIconChildren: SvgChildSpec[] = [
+  {
+    tag: "path",
+    attributes: {
+      d: "M3 12a9 9 0 1 0 3-6.7"
+    }
+  },
+  {
+    tag: "path",
+    attributes: {
+      d: "M3 3v6h6"
     }
   }
 ];
@@ -305,6 +354,18 @@ function targetIsInside(target: EventTarget | Node | null, container: HTMLElemen
   return target instanceof Node && container.contains(target);
 }
 
+function clampNumber(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function formatMermaidZoomValue(scale: number) {
+  return String(Math.round(scale * 100) / 100);
+}
+
+function mermaidZoomPercentLabel(scale: number) {
+  return `${Math.round(scale * 100)}%`;
+}
+
 function createIcon(ownerDocument: Document, className: string, children: SvgChildSpec[]) {
   const icon = ownerDocument.createElementNS(svgNamespace, "svg");
 
@@ -328,6 +389,22 @@ function createIcon(ownerDocument: Document, className: string, children: SvgChi
   }
 
   return icon;
+}
+
+function createIconButton(
+  ownerDocument: Document,
+  className: string,
+  label: string,
+  iconClassName: string,
+  iconChildren: SvgChildSpec[]
+) {
+  const button = ownerDocument.createElement("button");
+  button.className = className;
+  button.type = "button";
+  button.setAttribute("aria-label", label);
+  button.title = label;
+  button.append(createIcon(ownerDocument, iconClassName, iconChildren));
+  return button;
 }
 
 function openCodeBlockWithInsertedFence(view: EditorView, codeBlock: NodeType, text: string) {
@@ -473,6 +550,10 @@ class MarkraCodeBlockNodeView implements NodeView {
   private readonly mermaidThemeObserver: MutationObserver | null = null;
   private mermaidZoomDialog: HTMLElement | null = null;
   private mermaidZoomFocusTarget: HTMLElement | null = null;
+  private mermaidZoomDrag: MermaidZoomDragState | null = null;
+  private mermaidZoomScale = mermaidZoomDefaultScale;
+  private mermaidZoomTranslateX = 0;
+  private mermaidZoomTranslateY = 0;
   private mermaidSourceEditing = false;
   private mermaidRenderSignature = "";
   private mermaidRenderToken = 0;
@@ -741,8 +822,8 @@ class MarkraCodeBlockNodeView implements NodeView {
   }
 
   private updateMermaidZoomDiagram() {
-    const content = this.mermaidZoomDialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-content");
-    if (!content) return;
+    const canvas = this.mermaidZoomDialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-canvas");
+    if (!canvas) return;
 
     const svg = this.cloneMermaidPreviewSvg();
     if (!svg) {
@@ -750,7 +831,8 @@ class MarkraCodeBlockNodeView implements NodeView {
       return;
     }
 
-    content.replaceChildren(svg);
+    canvas.replaceChildren(svg);
+    this.syncMermaidZoomTransform();
   }
 
   private openMermaidZoom() {
@@ -758,35 +840,80 @@ class MarkraCodeBlockNodeView implements NodeView {
     if (!svg) return;
 
     this.closeMermaidZoom({ restoreFocus: false });
+    this.resetMermaidZoomState();
 
     const ownerDocument = this.dom.ownerDocument;
     const dialog = ownerDocument.createElement("div");
     const panel = ownerDocument.createElement("div");
-    const closeButton = ownerDocument.createElement("button");
+    const toolbar = ownerDocument.createElement("div");
+    const zoomValue = ownerDocument.createElement("span");
     const content = ownerDocument.createElement("div");
+    const canvas = ownerDocument.createElement("div");
+    const zoomOutButton = createIconButton(
+      ownerDocument,
+      "markra-mermaid-zoom-control-button markra-mermaid-zoom-out-button",
+      "Zoom out Mermaid diagram",
+      "markra-mermaid-zoom-out-icon",
+      zoomOutIconChildren
+    );
+    const zoomInButton = createIconButton(
+      ownerDocument,
+      "markra-mermaid-zoom-control-button markra-mermaid-zoom-in-button",
+      "Zoom in Mermaid diagram",
+      "markra-mermaid-zoom-in-icon",
+      zoomInIconChildren
+    );
+    const resetButton = createIconButton(
+      ownerDocument,
+      "markra-mermaid-zoom-control-button markra-mermaid-zoom-reset-button",
+      "Reset Mermaid diagram view",
+      "markra-mermaid-zoom-reset-icon",
+      resetViewIconChildren
+    );
+    const closeButton = createIconButton(
+      ownerDocument,
+      "markra-mermaid-zoom-close-button",
+      "Close enlarged Mermaid diagram",
+      "markra-mermaid-zoom-close-icon",
+      closeIconChildren
+    );
 
     dialog.className = "markra-mermaid-zoom-dialog";
     dialog.setAttribute("role", "dialog");
     dialog.setAttribute("aria-modal", "true");
     dialog.setAttribute("aria-label", "Enlarged Mermaid diagram");
     panel.className = "markra-mermaid-zoom-panel";
-    closeButton.className = "markra-mermaid-zoom-close-button";
-    closeButton.type = "button";
-    closeButton.setAttribute("aria-label", "Close enlarged Mermaid diagram");
-    closeButton.title = "Close enlarged Mermaid diagram";
-    closeButton.append(createIcon(ownerDocument, "markra-mermaid-zoom-close-icon", closeIconChildren));
+    toolbar.className = "markra-mermaid-zoom-toolbar";
+    zoomValue.className = "markra-mermaid-zoom-value";
+    zoomValue.setAttribute("aria-live", "polite");
+    zoomValue.textContent = mermaidZoomPercentLabel(this.mermaidZoomScale);
     content.className = "markra-mermaid-zoom-content";
+    content.tabIndex = 0;
+    content.setAttribute("aria-label", "Mermaid diagram viewport");
+    content.dataset.zoom = formatMermaidZoomValue(this.mermaidZoomScale);
+    canvas.className = "markra-mermaid-zoom-canvas";
 
-    content.append(svg);
-    panel.append(closeButton, content);
+    canvas.append(svg);
+    content.append(canvas);
+    toolbar.append(zoomOutButton, zoomValue, zoomInButton, resetButton, closeButton);
+    panel.append(toolbar, content);
     dialog.append(panel);
     dialog.addEventListener("mousedown", this.handleMermaidZoomDialogMouseDown);
+    zoomOutButton.addEventListener("click", this.handleMermaidZoomOutClick);
+    zoomInButton.addEventListener("click", this.handleMermaidZoomInClick);
+    resetButton.addEventListener("click", this.handleMermaidZoomResetClick);
     closeButton.addEventListener("click", this.handleMermaidZoomCloseClick);
+    content.addEventListener("wheel", this.handleMermaidZoomWheel, { passive: false });
+    content.addEventListener("pointerdown", this.handleMermaidZoomPointerDown);
+    content.addEventListener("pointermove", this.handleMermaidZoomPointerMove);
+    content.addEventListener("pointerup", this.handleMermaidZoomPointerUp);
+    content.addEventListener("pointercancel", this.handleMermaidZoomPointerUp);
     ownerDocument.addEventListener("keydown", this.handleMermaidZoomKeyDown, true);
     (this.view.dom.closest(".markdown-paper") ?? ownerDocument.body).append(dialog);
 
     this.mermaidZoomDialog = dialog;
     this.mermaidZoomFocusTarget = this.mermaidZoomButton;
+    this.syncMermaidZoomTransform();
     closeButton.focus();
   }
 
@@ -794,16 +921,62 @@ class MarkraCodeBlockNodeView implements NodeView {
     const dialog = this.mermaidZoomDialog;
     if (!dialog) return;
 
+    const zoomOutButton = dialog.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-out-button");
+    const zoomInButton = dialog.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-in-button");
+    const resetButton = dialog.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-reset-button");
     const closeButton = dialog.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-close-button");
+    const content = dialog.querySelector<HTMLElement>(".markra-mermaid-zoom-content");
     dialog.removeEventListener("mousedown", this.handleMermaidZoomDialogMouseDown);
+    zoomOutButton?.removeEventListener("click", this.handleMermaidZoomOutClick);
+    zoomInButton?.removeEventListener("click", this.handleMermaidZoomInClick);
+    resetButton?.removeEventListener("click", this.handleMermaidZoomResetClick);
     closeButton?.removeEventListener("click", this.handleMermaidZoomCloseClick);
+    content?.removeEventListener("wheel", this.handleMermaidZoomWheel);
+    content?.removeEventListener("pointerdown", this.handleMermaidZoomPointerDown);
+    content?.removeEventListener("pointermove", this.handleMermaidZoomPointerMove);
+    content?.removeEventListener("pointerup", this.handleMermaidZoomPointerUp);
+    content?.removeEventListener("pointercancel", this.handleMermaidZoomPointerUp);
+    if (content && this.mermaidZoomDrag && content.hasPointerCapture?.(this.mermaidZoomDrag.pointerId)) {
+      content.releasePointerCapture(this.mermaidZoomDrag.pointerId);
+    }
     this.dom.ownerDocument.removeEventListener("keydown", this.handleMermaidZoomKeyDown, true);
     dialog.remove();
     this.mermaidZoomDialog = null;
+    this.mermaidZoomDrag = null;
 
     const focusTarget = this.mermaidZoomFocusTarget;
     this.mermaidZoomFocusTarget = null;
     if (restoreFocus && focusTarget?.isConnected) focusTarget.focus();
+  }
+
+  private resetMermaidZoomState() {
+    this.mermaidZoomDrag = null;
+    this.mermaidZoomScale = mermaidZoomDefaultScale;
+    this.mermaidZoomTranslateX = 0;
+    this.mermaidZoomTranslateY = 0;
+  }
+
+  private resetMermaidZoomView() {
+    this.resetMermaidZoomState();
+    this.syncMermaidZoomTransform();
+  }
+
+  private setMermaidZoomScale(scale: number) {
+    this.mermaidZoomScale = clampNumber(scale, mermaidZoomMinScale, mermaidZoomMaxScale);
+    this.syncMermaidZoomTransform();
+  }
+
+  private syncMermaidZoomTransform() {
+    const dialog = this.mermaidZoomDialog;
+    const content = dialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-content");
+    const canvas = dialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-canvas");
+    const value = dialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-value");
+    if (!content || !canvas) return;
+
+    const zoomValue = formatMermaidZoomValue(this.mermaidZoomScale);
+    content.dataset.zoom = zoomValue;
+    canvas.style.transform = `translate(${this.mermaidZoomTranslateX}px, ${this.mermaidZoomTranslateY}px) scale(${zoomValue})`;
+    if (value) value.textContent = mermaidZoomPercentLabel(this.mermaidZoomScale);
   }
 
   private activateMermaidSourceEditing() {
@@ -869,6 +1042,65 @@ class MarkraCodeBlockNodeView implements NodeView {
     event.preventDefault();
     event.stopPropagation();
     this.openMermaidZoom();
+  };
+
+  private readonly handleMermaidZoomOutClick = (event: MouseEvent) => {
+    event.preventDefault();
+    this.setMermaidZoomScale(this.mermaidZoomScale - mermaidZoomStep);
+  };
+
+  private readonly handleMermaidZoomInClick = (event: MouseEvent) => {
+    event.preventDefault();
+    this.setMermaidZoomScale(this.mermaidZoomScale + mermaidZoomStep);
+  };
+
+  private readonly handleMermaidZoomResetClick = (event: MouseEvent) => {
+    event.preventDefault();
+    this.resetMermaidZoomView();
+  };
+
+  private readonly handleMermaidZoomWheel = (event: WheelEvent) => {
+    if (event.deltaY === 0) return;
+
+    event.preventDefault();
+    const factor = event.deltaY < 0 ? mermaidZoomWheelFactor : 1 / mermaidZoomWheelFactor;
+    this.setMermaidZoomScale(this.mermaidZoomScale * factor);
+  };
+
+  private readonly handleMermaidZoomPointerDown = (event: PointerEvent) => {
+    if (event.button !== 0) return;
+
+    event.preventDefault();
+    const content = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    content?.setPointerCapture?.(event.pointerId);
+    if (content) content.dataset.dragging = "true";
+    this.mermaidZoomDrag = {
+      originX: this.mermaidZoomTranslateX,
+      originY: this.mermaidZoomTranslateY,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY
+    };
+  };
+
+  private readonly handleMermaidZoomPointerMove = (event: PointerEvent) => {
+    const drag = this.mermaidZoomDrag;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+
+    event.preventDefault();
+    this.mermaidZoomTranslateX = drag.originX + event.clientX - drag.startX;
+    this.mermaidZoomTranslateY = drag.originY + event.clientY - drag.startY;
+    this.syncMermaidZoomTransform();
+  };
+
+  private readonly handleMermaidZoomPointerUp = (event: PointerEvent) => {
+    const drag = this.mermaidZoomDrag;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+
+    const content = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    if (content?.hasPointerCapture?.(event.pointerId)) content.releasePointerCapture(event.pointerId);
+    if (content) delete content.dataset.dragging;
+    this.mermaidZoomDrag = null;
   };
 
   private readonly handleMermaidZoomDialogMouseDown = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary
- Adds zoom in, zoom out, reset, mouse wheel zoom, and drag panning to the enlarged Mermaid diagram dialog.
- Updates the Mermaid zoom dialog layout so controls stay fixed above a pannable viewport.
- Adds coverage for zooming, panning, reset behavior, and the new zoom styles.

## Why
- Wide Mermaid diagrams previously only fit the preview container, so opening the enlarged view did not meaningfully help inspect them.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t Mermaid` passed
- `pnpm --filter @markra/app test -- src/styles.test.ts` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed

Closes #404
