### PR TITLE
feat(editor): default tables to auto column width

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -334,7 +334,7 @@ function createStoredEditorPreferences(
     spellcheckEnabled: overrides.spellcheckEnabled ?? false,
     spellcheckIgnoredWords: overrides.spellcheckIgnoredWords ?? [],
     spellcheckLanguage: overrides.spellcheckLanguage ?? "en",
-    tableColumnWidthMode: overrides.tableColumnWidthMode ?? "even",
+    tableColumnWidthMode: overrides.tableColumnWidthMode ?? "auto",
     titlebarActions: [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -4869,7 +4869,7 @@ describe("MarkdownPaper editing", () => {
     expect(screen.getByRole("button", { name: "Align table left" })).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("toggles table column width mode from the top-left controls and persists it for the current document", async () => {
+  it("defaults tables to auto column width and persists toggled width mode for the current document", async () => {
     window.localStorage.clear();
 
     const initialTable = [
@@ -4880,13 +4880,6 @@ describe("MarkdownPaper editing", () => {
     const firstRender = await renderEditor(initialTable, { documentPath: "/vault/current.md" });
     const wrapper = () => firstRender.container.querySelector(".ProseMirror .markra-table-controls-wrapper");
     const table = () => firstRender.container.querySelector(".ProseMirror table");
-
-    expect(wrapper()).toHaveAttribute("data-width-mode", "even");
-    expect(table()).toHaveAttribute("data-width-mode", "even");
-    expect(table()).not.toHaveClass("markra-table-width-auto");
-    expect(screen.getByRole("button", { name: tableColumnWidthModeLabel })).toHaveAttribute("aria-pressed", "false");
-
-    fireEvent.mouseDown(screen.getByRole("button", { name: tableColumnWidthModeLabel }));
 
     expect(wrapper()).toHaveAttribute("data-width-mode", "auto");
     expect(table()).toHaveAttribute("data-width-mode", "auto");
@@ -4900,23 +4893,31 @@ describe("MarkdownPaper editing", () => {
     });
     expect(screen.getByRole("button", { name: tableColumnWidthModeLabel })).toHaveAttribute("aria-pressed", "true");
 
+    fireEvent.mouseDown(screen.getByRole("button", { name: tableColumnWidthModeLabel }));
+
+    expect(wrapper()).toHaveAttribute("data-width-mode", "even");
+    expect(table()).toHaveAttribute("data-width-mode", "even");
+    expect(table()).not.toHaveClass("markra-table-width-auto");
+    expect(table()?.querySelectorAll("col")).toHaveLength(0);
+    expect(screen.getByRole("button", { name: tableColumnWidthModeLabel })).toHaveAttribute("aria-pressed", "false");
+
     firstRender.unmount();
 
     const secondRender = await renderEditor(initialTable, { documentPath: "/vault/current.md" });
-    expect(secondRender.container.querySelector(".ProseMirror table")).toHaveClass("markra-table-width-auto");
+    expect(secondRender.container.querySelector(".ProseMirror table")).not.toHaveClass("markra-table-width-auto");
 
     fireEvent.mouseDown(screen.getByRole("button", { name: tableColumnWidthModeLabel }));
 
-    const fixedTable = secondRender.container.querySelector<HTMLTableElement>(".ProseMirror table");
+    const autoTable = secondRender.container.querySelector<HTMLTableElement>(".ProseMirror table");
     expect(secondRender.container.querySelector(".ProseMirror .markra-table-controls-wrapper")).toHaveAttribute(
       "data-width-mode",
-      "even"
+      "auto"
     );
-    expect(fixedTable).not.toHaveClass("markra-table-width-auto");
-    expect(fixedTable?.querySelectorAll("col")).toHaveLength(0);
-    expect(fixedTable?.style.display).toBe("");
-    expect(fixedTable?.style.tableLayout).toBe("");
-    expect(fixedTable?.style.width).toBe("");
+    expect(autoTable).toHaveClass("markra-table-width-auto");
+    expect(autoTable?.querySelectorAll("col")).toHaveLength(2);
+    expect(autoTable?.style.display).toBe("");
+    expect(autoTable?.style.tableLayout).toBe("");
+    expect(autoTable?.style.width).toBe("");
     window.localStorage.clear();
   });
 
@@ -4950,11 +4951,16 @@ describe("MarkdownPaper editing", () => {
     const tables = firstRender.container.querySelectorAll(".ProseMirror table");
     const buttons = screen.getAllByRole("button", { name: tableColumnWidthModeLabel });
 
-    fireEvent.mouseDown(buttons[1]);
     expect(tables[0]).toHaveClass("markra-table-width-auto");
     expect(tables[1]).toHaveClass("markra-table-width-auto");
     expect(buttons[0]).toHaveAttribute("aria-pressed", "true");
     expect(buttons[1]).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.mouseDown(buttons[1]);
+    expect(tables[0]).not.toHaveClass("markra-table-width-auto");
+    expect(tables[1]).not.toHaveClass("markra-table-width-auto");
+    expect(buttons[0]).toHaveAttribute("aria-pressed", "false");
+    expect(buttons[1]).toHaveAttribute("aria-pressed", "false");
     firstRender.unmount();
 
     const insertedTable = ["| Inserted | Table |", "| --- | --- |", "| Before | Saved content |"].join("\n");
@@ -4963,9 +4969,9 @@ describe("MarkdownPaper editing", () => {
     });
     const restoredTables = secondRender.container.querySelectorAll(".ProseMirror table");
 
-    expect(restoredTables[0]).toHaveClass("markra-table-width-auto");
-    expect(restoredTables[1]).toHaveClass("markra-table-width-auto");
-    expect(restoredTables[2]).toHaveClass("markra-table-width-auto");
+    expect(restoredTables[0]).not.toHaveClass("markra-table-width-auto");
+    expect(restoredTables[1]).not.toHaveClass("markra-table-width-auto");
+    expect(restoredTables[2]).not.toHaveClass("markra-table-width-auto");
 
     window.localStorage.clear();
   });
@@ -4992,13 +4998,16 @@ describe("MarkdownPaper editing", () => {
     });
 
     const buttons = screen.getAllByRole("button", { name: tableColumnWidthModeLabel });
+    expect(buttons[0]).toHaveAttribute("aria-pressed", "true");
+    expect(buttons[1]).toHaveAttribute("aria-pressed", "true");
+
     fireEvent.mouseDown(buttons[1]);
 
     const tables = firstRender.container.querySelectorAll(".ProseMirror table");
-    expect(tables[0]).toHaveClass("markra-table-width-auto");
-    expect(tables[1]).toHaveClass("markra-table-width-auto");
-    expect(buttons[0]).toHaveAttribute("aria-pressed", "true");
-    expect(buttons[1]).toHaveAttribute("aria-pressed", "true");
+    expect(tables[0]).not.toHaveClass("markra-table-width-auto");
+    expect(tables[1]).not.toHaveClass("markra-table-width-auto");
+    expect(buttons[0]).toHaveAttribute("aria-pressed", "false");
+    expect(buttons[1]).toHaveAttribute("aria-pressed", "false");
 
     window.localStorage.clear();
   });
@@ -5011,15 +5020,18 @@ describe("MarkdownPaper editing", () => {
     const button = screen.getByRole("button", { name: tableColumnWidthModeLabel });
     const table = container.querySelector(".ProseMirror table");
 
-    fireEvent.keyDown(button, { key: " " });
-
     expect(table).toHaveClass("markra-table-width-auto");
     expect(button).toHaveAttribute("aria-pressed", "true");
 
-    fireEvent.keyDown(button, { key: "Enter" });
+    fireEvent.keyDown(button, { key: " " });
 
     expect(table).not.toHaveClass("markra-table-width-auto");
     expect(button).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.keyDown(button, { key: "Enter" });
+
+    expect(table).toHaveClass("markra-table-width-auto");
+    expect(button).toHaveAttribute("aria-pressed", "true");
 
     window.localStorage.clear();
   });
@@ -5032,7 +5044,6 @@ describe("MarkdownPaper editing", () => {
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
 
     fireEvent.mouseDown(screen.getByRole("button", { name: "Align table center" }));
-    fireEvent.mouseDown(screen.getByRole("button", { name: tableColumnWidthModeLabel }));
 
     expect(container.querySelector(".ProseMirror .markra-table-controls-wrapper")).toHaveAttribute(
       "data-width-mode",

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -124,7 +124,7 @@ export function MarkdownPaper({
   spellcheckEnabled = false,
   spellcheckIgnoredWords,
   spellchecker,
-  tableColumnWidthMode = "even",
+  tableColumnWidthMode = "auto",
   topInset = "titlebar",
   workspaceFiles,
   wrapCodeBlocks = true

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -242,7 +242,7 @@ function MilkdownEditorSurface({
   const resolveImageSrcRef = useRef(resolveImageSrc);
   const spellcheckEnabledRef = useRef(spellcheckEnabled);
   const spellcheckIgnoredWordsRef = useRef(spellcheckIgnoredWords);
-  const tableColumnWidthModeRef = useRef(tableColumnWidthMode ?? "even");
+  const tableColumnWidthModeRef = useRef(tableColumnWidthMode ?? "auto");
   const spellcheckMenuViewRef = useRef<EditorView | null>(null);
   const onAddSpellcheckIgnoredWordRef = useRef(onAddSpellcheckIgnoredWord);
   const workspaceFilesRef = useRef(workspaceFiles ?? []);
@@ -358,7 +358,7 @@ function MilkdownEditorSurface({
   }, [spellcheckIgnoredWords]);
 
   useEffect(() => {
-    tableColumnWidthModeRef.current = tableColumnWidthMode ?? "even";
+    tableColumnWidthModeRef.current = tableColumnWidthMode ?? "auto";
   }, [tableColumnWidthMode]);
 
   useEffect(() => {

--- a/packages/app/src/components/SideDocumentPane.tsx
+++ b/packages/app/src/components/SideDocumentPane.tsx
@@ -70,7 +70,7 @@ export function SideDocumentPane({
   spellcheckEnabled = false,
   spellcheckIgnoredWords,
   spellchecker,
-  tableColumnWidthMode = "even",
+  tableColumnWidthMode = "auto",
   onAddSpellcheckIgnoredWord,
   onSaveClipboardAttachment,
   workspaceFiles,

--- a/packages/app/src/hooks/useEditorPreferences.test.tsx
+++ b/packages/app/src/hooks/useEditorPreferences.test.tsx
@@ -91,7 +91,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     spellcheckIgnoredWords: [],
     spellcheckLanguage: "en",
     showWordCount: true,
-    tableColumnWidthMode: "even",
+    tableColumnWidthMode: "auto",
     wrapCodeBlocks: true
   },
   getStoredEditorPreferences: vi.fn()

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -490,7 +490,7 @@ export const defaultEditorPreferences: EditorPreferences = {
   spellcheckEnabled: false,
   spellcheckIgnoredWords: [],
   spellcheckLanguage: defaultSpellcheckLanguage,
-  tableColumnWidthMode: "even",
+  tableColumnWidthMode: "auto",
   titlebarActions: [...defaultTitlebarActions],
   showWordCount: true,
   wrapCodeBlocks: true

--- a/packages/app/src/lib/settings/editor-preferences.test.ts
+++ b/packages/app/src/lib/settings/editor-preferences.test.ts
@@ -81,7 +81,7 @@ describe("editor preferences", () => {
       spellcheckEnabled: false,
       spellcheckIgnoredWords: [],
       spellcheckLanguage: "en",
-      tableColumnWidthMode: "even",
+      tableColumnWidthMode: "auto",
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
@@ -212,7 +212,7 @@ describe("editor preferences", () => {
       spellcheckEnabled: false,
       spellcheckIgnoredWords: [],
       spellcheckLanguage: "en",
-      tableColumnWidthMode: "even",
+      tableColumnWidthMode: "auto",
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },
@@ -657,7 +657,7 @@ describe("editor preferences", () => {
       spellcheckEnabled: false,
       spellcheckIgnoredWords: [],
       spellcheckLanguage: "en",
-      tableColumnWidthMode: "even",
+      tableColumnWidthMode: "auto",
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -304,7 +304,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     spellcheckEnabled: false,
     spellcheckIgnoredWords: [],
     spellcheckLanguage: "en",
-    tableColumnWidthMode: "even",
+    tableColumnWidthMode: "auto",
     titlebarActions: [
       { id: "aiAgent", visible: true },
       { id: "sourceMode", visible: true },
@@ -1281,7 +1281,7 @@ export function installAppTestHarness() {
       spellcheckEnabled: false,
       spellcheckIgnoredWords: [],
       spellcheckLanguage: "en",
-      tableColumnWidthMode: "even",
+      tableColumnWidthMode: "auto",
       titlebarActions: [
         { id: "aiAgent", visible: true },
         { id: "sourceMode", visible: true },


### PR DESCRIPTION
## Summary
- Default table column width mode is now auto for new or unspecified editor preferences.
- Updated MarkdownPaper and side document fallbacks to match the app default.
- Adjusted table width tests and default preference fixtures.

## Validation
- `pnpm --filter @markra/app test` passed (100 files, 1497 tests).
- `pnpm --filter @markra/app build` passed.

Closes #412