### PR TITLE
fix(editor): copy tables as markdown text

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -11,7 +11,7 @@ vi.mock("mermaid", () => ({
 
 import type { Editor } from "@milkdown/kit/core";
 import { editorViewCtx, parserCtx, serializerCtx } from "@milkdown/kit/core";
-import { Slice } from "@milkdown/kit/prose/model";
+import { Fragment, Slice, type Node as ProseNode } from "@milkdown/kit/prose/model";
 import { NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { MarkdownPaper } from "./MarkdownPaper";
@@ -191,6 +191,39 @@ function selectNode(view: EditorView, position: number) {
 
 function selectText(view: EditorView, from: number, to: number) {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+}
+
+function selectedPlainClipboardText(view: EditorView) {
+  return plainClipboardTextFromSlice(view, view.state.selection.content());
+}
+
+function plainClipboardTextFromSlice(view: EditorView, slice: Slice) {
+  let text: string | null = null;
+
+  view.someProp("clipboardTextSerializer", (serializer) => {
+    text = serializer(slice, view);
+    return true;
+  });
+
+  return text ?? slice.content.textBetween(0, slice.content.size, "\n\n");
+}
+
+function findFirstProseNode(view: EditorView, typeName: string): ProseNode {
+  const matches: ProseNode[] = [];
+
+  view.state.doc.descendants((node) => {
+    if (matches.length > 0 || node.type.name !== typeName) return true;
+
+    matches.push(node);
+    return false;
+  });
+
+  const result = matches[0];
+  if (!result) {
+    throw new Error(`Could not find node in editor: ${typeName}`);
+  }
+
+  return result;
 }
 
 function clickFinalizedImage(target: Element) {
@@ -9675,6 +9708,31 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelector(".ProseMirror table")).not.toHaveTextContent("Column 2");
     expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("/ta");
     await settleMarkdownListener();
+  });
+
+  it("copies selected tables as markdown plain text", async () => {
+    const tableMarkdown = ["| Alpha | Beta |", "| --- | --- |", "| Gamma | Delta |"].join("\n");
+    const { view } = await renderEditor(tableMarkdown);
+    const expectedClipboardMarkdown = ["| Alpha | Beta  |", "| ----- | ----- |", "| Gamma | Delta |"].join("\n");
+
+    selectNode(view, findNodeStartPosition(view, "table"));
+
+    expect(selectedPlainClipboardText(view)).toBe(expectedClipboardMarkdown);
+  });
+
+  it("copies table row clipboard slices as markdown plain text", async () => {
+    const tableMarkdown = ["| Alpha | Beta |", "| --- | --- |", "| Gamma | Delta |"].join("\n");
+    const { view } = await renderEditor(tableMarkdown);
+    const table = findFirstProseNode(view, "table");
+    const rows: ProseNode[] = [];
+
+    table.forEach((row: ProseNode) => rows.push(row));
+
+    const slice = new Slice(Fragment.from(rows), 1, 1);
+
+    expect(plainClipboardTextFromSlice(view, slice)).toBe(
+      ["| Alpha | Beta  |", "| ----- | ----- |", "| Gamma | Delta |"].join("\n")
+    );
   });
 
   it("runs slash commands from a callout body line", async () => {

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -71,7 +71,8 @@ import {
   markraCommonmark,
   markraExternalLinkClickPlugin,
   markraGfm,
-  markraTextSelectionObserverPlugin
+  markraTextSelectionObserverPlugin,
+  serializeMarkdownClipboardText
 } from "./markdown-paper-plugins";
 import { SpellcheckSuggestionMenu, type SpellcheckSuggestionMenuState } from "./SpellcheckSuggestionMenu";
 
@@ -438,7 +439,9 @@ function MilkdownEditorSurface({
               spellcheck: "false",
               writingsuggestions: "false"
             },
-            editable: () => !readOnlyRef.current
+            editable: () => !readOnlyRef.current,
+            clipboardTextSerializer: (slice, view) =>
+              serializeMarkdownClipboardText(slice, view, ctx.get(serializerCtx))
           }));
           ctx.get(listenerCtx).updated((editorCtx, doc) => {
             try {

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -20,7 +20,7 @@ import {
   schema as gfmSchema,
   strikethroughSchema
 } from "@milkdown/kit/preset/gfm";
-import type { ResolvedPos } from "@milkdown/kit/prose/model";
+import { Fragment, type Node as ProseNode, type ResolvedPos, type Slice } from "@milkdown/kit/prose/model";
 import type { Selection } from "@milkdown/kit/prose/state";
 import { Plugin } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
@@ -587,6 +587,75 @@ type ExternalLinkClickPluginOptions = {
 
 const markdownDocumentHrefPattern = /\.(md|markdown)(?:[?#].*)?$/iu;
 const markdownImageHrefPattern = /\.(avif|bmp|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/iu;
+const markdownClipboardTableRowNodeNames = new Set(["table_header_row", "table_row"]);
+
+type MarkdownSerializer = (doc: ProseNode) => string;
+
+function defaultClipboardText(slice: Slice) {
+  return slice.content.textBetween(0, slice.content.size, "\n\n");
+}
+
+function fragmentContainsTableMarkdown(fragment: Fragment) {
+  let containsTable = false;
+
+  fragment.forEach((node) => {
+    if (containsTable) return;
+    if (node.type.name === "table" || markdownClipboardTableRowNodeNames.has(node.type.name)) {
+      containsTable = true;
+      return;
+    }
+
+    if (node.content.size > 0) {
+      containsTable = fragmentContainsTableMarkdown(node.content);
+    }
+  });
+
+  return containsTable;
+}
+
+function fragmentIsTableRows(fragment: Fragment) {
+  if (fragment.childCount === 0) return false;
+
+  for (let index = 0; index < fragment.childCount; index += 1) {
+    if (!markdownClipboardTableRowNodeNames.has(fragment.child(index).type.name)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function markdownClipboardDocumentFromSlice(slice: Slice, view: EditorView) {
+  const { schema } = view.state;
+  const directDocument = schema.topNodeType.createAndFill(null, slice.content);
+  if (directDocument) return directDocument;
+
+  if (!fragmentIsTableRows(slice.content)) return null;
+
+  // Cell selections can provide table rows without the outer table node.
+  const tableType = schema.nodes.table;
+  if (!tableType) return null;
+
+  const table = tableType.createAndFill(null, slice.content);
+  if (!table) return null;
+
+  return schema.topNodeType.createAndFill(null, Fragment.from(table));
+}
+
+function trimSerializerDocumentNewline(markdown: string) {
+  return markdown.endsWith("\n") ? markdown.slice(0, -1) : markdown;
+}
+
+export function serializeMarkdownClipboardText(slice: Slice, view: EditorView, serializeMarkdown: MarkdownSerializer) {
+  if (!fragmentContainsTableMarkdown(slice.content)) {
+    return defaultClipboardText(slice);
+  }
+
+  const doc = markdownClipboardDocumentFromSlice(slice, view);
+  if (!doc) return defaultClipboardText(slice);
+
+  return trimSerializerDocumentNewline(serializeMarkdown(doc));
+}
 
 function isLocalAttachmentHref(href: string) {
   const trimmed = href.trim();


### PR DESCRIPTION
## Summary
- Serialize copied table selections as Markdown plain text.
- Preserve the default plain-text clipboard behavior for non-table selections.
- Cover full table selections and table-row clipboard slices with focused tests.

## Why
- Closes #415.
- Copying a table from the WYSIWYG editor to plain-text targets dropped the Markdown table structure and only kept cell text.

## Validation
- `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx -t "markdown plain text"` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Low. The custom plain-text serializer only changes selections that contain table nodes; other selections keep the existing text fallback.
