### PR TITLE
feat(ui): add themed tooltip component

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -5940,7 +5940,7 @@ describe("Markra workspace", () => {
     expect(searchInput).toHaveAttribute("autocapitalize", "none");
     expect(searchInput).toHaveAttribute("autocorrect", "off");
     expect(searchInput).toHaveAttribute("spellcheck", "false");
-    expect(screen.getByRole("button", { name: "Case sensitive" })).toHaveAttribute("title", "Case sensitive");
+    expect(screen.getByRole("button", { name: "Case sensitive" })).not.toHaveAttribute("title");
     expect(container.querySelector(".editor-content-slot")).toHaveAttribute("data-document-search-open", "true");
   });
 

--- a/packages/app/src/components/AiAgentPanel.tsx
+++ b/packages/app/src/components/AiAgentPanel.tsx
@@ -30,7 +30,7 @@ import { clampNumber, t, type AppLanguage, type I18nKey } from "@markra/shared";
 import type { AiModelCapability, AiProviderApiStyle, StoredAiAgentSessionSummary } from "../lib/settings/app-settings";
 import type { AiAgentPanelMessage, WorkspacePlanApplyStatus } from "../hooks/useAiAgentSession";
 import type { WorkspacePlanVisualEvent } from "@markra/ai";
-import { IconButton, RoundIconButton, ToggleButton } from "@markra/ui";
+import { IconButton, RoundIconButton, ToggleButton, Tooltip } from "@markra/ui";
 
 type AiAgentModelOption = AiModelPickerOption & { capabilities: AiModelCapability[] };
 
@@ -465,7 +465,7 @@ export function AiAgentPanel({
           disabled={!message.text.trim()}
           label={copied ? label("app.aiCopied") : label("app.aiAgentCopyMessage")}
           size="icon-xs"
-          title={copied ? label("app.aiCopied") : label("app.aiAgentCopyMessage")}
+          tooltip={copied ? label("app.aiCopied") : label("app.aiAgentCopyMessage")}
           onClick={() => handleCopyMessage(message)}
         >
           {copied ? <Check aria-hidden="true" size={13} /> : <Copy aria-hidden="true" size={13} />}
@@ -477,7 +477,7 @@ export function AiAgentPanel({
             label={editing ? label("app.aiAgentCancelEditMessage") : label("app.aiAgentEditMessage")}
             pressed={editing}
             size="icon-xs"
-            title={editing ? label("app.aiAgentCancelEditMessage") : label("app.aiAgentEditMessage")}
+            tooltip={editing ? label("app.aiAgentCancelEditMessage") : label("app.aiAgentEditMessage")}
             onClick={editing ? handleCancelEditMessage : () => handleEditMessage(message)}
           >
             {editing ? <X aria-hidden="true" size={13} /> : <Pencil aria-hidden="true" size={13} />}
@@ -488,7 +488,7 @@ export function AiAgentPanel({
             disabled={!documentAvailable || submitting}
             label={label("app.aiAgentRetryMessage")}
             size="icon-xs"
-            title={label("app.aiAgentRetryMessage")}
+            tooltip={label("app.aiAgentRetryMessage")}
             onClick={() => handleRetryMessage(message.id)}
           >
             <RefreshCcw aria-hidden="true" size={13} />
@@ -780,7 +780,7 @@ export function AiAgentPanel({
               <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto pb-0.5">
                 <ToggleButton
                   label={label("app.aiDeepThinking")}
-                  title={label("app.aiDeepThinking")}
+                  tooltip={label("app.aiDeepThinking")}
                   pressed={thinkingEnabled}
                   disabled={!supportsThinking}
                   onClick={onToggleThinking}
@@ -790,7 +790,7 @@ export function AiAgentPanel({
                 </ToggleButton>
                 <ToggleButton
                   label={label("app.aiWebSearch")}
-                  title={label("app.aiWebSearch")}
+                  tooltip={label("app.aiWebSearch")}
                   pressed={webSearchEnabled}
                   disabled={!supportsWebSearch}
                   onClick={onToggleWebSearch}
@@ -848,12 +848,13 @@ function WorkspacePlanConfirmationBar({
       </span>
       <div className="min-w-0 flex-1">
         <p className="m-0 truncate text-[12px] leading-4 font-[620] text-(--text-heading)">{labelText}</p>
-        <p
-          className={`m-0 truncate text-[11px] leading-4 ${applyError ? "text-(--danger)" : "text-(--text-secondary)"}`}
-          title={detailText}
-        >
-          {detailText}
-        </p>
+        <Tooltip content={detailText}>
+          <p
+            className={`m-0 truncate text-[11px] leading-4 ${applyError ? "text-(--danger)" : "text-(--text-secondary)"}`}
+          >
+            {detailText}
+          </p>
+        </Tooltip>
       </div>
       {applied ? (
         <span className="inline-flex h-7 shrink-0 items-center rounded-md bg-(--bg-active) px-2 text-[11px] leading-4 font-[620] text-(--text-heading)">
@@ -871,15 +872,16 @@ function WorkspacePlanConfirmationBar({
         </button>
       )}
       {applied && onDismiss ? (
-        <button
-          aria-label="Dismiss workspace plan confirmation"
-          className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent bg-transparent text-(--text-secondary) transition-[background-color,color] duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
-          title="Dismiss workspace plan confirmation"
-          type="button"
-          onClick={onDismiss}
-        >
-          <X aria-hidden="true" size={13} />
-        </button>
+        <Tooltip content="Dismiss workspace plan confirmation">
+          <button
+            aria-label="Dismiss workspace plan confirmation"
+            className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent bg-transparent text-(--text-secondary) transition-[background-color,color] duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+            type="button"
+            onClick={onDismiss}
+          >
+            <X aria-hidden="true" size={13} />
+          </button>
+        </Tooltip>
       ) : null}
     </section>
   );

--- a/packages/app/src/components/AiModelCapabilities.tsx
+++ b/packages/app/src/components/AiModelCapabilities.tsx
@@ -52,7 +52,7 @@ function CapabilityPill({ capability, translate }: { capability: AiModelCapabili
     <Badge
       className={capabilityPillClasses[capability]}
       aria-label={label}
-      title={label}
+      tooltip={label}
     >
       <Icon aria-hidden="true" size={13} strokeWidth={2.1} />
       <span className="sr-only">{label}</span>

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useRef, useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
+import { Tooltip } from "@markra/ui";
 import {
   Bold,
   Check,
@@ -328,18 +329,17 @@ export function AiSelectionToolbar({
               const selected = option.type === "heading" && option.level === activeHeadingLevel;
 
               return (
+                <Tooltip key={option.type === "paragraph" ? "paragraph" : option.level} content={optionLabel}>
                 <button
                   className={`inline-flex size-8 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) ${
                     selected
                       ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
                       : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
                   }`}
-                  key={option.type === "paragraph" ? "paragraph" : option.level}
                   type="button"
                   role="menuitemradio"
                   aria-label={optionLabel}
                   aria-checked={selected}
-                  title={optionLabel}
                   onClick={() => {
                     setHeadingLevelMenuOpen(false);
                     if (option.type === "paragraph") {
@@ -352,6 +352,7 @@ export function AiSelectionToolbar({
                 >
                   <HeadingLevelIcon aria-hidden="true" size={15} />
                 </button>
+                </Tooltip>
               );
             })}
           </div>,
@@ -368,16 +369,17 @@ export function AiSelectionToolbar({
       aria-label={label("app.aiQuickActions")}
     >
       <div className="pointer-events-auto inline-flex max-w-[calc(100vw-24px)] items-center gap-1 overflow-x-auto rounded-lg border border-(--border-default) bg-(--bg-primary) p-1 shadow-(--ai-command-popover-shadow)">
-        <button
-          className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-(--accent-soft) text-(--accent) transition-colors duration-150 ease-out hover:bg-(--bg-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55"
-          type="button"
-          disabled={busy}
-          title={label("app.aiCommandInput")}
-          onClick={onOpenCommand}
-          aria-label={label("app.aiCommandInput")}
-        >
-          <WandSparkles aria-hidden="true" size={15} />
-        </button>
+        <Tooltip content={label("app.aiCommandInput")}>
+          <button
+            className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-(--accent-soft) text-(--accent) transition-colors duration-150 ease-out hover:bg-(--bg-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55"
+            type="button"
+            disabled={busy}
+            onClick={onOpenCommand}
+            aria-label={label("app.aiCommandInput")}
+          >
+            <WandSparkles aria-hidden="true" size={15} />
+          </button>
+        </Tooltip>
         <span className="mx-0.5 h-5 w-px bg-(--border-default)" aria-hidden="true" />
         {aiSelectionActions.map((action) => {
           const Icon = action.icon;
@@ -389,17 +391,17 @@ export function AiSelectionToolbar({
           );
 
           return (
+            <Tooltip key={action.intent} content={actionLabel}>
             <button
               className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-primary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55"
-              key={action.intent}
               type="button"
               disabled={busy}
-              title={actionLabel}
               onClick={() => onRunAction(action.intent, actionPrompt)}
               aria-label={actionLabel}
             >
               <Icon aria-hidden="true" size={14} />
             </button>
+            </Tooltip>
           );
         })}
         <span className="mx-0.5 h-5 w-px bg-(--border-default)" aria-hidden="true" />
@@ -410,80 +412,84 @@ export function AiSelectionToolbar({
 
           return (
             <Fragment key={action.action}>
-              <button
-                className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
-                  active
-                    ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
-                    : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
-                }`}
-                type="button"
-                disabled={busy}
-                title={actionLabel}
-                onClick={() => onRunFormattingAction(action.action)}
-                aria-label={actionLabel}
-                aria-pressed={active}
-              >
-                <Icon aria-hidden="true" size={14} />
-              </button>
+              <Tooltip content={actionLabel}>
+                <button
+                  className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
+                    active
+                      ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                      : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+                  }`}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => onRunFormattingAction(action.action)}
+                  aria-label={actionLabel}
+                  aria-pressed={active}
+                >
+                  <Icon aria-hidden="true" size={14} />
+                </button>
+              </Tooltip>
               {action.action === "highlight" ? (
                 <div className="relative inline-flex shrink-0">
-                  <button
-                    className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
-                      activeHeadingLevelOption
-                        ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
-                        : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
-                    }`}
-                    ref={headingLevelButtonRef}
-                    type="button"
-                    disabled={busy}
-                    title={headingLevelLabel}
-                    onClick={(event) => {
-                      if (!headingLevelMenuOpen) {
-                        positionHeadingLevelMenu(event.currentTarget);
-                      }
-                      setHeadingLevelMenuOpen(!headingLevelMenuOpen);
-                    }}
-                    aria-label={headingLevelLabel}
-                    aria-haspopup="menu"
-                    aria-expanded={headingLevelMenuOpen}
-                  >
-                    <ActiveHeadingLevelIcon aria-hidden="true" size={15} />
-                  </button>
+                  <Tooltip content={headingLevelLabel}>
+                    <button
+                      className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
+                        activeHeadingLevelOption
+                          ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                          : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+                      }`}
+                      ref={headingLevelButtonRef}
+                      type="button"
+                      disabled={busy}
+                      onClick={(event) => {
+                        if (!headingLevelMenuOpen) {
+                          positionHeadingLevelMenu(event.currentTarget);
+                        }
+                        setHeadingLevelMenuOpen(!headingLevelMenuOpen);
+                      }}
+                      aria-label={headingLevelLabel}
+                      aria-haspopup="menu"
+                      aria-expanded={headingLevelMenuOpen}
+                    >
+                      <ActiveHeadingLevelIcon aria-hidden="true" size={15} />
+                    </button>
+                  </Tooltip>
                 </div>
               ) : null}
             </Fragment>
           );
         })}
-        <button
-          className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
-            activeFormattingActionSet.has("link")
-              ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
-              : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
-          }`}
-          type="button"
-          disabled={busy}
-          title={label("menu.link")}
-          onClick={onInsertLink}
-          aria-label={label("menu.link")}
-          aria-pressed={activeFormattingActionSet.has("link")}
-        >
-          <Link aria-hidden="true" size={14} />
-        </button>
+        <Tooltip content={label("menu.link")}>
+          <button
+            className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
+              activeFormattingActionSet.has("link")
+                ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+            }`}
+            type="button"
+            disabled={busy}
+            onClick={onInsertLink}
+            aria-label={label("menu.link")}
+            aria-pressed={activeFormattingActionSet.has("link")}
+          >
+            <Link aria-hidden="true" size={14} />
+          </button>
+        </Tooltip>
         <span className="mx-0.5 h-5 w-px bg-(--border-default)" aria-hidden="true" />
-        <button
-          className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
-            copySucceeded
-              ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
-              : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
-          }`}
-          type="button"
-          disabled={busy}
-          title={copyLabel}
-          onClick={onCopySelection}
-          aria-label={copyLabel}
-        >
-          {copySucceeded ? <Check aria-hidden="true" size={14} /> : <Copy aria-hidden="true" size={14} />}
-        </button>
+        <Tooltip content={copyLabel}>
+          <button
+            className={`inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-default disabled:opacity-55 ${
+              copySucceeded
+                ? "bg-(--accent-soft) text-(--accent) hover:bg-(--accent-soft)"
+                : "bg-transparent text-(--text-primary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading)"
+            }`}
+            type="button"
+            disabled={busy}
+            onClick={onCopySelection}
+            aria-label={copyLabel}
+          >
+            {copySucceeded ? <Check aria-hidden="true" size={14} /> : <Copy aria-hidden="true" size={14} />}
+          </button>
+        </Tooltip>
       </div>
       {headingLevelMenu}
     </section>

--- a/packages/app/src/components/DocumentHistoryDialog.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { debug, t, type AppLanguage } from "@markra/shared";
+import { Tooltip } from "@markra/ui";
 import {
   listNativeMarkdownFileHistory,
   readNativeMarkdownFileHistory,
@@ -178,15 +179,16 @@ export function DocumentHistoryDialog({
         <h4 className="m-0 truncate text-[12px] leading-5 font-bold text-(--text-heading)">
           {label("app.documentHistory")}
         </h4>
-        <button
-          aria-label={label("app.closeDocumentHistory")}
-          className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent bg-transparent p-0 text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
-          title={label("app.closeDocumentHistory")}
-          type="button"
-          onClick={onClose}
-        >
-          <X aria-hidden="true" size={15} strokeWidth={2} />
-        </button>
+        <Tooltip content={label("app.closeDocumentHistory")}>
+          <button
+            aria-label={label("app.closeDocumentHistory")}
+            className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md border border-transparent bg-transparent p-0 text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+            type="button"
+            onClick={onClose}
+          >
+            <X aria-hidden="true" size={15} strokeWidth={2} />
+          </button>
+        </Tooltip>
       </div>
       <div className="min-h-0 overflow-auto bg-(--bg-secondary) p-2">
         {entriesLoading ? (

--- a/packages/app/src/components/DocumentSearchBar.tsx
+++ b/packages/app/src/components/DocumentSearchBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type KeyboardEvent } from "react";
 import { CaseSensitive, ChevronDown, ChevronUp, Replace, Search, X } from "lucide-react";
 import { t, type AppLanguage } from "@markra/shared";
+import { Tooltip } from "@markra/ui";
 
 type DocumentSearchBarProps = {
   activeIndex: number;
@@ -174,16 +175,17 @@ export function DocumentSearchBar({
         >
           <ChevronDown aria-hidden="true" size={14} />
         </button>
-        <button
-          className="document-search-icon-button"
-          aria-label={label.caseSensitive}
-          aria-pressed={caseSensitive}
-          title={label.caseSensitive}
-          type="button"
-          onClick={() => onCaseSensitiveChange(!caseSensitive)}
-        >
-          <CaseSensitive aria-hidden="true" size={14} />
-        </button>
+        <Tooltip content={label.caseSensitive}>
+          <button
+            className="document-search-icon-button"
+            aria-label={label.caseSensitive}
+            aria-pressed={caseSensitive}
+            type="button"
+            onClick={() => onCaseSensitiveChange(!caseSensitive)}
+          >
+            <CaseSensitive aria-hidden="true" size={14} />
+          </button>
+        </Tooltip>
         <button
           className="document-search-icon-button"
           aria-label={label.toggleReplace}

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -96,6 +96,10 @@ describe("MarkdownFileTreeDrawer", () => {
     mockedReadNativeClipboardText.mockResolvedValue(null);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps settings fixed in the lower-left", () => {
     const onOpenSettings = vi.fn();
     const { container } = render(
@@ -824,7 +828,9 @@ describe("MarkdownFileTreeDrawer", () => {
     });
   });
 
-  it("middle-truncates long duplicate recent folder paths while keeping the full path label", () => {
+  it("middle-truncates long duplicate recent folder paths while keeping the full path tooltip", async () => {
+    vi.useFakeTimers();
+
     const alphaPath = "/mock-workspaces/team-alpha/projects/handbook/content/docs";
     const betaPath = "/mock-workspaces/team-beta/projects/handbook/content/docs";
 
@@ -853,12 +859,21 @@ describe("MarkdownFileTreeDrawer", () => {
       name: `docs ${betaPath}`
     });
 
-    expect(alphaDocs).toHaveAttribute("title", alphaPath);
-    expect(betaDocs).toHaveAttribute("title", betaPath);
+    expect(alphaDocs).not.toHaveAttribute("title");
+    expect(betaDocs).not.toHaveAttribute("title");
     expect(within(alphaDocs).getByText("/mock-workspaces/team-alpha/.../content/docs")).toBeInTheDocument();
     expect(within(betaDocs).getByText("/mock-workspaces/team-beta/.../content/docs")).toBeInTheDocument();
     expect(alphaDocs).not.toHaveTextContent(alphaPath);
     expect(betaDocs).not.toHaveTextContent(betaPath);
+
+    fireEvent.pointerEnter(alphaDocs);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(alphaPath);
   });
 
   it("collapses recent folders and removes a recent folder without opening it", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -55,7 +55,7 @@ import {
   writeMarkdownImageDragPayload,
   type AppLanguage
 } from "@markra/shared";
-import { IconButton } from "@markra/ui";
+import { IconButton, Tooltip } from "@markra/ui";
 import { markraHighlightRemarkPlugin, type MarkdownOutlineItem } from "@markra/markdown";
 import { DocumentLinksPanel } from "./DocumentLinksPanel";
 import type { NativeMarkdownFolderFile } from "../lib/tauri";
@@ -2139,6 +2139,7 @@ export function MarkdownFileTreeDrawer({
     return (
       <FileTreeDragSource disabled={!dragMoveAvailable || asset} file={node.file}>
         {(dragSource) => (
+          <Tooltip content={node.file.path}>
           <button
             ref={dragSource.setNodeRef}
             className={`relative grid h-8 w-full cursor-pointer touch-none grid-cols-[17px_minmax(0,1fr)] items-center gap-1.5 border-0 bg-transparent py-0 pr-2 text-left text-[13px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-[current=page]:border-l-[3px] aria-[current=page]:border-(--text-secondary) aria-[current=page]:bg-(--bg-active) aria-[current=page]:text-(--text-heading) aria-selected:bg-(--accent-soft) aria-selected:text-(--text-heading) aria-selected:shadow-[inset_3px_0_0_var(--accent)] ${dragSource.isDragging ? "opacity-70" : ""} ${fileTreeContextRowSelectionClassName} ${rowIndentClass} ${rowBranchClass}`}
@@ -2154,7 +2155,6 @@ export function MarkdownFileTreeDrawer({
             data-reveal-file-tree-row={
               pendingRevealPath && sameNativePath(node.file.path, pendingRevealPath) ? "true" : undefined
             }
-            title={node.file.path}
             onContextMenu={(event) => openContextMenu(event, node.file)}
             onClick={(event) => handleFileRowClick(event, node.file)}
             {...dragSource.attributes}
@@ -2171,6 +2171,7 @@ export function MarkdownFileTreeDrawer({
               {node.name}
             </span>
           </button>
+          </Tooltip>
         )}
       </FileTreeDragSource>
     );
@@ -2444,24 +2445,25 @@ export function MarkdownFileTreeDrawer({
                         setFocusedRecentFolderActionPath((path) => (path === folder.path ? null : path));
                       }}
                     >
-                      <button
-                        aria-label={folderActionLabel}
-                        aria-current={currentRecentFolder ? "page" : undefined}
-                        className={`flex ${duplicateName ? "h-10 items-center" : "h-7 items-center"} min-w-0 cursor-pointer gap-2 rounded-sm border-0 px-2 text-left text-[12px] leading-none focus-visible:outline-none ${recentFolderButtonStateClassName}`}
-                        type="button"
-                        title={folder.path}
-                        onClick={() => onOpenRecentFolder(folder)}
-                      >
-                        <RecentFolderIcon aria-hidden="true" className="shrink-0" size={14} />
-                        <span className="flex min-w-0 flex-col gap-0.5">
-                          <span className="min-w-0 truncate leading-4">{folder.name}</span>
-                          {duplicateName ? (
-                            <span className="min-w-0 truncate text-[10px] leading-4 text-(--text-tertiary)">
-                              {folderPathLabel}
-                            </span>
-                          ) : null}
-                        </span>
-                      </button>
+                      <Tooltip content={folder.path}>
+                        <button
+                          aria-label={folderActionLabel}
+                          aria-current={currentRecentFolder ? "page" : undefined}
+                          className={`flex ${duplicateName ? "h-10 items-center" : "h-7 items-center"} min-w-0 cursor-pointer gap-2 rounded-sm border-0 px-2 text-left text-[12px] leading-none focus-visible:outline-none ${recentFolderButtonStateClassName}`}
+                          type="button"
+                          onClick={() => onOpenRecentFolder(folder)}
+                        >
+                          <RecentFolderIcon aria-hidden="true" className="shrink-0" size={14} />
+                          <span className="flex min-w-0 flex-col gap-0.5">
+                            <span className="min-w-0 truncate leading-4">{folder.name}</span>
+                            {duplicateName ? (
+                              <span className="min-w-0 truncate text-[10px] leading-4 text-(--text-tertiary)">
+                                {folderPathLabel}
+                              </span>
+                            ) : null}
+                          </span>
+                        </button>
+                      </Tooltip>
                       {onRemoveRecentFolder ? (
                         (() => {
                           const actionVisible =

--- a/packages/app/src/components/MarkdownTabsBar.test.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
 import { MarkdownTabsBar } from "./MarkdownTabsBar";
 
 describe("MarkdownTabsBar", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function mockElementFromPoint(element: Element) {
     const mock = vi.fn(() => element);
 
@@ -187,7 +191,9 @@ describe("MarkdownTabsBar", () => {
     });
   });
 
-  it("uses the full tab path as the hover tooltip when available", () => {
+  it("uses a delayed themed tooltip for the full tab path when available", async () => {
+    vi.useFakeTimers();
+
     render(
       <MarkdownTabsBar
         activeTabId="tab-a"
@@ -206,10 +212,21 @@ describe("MarkdownTabsBar", () => {
       />
     );
 
-    expect(screen.getByRole("tab", { name: /Alpha\.md/ })).toHaveAttribute(
-      "title",
-      "/synthetic/workspace/docs/Alpha.md"
-    );
+    const tab = screen.getByRole("tab", { name: /Alpha\.md/ });
+    expect(tab).not.toHaveAttribute("title");
+
+    fireEvent.pointerEnter(tab);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent("/synthetic/workspace/docs/Alpha.md");
+    expect(tooltip).toHaveClass("bg-(--bg-primary)");
+
+    vi.useRealTimers();
   });
 
   it("uses the focused pane tab as the grouped tab active state", () => {

--- a/packages/app/src/components/MarkdownTabsBar.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.tsx
@@ -8,7 +8,7 @@ import {
   type WheelEvent as ReactWheelEvent
 } from "react";
 import { Columns2, FileText, ImageIcon, LocateFixed, Pencil, Plus, X } from "lucide-react";
-import { IconButton } from "@markra/ui";
+import { IconButton, Tooltip } from "@markra/ui";
 import { t, type AppLanguage } from "@markra/shared";
 import type { MarkdownDocumentTab } from "../hooks/useMarkdownDocument";
 import { ContextMenu, type ContextMenuEntry } from "./ContextMenu";
@@ -490,7 +490,7 @@ export function MarkdownTabsBar({
     const renaming = tab.id === renamingTabId;
     const tabTitle = tab.path ?? (tab.name || "Untitled.md");
 
-    return renaming ? (
+    if (renaming) return (
       <div className="flex h-full min-w-0 items-center gap-1.5 rounded-l-md px-2">
         <TabIcon aria-hidden="true" className="shrink-0 opacity-65" size={13} />
         <input
@@ -515,30 +515,33 @@ export function MarkdownTabsBar({
           }}
         />
       </div>
-    ) : (
-      <button
-        className={`flex h-full min-w-0 items-center gap-1.5 rounded-l-md px-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) ${
-          active ? "text-(--text-heading)" : "text-(--text-secondary)"
-        }`}
-        draggable={false}
-        type="button"
-        role="tab"
-        aria-selected={active}
-        data-document-tab-id={tab.id}
-        data-document-tab-pane-focus={paneFocused ? "true" : undefined}
-        data-document-tab-drop-position={dropPosition ?? undefined}
-        title={tabTitle}
-        onClick={() => handleSelectTabClick(tab, selectTabId)}
-        onDoubleClick={() => startRenamingTab(tab)}
-        onDragStart={handlePreventNativeTabDrag}
-        onPointerDown={(event) => handleTabPointerDown(event, tab)}
-      >
-        <TabIcon aria-hidden="true" className="shrink-0 opacity-65" size={13} />
-        <span className="min-w-0 truncate">{tab.name || "Untitled.md"}</span>
-        {tab.dirty ? (
-          <span className="size-1.25 shrink-0 rounded-full bg-(--accent)" aria-label={label("app.unsavedChanges")} />
-        ) : null}
-      </button>
+    );
+
+    return (
+      <Tooltip content={tabTitle} side="bottom">
+        <button
+          className={`flex h-full min-w-0 items-center gap-1.5 rounded-l-md px-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) ${
+            active ? "text-(--text-heading)" : "text-(--text-secondary)"
+          }`}
+          draggable={false}
+          type="button"
+          role="tab"
+          aria-selected={active}
+          data-document-tab-id={tab.id}
+          data-document-tab-pane-focus={paneFocused ? "true" : undefined}
+          data-document-tab-drop-position={dropPosition ?? undefined}
+          onClick={() => handleSelectTabClick(tab, selectTabId)}
+          onDoubleClick={() => startRenamingTab(tab)}
+          onDragStart={handlePreventNativeTabDrag}
+          onPointerDown={(event) => handleTabPointerDown(event, tab)}
+        >
+          <TabIcon aria-hidden="true" className="shrink-0 opacity-65" size={13} />
+          <span className="min-w-0 truncate">{tab.name || "Untitled.md"}</span>
+          {tab.dirty ? (
+            <span className="size-1.25 shrink-0 rounded-full bg-(--accent)" aria-label={label("app.unsavedChanges")} />
+          ) : null}
+        </button>
+      </Tooltip>
     );
   };
   const renderCloseTabButton = (tab: MarkdownTabsBarDocumentItem, active: boolean, alwaysVisible = false) => (

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -14,6 +14,7 @@ import {
   type ContextMenuEntry
 } from "./ContextMenu";
 import { WindowsWindowControls } from "./WindowsWindowControls";
+import { Tooltip } from "@markra/ui";
 
 type WindowsAppMenuId = "app" | "file" | "edit" | "format" | "view";
 
@@ -284,16 +285,17 @@ export function WindowsNativeTitleBar({
     runToggleWindowMaximized();
   };
   const renderWindowsFolderContext = () => showWindowsFolderContext ? (
-    <span
-      className="windows-app-chrome-context flex h-7 min-w-0 max-w-72 shrink items-center justify-center gap-1.5 text-[12px] leading-none font-[620] text-(--text-heading)"
-      data-tauri-drag-region={nativeWindowChrome ? true : undefined}
-      title={windowsWorkspaceName}
-    >
-      <FolderOpen aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={13} />
-      <span className="min-w-0 truncate leading-4" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
-        {windowsWorkspaceName}
+    <Tooltip content={windowsWorkspaceName} side="bottom">
+      <span
+        className="windows-app-chrome-context flex h-7 min-w-0 max-w-72 shrink items-center justify-center gap-1.5 text-[12px] leading-none font-[620] text-(--text-heading)"
+        data-tauri-drag-region={nativeWindowChrome ? true : undefined}
+      >
+        <FolderOpen aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={13} />
+        <span className="min-w-0 truncate leading-4" data-tauri-drag-region={nativeWindowChrome ? true : undefined}>
+          {windowsWorkspaceName}
+        </span>
       </span>
-    </span>
+    </Tooltip>
   ) : null;
   const renderWindowsAppChrome = () => showWindowsAppChrome ? (
     <header

--- a/packages/app/src/components/settings/AppearanceSettings.tsx
+++ b/packages/app/src/components/settings/AppearanceSettings.tsx
@@ -17,6 +17,7 @@ import {
 } from "./ThemeSettingsControls";
 import { mergeClassNames } from "./class-names";
 import type { SettingsTranslate } from "./translate";
+import { Tooltip } from "@markra/ui";
 
 const appearanceModeIcons: Record<AppAppearanceMode, LucideIcon> = {
   dark: Moon,
@@ -42,10 +43,15 @@ function AppearanceModeControl({
       {appAppearanceModeOptions.map((mode) => {
         const Icon = appearanceModeIcons[mode];
         const selected = mode === selectedAppearanceMode;
+        const tooltipLabel = translate(mode === "system"
+          ? "settings.theme.useSystemLabel"
+          : mode === "dark"
+            ? "settings.theme.useDarkLabel"
+            : "settings.theme.useLightLabel");
 
         return (
+          <Tooltip key={mode} content={tooltipLabel}>
           <button
-            key={mode}
             className={mergeClassNames(
               "inline-flex h-8 min-w-20 cursor-pointer items-center justify-center gap-1.5 border-0 border-r border-(--border-default) bg-transparent px-3 text-[12px] leading-5 font-[620] text-(--text-secondary) transition-colors duration-150 ease-out last:border-r-0 hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) focus-visible:ring-inset",
               selected ? "bg-(--bg-active) text-(--text-heading)" : ""
@@ -53,11 +59,6 @@ function AppearanceModeControl({
             type="button"
             role="radio"
             aria-checked={selected}
-            title={translate(mode === "system"
-              ? "settings.theme.useSystemLabel"
-              : mode === "dark"
-                ? "settings.theme.useDarkLabel"
-                : "settings.theme.useLightLabel")}
             onClick={() => onSelectAppearanceMode(mode)}
           >
             <Icon aria-hidden="true" size={13} />
@@ -67,6 +68,7 @@ function AppearanceModeControl({
                 ? "settings.theme.dark"
                 : "settings.theme.light")}
           </button>
+          </Tooltip>
         );
       })}
     </div>

--- a/packages/app/src/components/settings/EditorSettings.tsx
+++ b/packages/app/src/components/settings/EditorSettings.tsx
@@ -28,7 +28,7 @@ import {
   type UniqueIdentifier
 } from "@dnd-kit/core";
 import { horizontalListSortingStrategy, SortableContext } from "@dnd-kit/sortable";
-import { IconButton, SegmentedControl, SegmentedControlItem } from "@markra/ui";
+import { IconButton, SegmentedControl, SegmentedControlItem, Tooltip } from "@markra/ui";
 import { clampNumber, type I18nKey } from "@markra/shared";
 import {
   defaultTitlebarActions,
@@ -383,26 +383,27 @@ function SettingsContentWidthInput({
           %
         </span>
       </div>
-      <button
-        className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center border-0 border-l border-(--border-default) bg-transparent text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
-        type="button"
-        aria-label={resetLabel}
-        title={resetLabel}
-        onClick={() => {
-          setDraftRatio(String(contentWidthRatioValue({
-            ...preferences,
-            contentWidth: "default",
-            contentWidthPx: null
-          })));
-          onUpdatePreferences({
-            ...preferences,
-            contentWidth: "default",
-            contentWidthPx: null
-          });
-        }}
-      >
-        <RotateCcw aria-hidden="true" size={13} />
-      </button>
+      <Tooltip content={resetLabel}>
+        <button
+          className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center border-0 border-l border-(--border-default) bg-transparent text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+          type="button"
+          aria-label={resetLabel}
+          onClick={() => {
+            setDraftRatio(String(contentWidthRatioValue({
+              ...preferences,
+              contentWidth: "default",
+              contentWidthPx: null
+            })));
+            onUpdatePreferences({
+              ...preferences,
+              contentWidth: "default",
+              contentWidthPx: null
+            });
+          }}
+        >
+          <RotateCcw aria-hidden="true" size={13} />
+        </button>
+      </Tooltip>
     </div>
   );
 }
@@ -595,7 +596,7 @@ function SettingsTitlebarActionsControl({
                         data-visible={action.visible ? "true" : "false"}
                         label={label}
                         pressed={action.visible}
-                        title={label}
+                        tooltip={label}
                         size="icon-xs"
                         onClick={(event) => handleClick(action.id, event)}
                         {...sortable.actionAttributes}

--- a/packages/app/src/components/settings/SpellcheckSettings.tsx
+++ b/packages/app/src/components/settings/SpellcheckSettings.tsx
@@ -264,7 +264,7 @@ export function SpellcheckSettings({
                 <IconButton
                   label={removeLabel}
                   size="icon-xs"
-                  title={removeLabel}
+                  tooltip={removeLabel}
                   variant="ghost"
                   onClick={() => handleRemoveIgnoredWord(word)}
                 >
@@ -290,7 +290,7 @@ export function SpellcheckSettings({
               disabled={!canAddIgnoredWord}
               label={translate("settings.editor.spellcheckWhitelistAddLabel")}
               size="icon-xs"
-              title={translate("settings.editor.spellcheckWhitelistAddLabel")}
+              tooltip={translate("settings.editor.spellcheckWhitelistAddLabel")}
               type="submit"
               variant="ghost"
             >
@@ -355,7 +355,7 @@ export function SpellcheckSettings({
                   disabled={disabled}
                   label={actionLabel}
                   size="icon-xs"
-                  title={actionLabel}
+                  tooltip={actionLabel}
                   variant="ghost"
                   onClick={() => handleDownload(language.code, showRedownload ? { forceDownload: true } : {})}
                 >
@@ -365,7 +365,7 @@ export function SpellcheckSettings({
                   disabled={disabled}
                   label={deleteLabel}
                   size="icon-xs"
-                  title={deleteLabel}
+                  tooltip={deleteLabel}
                   variant="ghost"
                   onClick={() => handleDelete(language.code)}
                 >

--- a/packages/app/src/components/settings/ThemeSettingsControls.tsx
+++ b/packages/app/src/components/settings/ThemeSettingsControls.tsx
@@ -7,6 +7,7 @@ import {
 import type { I18nKey } from "@markra/shared";
 import { mergeClassNames } from "./class-names";
 import { SettingsButton, SettingsTextarea } from "./SettingsControls";
+import { Tooltip } from "@markra/ui";
 
 type Translate = (key: I18nKey) => string;
 
@@ -258,47 +259,47 @@ export function ThemePreviewGrid<Theme extends EditorTheme>({
         const selected = theme === selectedTheme;
 
         return (
-          <button
-            key={theme}
-            className={mergeClassNames(
-              "relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border bg-(--bg-primary) p-0 transition-colors duration-150 ease-out hover:bg-(--bg-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)",
-              selected ? "border-(--accent) bg-(--accent-soft)" : "border-(--border-default)"
-            )}
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            aria-label={label}
-            title={label}
-            style={createThemePreviewStyle(themePreviewSwatches[theme])}
-            onClick={() => onSelectTheme(theme)}
-          >
-            <span
-              className="relative h-6 w-6 overflow-hidden rounded-[5px] border"
-              style={{
-                background: "var(--theme-preview-bg)",
-                borderColor: "var(--theme-preview-border)"
-              }}
-              aria-hidden="true"
+          <Tooltip key={theme} content={label}>
+            <button
+              className={mergeClassNames(
+                "relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border bg-(--bg-primary) p-0 transition-colors duration-150 ease-out hover:bg-(--bg-hover) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)",
+                selected ? "border-(--accent) bg-(--accent-soft)" : "border-(--border-default)"
+              )}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={label}
+              style={createThemePreviewStyle(themePreviewSwatches[theme])}
+              onClick={() => onSelectTheme(theme)}
             >
               <span
-                className="absolute top-1 left-1 h-1 w-3 rounded-full"
-                style={{ background: "var(--theme-preview-text)" }}
-              />
-              <span
-                className="absolute top-2.5 left-1 h-1 w-3.5 rounded-full"
-                style={{ background: "var(--theme-preview-muted)" }}
-              />
-              <span
-                className="absolute right-1 bottom-1 h-2 w-2 rounded-full"
-                style={{ background: "var(--theme-preview-accent)" }}
-              />
-              <span
-                className="absolute bottom-1 left-1 h-1.5 w-3.5 rounded-sm"
-                style={{ background: "var(--theme-preview-panel)" }}
-              />
-            </span>
-            {selected ? <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-(--accent)" aria-hidden="true" /> : null}
-          </button>
+                className="relative h-6 w-6 overflow-hidden rounded-[5px] border"
+                style={{
+                  background: "var(--theme-preview-bg)",
+                  borderColor: "var(--theme-preview-border)"
+                }}
+                aria-hidden="true"
+              >
+                <span
+                  className="absolute top-1 left-1 h-1 w-3 rounded-full"
+                  style={{ background: "var(--theme-preview-text)" }}
+                />
+                <span
+                  className="absolute top-2.5 left-1 h-1 w-3.5 rounded-full"
+                  style={{ background: "var(--theme-preview-muted)" }}
+                />
+                <span
+                  className="absolute right-1 bottom-1 h-2 w-2 rounded-full"
+                  style={{ background: "var(--theme-preview-accent)" }}
+                />
+                <span
+                  className="absolute bottom-1 left-1 h-1.5 w-3.5 rounded-sm"
+                  style={{ background: "var(--theme-preview-panel)" }}
+                />
+              </span>
+              {selected ? <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-(--accent)" aria-hidden="true" /> : null}
+            </button>
+          </Tooltip>
         );
       })}
     </div>

--- a/packages/ui/src/Badge.tsx
+++ b/packages/ui/src/Badge.tsx
@@ -1,11 +1,14 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { mergeClassNames } from "./classes";
+import { Tooltip, type TooltipSide } from "./Tooltip";
 
 export type BadgeSize = "md" | "sm";
 
 export type BadgeProps = ComponentPropsWithoutRef<"span"> & {
   size?: BadgeSize;
+  tooltip?: ReactNode;
+  tooltipSide?: TooltipSide;
 };
 
 const badgeSizeClassNames: Record<BadgeSize, string> = {
@@ -13,8 +16,8 @@ const badgeSizeClassNames: Record<BadgeSize, string> = {
   sm: "h-5 min-w-5 px-1.5 text-[11px] leading-4"
 };
 
-export function Badge({ children, className, size = "md", ...props }: BadgeProps) {
-  return (
+export function Badge({ children, className, size = "md", tooltip, tooltipSide, ...props }: BadgeProps) {
+  const badge = (
     <span
       className={mergeClassNames(
         "inline-flex shrink-0 items-center justify-center gap-1 rounded-full font-bold",
@@ -26,4 +29,10 @@ export function Badge({ children, className, size = "md", ...props }: BadgeProps
       {children}
     </span>
   );
+
+  return tooltip ? (
+    <Tooltip content={tooltip} side={tooltipSide}>
+      {badge}
+    </Tooltip>
+  ) : badge;
 }

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -2,12 +2,15 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { Button, type ButtonSize, type ButtonVariant } from "./Button";
 import { mergeClassNames } from "./classes";
+import { Tooltip, type TooltipSide } from "./Tooltip";
 
 export type IconButtonProps = Omit<ComponentPropsWithoutRef<"button">, "aria-label" | "children"> & {
   children: ReactNode;
   label: string;
   pressed?: boolean;
   size?: Extract<ButtonSize, `icon-${string}`>;
+  tooltip?: ReactNode;
+  tooltipSide?: TooltipSide;
   variant?: ButtonVariant;
 };
 
@@ -17,10 +20,12 @@ export function IconButton({
   label,
   pressed,
   size = "icon-sm",
+  tooltip,
+  tooltipSide,
   variant = "ghost",
   ...props
 }: IconButtonProps) {
-  return (
+  const button = (
     <Button
       className={mergeClassNames("rounded-lg", className)}
       size={size}
@@ -32,4 +37,10 @@ export function IconButton({
       {children}
     </Button>
   );
+
+  return tooltip ? (
+    <Tooltip content={tooltip} side={tooltipSide}>
+      {button}
+    </Tooltip>
+  ) : button;
 }

--- a/packages/ui/src/ToggleButton.tsx
+++ b/packages/ui/src/ToggleButton.tsx
@@ -1,6 +1,7 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { mergeClassNames } from "./classes";
+import { Tooltip, type TooltipSide } from "./Tooltip";
 
 export type ToggleButtonSize = "md" | "sm";
 
@@ -8,6 +9,8 @@ export type ToggleButtonProps = Omit<ComponentPropsWithoutRef<"button">, "aria-l
   label: string;
   pressed: boolean;
   size?: ToggleButtonSize;
+  tooltip?: ReactNode;
+  tooltipSide?: TooltipSide;
 };
 
 const toggleButtonSizeClassNames: Record<ToggleButtonSize, string> = {
@@ -21,10 +24,12 @@ export function ToggleButton({
   label,
   pressed,
   size = "md",
+  tooltip,
+  tooltipSide,
   type = "button",
   ...props
 }: ToggleButtonProps) {
-  return (
+  const button = (
     <button
       className={mergeClassNames(
         "inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-full border px-2.5 text-[12px] leading-5 font-[620] transition-[background-color,border-color,color,opacity] duration-150 ease-out focus-visible:outline-none disabled:cursor-default",
@@ -42,4 +47,10 @@ export function ToggleButton({
       {children}
     </button>
   );
+
+  return tooltip ? (
+    <Tooltip content={tooltip} side={tooltipSide}>
+      {button}
+    </Tooltip>
+  ) : button;
 }

--- a/packages/ui/src/Tooltip.test.tsx
+++ b/packages/ui/src/Tooltip.test.tsx
@@ -1,0 +1,164 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+import { Tooltip } from "./Tooltip";
+
+describe("Tooltip", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows themed tooltip content after a hover delay and hides it on leave", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <Tooltip content="/mock-workspace/docs/Alpha.md">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+
+    fireEvent.pointerEnter(trigger);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent("/mock-workspace/docs/Alpha.md");
+    expect(tooltip).toHaveClass("bg-(--bg-primary)");
+    expect(tooltip).toHaveClass("text-(--text-heading)");
+    expect(trigger).toHaveAttribute("aria-describedby", tooltip.id);
+
+    fireEvent.pointerLeave(trigger);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("cancels the hover delay when the pointer leaves early", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <Tooltip content="Full path">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+
+    fireEvent.pointerEnter(trigger);
+    fireEvent.pointerLeave(trigger);
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("opens for keyboard focus and closes with Escape", () => {
+    render(
+      <Tooltip content="Full path">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Full path");
+
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("closes on keyboard activation", () => {
+    render(
+      <Tooltip content="Full path">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Full path");
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Full path");
+
+    fireEvent.keyDown(trigger, { key: " " });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("does not open from pointer-initiated focus", () => {
+    render(
+      <Tooltip content="Full path">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+
+    fireEvent.pointerDown(trigger, { pointerType: "mouse" });
+    fireEvent.focus(trigger);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.pointerUp(trigger, { pointerType: "mouse" });
+  });
+
+  it("does not open from touch hover events", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <Tooltip content="Full path">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+
+    fireEvent.pointerEnter(trigger, { pointerType: "touch" });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("closes when the trigger is pressed", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <Tooltip content="Full path">
+        <button type="button">Alpha.md</button>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "Alpha.md" });
+
+    fireEvent.pointerEnter(trigger);
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Full path");
+
+    fireEvent.pointerDown(trigger, { pointerType: "mouse" });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -1,0 +1,243 @@
+import {
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type AriaAttributes,
+  type CSSProperties,
+  type DOMAttributes,
+  type FocusEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactElement,
+  type ReactNode,
+  type Ref
+} from "react";
+import { createPortal } from "react-dom";
+
+import { mergeClassNames } from "./classes";
+
+export type TooltipSide = "bottom" | "top";
+
+type TooltipTriggerProps = DOMAttributes<HTMLElement> & AriaAttributes & {
+  className?: string;
+  ref?: Ref<HTMLElement>;
+  title?: string;
+};
+
+export type TooltipProps = {
+  children: ReactElement<TooltipTriggerProps>;
+  className?: string;
+  content: ReactNode;
+  delayMs?: number;
+  disabled?: boolean;
+  side?: TooltipSide;
+};
+
+const tooltipGap = 8;
+const tooltipViewportMargin = 8;
+
+function setRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (!ref) return;
+
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+
+  (ref as { current: T | null }).current = value;
+}
+
+function mergeDescribedBy(current: string | undefined, tooltipId: string, open: boolean) {
+  if (!open) return current;
+
+  return [current, tooltipId].filter(Boolean).join(" ") || undefined;
+}
+
+function clampedTooltipLeft(trigger: DOMRect, tooltipWidth: number, viewportWidth: number) {
+  const preferredLeft = trigger.left + trigger.width / 2 - tooltipWidth / 2;
+  const maxLeft = viewportWidth - tooltipViewportMargin - tooltipWidth;
+
+  return Math.max(tooltipViewportMargin, Math.min(preferredLeft, maxLeft));
+}
+
+function tooltipTop(trigger: DOMRect, tooltipHeight: number, viewportHeight: number, side: TooltipSide) {
+  const preferredTop = side === "bottom"
+    ? trigger.bottom + tooltipGap
+    : trigger.top - tooltipHeight - tooltipGap;
+
+  if (side === "bottom" && preferredTop + tooltipHeight <= viewportHeight - tooltipViewportMargin) {
+    return preferredTop;
+  }
+
+  if (side === "top" && preferredTop >= tooltipViewportMargin) {
+    return preferredTop;
+  }
+
+  const fallbackTop = side === "bottom"
+    ? trigger.top - tooltipHeight - tooltipGap
+    : trigger.bottom + tooltipGap;
+
+  return Math.max(
+    tooltipViewportMargin,
+    Math.min(fallbackTop, viewportHeight - tooltipViewportMargin - tooltipHeight)
+  );
+}
+
+function callHandler<Event>(handler: ((event: Event) => unknown) | undefined, event: Event) {
+  handler?.(event);
+}
+
+export function Tooltip({
+  children,
+  className,
+  content,
+  delayMs = 500,
+  disabled = false,
+  side = "top"
+}: TooltipProps) {
+  const generatedId = useId();
+  const tooltipId = `${generatedId}-tooltip`;
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const hoverTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const pointerDownRef = useRef(false);
+  const [open, setOpen] = useState(false);
+  const [tooltipStyle, setTooltipStyle] = useState<CSSProperties>({
+    left: tooltipViewportMargin,
+    top: tooltipViewportMargin
+  });
+
+  const hasContent = content !== null && content !== undefined && content !== false && content !== "";
+  const tooltipOpen = open && hasContent && !disabled;
+
+  const clearHoverTimer = () => {
+    if (!hoverTimerRef.current) return;
+
+    globalThis.clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = null;
+  };
+  const openWithDelay = () => {
+    if (!hasContent || disabled) return;
+
+    clearHoverTimer();
+    if (delayMs <= 0) {
+      setOpen(true);
+      return;
+    }
+
+    hoverTimerRef.current = globalThis.setTimeout(() => {
+      hoverTimerRef.current = null;
+      setOpen(true);
+    }, delayMs);
+  };
+  const closeTooltip = () => {
+    clearHoverTimer();
+    setOpen(false);
+  };
+
+  useEffect(() => () => clearHoverTimer(), []);
+
+  useLayoutEffect(() => {
+    if (!tooltipOpen) return;
+
+    const trigger = triggerRef.current;
+    const tooltip = tooltipRef.current;
+    const ownerWindow = trigger?.ownerDocument.defaultView;
+    if (!trigger || !tooltip || !ownerWindow) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const tooltipWidth = tooltip.offsetWidth || 240;
+    const tooltipHeight = tooltip.offsetHeight || 32;
+
+    setTooltipStyle({
+      left: clampedTooltipLeft(triggerRect, tooltipWidth, ownerWindow.innerWidth),
+      top: tooltipTop(triggerRect, tooltipHeight, ownerWindow.innerHeight, side)
+    });
+  }, [side, tooltipOpen, content]);
+
+  if (!isValidElement<TooltipTriggerProps>(children)) return children;
+
+  const childRef = children.props.ref;
+  const setTriggerRef = (node: HTMLElement | null) => {
+    triggerRef.current = node;
+    setRef(childRef, node);
+  };
+  const describedBy = mergeDescribedBy(children.props["aria-describedby"], tooltipId, tooltipOpen);
+  const trigger = cloneElement(children, {
+    "aria-describedby": describedBy,
+    onBlur: (event: FocusEvent<HTMLElement>) => {
+      callHandler(children.props.onBlur, event);
+      pointerDownRef.current = false;
+      closeTooltip();
+    },
+    onClick: (event: MouseEvent<HTMLElement>) => {
+      callHandler(children.props.onClick, event);
+      closeTooltip();
+    },
+    onFocus: (event: FocusEvent<HTMLElement>) => {
+      callHandler(children.props.onFocus, event);
+      clearHoverTimer();
+      if (pointerDownRef.current) return;
+
+      setOpen(true);
+    },
+    onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+      callHandler(children.props.onKeyDown, event);
+      if (event.key === "Escape" || event.key === "Enter" || event.key === " ") closeTooltip();
+    },
+    onPointerCancel: (event: PointerEvent<HTMLElement>) => {
+      callHandler(children.props.onPointerCancel, event);
+      pointerDownRef.current = false;
+    },
+    onPointerDown: (event: PointerEvent<HTMLElement>) => {
+      callHandler(children.props.onPointerDown, event);
+      pointerDownRef.current = true;
+      closeTooltip();
+    },
+    onPointerEnter: (event: PointerEvent<HTMLElement>) => {
+      callHandler(children.props.onPointerEnter, event);
+      if (event.pointerType === "touch") return;
+
+      openWithDelay();
+    },
+    onPointerLeave: (event: PointerEvent<HTMLElement>) => {
+      callHandler(children.props.onPointerLeave, event);
+      closeTooltip();
+    },
+    onPointerUp: (event: PointerEvent<HTMLElement>) => {
+      callHandler(children.props.onPointerUp, event);
+      pointerDownRef.current = false;
+    },
+    ref: setTriggerRef,
+    title: undefined
+  });
+  const portalTarget = triggerRef.current?.ownerDocument.body ?? null;
+
+  return (
+    <>
+      {trigger}
+      {tooltipOpen && portalTarget
+        ? createPortal(
+            <div
+              ref={tooltipRef}
+              className={mergeClassNames(
+                "pointer-events-none fixed z-50 max-w-[min(28rem,calc(100vw-1rem))] rounded-md border border-(--border-default) bg-(--bg-primary) px-2 py-1 text-[11px] leading-4 font-[520] break-words text-(--text-heading) shadow-(--ai-command-popover-shadow)",
+                className
+              )}
+              id={tooltipId}
+              role="tooltip"
+              style={tooltipStyle}
+            >
+              {content}
+            </div>,
+            portalTarget
+          )
+        : null}
+    </>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,3 +18,4 @@ export { Switch, type SwitchProps } from "./Switch";
 export { Textarea, type TextareaProps } from "./Textarea";
 export { TextInput, type TextInputProps } from "./TextInput";
 export { ToggleButton, type ToggleButtonProps, type ToggleButtonSize } from "./ToggleButton";
+export { Tooltip, type TooltipProps, type TooltipSide } from "./Tooltip";


### PR DESCRIPTION
## Summary
- Add a reusable themed `Tooltip` component to `@markra/ui` with delayed hover behavior and keyboard focus support.
- Add `tooltip` support to shared UI primitives used for icon-like controls.
- Replace native `title` tooltips across app controls with the themed tooltip component, including document tabs, file tree paths, AI controls, search controls, and theme buttons.

## Why
- Native browser tooltips cannot follow Markra themes.
- The issue #408 follow-up asked for the path preview background to match the app theme.
- The custom tooltip keeps native-like delayed hover behavior while allowing Markra theme tokens.

## Validation
- `pnpm --filter @markra/ui test -- Tooltip.test.tsx` passed
- `pnpm --filter @markra/app test -- MarkdownTabsBar.test.tsx MarkdownFileTreeDrawer.test.tsx App.test.tsx` passed, 99 files / 1489 tests
- `pnpm --filter @markra/ui build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/ui typecheck:test` passed
- `pnpm --filter @markra/app typecheck:test` passed

Refs #408
