### PR TITLE
fix(editor): improve caret behavior around inline marks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -904,6 +904,53 @@ describe("MarkdownPaper editing", () => {
     expect(paper?.style.getPropertyValue("--editor-heading-font-family")).toBe("");
   });
 
+  it("renders a custom caret for focused collapsed ProseMirror selections", async () => {
+    const { view } = await renderEditor("Alpha");
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 42,
+      left: 24,
+      right: 25,
+      top: 10
+    });
+
+    focusEditor(view);
+    moveCursor(view, findTextPosition(view, "Alpha", 2));
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+
+    expect(view.dom).toHaveClass("markra-prosemirror-custom-caret");
+    expect(caret).toBeInTheDocument();
+    expect(caret).toHaveAttribute("aria-hidden", "true");
+    expect(caret?.style.display).toBe("block");
+    expect(caret?.style.left).toBe("24px");
+    expect(caret?.style.top).toBe("17px");
+    expect(caret?.style.height).toBe("18px");
+
+    coordsSpy.mockRestore();
+    await settleMarkdownListener();
+  });
+
+  it("hides the custom caret for non-collapsed ProseMirror selections", async () => {
+    const { view } = await renderEditor("Alpha");
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 42,
+      left: 24,
+      right: 25,
+      top: 10
+    });
+
+    focusEditor(view);
+    moveCursor(view, findTextPosition(view, "Alpha", 2));
+    selectText(view, findTextPosition(view, "Alpha"), findTextPosition(view, "Alpha", 2));
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+
+    expect(caret?.style.display).toBe("none");
+
+    coordsSpy.mockRestore();
+    await settleMarkdownListener();
+  });
+
   it("renders exact visual search highlights without width normalization", async () => {
     const { container, view } = await renderEditor("alpha, beta，gamma, delta");
 
@@ -7241,6 +7288,30 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps text typed at finalized formatting edges outside the mark", async () => {
+    const cases = [
+      { markdown: "*emphasis*", selector: "em", text: "emphasis", expected: "before *emphasis* after" },
+      { markdown: "**strong**", selector: "strong", text: "strong", expected: "before **strong** after" },
+      { markdown: "~~strike~~", selector: "del", text: "strike", expected: "before ~~strike~~ after" }
+    ];
+
+    for (const { markdown, selector, text, expected } of cases) {
+      const { container, editor, view } = await renderEditor(markdown);
+      const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+      moveCursor(view, findTextPosition(view, text));
+      typeText(view, "before ");
+      moveCursor(view, findTextPosition(view, text, text.length));
+      typeText(view, " after");
+
+      expect(container.querySelector(`.ProseMirror ${selector}`)).toHaveTextContent(text);
+      expect(container.querySelector(".ProseMirror")?.textContent).toBe(`before ${text} after`);
+      expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
+    }
+
+    await settleMarkdownListener();
+  });
+
   it("hides folded markdown delimiters after the cursor moves to other text", async () => {
     const { container, view } = await renderEditor();
 
@@ -7311,6 +7382,77 @@ describe("MarkdownPaper editing", () => {
     moveCursor(view, 3);
     expect(pressArrowLeft(view)).toBe(true);
     expect(view.state.selection.from).toBe(1);
+    await settleMarkdownListener();
+  });
+
+  it("places the cursor outside active live markdown delimiters from mouse clicks", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**ABC**");
+
+    expectLiveMark(container, "strong", "ABC");
+
+    const sourceStart = findFirstTextBlockCursor(view);
+    const sourceEnd = findLastTextBlockEndCursor(view);
+    const delimiters = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-delimiter"));
+    expect(delimiters).toHaveLength(2);
+    const [openingDelimiter] = delimiters;
+
+    moveCursor(view, findTextPosition(view, "ABC", 1));
+    openingDelimiter?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, cancelable: true }));
+
+    expect(view.state.selection.from).toBe(sourceStart);
+
+    const nextDelimiters = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-delimiter"));
+    expect(nextDelimiters).toHaveLength(2);
+    const [, closingDelimiter] = nextDelimiters;
+
+    moveCursor(view, findTextPosition(view, "ABC", 1));
+    closingDelimiter?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, cancelable: true }));
+
+    expect(view.state.selection.from).toBe(sourceEnd);
+    await settleMarkdownListener();
+  });
+
+  it("places the cursor before adjacent punctuation from live closing delimiter clicks", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**ABC**:");
+
+    expectLiveMark(container, "strong", "ABC");
+
+    const punctuationPosition = findTextPosition(view, ":");
+
+    moveCursor(view, findTextPosition(view, "ABC", 1));
+
+    const delimiters = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-delimiter")).filter(
+      (delimiter) => !delimiter.classList.contains("markra-md-virtual-delimiter")
+    );
+    expect(delimiters).toHaveLength(2);
+    const [, closingDelimiter] = delimiters;
+
+    closingDelimiter?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, cancelable: true }));
+
+    expect(view.state.selection.from).toBe(punctuationPosition);
+    await settleMarkdownListener();
+  });
+
+  it("places the cursor before adjacent punctuation from folded closing delimiter clicks", async () => {
+    const { container, view } = await renderEditor("**ABC**:");
+
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("ABC");
+
+    const punctuationPosition = findTextPosition(view, ":");
+
+    moveCursor(view, findTextPosition(view, "ABC", 1));
+
+    const delimiters = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-virtual-delimiter"));
+    expect(delimiters).toHaveLength(2);
+    const [, closingDelimiter] = delimiters;
+
+    closingDelimiter?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, cancelable: true }));
+
+    expect(view.state.selection.from).toBe(punctuationPosition);
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -26,6 +26,7 @@ import {
   markraCalloutSerializerPlugin,
   markraClipboardImagePluginWithOptions,
   markraCodeBlockPlugin,
+  markraVisualCaretPlugin,
   markraFrontmatterRemarkPlugin,
   markraFrontmatterSchema,
   markraFootnoteDefinitionInputPlugin,
@@ -483,6 +484,7 @@ function MilkdownEditorSurface({
         .use(markraMathPlugin)
         .use(markraAiSelectionHoldPlugin)
         .use(markraAiEditorPreviewPlugin)
+        .use(markraVisualCaretPlugin)
         .use(markraSearchPlugin())
         .use(markraSpellcheckPlugin({
           enabled: spellcheckEnabledRef.current,

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -1,5 +1,6 @@
 import {
   commands as commonmarkCommands,
+  emphasisSchema,
   hardbreakAttr,
   hardbreakSchema,
   imageSchema,
@@ -7,7 +8,8 @@ import {
   keymap as commonmarkKeymap,
   plugins as commonmarkPlugins,
   remarkPreserveEmptyLinePlugin,
-  schema as commonmarkSchema
+  schema as commonmarkSchema,
+  strongSchema
 } from "@milkdown/kit/preset/commonmark";
 import {
   commands as gfmCommands,
@@ -15,7 +17,8 @@ import {
   keymap as gfmKeymap,
   pasteRules as gfmPasteRules,
   plugins as gfmPlugins,
-  schema as gfmSchema
+  schema as gfmSchema,
+  strikethroughSchema
 } from "@milkdown/kit/preset/gfm";
 import type { ResolvedPos } from "@milkdown/kit/prose/model";
 import type { Selection } from "@milkdown/kit/prose/state";
@@ -66,6 +69,25 @@ const markraBlockImageSchema = imageSchema.extendSchema((previous) => (ctx) => (
     }
   }
 }));
+
+function keepMarkBoundariesPlainText<T extends Record<string, unknown>>(schema: T) {
+  return {
+    ...schema,
+    inclusive: false
+  };
+}
+
+const markraEmphasisSchema = emphasisSchema.extendSchema((previous) => (ctx) =>
+  keepMarkBoundariesPlainText(previous(ctx))
+);
+
+const markraStrongSchema = strongSchema.extendSchema((previous) => (ctx) =>
+  keepMarkBoundariesPlainText(previous(ctx))
+);
+
+const markraStrikethroughSchema = strikethroughSchema.extendSchema((previous) => (ctx) =>
+  keepMarkBoundariesPlainText(previous(ctx))
+);
 
 function hardbreakDomAttrs(attrs: Record<string, unknown>) {
   const existingClass = typeof attrs.class === "string" && attrs.class.length > 0 ? attrs.class : "";
@@ -302,6 +324,8 @@ export const markraCommonmark = [
   markraBlankParagraphRemarkPlugin,
   markraBlockImageRemarkPlugin,
   commonmarkSchema,
+  markraEmphasisSchema,
+  markraStrongSchema,
   markraBlockImageSchema,
   markraHardbreakSchema,
   commonmarkInputRules,
@@ -315,6 +339,7 @@ export const markraCommonmark = [
 
 export const markraGfm = [
   gfmSchema,
+  markraStrikethroughSchema,
   gfmInputRules,
   gfmPasteRules,
   gfmKeymap,

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -17,6 +17,18 @@
   }
 }
 
+@keyframes markra-prosemirror-caret-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
 @keyframes markra-ai-float-in {
   from {
     opacity: 0;
@@ -832,6 +844,25 @@
 
   .markdown-paper .ProseMirror {
     @apply wrap-break-word whitespace-pre-wrap;
+  }
+
+  .markdown-paper .ProseMirror.markra-prosemirror-custom-caret {
+    caret-color: transparent;
+  }
+
+  .markdown-paper .markra-prosemirror-caret {
+    position: fixed;
+    z-index: 70;
+    display: none;
+    width: 1px;
+    background: var(--accent);
+    border-radius: 999px;
+    pointer-events: none;
+    animation: markra-prosemirror-caret-blink 1.05s steps(1, end) infinite;
+  }
+
+  .editor-content-slot[data-document-search-open="true"] .markdown-paper .markra-prosemirror-caret {
+    display: none !important;
   }
 
   .markdown-paper .ProseMirror li[data-item-type="task"] {

--- a/packages/editor/src/caret.ts
+++ b/packages/editor/src/caret.ts
@@ -1,0 +1,128 @@
+import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+const customCaretClassName = "markra-prosemirror-custom-caret";
+const caretClassName = "markra-prosemirror-caret";
+
+function focused(view: EditorView) {
+  return view.hasFocus() || view.dom.classList.contains("ProseMirror-focused");
+}
+
+function caretFontSize(view: EditorView) {
+  const fontSize = view.dom.ownerDocument.defaultView?.getComputedStyle(view.dom).fontSize ?? "";
+  const parsed = Number.parseFloat(fontSize);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 16;
+}
+
+function caretHeight(view: EditorView, lineHeight: number) {
+  const targetHeight = Math.round(caretFontSize(view) * 1.125);
+  return Math.max(1, Math.min(targetHeight, lineHeight > 0 ? lineHeight : targetHeight));
+}
+
+function hideCaret(caret: HTMLElement) {
+  caret.style.display = "none";
+}
+
+class VisualCaretView {
+  private readonly caret: HTMLElement;
+  private composing = false;
+
+  constructor(private view: EditorView) {
+    this.caret = view.dom.ownerDocument.createElement("span");
+    this.caret.className = caretClassName;
+    this.caret.setAttribute("aria-hidden", "true");
+    hideCaret(this.caret);
+
+    const root = view.dom.closest<HTMLElement>(".markdown-paper") ?? view.dom.ownerDocument.body;
+    root.append(this.caret);
+    view.dom.classList.add(customCaretClassName);
+    this.bind();
+    this.update(view);
+  }
+
+  private readonly handleFocus = () => {
+    this.update(this.view);
+  };
+
+  private readonly handleBlur = () => {
+    hideCaret(this.caret);
+  };
+
+  private readonly handleCompositionStart = () => {
+    this.composing = true;
+    hideCaret(this.caret);
+  };
+
+  private readonly handleCompositionEnd = () => {
+    this.composing = false;
+    this.update(this.view);
+  };
+
+  private readonly handleViewportChange = () => {
+    this.update(this.view);
+  };
+
+  private bind() {
+    const window = this.view.dom.ownerDocument.defaultView;
+    this.view.dom.addEventListener("focus", this.handleFocus);
+    this.view.dom.addEventListener("blur", this.handleBlur);
+    this.view.dom.addEventListener("compositionstart", this.handleCompositionStart);
+    this.view.dom.addEventListener("compositionend", this.handleCompositionEnd);
+    this.view.dom.ownerDocument.addEventListener("selectionchange", this.handleViewportChange);
+    window?.addEventListener("resize", this.handleViewportChange);
+    window?.addEventListener("scroll", this.handleViewportChange, true);
+  }
+
+  update(view: EditorView) {
+    this.view = view;
+
+    const { selection } = view.state;
+    if (
+      this.composing ||
+      !view.editable ||
+      !focused(view) ||
+      !(selection instanceof TextSelection) ||
+      !selection.empty
+    ) {
+      hideCaret(this.caret);
+      return;
+    }
+
+    let coords: ReturnType<EditorView["coordsAtPos"]>;
+    try {
+      coords = view.coordsAtPos(selection.from);
+    } catch {
+      hideCaret(this.caret);
+      return;
+    }
+
+    const lineHeight = coords.bottom - coords.top;
+    const height = caretHeight(view, lineHeight);
+    const top = coords.top + Math.max(0, lineHeight - height) / 2;
+
+    this.caret.style.display = "block";
+    this.caret.style.left = `${Math.round(coords.left)}px`;
+    this.caret.style.top = `${Math.round(top)}px`;
+    this.caret.style.height = `${height}px`;
+  }
+
+  destroy() {
+    const window = this.view.dom.ownerDocument.defaultView;
+    this.view.dom.classList.remove(customCaretClassName);
+    this.view.dom.removeEventListener("focus", this.handleFocus);
+    this.view.dom.removeEventListener("blur", this.handleBlur);
+    this.view.dom.removeEventListener("compositionstart", this.handleCompositionStart);
+    this.view.dom.removeEventListener("compositionend", this.handleCompositionEnd);
+    this.view.dom.ownerDocument.removeEventListener("selectionchange", this.handleViewportChange);
+    window?.removeEventListener("resize", this.handleViewportChange);
+    window?.removeEventListener("scroll", this.handleViewportChange, true);
+    this.caret.remove();
+  }
+}
+
+export const markraVisualCaretPlugin = $prose(() =>
+  new Plugin({
+    view: (view) => new VisualCaretView(view)
+  })
+);

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ai-preview.ts";
 export * from "./block-drag.ts";
 export * from "./block-gap.ts";
 export * from "./callout.ts";
+export * from "./caret.ts";
 export * from "./code-block.ts";
 export * from "./clipboard-images.ts";
 export * from "./footnote.ts";

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -71,6 +71,7 @@ type LiveMarkdownPluginState = {
 };
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
+const liveMarkdownDelimiterSelector = ".markra-md-delimiter[data-markra-live-delimiter-position]";
 
 function getLiveMarkdownKinds(spec: LiveMarkdownSpec) {
   return spec.kinds ?? spec.marks.map((mark) => mark.kind);
@@ -533,11 +534,54 @@ function getFoldedMarkdownRangeAtCursor(
   return foldedRange;
 }
 
-function createDelimiterWidget(marker: string) {
+function createDelimiterWidget(marker: string, position: number | null = null) {
   const delimiter = document.createElement("span");
   delimiter.className = "markra-md-delimiter markra-md-virtual-delimiter";
   delimiter.textContent = marker;
+  if (position !== null) {
+    delimiter.dataset.markraLiveDelimiterPosition = String(position);
+  }
   return delimiter;
+}
+
+function liveMarkdownDelimiterAttrs(className: string, position: number | null) {
+  if (position === null) return { class: className };
+
+  return {
+    class: className,
+    "data-markra-live-delimiter-position": String(position)
+  };
+}
+
+function liveMarkdownDelimiterTarget(target: EventTarget | null) {
+  const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+  return element?.closest<HTMLElement>(liveMarkdownDelimiterSelector) ?? null;
+}
+
+function liveMarkdownDelimiterPosition(target: HTMLElement) {
+  const value = Number(target.dataset.markraLiveDelimiterPosition);
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function selectLiveMarkdownDelimiterEdge(view: EditorView, event: Event) {
+  if (!(event instanceof MouseEvent)) return false;
+  if (event.button !== 0) return false;
+
+  const target = liveMarkdownDelimiterTarget(event.target);
+  if (!target) return false;
+
+  const position = liveMarkdownDelimiterPosition(target);
+  if (position === null || position > view.state.doc.content.size) return false;
+
+  event.preventDefault();
+  event.stopPropagation();
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, position))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
 }
 
 function buildLiveMarkdownDecorations(
@@ -569,15 +613,12 @@ function buildLiveMarkdownDecorations(
         activeLiveRange?.from === from && activeLiveRange.to === to
           ? "markra-md-delimiter"
           : "markra-md-hidden-delimiter";
+      const rangeIsActive = delimiterClass === "markra-md-delimiter";
 
       // Keep Markdown markers in the document, but reveal them only for the currently active range.
       decorations.push(
-        Decoration.inline(from, contentFrom, {
-          class: delimiterClass
-        }),
-        Decoration.inline(contentTo, to, {
-          class: delimiterClass
-        })
+        Decoration.inline(from, contentFrom, liveMarkdownDelimiterAttrs(delimiterClass, rangeIsActive ? from : null)),
+        Decoration.inline(contentTo, to, liveMarkdownDelimiterAttrs(delimiterClass, rangeIsActive ? to : null))
       );
 
       if (range.contentFrom < range.contentTo) {
@@ -595,8 +636,10 @@ function buildLiveMarkdownDecorations(
   if (foldedRange) {
     // Finalized marks use virtual markers so the user can re-enter an editable Markdown-like state.
     decorations.push(
-      Decoration.widget(foldedRange.from, () => createDelimiterWidget(foldedRange.marker), { side: -1 }),
-      Decoration.widget(foldedRange.to, () => createDelimiterWidget(foldedRange.marker), {
+      Decoration.widget(foldedRange.from, () => createDelimiterWidget(foldedRange.marker, foldedRange.from), {
+        side: -1
+      }),
+      Decoration.widget(foldedRange.to, () => createDelimiterWidget(foldedRange.marker, foldedRange.to), {
         side: exitedFoldedRange ? -1 : 1,
         marks: exitedFoldedRange ? [] : undefined
       }),
@@ -965,6 +1008,9 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       }
     },
     props: {
+      handleDOMEvents: {
+        mousedown: selectLiveMarkdownDelimiterEdge
+      },
       decorations: (state) => {
         const pluginState = liveMarkdownKey.getState(state) as LiveMarkdownPluginState | undefined;
         const active = findActiveLiveMarkdownRange(state, specs);


### PR DESCRIPTION
## Summary
- Add a ProseMirror-only visual caret overlay for collapsed WYSIWYG selections.
- Keep finalized emphasis, strong, and strikethrough mark boundaries non-inclusive so edge typing stays plain text.
- Route live and folded Markdown delimiter mouse clicks to real document boundary positions, including closing delimiter clicks before adjacent punctuation.

## Why
- Native caret rendering around inline Markdown markers was inconsistent and hard to size reliably.
- Browser hit testing around visible Markdown delimiters could leave the cursor inside the formatted text instead of at the intended source boundary.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx src/styles.test.ts` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed

## Risk
- Draft because the visual caret still needs real browser/manual QA for blink, scroll, IME, and wrapped-line behavior.

Closes #406