### PR TITLE
fix(app): improve editor resize behavior

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2287,7 +2287,7 @@ describe("Markra workspace", () => {
       });
       await waitFor(() => expect(mockedSaveStoredEditorPreferences).toHaveBeenCalledWith(expect.objectContaining({
         contentWidth: "default",
-        contentWidthPx: 910
+        contentWidthPx: 930
       })));
     } finally {
       restoreWindowInnerWidth();

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2249,6 +2249,51 @@ describe("Markra workspace", () => {
     }
   });
 
+  it("scales saved custom editor writing widths when the workspace has extra room", async () => {
+    const restoreWindowInnerWidth = mockWindowInnerWidth(1688);
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      contentWidth: "default",
+      contentWidthPx: 860
+    }));
+
+    try {
+      renderApp();
+
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+      expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+        maxWidth: "1210px"
+      });
+      expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "1210");
+    } finally {
+      restoreWindowInnerWidth();
+    }
+  });
+
+  it("persists editor writing width resizes as a responsive base width", async () => {
+    const restoreWindowInnerWidth = mockWindowInnerWidth(1688);
+
+    try {
+      renderApp();
+
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+      const resizeHandle = await screen.findByRole("separator", { name: "Resize editor width" });
+
+      fireEvent.pointerDown(resizeHandle, { clientX: 1210, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 1280 });
+      fireEvent.pointerUp(window);
+
+      expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+        maxWidth: "1280px"
+      });
+      await waitFor(() => expect(mockedSaveStoredEditorPreferences).toHaveBeenCalledWith(expect.objectContaining({
+        contentWidth: "default",
+        contentWidthPx: 910
+      })));
+    } finally {
+      restoreWindowInnerWidth();
+    }
+  });
+
   it("hides the editor writing width handle while the right AI sidebar leaves little editor space", async () => {
     const restoreWindowInnerWidth = mockWindowInnerWidth(1120);
     const { container } = renderApp();

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2233,7 +2233,7 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "980");
   });
 
-  it("scales the preset editor writing width when the workspace has extra room", async () => {
+  it("keeps the preset editor writing width fixed when the workspace has extra room", async () => {
     const restoreWindowInnerWidth = mockWindowInnerWidth(1688);
 
     try {
@@ -2241,15 +2241,15 @@ describe("Markra workspace", () => {
 
       expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
       expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
-        maxWidth: "1210px"
+        maxWidth: "860px"
       });
-      expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "1210");
+      expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "860");
     } finally {
       restoreWindowInnerWidth();
     }
   });
 
-  it("scales saved custom editor writing widths when the workspace has extra room", async () => {
+  it("keeps saved custom editor writing widths fixed when the workspace has extra room", async () => {
     const restoreWindowInnerWidth = mockWindowInnerWidth(1688);
     mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
       contentWidth: "default",
@@ -2261,15 +2261,15 @@ describe("Markra workspace", () => {
 
       expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
       expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
-        maxWidth: "1210px"
+        maxWidth: "860px"
       });
-      expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "1210");
+      expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "860");
     } finally {
       restoreWindowInnerWidth();
     }
   });
 
-  it("persists editor writing width resizes as a responsive base width", async () => {
+  it("persists editor writing width resizes as fixed custom widths", async () => {
     const restoreWindowInnerWidth = mockWindowInnerWidth(1688);
 
     try {
@@ -2278,16 +2278,16 @@ describe("Markra workspace", () => {
       expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
       const resizeHandle = await screen.findByRole("separator", { name: "Resize editor width" });
 
-      fireEvent.pointerDown(resizeHandle, { clientX: 1210, pointerId: 1 });
-      fireEvent.pointerMove(window, { clientX: 1280 });
+      fireEvent.pointerDown(resizeHandle, { clientX: 860, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 980 });
       fireEvent.pointerUp(window);
 
       expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
-        maxWidth: "1280px"
+        maxWidth: "980px"
       });
       await waitFor(() => expect(mockedSaveStoredEditorPreferences).toHaveBeenCalledWith(expect.objectContaining({
         contentWidth: "default",
-        contentWidthPx: 930
+        contentWidthPx: 980
       })));
     } finally {
       restoreWindowInnerWidth();

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -218,6 +218,25 @@ function mockElementFromPoint(element: Element) {
   return mock;
 }
 
+function mockWindowInnerWidth(width: number) {
+  const descriptor = Object.getOwnPropertyDescriptor(window, "innerWidth");
+
+  act(() => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width
+    });
+    window.dispatchEvent(new Event("resize"));
+  });
+
+  return () => {
+    act(() => {
+      if (descriptor) Object.defineProperty(window, "innerWidth", descriptor);
+      window.dispatchEvent(new Event("resize"));
+    });
+  };
+}
+
 function getMarkdownSourceView(sourceEditor: HTMLElement) {
   const view = EditorView.findFromDOM(sourceEditor);
   if (!view) {
@@ -2135,6 +2154,21 @@ describe("Markra workspace", () => {
 
     fireEvent.pointerDown(resizeHandle, { clientX: 288, pointerId: 1 });
     fireEvent.pointerMove(window, { clientX: 360 });
+
+    expect(container.querySelector(".workspace-layout")).toHaveStyle({
+      gridTemplateColumns: "360px minmax(0,1fr)"
+    });
+    expect(container.querySelector(".native-titlebar-sidebar-surface")).toHaveStyle({
+      width: "360px"
+    });
+    expect(container.querySelector(".native-title-slot")).toHaveStyle({
+      marginLeft: "196px"
+    });
+    expect(container.querySelector(".markdown-file-tree")).toHaveStyle({
+      width: "360px"
+    });
+    expect(container.querySelector(".markdown-file-tree")).toHaveClass("transition-none");
+
     fireEvent.pointerMove(window, { clientX: 680 });
     fireEvent.pointerMove(window, { clientX: 100 });
     fireEvent.pointerUp(window);
@@ -2154,7 +2188,7 @@ describe("Markra workspace", () => {
   });
 
   it("resizes the editor writing column and persists the custom width", async () => {
-    renderApp();
+    const { container } = renderApp();
 
     expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
     expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
@@ -2162,8 +2196,15 @@ describe("Markra workspace", () => {
     });
 
     const resizeHandle = await screen.findByRole("separator", { name: "Resize editor width" });
+    const resizeShell = container.querySelector(".editor-width-resizer-shell");
+    const resizeIndicator = container.querySelector(".editor-width-resizer-indicator");
+
+    expect(resizeShell).toHaveClass("w-8");
+    expect(resizeIndicator).toHaveClass("opacity-0");
+    expect(resizeIndicator).toHaveClass("group-hover/width-resizer:opacity-100");
 
     fireEvent.pointerDown(resizeHandle, { clientX: 860, pointerId: 1 });
+    await waitFor(() => expect(resizeIndicator).toHaveClass("opacity-100"));
     fireEvent.pointerMove(window, { clientX: 980 });
     fireEvent.pointerUp(window);
 
@@ -2192,25 +2233,59 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "980");
   });
 
-  it("keeps editor writing width controls out of the titlebar", async () => {
+  it("scales the preset editor writing width when the workspace has extra room", async () => {
+    const restoreWindowInnerWidth = mockWindowInnerWidth(1688);
+
+    try {
+      renderApp();
+
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+      expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+        maxWidth: "1210px"
+      });
+      expect(screen.getByRole("separator", { name: "Resize editor width" })).toHaveAttribute("aria-valuenow", "1210");
+    } finally {
+      restoreWindowInnerWidth();
+    }
+  });
+
+  it("hides the editor writing width handle while the right AI sidebar leaves little editor space", async () => {
+    const restoreWindowInnerWidth = mockWindowInnerWidth(1120);
     const { container } = renderApp();
 
-    expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
-    expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
-      maxWidth: "860px"
-    });
+    try {
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+      expect(screen.getByLabelText("Markdown editor")).toHaveStyle({
+        maxWidth: "860px"
+      });
+      expect(screen.getByRole("separator", { name: "Resize editor width" })).toBeInTheDocument();
 
-    const resizeHandle = screen.getByRole("separator", { name: "Resize editor width" });
-    const resizeIndicator = container.querySelector(".editor-width-resizer-indicator");
+      fireEvent.click(screen.getByRole("button", { name: "Toggle Markra AI" }));
 
-    expect(resizeIndicator).not.toHaveClass("rounded-full");
-    expect(resizeIndicator).toHaveClass("opacity-0");
-    expect(resizeIndicator).toHaveClass("group-hover/width-resizer:opacity-100");
-    expect(resizeIndicator).toHaveClass("group-focus-within/width-resizer:opacity-100");
-    expect(resizeHandle.closest(".editor-width-resizer-shell")?.querySelector(".editor-width-menu-popover")).not.toBeInTheDocument();
-    expect(container.querySelector(".document-actions")?.querySelector('[data-icon^="editor-width-"]')).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Content width:/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole("group", { name: "Content width" })).not.toBeInTheDocument();
+      expect(await screen.findByRole("complementary", { name: "Markra AI" })).toBeInTheDocument();
+      expect(screen.queryByRole("separator", { name: "Resize editor width" })).not.toBeInTheDocument();
+      expect(container.querySelector(".editor-width-resizer-indicator")).not.toBeInTheDocument();
+    } finally {
+      restoreWindowInnerWidth();
+    }
+  });
+
+  it("keeps the editor writing width handle visible with the right AI sidebar when the editor has wide gutters", async () => {
+    const restoreWindowInnerWidth = mockWindowInnerWidth(1600);
+    const { container } = renderApp();
+
+    try {
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Toggle Markra AI" }));
+
+      expect(await screen.findByRole("complementary", { name: "Markra AI" })).toBeInTheDocument();
+      expect(screen.getByRole("separator", { name: "Resize editor width" })).toBeInTheDocument();
+      expect(container.querySelector(".editor-width-resizer-shell")).toHaveClass("w-8");
+      expect(container.querySelector(".editor-width-resizer-indicator")).toHaveClass("opacity-0");
+    } finally {
+      restoreWindowInnerWidth();
+    }
   });
 
   it("removes the markdown file tree hit area when the sidebar is collapsed", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1191,10 +1191,11 @@ function WorkspaceApp() {
   });
   const handleResponsiveEditorContentWidthChange = useCallback((nextWidthPx: number) => {
     handleEditorContentWidthChange(resolveEditorContentWidthBasePx({
+      contentWidth: activeEditorContentWidth,
       editorAreaWidth,
       renderedContentWidthPx: nextWidthPx
     }));
-  }, [editorAreaWidth, handleEditorContentWidthChange]);
+  }, [activeEditorContentWidth, editorAreaWidth, handleEditorContentWidthChange]);
   const editorWidthResizerVisible = shouldShowEditorWidthResizer({
     aiAgentOpen: aiFeatureEnabled && aiAgentOpen,
     editorAreaWidth,

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -106,11 +106,7 @@ import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
 import { replaceMovedPath, sameNativePath } from "./lib/path-move";
 import { createAppSpellcheckerForLanguage } from "./lib/spellcheck";
-import {
-  resolveEditorContentWidthBasePx,
-  resolveResponsiveEditorContentWidthPx,
-  shouldShowEditorWidthResizer
-} from "./lib/editor-width";
+import { editorContentWidthPixels, shouldShowEditorWidthResizer } from "./lib/editor-width";
 import {
   resolveDesktopOsVersion,
   resolveDesktopPlatform,
@@ -1184,22 +1180,11 @@ function WorkspaceApp() {
   const editorAreaWidth = Math.max(0, viewportWidth -
     (fileTreeOpen ? fileTreeWidth : 0) -
     (aiFeatureEnabled && aiAgentOpen ? aiAgentPanelWidth : 0));
-  const responsiveEditorContentWidthPx = resolveResponsiveEditorContentWidthPx({
-    contentWidth: activeEditorContentWidth,
-    contentWidthPx: activeEditorContentWidthPx,
-    editorAreaWidth
-  });
-  const handleResponsiveEditorContentWidthChange = useCallback((nextWidthPx: number) => {
-    handleEditorContentWidthChange(resolveEditorContentWidthBasePx({
-      contentWidth: activeEditorContentWidth,
-      editorAreaWidth,
-      renderedContentWidthPx: nextWidthPx
-    }));
-  }, [activeEditorContentWidth, editorAreaWidth, handleEditorContentWidthChange]);
+  const activeEditorContentWidthValue = activeEditorContentWidthPx ?? editorContentWidthPixels[activeEditorContentWidth];
   const editorWidthResizerVisible = shouldShowEditorWidthResizer({
     aiAgentOpen: aiFeatureEnabled && aiAgentOpen,
     editorAreaWidth,
-    editorContentWidth: responsiveEditorContentWidthPx
+    editorContentWidth: activeEditorContentWidthValue
   });
   const editorAgentLayoutClassName = `editor-agent-layout grid min-h-0 ${
     aiAgentPanelResizing
@@ -1598,12 +1583,13 @@ function WorkspaceApp() {
     splitMode ? resolvedSplitVisualPanePercent : "split-closed",
     activeEditorSurface,
     activeEditorContentWidth,
-    responsiveEditorContentWidthPx,
+    activeEditorContentWidthPx ?? "auto",
     documentSearchOpen && documentSearchAvailable ? "search-open" : "search-closed",
     documentSearchReplaceOpen ? "replace-open" : "replace-closed",
     editorPreferences.preferences.showDocumentTabs ? "tabs-open" : "tabs-closed"
   ].join(":"), [
     activeEditorContentWidth,
+    activeEditorContentWidthPx,
     activeEditorSurface,
     aiAgentOpen,
     aiAgentPanelResizing,
@@ -1618,7 +1604,6 @@ function WorkspaceApp() {
     fileTreeWidth,
     resolvedSideDocumentMainPanePercent,
     resolvedSplitVisualPanePercent,
-    responsiveEditorContentWidthPx,
     sideDocumentOpen,
     splitMode
   ]);
@@ -3727,7 +3712,7 @@ function WorkspaceApp() {
               }
               bodyFontSize={editorPreferences.preferences.bodyFontSize}
               contentWidth={activeEditorContentWidth}
-              contentWidthPx={responsiveEditorContentWidthPx}
+              contentWidthPx={activeEditorContentWidthPx}
               documentKey={tab.id}
               documentPath={tab.path}
               editorFontFamily={editorPreferences.preferences.editorFontFamily}
@@ -3748,7 +3733,7 @@ function WorkspaceApp() {
 
                 handleMarkdownTabChange(tab.id, content, { ...options, surface: "visual" });
               }}
-              onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
+              onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
               onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
               onSaveClipboardAttachment={handleSaveClipboardAttachment}
               onSaveClipboardImage={handleSaveClipboardImage}
@@ -4085,7 +4070,7 @@ function WorkspaceApp() {
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
                           contentWidth={activeEditorContentWidth}
-                          contentWidthPx={responsiveEditorContentWidthPx}
+                          contentWidthPx={activeEditorContentWidthPx}
                           editorFontFamily={editorPreferences.preferences.editorFontFamily}
                           extendedSyntax={editorPreferences.preferences.extendedSyntax}
                           language={appLanguage.language}
@@ -4093,7 +4078,7 @@ function WorkspaceApp() {
                           onChange={(content) => handleSourceMarkdownChange(content, {
                             documentRevision: document.revision
                           })}
-                          onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
+                          onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
                           onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
@@ -4115,7 +4100,7 @@ function WorkspaceApp() {
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
                           contentWidth={activeEditorContentWidth}
-                          contentWidthPx={responsiveEditorContentWidthPx}
+                          contentWidthPx={activeEditorContentWidthPx}
                           editorFontFamily={editorPreferences.preferences.editorFontFamily}
                           extendedSyntax={editorPreferences.preferences.extendedSyntax}
                           language={appLanguage.language}
@@ -4123,7 +4108,7 @@ function WorkspaceApp() {
                           onChange={(content) => handleSourceMarkdownChange(content, {
                             documentRevision: document.revision
                           })}
-                          onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
+                          onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
                           onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
@@ -4167,7 +4152,7 @@ function WorkspaceApp() {
                         bodyFontSize={editorPreferences.preferences.bodyFontSize}
                         content={sideDocumentTab.content}
                         contentWidth={activeEditorContentWidth}
-                        contentWidthPx={responsiveEditorContentWidthPx}
+                        contentWidthPx={activeEditorContentWidthPx}
                         documentKey={sideDocumentTab.id}
                         documentPath={sideDocumentTab.path}
                         editorFontFamily={editorPreferences.preferences.editorFontFamily}
@@ -4191,7 +4176,7 @@ function WorkspaceApp() {
                         onAddSpellcheckIgnoredWord={handleAddSpellcheckIgnoredWord}
                         workspaceFiles={fileTreeFiles}
                         onChange={handleSideDocumentChange}
-                        onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
+                        onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
                         onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                         onFocus={handleSideDocumentPaneFocus}
                         wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -106,7 +106,11 @@ import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
 import { replaceMovedPath, sameNativePath } from "./lib/path-move";
 import { createAppSpellcheckerForLanguage } from "./lib/spellcheck";
-import { resolveResponsiveEditorContentWidthPx, shouldShowEditorWidthResizer } from "./lib/editor-width";
+import {
+  resolveEditorContentWidthBasePx,
+  resolveResponsiveEditorContentWidthPx,
+  shouldShowEditorWidthResizer
+} from "./lib/editor-width";
 import {
   resolveDesktopOsVersion,
   resolveDesktopPlatform,
@@ -1185,6 +1189,12 @@ function WorkspaceApp() {
     contentWidthPx: activeEditorContentWidthPx,
     editorAreaWidth
   });
+  const handleResponsiveEditorContentWidthChange = useCallback((nextWidthPx: number) => {
+    handleEditorContentWidthChange(resolveEditorContentWidthBasePx({
+      editorAreaWidth,
+      renderedContentWidthPx: nextWidthPx
+    }));
+  }, [editorAreaWidth, handleEditorContentWidthChange]);
   const editorWidthResizerVisible = shouldShowEditorWidthResizer({
     aiAgentOpen: aiFeatureEnabled && aiAgentOpen,
     editorAreaWidth,
@@ -3737,7 +3747,7 @@ function WorkspaceApp() {
 
                 handleMarkdownTabChange(tab.id, content, { ...options, surface: "visual" });
               }}
-              onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+              onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
               onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
               onSaveClipboardAttachment={handleSaveClipboardAttachment}
               onSaveClipboardImage={handleSaveClipboardImage}
@@ -4082,7 +4092,7 @@ function WorkspaceApp() {
                           onChange={(content) => handleSourceMarkdownChange(content, {
                             documentRevision: document.revision
                           })}
-                          onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+                          onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
                           onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
@@ -4112,7 +4122,7 @@ function WorkspaceApp() {
                           onChange={(content) => handleSourceMarkdownChange(content, {
                             documentRevision: document.revision
                           })}
-                          onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+                          onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
                           onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
@@ -4180,7 +4190,7 @@ function WorkspaceApp() {
                         onAddSpellcheckIgnoredWord={handleAddSpellcheckIgnoredWord}
                         workspaceFiles={fileTreeFiles}
                         onChange={handleSideDocumentChange}
-                        onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+                        onContentWidthChange={editorWidthResizerVisible ? handleResponsiveEditorContentWidthChange : undefined}
                         onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                         onFocus={handleSideDocumentPaneFocus}
                         wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -106,6 +106,7 @@ import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
 import { replaceMovedPath, sameNativePath } from "./lib/path-move";
 import { createAppSpellcheckerForLanguage } from "./lib/spellcheck";
+import { resolveResponsiveEditorContentWidthPx, shouldShowEditorWidthResizer } from "./lib/editor-width";
 import {
   resolveDesktopOsVersion,
   resolveDesktopPlatform,
@@ -501,10 +502,22 @@ function WorkspaceApp() {
     setActiveOutlineIndex((current) => current === index ? current : index);
   }, []);
   useDefaultContextMenuBlocker();
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const fileTree = useMarkdownFileTree({
     managedAttachmentFolder: editorPreferences.preferences.clipboardImageFolder,
     onWorkspaceSessionChange: setAiAgentSessionId
   });
+  useEffect(() => {
+    const handleViewportResize = () => {
+      setViewportWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleViewportResize);
+
+    return () => {
+      window.removeEventListener("resize", handleViewportResize);
+    };
+  }, []);
   const {
     files: fileTreeFiles,
     createFile: createMarkdownTreeFile,
@@ -1164,6 +1177,19 @@ function WorkspaceApp() {
     restoreAiAgentPanelSession(session);
   }, [restoreAiAgentPanelSession]);
   const aiAgentInset = aiFeatureEnabled && aiAgentOpen ? `${aiAgentPanelWidth}px` : "0px";
+  const editorAreaWidth = Math.max(0, viewportWidth -
+    (fileTreeOpen ? fileTreeWidth : 0) -
+    (aiFeatureEnabled && aiAgentOpen ? aiAgentPanelWidth : 0));
+  const responsiveEditorContentWidthPx = resolveResponsiveEditorContentWidthPx({
+    contentWidth: activeEditorContentWidth,
+    contentWidthPx: activeEditorContentWidthPx,
+    editorAreaWidth
+  });
+  const editorWidthResizerVisible = shouldShowEditorWidthResizer({
+    aiAgentOpen: aiFeatureEnabled && aiAgentOpen,
+    editorAreaWidth,
+    editorContentWidth: responsiveEditorContentWidthPx
+  });
   const editorAgentLayoutClassName = `editor-agent-layout grid min-h-0 ${
     aiAgentPanelResizing
       ? "transition-none"
@@ -1561,13 +1587,12 @@ function WorkspaceApp() {
     splitMode ? resolvedSplitVisualPanePercent : "split-closed",
     activeEditorSurface,
     activeEditorContentWidth,
-    activeEditorContentWidthPx ?? "auto",
+    responsiveEditorContentWidthPx,
     documentSearchOpen && documentSearchAvailable ? "search-open" : "search-closed",
     documentSearchReplaceOpen ? "replace-open" : "replace-closed",
     editorPreferences.preferences.showDocumentTabs ? "tabs-open" : "tabs-closed"
   ].join(":"), [
     activeEditorContentWidth,
-    activeEditorContentWidthPx,
     activeEditorSurface,
     aiAgentOpen,
     aiAgentPanelResizing,
@@ -1582,6 +1607,7 @@ function WorkspaceApp() {
     fileTreeWidth,
     resolvedSideDocumentMainPanePercent,
     resolvedSplitVisualPanePercent,
+    responsiveEditorContentWidthPx,
     sideDocumentOpen,
     splitMode
   ]);
@@ -3690,7 +3716,7 @@ function WorkspaceApp() {
               }
               bodyFontSize={editorPreferences.preferences.bodyFontSize}
               contentWidth={activeEditorContentWidth}
-              contentWidthPx={activeEditorContentWidthPx}
+              contentWidthPx={responsiveEditorContentWidthPx}
               documentKey={tab.id}
               documentPath={tab.path}
               editorFontFamily={editorPreferences.preferences.editorFontFamily}
@@ -3711,8 +3737,8 @@ function WorkspaceApp() {
 
                 handleMarkdownTabChange(tab.id, content, { ...options, surface: "visual" });
               }}
-              onContentWidthChange={handleEditorContentWidthChange}
-              onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+              onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+              onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
               onSaveClipboardAttachment={handleSaveClipboardAttachment}
               onSaveClipboardImage={handleSaveClipboardImage}
               onSaveRemoteClipboardImage={handleSaveRemoteClipboardImage}
@@ -3906,6 +3932,7 @@ function WorkspaceApp() {
             recentFolders: recentMarkdownFolders,
             recentFoldersOpen: recentMarkdownFoldersOpen,
             revealPathRequest: fileTreeRevealPathRequest,
+            resizing: fileTreeResizing,
             rootPath: fileTree.sourcePath,
             rootName: fileTreeRootName,
             sidebarLayoutMode: editorPreferences.preferences.sidebarLayoutMode,
@@ -4047,7 +4074,7 @@ function WorkspaceApp() {
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
                           contentWidth={activeEditorContentWidth}
-                          contentWidthPx={activeEditorContentWidthPx}
+                          contentWidthPx={responsiveEditorContentWidthPx}
                           editorFontFamily={editorPreferences.preferences.editorFontFamily}
                           extendedSyntax={editorPreferences.preferences.extendedSyntax}
                           language={appLanguage.language}
@@ -4055,8 +4082,8 @@ function WorkspaceApp() {
                           onChange={(content) => handleSourceMarkdownChange(content, {
                             documentRevision: document.revision
                           })}
-                          onContentWidthChange={handleEditorContentWidthChange}
-                          onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+                          onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+                          onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
                           readOnly={readOnlyMode}
@@ -4077,7 +4104,7 @@ function WorkspaceApp() {
                           bodyFontSize={editorPreferences.preferences.bodyFontSize}
                           content={document.content}
                           contentWidth={activeEditorContentWidth}
-                          contentWidthPx={activeEditorContentWidthPx}
+                          contentWidthPx={responsiveEditorContentWidthPx}
                           editorFontFamily={editorPreferences.preferences.editorFontFamily}
                           extendedSyntax={editorPreferences.preferences.extendedSyntax}
                           language={appLanguage.language}
@@ -4085,8 +4112,8 @@ function WorkspaceApp() {
                           onChange={(content) => handleSourceMarkdownChange(content, {
                             documentRevision: document.revision
                           })}
-                          onContentWidthChange={handleEditorContentWidthChange}
-                          onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+                          onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+                          onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
                           readOnly={readOnlyMode}
@@ -4129,7 +4156,7 @@ function WorkspaceApp() {
                         bodyFontSize={editorPreferences.preferences.bodyFontSize}
                         content={sideDocumentTab.content}
                         contentWidth={activeEditorContentWidth}
-                        contentWidthPx={activeEditorContentWidthPx}
+                        contentWidthPx={responsiveEditorContentWidthPx}
                         documentKey={sideDocumentTab.id}
                         documentPath={sideDocumentTab.path}
                         editorFontFamily={editorPreferences.preferences.editorFontFamily}
@@ -4153,8 +4180,8 @@ function WorkspaceApp() {
                         onAddSpellcheckIgnoredWord={handleAddSpellcheckIgnoredWord}
                         workspaceFiles={fileTreeFiles}
                         onChange={handleSideDocumentChange}
-                        onContentWidthChange={handleEditorContentWidthChange}
-                        onContentWidthResizeEnd={handleEditorContentWidthResizeEnd}
+                        onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
+                        onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                         onFocus={handleSideDocumentPaneFocus}
                         wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
                       />

--- a/packages/app/src/components/AiAgentPanel.test.tsx
+++ b/packages/app/src/components/AiAgentPanel.test.tsx
@@ -711,6 +711,8 @@ describe("AiAgentPanel", () => {
     expect(handle).toHaveAttribute("aria-valuemax", "640");
     expect(handle).toHaveAttribute("aria-valuenow", "420");
     expect(handle).toHaveClass("top-10", "bottom-0");
+    expect(handle).not.toHaveClass("hover:[&>span]:bg-(--accent)", "focus-visible:[&>span]:bg-(--accent)");
+    expect(handle.querySelector("span")).not.toBeInTheDocument();
   });
 
   it("switches models and toggles supported agent modes", () => {

--- a/packages/app/src/components/AiAgentPanel.tsx
+++ b/packages/app/src/components/AiAgentPanel.tsx
@@ -509,7 +509,7 @@ export function AiAgentPanel({
       style={resolvedWidth === null ? undefined : { maxWidth: resolvedWidth, minWidth: resolvedWidth, width: resolvedWidth }}
     >
       <div
-        className="absolute top-10 bottom-0 left-0 z-30 w-2 cursor-col-resize touch-none outline-none hover:[&>span]:bg-(--accent) focus-visible:[&>span]:bg-(--accent)"
+        className="absolute top-10 bottom-0 left-0 z-30 w-2 cursor-col-resize touch-none outline-none"
         role="separator"
         tabIndex={0}
         aria-label={label("app.resizeAiAgent")}
@@ -519,9 +519,7 @@ export function AiAgentPanel({
         aria-valuenow={resolvedWidth ?? undefined}
         onKeyDown={handleResizeKeyDown}
         onPointerDown={handleResizePointerDown}
-      >
-        <span className="pointer-events-none absolute top-2 bottom-2 left-0 w-px rounded-full bg-transparent transition-colors duration-150 ease-out" />
-      </div>
+      />
       <header className="relative z-20 min-h-12 shrink-0 border-b border-(--border-default) px-2 py-1.5">
         <IconButton
           className="absolute top-1.5 left-2"

--- a/packages/app/src/components/EditorWidthResizer.tsx
+++ b/packages/app/src/components/EditorWidthResizer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent } from "react";
 import { clampNumber, t, type AppLanguage } from "@markra/shared";
 
 type EditorWidthResizerProps = {
@@ -21,6 +21,7 @@ export function EditorWidthResizer({
   onResizeStart
 }: EditorWidthResizerProps) {
   const resizeCleanupRef = useRef<(() => unknown) | null>(null);
+  const [resizing, setResizing] = useState(false);
   const resolvedMinWidth = Math.max(480, minWidth);
   const resolvedMaxWidth = Math.max(resolvedMinWidth, maxWidth);
   const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
@@ -51,6 +52,7 @@ export function EditorWidthResizer({
 
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
+    setResizing(true);
     onResizeStart?.();
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
@@ -64,6 +66,7 @@ export function EditorWidthResizer({
       document.body.style.cursor = previousCursor;
       document.body.style.userSelect = previousUserSelect;
       resizeCleanupRef.current = null;
+      setResizing(false);
       onResizeEnd?.();
     };
 
@@ -106,9 +109,12 @@ export function EditorWidthResizer({
       onResizeEnd?.();
     }
   };
+  const indicatorVisibilityClassName = resizing
+    ? "bg-(--accent) opacity-100"
+    : "bg-(--border-default) opacity-0 group-hover/width-resizer:bg-(--border-strong) group-hover/width-resizer:opacity-100 group-focus-within/width-resizer:bg-(--accent) group-focus-within/width-resizer:opacity-100";
 
   return (
-    <div className="editor-width-resizer-shell group/width-resizer absolute top-8 right-0 bottom-8 z-20 w-3 translate-x-1/2">
+    <div className="editor-width-resizer-shell group/width-resizer absolute top-8 right-0 bottom-8 z-20 w-8 translate-x-1/2">
       <div
         className="editor-width-resizer absolute inset-0 cursor-col-resize touch-none outline-none"
         role="separator"
@@ -122,7 +128,7 @@ export function EditorWidthResizer({
         onPointerDown={handleResizePointerDown}
       >
         <span
-          className="editor-width-resizer-indicator pointer-events-none absolute top-2 right-1.5 bottom-2 w-px bg-(--border-default) opacity-0 transition-colors duration-150 ease-out group-hover/width-resizer:bg-(--border-strong) group-hover/width-resizer:opacity-100 group-focus-within/width-resizer:bg-(--accent) group-focus-within/width-resizer:opacity-100"
+          className={`editor-width-resizer-indicator pointer-events-none absolute top-2 right-4 bottom-2 w-px transition-colors duration-150 ease-out ${indicatorVisibilityClassName}`}
         />
       </div>
     </div>

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -152,6 +152,7 @@ type MarkdownFileTreeDrawerProps = {
   recentFolders?: readonly RecentMarkdownFolder[];
   recentFoldersOpen?: boolean;
   revealPathRequest?: { id: number; path: string | null } | null;
+  resizing?: boolean;
   rootPath?: string | null;
   rootName: string;
   sidebarLayoutMode?: SidebarLayoutMode;
@@ -450,6 +451,7 @@ export function MarkdownFileTreeDrawer({
   recentFolders = [],
   recentFoldersOpen: controlledRecentFoldersOpen,
   revealPathRequest = null,
+  resizing = false,
   rootPath = null,
   rootName,
   sidebarLayoutMode = "stacked",
@@ -682,6 +684,9 @@ export function MarkdownFileTreeDrawer({
   const label = (key: Parameters<typeof t>[1]) => t(language, key);
   const drawerStateClass = open ? "" : "pointer-events-none";
   const drawerContentStateClass = open ? "opacity-100" : "opacity-0";
+  const drawerWidthTransitionClassName = resizing
+    ? "transition-none"
+    : "transition-[width,min-width,max-width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]";
   const resolvedMinWidth = Math.max(160, minWidth);
   const resolvedMaxWidth = Math.max(resolvedMinWidth, maxWidth);
   const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
@@ -2581,7 +2586,7 @@ export function MarkdownFileTreeDrawer({
       ) : null}
 
       <aside
-        className={`markdown-file-tree relative flex h-full min-h-0 w-full flex-col overflow-hidden border-r border-(--border-default) ${fileTreeSurfaceClassName} ${drawerTopPaddingClassName} will-change-[width,min-width,max-width] transition-[width,min-width,max-width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${drawerStateClass}`}
+        className={`markdown-file-tree relative flex h-full min-h-0 w-full flex-col overflow-hidden border-r border-(--border-default) ${fileTreeSurfaceClassName} ${drawerTopPaddingClassName} will-change-[width,min-width,max-width] ${drawerWidthTransitionClassName} ${drawerStateClass}`}
         aria-label={label("app.markdownFileTree")}
         aria-hidden={!open}
         inert={!open}

--- a/packages/app/src/lib/editor-width.test.ts
+++ b/packages/app/src/lib/editor-width.test.ts
@@ -24,20 +24,37 @@ describe("editor width", () => {
     })).toBe(1280);
   });
 
-  it("scales custom editor content widths from their stored base width", () => {
+  it("applies custom editor content widths as offsets from the responsive preset width", () => {
     expect(resolveResponsiveEditorContentWidthPx({
       contentWidth: "default",
       contentWidthPx: 980,
       editorAreaWidth: 1688
     })).toBe(1280);
+    expect(resolveResponsiveEditorContentWidthPx({
+      contentWidth: "default",
+      contentWidthPx: 780,
+      editorAreaWidth: 2200
+    })).toBe(1200);
+    expect(resolveResponsiveEditorContentWidthPx({
+      contentWidth: "default",
+      contentWidthPx: 780,
+      editorAreaWidth: 1024
+    })).toBe(780);
   });
 
   it("converts the displayed editor content width back to the stored base width", () => {
     expect(resolveEditorContentWidthBasePx({
+      contentWidth: "default",
       editorAreaWidth: 1688,
-      renderedContentWidthPx: 1210
-    })).toBe(860);
+      renderedContentWidthPx: 1280
+    })).toBe(930);
     expect(resolveEditorContentWidthBasePx({
+      contentWidth: "default",
+      editorAreaWidth: 2200,
+      renderedContentWidthPx: 1200
+    })).toBe(780);
+    expect(resolveEditorContentWidthBasePx({
+      contentWidth: "default",
       editorAreaWidth: 1024,
       renderedContentWidthPx: 980
     })).toBe(980);

--- a/packages/app/src/lib/editor-width.test.ts
+++ b/packages/app/src/lib/editor-width.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveEditorContentWidthBasePx,
   resolveResponsiveEditorContentWidthPx,
   shouldShowEditorWidthResizer
 } from "./editor-width";
@@ -23,11 +24,22 @@ describe("editor width", () => {
     })).toBe(1280);
   });
 
-  it("keeps custom editor content widths exact", () => {
+  it("scales custom editor content widths from their stored base width", () => {
     expect(resolveResponsiveEditorContentWidthPx({
       contentWidth: "default",
       contentWidthPx: 980,
       editorAreaWidth: 1688
+    })).toBe(1280);
+  });
+
+  it("converts the displayed editor content width back to the stored base width", () => {
+    expect(resolveEditorContentWidthBasePx({
+      editorAreaWidth: 1688,
+      renderedContentWidthPx: 1210
+    })).toBe(860);
+    expect(resolveEditorContentWidthBasePx({
+      editorAreaWidth: 1024,
+      renderedContentWidthPx: 980
     })).toBe(980);
   });
 

--- a/packages/app/src/lib/editor-width.test.ts
+++ b/packages/app/src/lib/editor-width.test.ts
@@ -1,66 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  resolveEditorContentWidthBasePx,
-  resolveResponsiveEditorContentWidthPx,
-  shouldShowEditorWidthResizer
-} from "./editor-width";
+import { shouldShowEditorWidthResizer } from "./editor-width";
 
 describe("editor width", () => {
-  it("scales preset editor content widths when the editor area has extra horizontal room", () => {
-    expect(resolveResponsiveEditorContentWidthPx({
-      contentWidth: "default",
-      contentWidthPx: null,
-      editorAreaWidth: 1024
-    })).toBe(860);
-    expect(resolveResponsiveEditorContentWidthPx({
-      contentWidth: "default",
-      contentWidthPx: null,
-      editorAreaWidth: 1688
-    })).toBe(1210);
-    expect(resolveResponsiveEditorContentWidthPx({
-      contentWidth: "wide",
-      contentWidthPx: null,
-      editorAreaWidth: 1688
-    })).toBe(1280);
-  });
-
-  it("applies custom editor content widths as offsets from the responsive preset width", () => {
-    expect(resolveResponsiveEditorContentWidthPx({
-      contentWidth: "default",
-      contentWidthPx: 980,
-      editorAreaWidth: 1688
-    })).toBe(1280);
-    expect(resolveResponsiveEditorContentWidthPx({
-      contentWidth: "default",
-      contentWidthPx: 780,
-      editorAreaWidth: 2200
-    })).toBe(1200);
-    expect(resolveResponsiveEditorContentWidthPx({
-      contentWidth: "default",
-      contentWidthPx: 780,
-      editorAreaWidth: 1024
-    })).toBe(780);
-  });
-
-  it("converts the displayed editor content width back to the stored base width", () => {
-    expect(resolveEditorContentWidthBasePx({
-      contentWidth: "default",
-      editorAreaWidth: 1688,
-      renderedContentWidthPx: 1280
-    })).toBe(930);
-    expect(resolveEditorContentWidthBasePx({
-      contentWidth: "default",
-      editorAreaWidth: 2200,
-      renderedContentWidthPx: 1200
-    })).toBe(780);
-    expect(resolveEditorContentWidthBasePx({
-      contentWidth: "default",
-      editorAreaWidth: 1024,
-      renderedContentWidthPx: 980
-    })).toBe(980);
-  });
-
-  it("uses the responsive content width when deciding whether to show the resize handle", () => {
+  it("uses the fixed content width when deciding whether to show the resize handle", () => {
     expect(shouldShowEditorWidthResizer({
       aiAgentOpen: true,
       editorAreaWidth: 1216,

--- a/packages/app/src/lib/editor-width.test.ts
+++ b/packages/app/src/lib/editor-width.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveResponsiveEditorContentWidthPx,
+  shouldShowEditorWidthResizer
+} from "./editor-width";
+
+describe("editor width", () => {
+  it("scales preset editor content widths when the editor area has extra horizontal room", () => {
+    expect(resolveResponsiveEditorContentWidthPx({
+      contentWidth: "default",
+      contentWidthPx: null,
+      editorAreaWidth: 1024
+    })).toBe(860);
+    expect(resolveResponsiveEditorContentWidthPx({
+      contentWidth: "default",
+      contentWidthPx: null,
+      editorAreaWidth: 1688
+    })).toBe(1210);
+    expect(resolveResponsiveEditorContentWidthPx({
+      contentWidth: "wide",
+      contentWidthPx: null,
+      editorAreaWidth: 1688
+    })).toBe(1280);
+  });
+
+  it("keeps custom editor content widths exact", () => {
+    expect(resolveResponsiveEditorContentWidthPx({
+      contentWidth: "default",
+      contentWidthPx: 980,
+      editorAreaWidth: 1688
+    })).toBe(980);
+  });
+
+  it("uses the responsive content width when deciding whether to show the resize handle", () => {
+    expect(shouldShowEditorWidthResizer({
+      aiAgentOpen: true,
+      editorAreaWidth: 1216,
+      editorContentWidth: 872
+    })).toBe(true);
+    expect(shouldShowEditorWidthResizer({
+      aiAgentOpen: true,
+      editorAreaWidth: 928,
+      editorContentWidth: 860
+    })).toBe(false);
+  });
+});

--- a/packages/app/src/lib/editor-width.ts
+++ b/packages/app/src/lib/editor-width.ts
@@ -27,6 +27,14 @@ function responsiveEditorContentWidthScale(editorAreaWidth: number) {
   return editorAreaWidth / editorResponsiveContentWidthBaseArea;
 }
 
+function resolveResponsiveEditorContentWidthBasePx(baseWidth: number, editorAreaWidth: number) {
+  const width = normalizeEditorContentWidthPx(Math.round(
+    baseWidth * responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
+  ));
+
+  return width ?? baseWidth;
+}
+
 export function resolveResponsiveEditorContentWidthPx({
   contentWidth,
   contentWidthPx,
@@ -36,24 +44,26 @@ export function resolveResponsiveEditorContentWidthPx({
   contentWidthPx: number | null;
   editorAreaWidth: number;
 }) {
-  const baseWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
-  const width = normalizeEditorContentWidthPx(Math.round(
-    baseWidth * responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
-  ));
+  const presetBaseWidth = editorContentWidthPixels[contentWidth];
+  const presetWidth = resolveResponsiveEditorContentWidthBasePx(presetBaseWidth, editorAreaWidth);
+  if (contentWidthPx === null) return presetWidth;
 
-  return width ?? baseWidth;
+  const customOffset = contentWidthPx - presetBaseWidth;
+  return normalizeEditorContentWidthPx(presetWidth + customOffset) ?? presetWidth;
 }
 
 export function resolveEditorContentWidthBasePx({
+  contentWidth,
   editorAreaWidth,
   renderedContentWidthPx
 }: {
+  contentWidth: EditorContentWidth;
   editorAreaWidth: number;
   renderedContentWidthPx: number;
 }) {
-  const width = normalizeEditorContentWidthPx(Math.round(
-    renderedContentWidthPx / responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
-  ));
+  const presetBaseWidth = editorContentWidthPixels[contentWidth];
+  const presetWidth = resolveResponsiveEditorContentWidthBasePx(presetBaseWidth, editorAreaWidth);
+  const width = normalizeEditorContentWidthPx(presetBaseWidth + renderedContentWidthPx - presetWidth);
 
   return width ?? renderedContentWidthPx;
 }

--- a/packages/app/src/lib/editor-width.ts
+++ b/packages/app/src/lib/editor-width.ts
@@ -12,60 +12,12 @@ export const editorContentWidthPixels = {
 
 export const editorCustomContentWidthMin = 640;
 export const editorCustomContentWidthMax = 1280;
-export const editorResponsiveContentWidthBaseArea = 1200;
 export const editorWidthResizeGutterMin = 48;
 
 export function normalizeEditorContentWidthPx(value: unknown) {
   const width = clampNumber(value, editorCustomContentWidthMin, editorCustomContentWidthMax);
 
   return width === null ? null : Math.round(width);
-}
-
-function responsiveEditorContentWidthScale(editorAreaWidth: number) {
-  if (editorAreaWidth <= editorResponsiveContentWidthBaseArea) return 1;
-
-  return editorAreaWidth / editorResponsiveContentWidthBaseArea;
-}
-
-function resolveResponsiveEditorContentWidthBasePx(baseWidth: number, editorAreaWidth: number) {
-  const width = normalizeEditorContentWidthPx(Math.round(
-    baseWidth * responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
-  ));
-
-  return width ?? baseWidth;
-}
-
-export function resolveResponsiveEditorContentWidthPx({
-  contentWidth,
-  contentWidthPx,
-  editorAreaWidth
-}: {
-  contentWidth: EditorContentWidth;
-  contentWidthPx: number | null;
-  editorAreaWidth: number;
-}) {
-  const presetBaseWidth = editorContentWidthPixels[contentWidth];
-  const presetWidth = resolveResponsiveEditorContentWidthBasePx(presetBaseWidth, editorAreaWidth);
-  if (contentWidthPx === null) return presetWidth;
-
-  const customOffset = contentWidthPx - presetBaseWidth;
-  return normalizeEditorContentWidthPx(presetWidth + customOffset) ?? presetWidth;
-}
-
-export function resolveEditorContentWidthBasePx({
-  contentWidth,
-  editorAreaWidth,
-  renderedContentWidthPx
-}: {
-  contentWidth: EditorContentWidth;
-  editorAreaWidth: number;
-  renderedContentWidthPx: number;
-}) {
-  const presetBaseWidth = editorContentWidthPixels[contentWidth];
-  const presetWidth = resolveResponsiveEditorContentWidthBasePx(presetBaseWidth, editorAreaWidth);
-  const width = normalizeEditorContentWidthPx(presetBaseWidth + renderedContentWidthPx - presetWidth);
-
-  return width ?? renderedContentWidthPx;
 }
 
 export function shouldShowEditorWidthResizer({

--- a/packages/app/src/lib/editor-width.ts
+++ b/packages/app/src/lib/editor-width.ts
@@ -36,14 +36,26 @@ export function resolveResponsiveEditorContentWidthPx({
   contentWidthPx: number | null;
   editorAreaWidth: number;
 }) {
-  if (contentWidthPx !== null) return contentWidthPx;
-
-  const baseWidth = editorContentWidthPixels[contentWidth];
+  const baseWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const width = normalizeEditorContentWidthPx(Math.round(
     baseWidth * responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
   ));
 
   return width ?? baseWidth;
+}
+
+export function resolveEditorContentWidthBasePx({
+  editorAreaWidth,
+  renderedContentWidthPx
+}: {
+  editorAreaWidth: number;
+  renderedContentWidthPx: number;
+}) {
+  const width = normalizeEditorContentWidthPx(Math.round(
+    renderedContentWidthPx / responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
+  ));
+
+  return width ?? renderedContentWidthPx;
 }
 
 export function shouldShowEditorWidthResizer({

--- a/packages/app/src/lib/editor-width.ts
+++ b/packages/app/src/lib/editor-width.ts
@@ -12,9 +12,52 @@ export const editorContentWidthPixels = {
 
 export const editorCustomContentWidthMin = 640;
 export const editorCustomContentWidthMax = 1280;
+export const editorResponsiveContentWidthBaseArea = 1200;
+export const editorWidthResizeGutterMin = 48;
 
 export function normalizeEditorContentWidthPx(value: unknown) {
   const width = clampNumber(value, editorCustomContentWidthMin, editorCustomContentWidthMax);
 
   return width === null ? null : Math.round(width);
+}
+
+function responsiveEditorContentWidthScale(editorAreaWidth: number) {
+  if (editorAreaWidth <= editorResponsiveContentWidthBaseArea) return 1;
+
+  return editorAreaWidth / editorResponsiveContentWidthBaseArea;
+}
+
+export function resolveResponsiveEditorContentWidthPx({
+  contentWidth,
+  contentWidthPx,
+  editorAreaWidth
+}: {
+  contentWidth: EditorContentWidth;
+  contentWidthPx: number | null;
+  editorAreaWidth: number;
+}) {
+  if (contentWidthPx !== null) return contentWidthPx;
+
+  const baseWidth = editorContentWidthPixels[contentWidth];
+  const width = normalizeEditorContentWidthPx(Math.round(
+    baseWidth * responsiveEditorContentWidthScale(Math.max(0, editorAreaWidth))
+  ));
+
+  return width ?? baseWidth;
+}
+
+export function shouldShowEditorWidthResizer({
+  aiAgentOpen,
+  editorAreaWidth,
+  editorContentWidth,
+  gutterMin = editorWidthResizeGutterMin
+}: {
+  aiAgentOpen: boolean;
+  editorAreaWidth: number;
+  editorContentWidth: number;
+  gutterMin?: number;
+}) {
+  if (!aiAgentOpen) return true;
+
+  return editorAreaWidth - editorContentWidth >= gutterMin * 2;
 }


### PR DESCRIPTION
## Summary
- Restore editor writing width to fixed pixel behavior so existing saved widths keep their old meaning.
- Keep the editor resize handle hidden when the right AI sidebar leaves too little room, but available in wide layouts.
- Enlarge the editor width handle hit area and show its line only on hover/focus/drag.
- Sync left sidebar resizing immediately and remove the AI panel resize highlight line.

## Why
- Addresses resize discoverability, left sidebar resize syncing, and right-sidebar editor-width behavior from issue #385 without changing existing content width preferences.

## Validation
- `pnpm --filter @markra/app test -- App.test.tsx MarkdownFileTreeDrawer.test.tsx NativeTitleBar.test.tsx AiAgentPanel.test.tsx editor-width.test.ts` passed in the final PR worktree: 5 files, 342 tests.
- `pnpm --filter @markra/app build` passed.

## Related Issues
- Refs #385