### PR TITLE
fix(editor): add table cell soft line breaks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8097,6 +8097,31 @@ describe("MarkdownPaper editing", () => {
     expect(table).toHaveTextContent("Editor");
   });
 
+  it("inserts a cell line break with Shift+Enter inside tables", async () => {
+    const { container, editor, view } = await renderEditor("| Name | Notes |\n| --- | --- |\n| Example | First line |");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "First line", "First line".length));
+
+    expect(pressShortcut(view, "Enter", { shiftKey: true })).toBe(true);
+
+    typeText(view, "Second line");
+
+    const cellHardbreak = view.state.doc.resolve(findTextPosition(view, "Second line")).parent.child(1);
+    expect(cellHardbreak.type.name).toBe("hardbreak");
+    expect(cellHardbreak.attrs.renderLineBreak).toBe(true);
+
+    const notesCell = container.querySelector<HTMLElement>(".ProseMirror tbody td:nth-child(2)");
+    const hardbreak = notesCell?.querySelector<HTMLElement>(
+      'br[data-type="hardbreak"], span.markra-hardbreak[data-type="hardbreak"] br'
+    );
+    expect(hardbreak).toBeInTheDocument();
+
+    expect(notesCell).toHaveTextContent("First lineSecond line");
+    expect(serializeMarkdown(view.state.doc)).toContain("| Example | First line<br>Second line |");
+    await settleMarkdownListener();
+  });
+
   it("keeps a preceding table when pressing Backspace from an empty paragraph below it", async () => {
     const tableMarkdown = ["| Name | Role |", "| --- | --- |", "| Markra | Editor |"].join("\n");
     const { container, editor, view } = await renderEditor([tableMarkdown, "", "![Screenshot](assets/pasted-image.png)"].join("\n"));

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -97,6 +97,11 @@ function hardbreakDomAttrs(attrs: Record<string, unknown>) {
   };
 }
 
+function serializerHasOpenNode(state: unknown, type: string) {
+  const elements = (state as { elements?: Array<{ type?: unknown }> }).elements;
+  return Array.isArray(elements) && elements.some((element) => element.type === type);
+}
+
 const markraHardbreakSchema = hardbreakSchema.extendSchema((previous) => (ctx) => {
   const baseSchema = previous(ctx);
 
@@ -133,6 +138,17 @@ const markraHardbreakSchema = hardbreakSchema.extendSchema((previous) => (ctx) =
 
       const attrs = hardbreakDomAttrs(ctx.get(hardbreakAttr.key)(node));
       return ["span", attrs, ["br"]];
+    },
+    toMarkdown: {
+      ...baseSchema.toMarkdown,
+      runner: (state, node) => {
+        if (node.attrs.renderLineBreak === true && serializerHasOpenNode(state, "tableCell")) {
+          state.addNode("html", undefined, "<br>");
+          return;
+        }
+
+        baseSchema.toMarkdown.runner(state, node);
+      }
     }
   };
 });

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -81,6 +81,22 @@ function selectionIsInsideNodeType(
   });
 }
 
+function selectionIsInsideNodeName(selection: Selection, nodeName: string) {
+  const positions = [selection.$from, selection.$to];
+
+  return positions.every(($pos) => {
+    for (let depth = $pos.depth; depth > 0; depth -= 1) {
+      if ($pos.node(depth).type.name === nodeName) return true;
+    }
+
+    return false;
+  });
+}
+
+function selectionIsInsideTableCell(selection: Selection) {
+  return selectionIsInsideNodeName(selection, "table_cell") || selectionIsInsideNodeName(selection, "table_header");
+}
+
 function nodeIsList(node: ProseNode) {
   return node.type.name === "bullet_list" || node.type.name === "ordered_list";
 }
@@ -633,6 +649,23 @@ function insertPlainTextIndentation(view: EditorView) {
   return true;
 }
 
+function insertRenderedHardbreak(view: EditorView) {
+  if (!(view.state.selection instanceof TextSelection)) return false;
+
+  const hardbreak = view.state.schema.nodes.hardbreak;
+  if (!hardbreak) return false;
+
+  view.dispatch(
+    view.state.tr
+      // Milkdown filters built-in hardbreak transactions inside tables; Markra table breaks are deliberate.
+      .replaceSelectionWith(hardbreak.create({ renderLineBreak: true }))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
 export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap = {}) => $prose((ctx) => {
   const strong = strongSchema.type(ctx);
   const emphasis = emphasisSchema.type(ctx);
@@ -698,6 +731,19 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
             event.preventDefault();
             return true;
           }
+        } else if (
+          event.key === "Enter" &&
+          event.shiftKey &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          selectionIsInsideTableCell(view.state.selection)
+        ) {
+          const handled = insertRenderedHardbreak(view);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
         } else if (
           (event.key === "Backspace" || event.key === "Delete") &&
           !hasModifier &&


### PR DESCRIPTION
## Summary
- Add Shift+Enter handling in table cells and table headers to insert a rendered hardbreak.
- Serialize table-cell hardbreaks as `<br>` so saved Markdown tables stay valid.
- Cover the behavior with a MarkdownPaper regression test.

## Why
- Milkdown filters built-in hardbreak transactions inside tables, so table-cell line breaks needed Markra-specific handling.
- Closes #413

## Validation
- `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx -t "inserts a cell line break with Shift+Enter inside tables"` passed.
- `pnpm --filter @markra/editor test` passed.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low. The shortcut is scoped to selections inside table cells and table headers; serialization only changes hardbreaks emitted while writing table cells.
