### PR TITLE
perf(app): optimize workspace file loading

### DIFF
--- a/apps/desktop/src-tauri/src/markdown_files.rs
+++ b/apps/desktop/src-tauri/src/markdown_files.rs
@@ -22,7 +22,7 @@ pub(crate) use open::{
     open_containing_folder, open_markdown_attachment, open_markdown_file_in_new_window,
     open_markdown_folder_in_new_window, open_markdown_path, resolve_markdown_path,
 };
-pub(crate) use path::markdown_open_path_for_path;
+pub(crate) use path::{markdown_open_path_for_path, should_skip_markdown_tree_component};
 pub(crate) use search::search_markdown_files_for_path;
 pub(crate) use template::{
     delete_markdown_template_file, read_markdown_template_file, write_markdown_template_file,

--- a/apps/desktop/src-tauri/src/markdown_files/path.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/path.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -94,10 +95,25 @@ pub(crate) fn markdown_open_path_for_path(path: &Path) -> Result<MarkdownOpenPat
     Err("Selected path is not a supported Markdown file or folder".to_string())
 }
 
+pub(crate) fn should_skip_markdown_tree_component(component: &OsStr) -> bool {
+    component.to_str().is_some_and(|name| {
+        matches!(
+            name,
+            ".codex"
+                | ".git"
+                | ".markra-sync"
+                | ".obsidian"
+                | "build"
+                | "dist"
+                | "node_modules"
+                | "target"
+        )
+    })
+}
+
 pub(super) fn should_skip_markdown_tree_directory(path: &Path) -> bool {
     path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| matches!(name, ".git" | "node_modules"))
+        .is_some_and(should_skip_markdown_tree_component)
 }
 
 pub(super) fn markdown_tree_relative_path(root: &Path, path: &Path) -> Result<String, String> {
@@ -125,6 +141,11 @@ pub(super) fn markdown_folder_file(
         modified_at,
         path: path_to_string(path),
         relative_path: markdown_tree_relative_path(root, path)?,
+        size_bytes: if metadata.is_file() {
+            Some(metadata.len())
+        } else {
+            None
+        },
     })
 }
 

--- a/apps/desktop/src-tauri/src/markdown_files/search.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/search.rs
@@ -792,6 +792,7 @@ mod tests {
             modified_at: Some(1),
             path: "/synthetic/first.md".to_string(),
             relative_path: "first.md".to_string(),
+            size_bytes: Some(10),
         };
         let second = MarkdownFolderFile {
             created_at: None,
@@ -799,6 +800,7 @@ mod tests {
             modified_at: Some(1),
             path: "/synthetic/second.md".to_string(),
             relative_path: "second.md".to_string(),
+            size_bytes: Some(20),
         };
         let mut index = WorkspaceSearchIndex::default();
         let mut first_signature = WorkspaceSearchFileSignature {

--- a/apps/desktop/src-tauri/src/markdown_files/tree.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/tree.rs
@@ -543,21 +543,29 @@ mod tests {
                     "assets/reference.docx",
                 ),
                 (&MarkdownFolderEntryKind::File, "AWS.md"),
-                (&MarkdownFolderEntryKind::Folder, "build"),
-                (&MarkdownFolderEntryKind::File, "build/output.md"),
-                (&MarkdownFolderEntryKind::Folder, "dist"),
-                (&MarkdownFolderEntryKind::File, "dist/bundle.md"),
                 (&MarkdownFolderEntryKind::Folder, "docs"),
                 (&MarkdownFolderEntryKind::File, "docs/guide.markdown"),
                 (&MarkdownFolderEntryKind::Folder, "empty"),
                 (&MarkdownFolderEntryKind::Attachment, "notes.txt"),
-                (&MarkdownFolderEntryKind::Folder, "target"),
-                (&MarkdownFolderEntryKind::File, "target/cache.md"),
                 (&MarkdownFolderEntryKind::File, "Untitled.md"),
             ]
         );
         assert!(files.iter().all(|file| file.created_at.is_some()));
         assert!(files.iter().all(|file| file.modified_at.is_some()));
+        assert_eq!(
+            files
+                .iter()
+                .find(|file| file.relative_path == "Untitled.md")
+                .and_then(|file| file.size_bytes),
+            Some("# Untitled".len() as u64)
+        );
+        assert_eq!(
+            files
+                .iter()
+                .find(|file| file.relative_path == "assets")
+                .and_then(|file| file.size_bytes),
+            None
+        );
 
         fs::remove_dir_all(root).expect("test tree should be removed");
     }
@@ -643,6 +651,101 @@ mod tests {
                 (&MarkdownFolderEntryKind::File, "index.md"),
             ]
         );
+
+        fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn skips_tool_metadata_directories_when_listing_markdown_files() {
+        let root = std::env::temp_dir().join(format!(
+            "markra-tool-metadata-tree-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after epoch")
+                .as_nanos()
+        ));
+        let obsidian_plugin = root.join(".obsidian").join("plugins").join("mock-plugin");
+        let codex_sessions = root.join(".codex").join("sessions");
+        let sync_metadata = root.join(".markra-sync").join("objects");
+
+        fs::create_dir_all(&obsidian_plugin).expect("obsidian plugin folder should be created");
+        fs::create_dir_all(&codex_sessions).expect("codex sessions folder should be created");
+        fs::create_dir_all(&sync_metadata).expect("sync metadata folder should be created");
+        fs::write(root.join("index.md"), "# Index").expect("markdown file should be created");
+        fs::write(obsidian_plugin.join("data.json"), "{}")
+            .expect("obsidian plugin data should be created");
+        fs::write(obsidian_plugin.join("readme.md"), "# Plugin")
+            .expect("obsidian plugin markdown should be created");
+        fs::write(codex_sessions.join("session.json"), "{}")
+            .expect("codex session should be created");
+        fs::write(sync_metadata.join("entry.md"), "# Metadata")
+            .expect("sync metadata markdown should be created");
+
+        let files = list_markdown_files_for_path_with_asset_scope(
+            root.to_string_lossy().to_string(),
+            Some("assets"),
+            |_| Ok(()),
+        )
+        .expect("markdown tree should be listed");
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| (&file.kind, file.relative_path.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(&MarkdownFolderEntryKind::File, "index.md")]
+        );
+
+        fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn skips_build_artifact_directories_when_listing_markdown_files() {
+        let root = std::env::temp_dir().join(format!(
+            "markra-build-artifact-tree-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after epoch")
+                .as_nanos()
+        ));
+        let rust_target_deps = root
+            .join("src-tauri")
+            .join("target")
+            .join("debug")
+            .join("deps");
+        let vite_dist_assets = root.join("web").join("dist").join("assets");
+        let generated_build = root.join("site").join("build").join("static");
+
+        fs::create_dir_all(&rust_target_deps).expect("target folder should be created");
+        fs::create_dir_all(&vite_dist_assets).expect("dist folder should be created");
+        fs::create_dir_all(&generated_build).expect("build folder should be created");
+        fs::write(root.join("index.md"), "# Index").expect("markdown file should be created");
+        fs::write(rust_target_deps.join("compiled-artifact.d"), "compiled")
+            .expect("target artifact should be created");
+        fs::write(vite_dist_assets.join("bundle.js"), "compiled")
+            .expect("dist artifact should be created");
+        fs::write(generated_build.join("page.md"), "# Generated")
+            .expect("build artifact markdown should be created");
+
+        let files = list_markdown_files_for_path_with_asset_scope(
+            root.to_string_lossy().to_string(),
+            Some("assets"),
+            |_| Ok(()),
+        )
+        .expect("markdown tree should be listed");
+
+        let relative_paths = files
+            .iter()
+            .map(|file| file.relative_path.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(relative_paths.contains(&"index.md"));
+        assert!(relative_paths.contains(&"site"));
+        assert!(relative_paths.contains(&"src-tauri"));
+        assert!(relative_paths.contains(&"web"));
+        assert!(!relative_paths.iter().any(|path| path
+            .split('/')
+            .any(|part| matches!(part, "build" | "dist" | "target"))));
 
         fs::remove_dir_all(root).expect("test tree should be removed");
     }

--- a/apps/desktop/src-tauri/src/markdown_files/types.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/types.rs
@@ -71,6 +71,8 @@ pub(crate) struct MarkdownFolderFile {
     pub(crate) modified_at: Option<u64>,
     pub(crate) path: String,
     pub(crate) relative_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) size_bytes: Option<u64>,
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize)]

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -5,6 +5,8 @@ use std::sync::Mutex;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tauri::Emitter;
 
+use crate::markdown_files::should_skip_markdown_tree_component;
+
 const MARKDOWN_FILE_CHANGED_EVENT: &str = "markra://file-changed";
 const MARKDOWN_TREE_CHANGED_EVENT: &str = "markra://tree-changed";
 
@@ -50,12 +52,6 @@ fn is_target_file_event(event: &Event, watched_path: &Path) -> bool {
     })
 }
 
-fn is_ignored_tree_component(component: &std::ffi::OsStr) -> bool {
-    component
-        .to_str()
-        .is_some_and(|name| matches!(name, ".git" | "node_modules" | "target" | "dist" | "build"))
-}
-
 fn is_markdown_tree_path(_path: &Path) -> bool {
     true
 }
@@ -75,7 +71,7 @@ fn markdown_tree_event_path<'a>(event: &'a Event, root: &Path) -> Option<&'a Pat
 
         let has_ignored_component = relative_path
             .components()
-            .any(|component| is_ignored_tree_component(component.as_os_str()));
+            .any(|component| should_skip_markdown_tree_component(component.as_os_str()));
 
         !has_ignored_component && is_markdown_tree_path(event_path)
     })
@@ -318,6 +314,16 @@ mod tests {
         let root = PathBuf::from("/mock-files");
         let event = Event::new(EventKind::Create(CreateKind::File))
             .add_path(PathBuf::from("/mock-files/node_modules/pkg/readme.md"));
+
+        assert!(markdown_tree_event_path(&event, &root).is_none());
+    }
+
+    #[test]
+    fn ignores_tool_metadata_folder_tree_events() {
+        let root = PathBuf::from("/mock-files");
+        let event = Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content))).add_path(
+            PathBuf::from("/mock-files/.obsidian/plugins/mock-plugin/data.json"),
+        );
 
         assert!(markdown_tree_event_path(&event, &root).is_none());
     }

--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -56,7 +56,7 @@ describe("Markra AI workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Toggle Markra AI" }));
 
     expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toHaveAttribute("aria-pressed", "true");
-    const agentPanel = screen.getByRole("complementary", { name: "Markra AI" });
+    const agentPanel = await screen.findByRole("complementary", { name: "Markra AI" });
     expect(agentPanel).toBeInTheDocument();
     expect(within(agentPanel).getAllByText("OpenAI · GPT-5.5")[0]).toBeInTheDocument();
     expect(within(agentPanel).getByRole("combobox", { name: "AI model" })).toHaveTextContent("OpenAI · GPT-5.5");
@@ -80,7 +80,7 @@ describe("Markra AI workspace", () => {
     fireEvent.keyDown(window, { key: "j", altKey: true, metaKey: true });
 
     expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("complementary", { name: "Markra AI" })).toBeInTheDocument();
+    expect(await screen.findByRole("complementary", { name: "Markra AI" })).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "j", altKey: true, metaKey: true });
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1082,14 +1082,51 @@ describe("Markra workspace", () => {
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Toggle file list" })).toHaveAttribute("aria-pressed", "true")
     );
-    expect(screen.getAllByText("vault").length).toBeGreaterThan(0);
     expect(await screen.findByRole("button", { name: "index.md" })).toBeInTheDocument();
     expect(screen.getAllByText("vault").length).toBeGreaterThan(0);
-    expect(screen.queryByRole("heading", { name: "Untitled.md" })).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("heading", { name: "Untitled.md" })).not.toBeInTheDocument()
+    );
     expect(screen.queryByLabelText("Markdown editor")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Markdown" })).toBeDisabled();
     expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith(mockFolderPath, defaultFileTreeListOptions);
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
+  });
+
+  it("does not read extra markdown contents for document links while the links panel is closed", async () => {
+    const alphaPath = "/mock-files/vault/Alpha.md";
+    const betaPath = "/mock-files/vault/Beta.md";
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      documentLinksOpen: false,
+      documentLinksVisible: true
+    }));
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-app",
+      filePath: alphaPath,
+      fileTreeOpen: true,
+      folderName: "vault",
+      folderPath: mockFolderPath,
+      openFilePaths: [alphaPath]
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Alpha\n\nCurrent document.",
+      name: "Alpha.md",
+      path: alphaPath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "Alpha.md", path: alphaPath, relativePath: "Alpha.md", sizeBytes: 10 },
+      { name: "Beta.md", path: betaPath, relativePath: "Beta.md", sizeBytes: 10 }
+    ]);
+
+    renderApp();
+
+    expect(await screen.findByRole("heading", { name: "Alpha" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Document links" })).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() =>
+      expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith(mockFolderPath, defaultFileTreeListOptions)
+    );
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(alphaPath);
+    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalledWith(betaPath);
   });
 
   it("falls back to an empty document when the restored markdown folder is gone", async () => {
@@ -2241,8 +2278,8 @@ describe("Markra workspace", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open Folder" }));
 
     expect(await screen.findByRole("complementary", { name: "Markdown file tree" })).toBeInTheDocument();
-    expect(screen.getAllByText("vault").length).toBeGreaterThan(0);
     expect(await screen.findByRole("button", { name: "index.md" })).toBeInTheDocument();
+    expect(screen.getAllByText("vault").length).toBeGreaterThan(0);
     expect(mockedOpenNativeMarkdownFolder).toHaveBeenCalledTimes(1);
     expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith(mockFolderPath, defaultFileTreeListOptions);
     expect(mockedOpenNativeMarkdownPath).not.toHaveBeenCalled();

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -13,7 +15,6 @@ import {
 import { flushSync } from "react-dom";
 import { AppToaster } from "./components/AppToaster";
 import { AiCommandBar } from "./components/AiCommandBar";
-import { AiAgentPanel } from "./components/AiAgentPanel";
 import { AiSelectionToolbar } from "./components/AiSelectionToolbar";
 import { DocumentHistoryDialog } from "./components/DocumentHistoryDialog";
 import { DocumentSearchBar } from "./components/DocumentSearchBar";
@@ -36,7 +37,6 @@ import { NativeTitleBar } from "./components/NativeTitleBar";
 import { QuietStatus } from "./components/QuietStatus";
 import { QuickOpenPanel } from "./components/QuickOpenPanel";
 import { SideDocumentPane } from "./components/SideDocumentPane";
-import { SettingsWindow } from "./components/SettingsWindow";
 import { WorkspaceLayout } from "./components/WorkspaceLayout";
 import { WorkspaceOperationOverlay } from "./components/WorkspaceOperationOverlay";
 import { useAppLanguage } from "./hooks/useAppLanguage";
@@ -255,6 +255,18 @@ type PendingEditorModeScroll = {
 export { runEditorLinkCommand } from "./app/editor-link-command";
 export { globalSearchDebounceMs } from "./hooks/useWorkspaceSearch";
 
+const AiAgentPanel = lazy(async () => {
+  const module = await import("./components/AiAgentPanel");
+
+  return { default: module.AiAgentPanel };
+});
+const SettingsWindow = lazy(async () => {
+  const module = await import("./components/SettingsWindow");
+
+  return { default: module.SettingsWindow };
+});
+const workspaceLinkIndexDeferMs = 320;
+
 export default function App() {
   const isSettingsRoute = useSettingsWindowRoute();
 
@@ -264,7 +276,11 @@ export default function App() {
 function SettingsRouteApp() {
   useStartupWindowReveal({ ready: true });
 
-  return <SettingsWindow />;
+  return (
+    <Suspense fallback={null}>
+      <SettingsWindow />
+    </Suspense>
+  );
 }
 
 function WorkspaceApp() {
@@ -610,10 +626,14 @@ function WorkspaceApp() {
   };
   const documentLinksOpen = editorPreferences.preferences.documentLinksOpen;
   const documentLinksVisible = editorPreferences.preferences.documentLinksVisible;
+  const documentLinksIndexEnabled = documentLinksVisible === true && (
+    editorPreferences.preferences.sidebarLayoutMode === "tabs" || documentLinksOpen === true
+  );
   const workspaceLinkIndex = useWorkspaceLinkIndex({
+    deferMs: workspaceLinkIndexDeferMs,
     documentContent: document.content,
     documentPath: document.path,
-    enabled: documentLinksVisible === true,
+    enabled: documentLinksIndexEnabled,
     fileTreeFiles
   });
   const handleDocumentLinksOpenChange = useCallback((openDocumentLinks: boolean) => {
@@ -1198,7 +1218,7 @@ function WorkspaceApp() {
     aiAgent.draft.trim().slice(0, 24),
     aiAgent.titleVersion
   ].join(":");
-  const aiAgentSessions = useAiAgentSessionList(workspaceKey, aiAgentSessionRefreshKey);
+  const aiAgentSessions = useAiAgentSessionList(workspaceKey, aiAgentSessionRefreshKey, aiAgentPanelEnabledOpen);
   useEffect(() => {
     if (!aiFeatureEnabled) return;
     if (!workspaceKey || !activeAiAgentSessionId || !aiAgentSessions.ready) return;
@@ -3717,60 +3737,62 @@ function WorkspaceApp() {
       })}
     </>
   );
-  const aiAgentPanel = aiFeatureEnabled ? (
-    <AiAgentPanel
-      activeSessionId={activeAiAgentSessionId}
-      availableModels={aiSettings.availableTextModels}
-      context={aiAgentContext}
-      documentAvailable={hasOpenDocument && !activeImageFile}
-      draft={aiAgent.draft}
-      language={appLanguage.language}
-      messages={aiAgent.messages}
-      modelName={aiAgentModelName}
-      open={aiAgentOpen}
-      providerName={aiAgentProviderName}
-      sessions={aiAgentSessions.sessions}
-      selectedModelId={aiSettings.agentModelId}
-      selectedProviderId={aiSettings.agentProviderId}
-      status={aiAgent.status}
-      thinkingEnabled={aiAgent.thinkingEnabled}
-      webSearchAvailable={webSearchAvailable}
-      webSearchEnabled={aiAgent.webSearchEnabled}
-      workspaceAvailable={Boolean(fileTree.sourcePath)}
-      workspacePlanApplyError={aiAgent.workspacePlanApplyError}
-      workspacePlanApplyStatus={aiAgent.workspacePlanApplyStatus}
-      workspacePlanEvents={aiAgent.workspacePlanEvents}
-      maxWidth={aiAgentPanelMaxWidth}
-      minWidth={aiAgentPanelMinWidth}
-      width={aiAgentPanelWidth}
-      onArchiveSession={(sessionId, archived) => {
-        handleArchiveAiAgentSession(sessionId, archived).catch(() => {});
-      }}
-      onApplyWorkspacePlan={() => {
-        aiAgent.applyWorkspacePlan().catch(() => {});
-      }}
-      onClose={closeAiAgentPanel}
-      onCreateSession={handleCreateAiAgentSession}
-      onDeleteSession={(sessionId) => {
-        handleDeleteAiAgentSession(sessionId).catch(() => {});
-      }}
-      onDisableThinking={() => aiAgent.setSessionThinkingEnabled(false)}
-      onDraftChange={aiAgent.setDraft}
-      onInterrupt={aiAgent.interrupt}
-      onRenameSession={(sessionId, title) => {
-        handleRenameAiAgentSession(sessionId, title).catch(() => {});
-      }}
-      onResize={setAiAgentPanelWidth}
-      onResizeEnd={endAiAgentPanelResize}
-      onResizeStart={startAiAgentPanelResize}
-      onRetryMessage={aiAgent.retryMessage}
-      onSelectSession={handleSelectAiAgentSession}
-      onSelectModel={aiSettings.selectAgentModel}
-      onSubmit={aiAgent.submit}
-      onSubmitEditedMessage={aiAgent.submitEditedMessage}
-      onToggleThinking={() => aiAgent.setThinkingEnabled((enabled) => !enabled)}
-      onToggleWebSearch={() => aiAgent.setWebSearchEnabled((enabled) => !enabled)}
-    />
+  const aiAgentPanel = aiFeatureEnabled && aiAgentOpen ? (
+    <Suspense fallback={null}>
+      <AiAgentPanel
+        activeSessionId={activeAiAgentSessionId}
+        availableModels={aiSettings.availableTextModels}
+        context={aiAgentContext}
+        documentAvailable={hasOpenDocument && !activeImageFile}
+        draft={aiAgent.draft}
+        language={appLanguage.language}
+        messages={aiAgent.messages}
+        modelName={aiAgentModelName}
+        open={aiAgentOpen}
+        providerName={aiAgentProviderName}
+        sessions={aiAgentSessions.sessions}
+        selectedModelId={aiSettings.agentModelId}
+        selectedProviderId={aiSettings.agentProviderId}
+        status={aiAgent.status}
+        thinkingEnabled={aiAgent.thinkingEnabled}
+        webSearchAvailable={webSearchAvailable}
+        webSearchEnabled={aiAgent.webSearchEnabled}
+        workspaceAvailable={Boolean(fileTree.sourcePath)}
+        workspacePlanApplyError={aiAgent.workspacePlanApplyError}
+        workspacePlanApplyStatus={aiAgent.workspacePlanApplyStatus}
+        workspacePlanEvents={aiAgent.workspacePlanEvents}
+        maxWidth={aiAgentPanelMaxWidth}
+        minWidth={aiAgentPanelMinWidth}
+        width={aiAgentPanelWidth}
+        onArchiveSession={(sessionId, archived) => {
+          handleArchiveAiAgentSession(sessionId, archived).catch(() => {});
+        }}
+        onApplyWorkspacePlan={() => {
+          aiAgent.applyWorkspacePlan().catch(() => {});
+        }}
+        onClose={closeAiAgentPanel}
+        onCreateSession={handleCreateAiAgentSession}
+        onDeleteSession={(sessionId) => {
+          handleDeleteAiAgentSession(sessionId).catch(() => {});
+        }}
+        onDisableThinking={() => aiAgent.setSessionThinkingEnabled(false)}
+        onDraftChange={aiAgent.setDraft}
+        onInterrupt={aiAgent.interrupt}
+        onRenameSession={(sessionId, title) => {
+          handleRenameAiAgentSession(sessionId, title).catch(() => {});
+        }}
+        onResize={setAiAgentPanelWidth}
+        onResizeEnd={endAiAgentPanelResize}
+        onResizeStart={startAiAgentPanelResize}
+        onRetryMessage={aiAgent.retryMessage}
+        onSelectSession={handleSelectAiAgentSession}
+        onSelectModel={aiSettings.selectAgentModel}
+        onSubmit={aiAgent.submit}
+        onSubmitEditedMessage={aiAgent.submitEditedMessage}
+        onToggleThinking={() => aiAgent.setThinkingEnabled((enabled) => !enabled)}
+        onToggleWebSearch={() => aiAgent.setWebSearchEnabled((enabled) => !enabled)}
+      />
+    </Suspense>
   ) : null;
   const workspaceOperationEvents = useMemo(
     () => workspaceOperationEventsFromPlanEvents(aiAgent.workspacePlanEvents),
@@ -3874,6 +3896,7 @@ function WorkspaceApp() {
             folderOpen: Boolean(fileTree.sourcePath),
             language: appLanguage.language,
             linkIndex: workspaceLinkIndex.index,
+            linkIndexLoading: workspaceLinkIndex.loading,
             maxWidth: fileTreeMaxWidth,
             minWidth: fileTreeMinWidth,
             open: fileTreeOpen,

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -141,6 +141,7 @@ type MarkdownFileTreeDrawerProps = {
   files: NativeMarkdownFolderFile[];
   language?: AppLanguage;
   linkIndex?: WorkspaceLinkIndex | null;
+  linkIndexLoading?: boolean;
   maxWidth?: number;
   minWidth?: number;
   folderOpen?: boolean;
@@ -438,6 +439,7 @@ export function MarkdownFileTreeDrawer({
   files,
   language = "en",
   linkIndex = null,
+  linkIndexLoading = false,
   maxWidth = 440,
   minWidth = 220,
   folderOpen = true,
@@ -735,12 +737,14 @@ export function MarkdownFileTreeDrawer({
   const documentLinksOpen = controlledDocumentLinksOpen ?? localDocumentLinksOpen;
   const recentFolderAreaVisible = recentFolderChoices.length > 0 && Boolean(onOpenRecentFolder);
   const tabbedSidebarLayout = sidebarLayoutMode === "tabs";
-  const linkPanelAvailable = Boolean(
-    documentLinksVisible &&
-    linkIndex &&
-    currentPath &&
-    linkIndex.files.some((file) => file.file.path === currentPath)
+  const activeFileInLinkIndex = Boolean(
+    linkIndex && currentPath && linkIndex.files.some((file) => file.file.path === currentPath)
   );
+  const linkPanelAvailable = Boolean(documentLinksVisible && currentPath && (
+    activeFileInLinkIndex ||
+    linkIndexLoading ||
+    (!tabbedSidebarLayout && !documentLinksOpen)
+  ));
   const activeBacklinks = linkIndex && currentPath ? workspaceBacklinksForPath(linkIndex, currentPath) : [];
   const activeUnlinkedMentions = linkIndex && currentPath ? workspaceUnlinkedMentionsForPath(linkIndex, currentPath) : [];
   const filePanelAvailable = folderOpen || (open && fileCreationAvailable);

--- a/packages/app/src/hooks/useAiAgentSessionList.test.tsx
+++ b/packages/app/src/hooks/useAiAgentSessionList.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { listStoredAiAgentSessions, type StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
+import { useAiAgentSessionList } from "./useAiAgentSessionList";
+
+vi.mock("../lib/settings/app-settings", () => ({
+  listStoredAiAgentSessions: vi.fn()
+}));
+
+const mockedListStoredAiAgentSessions = vi.mocked(listStoredAiAgentSessions);
+
+const sessions: StoredAiAgentSessionSummary[] = [
+  {
+    archivedAt: null,
+    createdAt: 1,
+    id: "session-1",
+    messageCount: 2,
+    title: "Draft",
+    titleSource: "manual",
+    updatedAt: 2,
+    workspaceKey: "/mock-vault"
+  }
+];
+
+describe("useAiAgentSessionList", () => {
+  beforeEach(() => {
+    mockedListStoredAiAgentSessions.mockReset();
+    mockedListStoredAiAgentSessions.mockResolvedValue(sessions);
+  });
+
+  it("does not read stored sessions while disabled", () => {
+    const { result } = renderHook(() => useAiAgentSessionList("/mock-vault", "refresh-1", false));
+
+    expect(result.current.ready).toBe(false);
+    expect(result.current.sessions).toEqual([]);
+    expect(mockedListStoredAiAgentSessions).not.toHaveBeenCalled();
+  });
+
+  it("loads stored sessions when enabled after being disabled", async () => {
+    const { rerender, result } = renderHook(
+      ({ enabled }) => useAiAgentSessionList("/mock-vault", "refresh-1", enabled),
+      { initialProps: { enabled: false } }
+    );
+
+    expect(mockedListStoredAiAgentSessions).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.sessions).toEqual(sessions);
+    expect(mockedListStoredAiAgentSessions).toHaveBeenCalledWith("/mock-vault", { includeArchived: true });
+  });
+});

--- a/packages/app/src/hooks/useAiAgentSessionList.ts
+++ b/packages/app/src/hooks/useAiAgentSessionList.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { listStoredAiAgentSessions, type StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
 
-export function useAiAgentSessionList(workspaceKey: string | null, refreshKey: string) {
+export function useAiAgentSessionList(workspaceKey: string | null, refreshKey: string, enabled = true) {
   const [sessions, setSessions] = useState<StoredAiAgentSessionSummary[]>([]);
   const [readyWorkspaceKey, setReadyWorkspaceKey] = useState<string | null | undefined>();
 
@@ -16,11 +16,17 @@ export function useAiAgentSessionList(workspaceKey: string | null, refreshKey: s
   }, [workspaceKey]);
 
   useEffect(() => {
+    if (!enabled) {
+      setReadyWorkspaceKey(undefined);
+      return undefined;
+    }
+
     setReadyWorkspaceKey(undefined);
     refresh().catch(() => {});
-  }, [refresh]);
+  }, [enabled, refresh]);
 
   useEffect(() => {
+    if (!enabled) return undefined;
     if (readyWorkspaceKey !== workspaceKey) return undefined;
 
     const timer = window.setTimeout(() => {
@@ -30,11 +36,11 @@ export function useAiAgentSessionList(workspaceKey: string | null, refreshKey: s
     return () => {
       window.clearTimeout(timer);
     };
-  }, [readyWorkspaceKey, refresh, refreshKey, workspaceKey]);
+  }, [enabled, readyWorkspaceKey, refresh, refreshKey, workspaceKey]);
 
   return {
     refresh,
-    ready: readyWorkspaceKey === workspaceKey,
+    ready: enabled && readyWorkspaceKey === workspaceKey,
     sessions
   };
 }

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   createNativeMarkdownTreeFile,
   createNativeMarkdownTreeFolder,
@@ -69,6 +69,19 @@ const mockedRemoveStoredRecentMarkdownFolder = vi.mocked(removeStoredRecentMarkd
 const mockedSaveStoredFileTreeSortForWorkspace = vi.mocked(saveStoredFileTreeSortForWorkspace);
 const mockedSaveStoredRecentMarkdownFolder = vi.mocked(saveStoredRecentMarkdownFolder);
 const mockedSaveStoredWorkspaceState = vi.mocked(saveStoredWorkspaceState);
+type ListedMarkdownFiles = Awaited<ReturnType<typeof listNativeMarkdownFilesForPath>>;
+
+function createDeferredMarkdownFileList() {
+  let resolve!: (files: ListedMarkdownFiles) => undefined;
+  const promise = new Promise<ListedMarkdownFiles>((resolvePromise) => {
+    resolve = (files) => {
+      resolvePromise(files);
+      return undefined;
+    };
+  });
+
+  return { promise, resolve };
+}
 
 function mockWorkspaceState(
   patch: Partial<Awaited<ReturnType<typeof getStoredWorkspaceState>>> = {}
@@ -447,6 +460,116 @@ describe("useMarkdownFileTree", () => {
     expect(screen.getByText("docs/added.md")).toBeInTheDocument();
   });
 
+  it("ignores stale native tree refreshes after switching folders", async () => {
+    let emitTreeChange: (path: string) => unknown | Promise<unknown> = () => {};
+    const staleVaultRefresh = createDeferredMarkdownFileList();
+    const docsLoad = createDeferredMarkdownFileList();
+
+    mockedListNativeMarkdownFilesForPath
+      .mockResolvedValueOnce([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+      ])
+      .mockReturnValueOnce(staleVaultRefresh.promise)
+      .mockReturnValueOnce(docsLoad.promise);
+    mockedWatchNativeMarkdownTree.mockImplementation(async (_rootPath, onTreeChange) => {
+      emitTreeChange = onTreeChange;
+      return () => {};
+    });
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore collapsed folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+    await waitFor(() => expect(mockedWatchNativeMarkdownTree).toHaveBeenCalledWith("/vault", expect.any(Function)));
+
+    const staleRefreshPromise = emitTreeChange("/vault/index.md");
+    await waitFor(() => expect(mockedListNativeMarkdownFilesForPath).toHaveBeenLastCalledWith("/vault", {
+      managedAttachmentFolder: "assets"
+    }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
+
+    await waitFor(() => expect(mockedListNativeMarkdownFilesForPath).toHaveBeenLastCalledWith("/mock-workspaces/beta/docs", {
+      managedAttachmentFolder: "assets"
+    }));
+
+    await act(async () => {
+      docsLoad.resolve([
+        { path: "/mock-workspaces/beta/docs/current.md", name: "current.md", relativePath: "current.md" }
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("current.md")).toBeInTheDocument();
+
+    await act(async () => {
+      staleVaultRefresh.resolve([
+        { path: "/vault/stale.md", name: "stale.md", relativePath: "stale.md" }
+      ]);
+      await staleRefreshPromise;
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("stale.md")).not.toBeInTheDocument();
+    expect(screen.getByText("current.md")).toBeInTheDocument();
+  });
+
+  it("ignores previous-folder refreshes while a new folder is loading", async () => {
+    let emitTreeChange: (path: string) => unknown | Promise<unknown> = () => {};
+    const staleVaultRefresh = createDeferredMarkdownFileList();
+    const docsLoad = createDeferredMarkdownFileList();
+
+    mockedListNativeMarkdownFilesForPath
+      .mockResolvedValueOnce([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+      ])
+      .mockReturnValueOnce(staleVaultRefresh.promise)
+      .mockReturnValueOnce(docsLoad.promise);
+    mockedWatchNativeMarkdownTree.mockImplementation(async (_rootPath, onTreeChange) => {
+      emitTreeChange = onTreeChange;
+      return () => {};
+    });
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore collapsed folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+    await waitFor(() => expect(mockedWatchNativeMarkdownTree).toHaveBeenCalledWith("/vault", expect.any(Function)));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
+    const staleRefreshPromise = emitTreeChange("/vault/index.md");
+
+    await waitFor(() => expect(mockedListNativeMarkdownFilesForPath).toHaveBeenLastCalledWith("/vault", {
+      managedAttachmentFolder: "assets"
+    }));
+
+    await act(async () => {
+      staleVaultRefresh.resolve([
+        { path: "/vault/stale.md", name: "stale.md", relativePath: "stale.md" }
+      ]);
+      await staleRefreshPromise;
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("stale.md")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(mockedListNativeMarkdownFilesForPath).toHaveBeenLastCalledWith("/mock-workspaces/beta/docs", {
+      managedAttachmentFolder: "assets"
+    }));
+
+    await act(async () => {
+      docsLoad.resolve([
+        { path: "/mock-workspaces/beta/docs/current.md", name: "current.md", relativePath: "current.md" }
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("current.md")).toBeInTheDocument();
+    expect(screen.queryByText("stale.md")).not.toBeInTheDocument();
+  });
+
   it("loads recent markdown folders from settings", async () => {
     mockedGetStoredRecentMarkdownFolders.mockResolvedValue([
       { name: "notes", path: "/recent/notes" }
@@ -621,6 +744,104 @@ describe("useMarkdownFileTree", () => {
     });
   });
 
+  it("coalesces rapid folder selections before starting a native folder load", async () => {
+    vi.useFakeTimers();
+
+    try {
+      mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+        { path: "/mock-workspaces/beta/docs/current.md", name: "current.md", relativePath: "current.md" }
+      ]);
+
+      render(<FileTreeProbe />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Open recent folder" }));
+      fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
+
+      expect(mockedListNativeMarkdownFilesForPath).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+        await Promise.resolve();
+      });
+
+      expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledTimes(1);
+      expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith("/mock-workspaces/beta/docs", {
+        managedAttachmentFolder: "assets"
+      });
+      expect(screen.getByText("current.md")).toBeInTheDocument();
+      expect(screen.getByTestId("root-name")).toHaveTextContent("docs");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the latest folder selection when folder loads finish out of order", async () => {
+    vi.useFakeTimers();
+    const notesLoad = createDeferredMarkdownFileList();
+    const docsLoad = createDeferredMarkdownFileList();
+
+    try {
+      mockedListNativeMarkdownFilesForPath
+        .mockReturnValueOnce(notesLoad.promise)
+        .mockReturnValueOnce(docsLoad.promise);
+
+      render(<FileTreeProbe />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Open recent folder" }));
+
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+        await Promise.resolve();
+      });
+
+      expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith("/recent/notes", {
+        managedAttachmentFolder: "assets"
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
+
+      await act(async () => {
+        vi.advanceTimersByTime(150);
+        await Promise.resolve();
+      });
+
+      expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith("/mock-workspaces/beta/docs", {
+        managedAttachmentFolder: "assets"
+      });
+
+      await act(async () => {
+        docsLoad.resolve([
+          { path: "/mock-workspaces/beta/docs/current.md", name: "current.md", relativePath: "current.md" }
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText("current.md")).toBeInTheDocument();
+      expect(screen.getByTestId("root-name")).toHaveTextContent("docs");
+
+      await act(async () => {
+        notesLoad.resolve([
+          { path: "/recent/notes/stale.md", name: "stale.md", relativePath: "stale.md" }
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("stale.md")).not.toBeInTheDocument();
+      expect(screen.getByText("current.md")).toBeInTheDocument();
+      expect(screen.getByTestId("root-name")).toHaveTextContent("docs");
+      expect(mockedSaveStoredRecentMarkdownFolder).toHaveBeenCalledWith({
+        name: "docs",
+        path: "/mock-workspaces/beta/docs"
+      });
+      expect(mockedSaveStoredRecentMarkdownFolder).not.toHaveBeenCalledWith({
+        name: "notes",
+        path: "/recent/notes"
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("restores a markdown folder root without reopening a collapsed tree", async () => {
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([
       { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
@@ -639,6 +860,26 @@ describe("useMarkdownFileTree", () => {
       folderName: "vault",
       folderPath: "/vault"
     });
+  });
+
+  it("loads an explicit folder path immediately for workspace restoration", () => {
+    vi.useFakeTimers();
+
+    try {
+      mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+        { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
+      ]);
+
+      render(<FileTreeProbe currentPath="/vault/docs/guide.md" />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Restore collapsed folder" }));
+
+      expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith("/vault", {
+        managedAttachmentFolder: "assets"
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not open a remembered markdown folder after it was deleted outside Markra", async () => {

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { startTransition, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import {
   createAiAgentSessionId,
   defaultStoredFileTreeSort,
@@ -31,6 +31,7 @@ import { clampNumber, folderNameFromDocumentPath, isMarkdownPath, parentPathFrom
 export const markdownFileTreeDefaultWidth = 288;
 export const markdownFileTreeMinWidth = 220;
 export const markdownFileTreeMaxWidth = 440;
+const openFolderLoadCoalesceMs = 120;
 
 function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState>[0]) {
   saveStoredWorkspaceState(patch).catch(() => {});
@@ -44,6 +45,9 @@ type UseMarkdownFileTreeOptions = {
 type OpenMarkdownFolderOptions = {
   beforeOpenFolder?: () => unknown | Promise<unknown>;
   pickerTitle?: string;
+};
+type OpenFolderPathOptions = {
+  coalesce?: boolean;
 };
 
 function normalizeTreeParentPath(path: string | null | undefined) {
@@ -85,6 +89,10 @@ type LoadedFileTreeRequest = {
   managedAttachmentFolder: string;
   path: string;
 };
+type PendingOpenFolderLoad = {
+  cancel: () => undefined;
+  timeoutId: number;
+};
 
 function filterManagedAttachmentFiles(
   files: readonly NativeMarkdownFolderFile[],
@@ -122,6 +130,9 @@ export function useMarkdownFileTree({
   const [width, setWidth] = useState(markdownFileTreeDefaultWidth);
   const [resizing, setResizing] = useState(false);
   const loadedFileTreeRequestRef = useRef<LoadedFileTreeRequest | null>(null);
+  const openFolderRequestIdRef = useRef(0);
+  const openingFolderPathRef = useRef<string | null>(null);
+  const pendingOpenFolderLoadRef = useRef<PendingOpenFolderLoad | null>(null);
   const openChangedBeforeWorkspaceRestoreRef = useRef(false);
   const normalizedManagedAttachmentFolder = useMemo(
     () => normalizeManagedAttachmentFolder(managedAttachmentFolder),
@@ -165,6 +176,7 @@ export function useMarkdownFileTree({
   const refresh = useCallback(
     async (fallbackPath: string | null = null) => {
       const path = sourcePath ?? fallbackPath;
+      const requestId = openFolderRequestIdRef.current;
       if (!path) {
         setFiles([]);
         return;
@@ -174,9 +186,17 @@ export function useMarkdownFileTree({
         const nextFiles = await listNativeMarkdownFilesForPath(path, {
           managedAttachmentFolder: normalizedManagedAttachmentFolder
         });
+        if (openFolderRequestIdRef.current !== requestId) return;
+        if (openingFolderPathRef.current && openingFolderPathRef.current !== path) return;
+
         loadedFileTreeRequestRef.current = { managedAttachmentFolder: normalizedManagedAttachmentFolder, path };
-        setFiles(nextFiles);
+        startTransition(() => {
+          setFiles(nextFiles);
+        });
       } catch {
+        if (openFolderRequestIdRef.current !== requestId) return;
+        if (openingFolderPathRef.current && openingFolderPathRef.current !== path) return;
+
         setFiles([]);
       }
     },
@@ -184,8 +204,35 @@ export function useMarkdownFileTree({
   );
 
   const setRootFromMarkdownFilePath = useCallback((path: string) => {
+    openFolderRequestIdRef.current += 1;
+    openingFolderPathRef.current = null;
+    pendingOpenFolderLoadRef.current?.cancel();
+    pendingOpenFolderLoadRef.current = null;
     setSourcePath(path);
     setRootName(folderNameFromDocumentPath(path));
+  }, []);
+
+  const waitForLatestOpenFolderLoad = useCallback((requestId: number) => {
+    pendingOpenFolderLoadRef.current?.cancel();
+
+    return new Promise<boolean>((resolve) => {
+      const timeoutId = window.setTimeout(() => {
+        if (pendingOpenFolderLoadRef.current?.timeoutId === timeoutId) {
+          pendingOpenFolderLoadRef.current = null;
+        }
+
+        resolve(openFolderRequestIdRef.current === requestId);
+      }, openFolderLoadCoalesceMs);
+
+      pendingOpenFolderLoadRef.current = {
+        cancel: () => {
+          window.clearTimeout(timeoutId);
+          resolve(false);
+          return undefined;
+        },
+        timeoutId
+      };
+    });
   }, []);
 
   const rememberFolder = useCallback((folder: RecentMarkdownFolder) => {
@@ -203,17 +250,39 @@ export function useMarkdownFileTree({
     name = pathNameFromPath(path),
     preferredSessionId?: string | null,
     clearFilePath = true,
-    openTree = true
+    openTree = true,
+    options: OpenFolderPathOptions = {}
   ) => {
     const folderName = name || pathNameFromPath(path);
     const sessionId = preferredSessionId?.trim() ? preferredSessionId : createAiAgentSessionId();
+    const requestId = openFolderRequestIdRef.current + 1;
     let nextFiles: NativeMarkdownFolderFile[];
+
+    openFolderRequestIdRef.current = requestId;
+    openingFolderPathRef.current = path;
+
+    if (options.coalesce) {
+      setRootName(folderName);
+      openChangedBeforeWorkspaceRestoreRef.current = true;
+
+      const latestRequestStillActive = await waitForLatestOpenFolderLoad(requestId);
+      if (!latestRequestStillActive) {
+        if (openingFolderPathRef.current === path) openingFolderPathRef.current = null;
+        return null;
+      }
+    } else {
+      pendingOpenFolderLoadRef.current?.cancel();
+      pendingOpenFolderLoadRef.current = null;
+    }
 
     try {
       nextFiles = await listNativeMarkdownFilesForPath(path, {
         managedAttachmentFolder: normalizedManagedAttachmentFolder
       });
     } catch {
+      if (openFolderRequestIdRef.current !== requestId) return null;
+
+      openingFolderPathRef.current = null;
       forgetRecentFolder(path);
 
       if (!sourcePath || sourcePath === path) {
@@ -223,17 +292,25 @@ export function useMarkdownFileTree({
         loadedFileTreeRequestRef.current = null;
         openChangedBeforeWorkspaceRestoreRef.current = true;
         setOpen(false);
+      } else {
+        setRootName(rootName);
+        setOpen(open);
       }
 
       return null;
     }
 
+    if (openFolderRequestIdRef.current !== requestId) return null;
+
+    openingFolderPathRef.current = null;
     setSourcePath(path);
     setRootName(folderName);
     openChangedBeforeWorkspaceRestoreRef.current = true;
     setOpen(openTree);
     loadedFileTreeRequestRef.current = { managedAttachmentFolder: normalizedManagedAttachmentFolder, path };
-    setFiles(nextFiles);
+    startTransition(() => {
+      setFiles(nextFiles);
+    });
     rememberFolder({ name: folderName, path });
     onWorkspaceSessionChange?.(sessionId);
     // Opening a folder replaces the startup workspace, so clear the previous file path in the same write.
@@ -245,7 +322,24 @@ export function useMarkdownFileTree({
       folderPath: path
     });
     return { name: folderName, path };
-  }, [forgetRecentFolder, normalizedManagedAttachmentFolder, onWorkspaceSessionChange, rememberFolder, sourcePath]);
+  }, [
+    forgetRecentFolder,
+    normalizedManagedAttachmentFolder,
+    onWorkspaceSessionChange,
+    open,
+    rememberFolder,
+    rootName,
+    sourcePath,
+    waitForLatestOpenFolderLoad
+  ]);
+
+  useEffect(() => {
+    return () => {
+      openingFolderPathRef.current = null;
+      pendingOpenFolderLoadRef.current?.cancel();
+      pendingOpenFolderLoadRef.current = null;
+    };
+  }, []);
 
   const openMarkdownFolder = useCallback(async (options: OpenMarkdownFolderOptions = {}) => {
     const folder = await openNativeMarkdownFolder(
@@ -256,11 +350,11 @@ export function useMarkdownFileTree({
     const beforeOpenResult = await options.beforeOpenFolder?.();
     if (beforeOpenResult === false) return null;
 
-    return openFolderPath(folder.path, folder.name);
+    return openFolderPath(folder.path, folder.name, undefined, true, true, { coalesce: true });
   }, [openFolderPath]);
 
   const openRecentFolder = useCallback(async (folder: RecentMarkdownFolder, preferredSessionId?: string | null) => {
-    return openFolderPath(folder.path, folder.name, preferredSessionId);
+    return openFolderPath(folder.path, folder.name, preferredSessionId, true, true, { coalesce: true });
   }, [openFolderPath]);
 
   const removeRecentFolder = useCallback((folder: RecentMarkdownFolder) => {

--- a/packages/app/src/hooks/useWorkspaceLinkIndex.test.tsx
+++ b/packages/app/src/hooks/useWorkspaceLinkIndex.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { readNativeMarkdownFile } from "../lib/tauri";
 import { workspaceBacklinksForPath, workspaceUnlinkedMentionsForPath } from "../lib/workspace-links";
 import { useWorkspaceLinkIndex } from "./useWorkspaceLinkIndex";
@@ -81,5 +81,107 @@ describe("useWorkspaceLinkIndex", () => {
       unreadableFileCount: 0
     });
     expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+  });
+
+  it("defers workspace reads until the lazy index delay elapses", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { result } = renderHook(() => useWorkspaceLinkIndex({
+        deferMs: 200,
+        documentContent: "See [Alpha](./Alpha.md).",
+        documentPath: "/mock-vault/Beta.md",
+        fileTreeFiles: files
+      }));
+
+      expect(result.current.loading).toBe(true);
+      expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(199);
+      });
+
+      expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(mockedReadNativeMarkdownFile).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels pending deferred reads when disabled before the delay elapses", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { rerender, result } = renderHook(
+        ({ enabled }) => useWorkspaceLinkIndex({
+          deferMs: 200,
+          documentContent: "See [Alpha](./Alpha.md).",
+          documentPath: "/mock-vault/Beta.md",
+          enabled,
+          fileTreeFiles: files
+        }),
+        { initialProps: { enabled: true } }
+      );
+
+      expect(result.current.loading).toBe(true);
+      expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+
+      rerender({ enabled: false });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports loading immediately when a disabled deferred index is enabled", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { rerender, result } = renderHook(
+        ({ enabled }) => useWorkspaceLinkIndex({
+          deferMs: 200,
+          documentContent: "See [Alpha](./Alpha.md).",
+          documentPath: "/mock-vault/Beta.md",
+          enabled,
+          fileTreeFiles: files
+        }),
+        { initialProps: { enabled: false } }
+      );
+
+      expect(result.current.loading).toBe(false);
+
+      rerender({ enabled: true });
+
+      expect(result.current.loading).toBe(true);
+      expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(mockedReadNativeMarkdownFile).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/app/src/hooks/useWorkspaceLinkIndex.ts
+++ b/packages/app/src/hooks/useWorkspaceLinkIndex.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   buildWorkspaceLinkIndex,
   type WorkspaceLinkFile,
@@ -7,6 +7,7 @@ import {
 import { readNativeMarkdownFile } from "../lib/tauri";
 
 type UseWorkspaceLinkIndexInput = {
+  deferMs?: number;
   documentContent: string;
   documentPath: string | null;
   enabled?: boolean;
@@ -22,6 +23,7 @@ const emptyWorkspaceLinkIndex = {
 } satisfies WorkspaceLinkIndex;
 
 export function useWorkspaceLinkIndex({
+  deferMs = 0,
   documentContent,
   documentPath,
   enabled = true,
@@ -29,8 +31,12 @@ export function useWorkspaceLinkIndex({
 }: UseWorkspaceLinkIndexInput) {
   const [index, setIndex] = useState<WorkspaceLinkIndex>(emptyWorkspaceLinkIndex);
   const [loading, setLoading] = useState(() => enabled);
+  const previousEnabledRef = useRef(enabled);
+  const enabling = enabled && !previousEnabledRef.current;
 
   useEffect(() => {
+    previousEnabledRef.current = enabled;
+
     if (!enabled) {
       setIndex(emptyWorkspaceLinkIndex);
       setLoading(false);
@@ -38,39 +44,49 @@ export function useWorkspaceLinkIndex({
     }
 
     let active = true;
+    let buildTimer: number | null = null;
 
     setLoading(true);
 
-    buildWorkspaceLinkIndex(fileTreeFiles, {
-      currentDocument: documentPath
-        ? {
-            content: documentContent,
-            path: documentPath
-          }
-        : null,
-      readFile: async (path) => {
-        const file = await readNativeMarkdownFile(path);
+    const buildIndex = () => {
+      buildWorkspaceLinkIndex(fileTreeFiles, {
+        currentDocument: documentPath
+          ? {
+              content: documentContent,
+              path: documentPath
+            }
+          : null,
+        readFile: async (path) => {
+          const file = await readNativeMarkdownFile(path);
 
-        return {
-          content: file.content,
-          path: file.path
-        };
-      }
-    }).then((nextIndex) => {
-      if (active) setIndex(nextIndex);
-    }).catch(() => {
-      if (active) setIndex(emptyWorkspaceLinkIndex);
-    }).finally(() => {
-      if (active) setLoading(false);
-    });
+          return {
+            content: file.content,
+            path: file.path
+          };
+        }
+      }).then((nextIndex) => {
+        if (active) setIndex(nextIndex);
+      }).catch(() => {
+        if (active) setIndex(emptyWorkspaceLinkIndex);
+      }).finally(() => {
+        if (active) setLoading(false);
+      });
+    };
+
+    if (deferMs > 0) {
+      buildTimer = window.setTimeout(buildIndex, deferMs);
+    } else {
+      buildIndex();
+    }
 
     return () => {
       active = false;
+      if (buildTimer !== null) window.clearTimeout(buildTimer);
     };
-  }, [documentContent, documentPath, enabled, fileTreeFiles]);
+  }, [deferMs, documentContent, documentPath, enabled, fileTreeFiles]);
 
   return {
     index,
-    loading
+    loading: enabled && (loading || enabling)
   };
 }

--- a/packages/app/src/lib/tauri/file.ts
+++ b/packages/app/src/lib/tauri/file.ts
@@ -38,6 +38,7 @@ export type NativeMarkdownFolderFile = {
   path: string;
   name: string;
   relativePath: string;
+  sizeBytes?: number;
 };
 
 export type ListNativeMarkdownFilesOptions = {

--- a/packages/app/src/lib/workspace-links.test.ts
+++ b/packages/app/src/lib/workspace-links.test.ts
@@ -4,6 +4,7 @@ import {
   workspaceUnlinkedMentionsForPath,
   type WorkspaceLinkFile
 } from "./workspace-links";
+import { largeMarkdownVisualLimitBytes, largeMarkdownVisualLimitChars } from "./large-markdown";
 
 const files = [
   { name: "Alpha.md", path: "/mock-vault/Alpha.md", relativePath: "Alpha.md" },
@@ -82,5 +83,44 @@ describe("workspace links", () => {
 
     expect(workspaceUnlinkedMentionsForPath(index, "/mock-vault/Alpha.md")).toEqual([]);
     expect(workspaceUnlinkedMentionsForPath(index, "/mock-vault/nested/Alpha.md")).toEqual([]);
+  });
+
+  it("keeps oversized markdown files as link targets without scanning their contents", async () => {
+    const bigFile = {
+      name: "Big.md",
+      path: "/mock-vault/Big.md",
+      relativePath: "Big.md",
+      sizeBytes: largeMarkdownVisualLimitBytes
+    };
+    const alphaFile = { name: "Alpha.md", path: "/mock-vault/Alpha.md", relativePath: "Alpha.md" };
+    const noteFile = { name: "Note.md", path: "/mock-vault/Note.md", relativePath: "Note.md" };
+    const readFile = vi.fn(async (path: string) => ({
+      content: path.endsWith("Big.md")
+        ? `[Alpha](./Alpha.md)\nAlpha\n${"x".repeat(largeMarkdownVisualLimitChars)}`
+        : path.endsWith("Note.md")
+          ? "Big appears here."
+          : "# Alpha",
+      path
+    }));
+    const index = await buildWorkspaceLinkIndex([bigFile, alphaFile, noteFile], {
+      readFile
+    });
+
+    expect(readFile).not.toHaveBeenCalledWith("/mock-vault/Big.md");
+    expect(workspaceBacklinksForPath(index, "/mock-vault/Alpha.md")).toEqual([]);
+    expect(workspaceUnlinkedMentionsForPath(index, "/mock-vault/Alpha.md")).toEqual([]);
+    expect(workspaceUnlinkedMentionsForPath(index, "/mock-vault/Big.md").map((mention) => ({
+      relativePath: mention.sourceFile.relativePath,
+      text: mention.text
+    }))).toEqual([
+      {
+        relativePath: "Note.md",
+        text: "Big"
+      }
+    ]);
+    expect(index.files.find((file) => file.file.path === "/mock-vault/Big.md")).toMatchObject({
+      mentionRanges: [],
+      titleCandidates: ["Big"]
+    });
   });
 });

--- a/packages/app/src/lib/workspace-links.ts
+++ b/packages/app/src/lib/workspace-links.ts
@@ -6,6 +6,7 @@ import {
   type MarkdownMentionRange
 } from "@markra/markdown";
 import { resolveMarkdownDocumentLinkFile } from "./document-links";
+import { shouldBlockLargeMarkdownVisual } from "./large-markdown";
 
 export type WorkspaceLinkFile = {
   createdAt?: number;
@@ -14,6 +15,7 @@ export type WorkspaceLinkFile = {
   name: string;
   path: string;
   relativePath: string;
+  sizeBytes?: number;
 };
 
 export type WorkspaceLinkReadResult = {
@@ -108,6 +110,10 @@ function titleCandidatesForFile(file: WorkspaceLinkFile, content: string) {
   return uniqueValues([markdownFileTitle(file), firstHeading ?? ""]);
 }
 
+function fallbackTitleCandidatesForFile(file: WorkspaceLinkFile) {
+  return uniqueValues([markdownFileTitle(file)]);
+}
+
 function relativePathWithoutMarkdownExtension(file: WorkspaceLinkFile) {
   return normalizePathSeparators(file.relativePath).replace(markdownDocumentExtensionPattern, "");
 }
@@ -177,9 +183,27 @@ export async function buildWorkspaceLinkIndex(
   let unreadableFileCount = 0;
   const indexedFiles = await Promise.all(markdownFiles.map(async (file) => {
     try {
+      if (shouldBlockLargeMarkdownVisual("", { sizeBytes: file.sizeBytes })) {
+        return {
+          content: "",
+          file,
+          mentionRanges: [],
+          titleCandidates: fallbackTitleCandidatesForFile(file)
+        };
+      }
+
       const read = options.currentDocument?.path === file.path
         ? options.currentDocument
         : await options.readFile(file.path);
+
+      if (shouldBlockLargeMarkdownVisual(read.content)) {
+        return {
+          content: "",
+          file,
+          mentionRanges: [],
+          titleCandidates: fallbackTitleCandidatesForFile(file)
+        };
+      }
 
       return {
         content: read.content,

--- a/packages/markdown/src/links.test.ts
+++ b/packages/markdown/src/links.test.ts
@@ -96,4 +96,27 @@ describe("markdown links", () => {
       }
     ]);
   });
+
+  it("parses mention ranges from long line-oriented documents without quadratic line counting", () => {
+    const markdown = Array.from(
+      { length: 15_000 },
+      (_, index) => `Synthetic line ${index} mentions Alpha and Beta.`
+    ).join("\n");
+    const startedAt = performance.now();
+    const ranges = parseMarkdownMentionRanges(markdown);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(ranges).toHaveLength(15_000);
+    expect(ranges.at(0)).toMatchObject({
+      columnNumber: 1,
+      lineNumber: 1,
+      text: "Synthetic line 0 mentions Alpha and Beta."
+    });
+    expect(ranges.at(-1)).toMatchObject({
+      columnNumber: 1,
+      lineNumber: 15_000,
+      text: "Synthetic line 14999 mentions Alpha and Beta."
+    });
+    expect(elapsedMs).toBeLessThan(12_000);
+  }, 15_000);
 });

--- a/packages/markdown/src/links.ts
+++ b/packages/markdown/src/links.ts
@@ -100,6 +100,34 @@ function leadingDelimitedFrontmatterRange(markdown: string): ProtectedRange | nu
   return null;
 }
 
+function lineStartOffsets(markdown: string) {
+  const offsets = [0];
+
+  for (let index = 0; index < markdown.length; index += 1) {
+    if (markdown[index] === "\n") offsets.push(index + 1);
+  }
+
+  return offsets;
+}
+
+function lineStartIndexForOffset(lineStarts: readonly number[], offset: number) {
+  let low = 0;
+  let high = lineStarts.length - 1;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const lineStart = lineStarts[middle] ?? 0;
+
+    if (lineStart <= offset) {
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+
+  return Math.max(0, high);
+}
+
 function markdownNodeStart(node: MarkdownNode) {
   return node.position?.start?.offset;
 }
@@ -108,16 +136,16 @@ function markdownNodeEnd(node: MarkdownNode) {
   return node.position?.end?.offset;
 }
 
-function lineInfoForOffset(markdown: string, offset: number) {
+function lineInfoForOffset(markdown: string, offset: number, lineStarts: readonly number[]) {
   const safeOffset = Math.max(0, Math.min(offset, markdown.length));
-  const lineStart = markdown.lastIndexOf("\n", Math.max(0, safeOffset - 1)) + 1;
-  const lineEndIndex = markdown.indexOf("\n", safeOffset);
-  const lineEnd = lineEndIndex >= 0 ? lineEndIndex : markdown.length;
-  const lineNumber = markdown.slice(0, safeOffset).split("\n").length;
+  const lineIndex = lineStartIndexForOffset(lineStarts, safeOffset);
+  const lineStart = lineStarts[lineIndex] ?? 0;
+  const nextLineStart = lineStarts[lineIndex + 1];
+  const lineEnd = typeof nextLineStart === "number" ? nextLineStart - 1 : markdown.length;
 
   return {
     columnNumber: safeOffset - lineStart + 1,
-    lineNumber,
+    lineNumber: lineIndex + 1,
     lineText: markdown.slice(lineStart, lineEnd)
   };
 }
@@ -160,7 +188,12 @@ function isWikiDocumentHref(href: string) {
   return !extensionMatch || markdownDocumentExtensionPattern.test(target);
 }
 
-function wikiReferenceFromSource(markdown: string, source: string, absoluteOffset: number) {
+function wikiReferenceFromSource(
+  markdown: string,
+  source: string,
+  absoluteOffset: number,
+  lineStarts: readonly number[]
+) {
   const wikiLinks: MarkdownLinkReference[] = [];
 
   wikiLinkPattern.lastIndex = 0;
@@ -176,7 +209,7 @@ function wikiReferenceFromSource(markdown: string, source: string, absoluteOffse
     const text = rawLabel?.trim() || href;
     const from = absoluteOffset + (match.index ?? 0);
     const to = from + matchText.length;
-    const line = lineInfoForOffset(markdown, from);
+    const line = lineInfoForOffset(markdown, from, lineStarts);
 
     wikiLinks.push({
       columnNumber: line.columnNumber,
@@ -203,7 +236,7 @@ function overlapsProtectedRange(from: number, to: number, protectedRange: Protec
   return Boolean(protectedRange && from < protectedRange.to && to > protectedRange.from);
 }
 
-function splitTextNodeLines(markdown: string, text: string, start: number) {
+function splitTextNodeLines(markdown: string, text: string, start: number, lineStarts: readonly number[]) {
   const ranges: MarkdownMentionRange[] = [];
   let cursor = 0;
 
@@ -211,7 +244,7 @@ function splitTextNodeLines(markdown: string, text: string, start: number) {
     const from = start + cursor;
     const to = from + lineText.length;
     if (lineText) {
-      const line = lineInfoForOffset(markdown, from);
+      const line = lineInfoForOffset(markdown, from, lineStarts);
       ranges.push({
         columnNumber: line.columnNumber,
         from,
@@ -289,6 +322,7 @@ function hasWordBoundary(text: string, from: number, to: number, title: string) 
 export function parseMarkdownLinkReferences(markdown: string): MarkdownLinkReference[] {
   const tree = parseMarkdown(markdown);
   const frontmatterRange = leadingDelimitedFrontmatterRange(markdown);
+  const lineStarts = lineStartOffsets(markdown);
   const links: MarkdownLinkReference[] = [];
 
   traverseMarkdownNode(tree, (node, parents) => {
@@ -298,7 +332,7 @@ export function parseMarkdownLinkReferences(markdown: string): MarkdownLinkRefer
       if (typeof from !== "number" || typeof to !== "number") return;
       if (overlapsProtectedRange(from, to, frontmatterRange)) return;
 
-      const line = lineInfoForOffset(markdown, from);
+      const line = lineInfoForOffset(markdown, from, lineStarts);
       links.push({
         columnNumber: line.columnNumber,
         from,
@@ -317,7 +351,7 @@ export function parseMarkdownLinkReferences(markdown: string): MarkdownLinkRefer
     if (start === null) return;
     if (overlapsProtectedRange(start, start + node.value.length, frontmatterRange)) return;
 
-    links.push(...wikiReferenceFromSource(markdown, node.value, start));
+    links.push(...wikiReferenceFromSource(markdown, node.value, start, lineStarts));
   });
 
   return links.sort((left, right) => left.from - right.from);
@@ -326,6 +360,7 @@ export function parseMarkdownLinkReferences(markdown: string): MarkdownLinkRefer
 export function parseMarkdownMentionRanges(markdown: string): MarkdownMentionRange[] {
   const tree = parseMarkdown(markdown);
   const frontmatterRange = leadingDelimitedFrontmatterRange(markdown);
+  const lineStarts = lineStartOffsets(markdown);
   const ranges: MarkdownMentionRange[] = [];
 
   traverseMarkdownNode(tree, (node, parents) => {
@@ -335,7 +370,7 @@ export function parseMarkdownMentionRanges(markdown: string): MarkdownMentionRan
     if (start === null) return;
     if (overlapsProtectedRange(start, start + node.value.length, frontmatterRange)) return;
 
-    splitTextNodeLines(markdown, node.value, start).forEach((range) => {
+    splitTextNodeLines(markdown, node.value, start, lineStarts).forEach((range) => {
       ranges.push(...removeWikiSourceRanges(range));
     });
   });


### PR DESCRIPTION
## Summary
- Optimize workspace folder switching by coalescing rapid folder loads and ignoring generated/tooling-heavy directories in the file tree and watcher.
- Add file size metadata so oversized Markdown files are skipped before workspace link indexing reads content.
- Defer workspace link indexing and AI side-panel/session loading until the related side UI needs it.

## Validation
- pnpm --filter @markra/app exec vitest run
- pnpm --filter @markra/app build
- pnpm --filter @markra/markdown test
- cargo test
- cargo fmt --check

## Risk
- The branch history was squashed into one commit as requested and force-pushed with --force-with-lease.