### PR TITLE
fix(app): keep file tree resize handle off scrollbar

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1145,6 +1145,27 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(container.querySelector(".markdown-file-tree-resizer-indicator")).not.toBeInTheDocument();
   });
 
+  it("keeps the file tree resize handle narrow so scrollbar clicks remain available", () => {
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath={null}
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        width={288}
+        onOpenFile={() => {}}
+        onResize={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const resizeHandle = container.querySelector(".markdown-file-tree-resizer");
+
+    expect(resizeHandle).toHaveClass("w-px");
+    expect(resizeHandle).not.toHaveClass("w-2");
+  });
+
   it("does not render a Windows sidebar toggle when the drawer is collapsed", () => {
     const toggleMarkdownFiles = vi.fn();
     const { container } = render(

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -2596,7 +2596,7 @@ export function MarkdownFileTreeDrawer({
         {renderSidebarPanelTabs()}
         {open && onResize && resolvedWidth !== null ? (
           <div
-            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-2 cursor-col-resize touch-none outline-none"
+            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-px cursor-col-resize touch-none outline-none"
             role="separator"
             tabIndex={0}
             aria-label={label("app.resizeMarkdownFiles")}


### PR DESCRIPTION
## Summary
- Narrow the file tree resize separator hitbox from 8px to 1px so it no longer overlaps the scrollbar.
- Add a regression test that keeps the resize handle narrow while preserving resize accessibility.

## Why
- The previous transparent resize hitbox sat above the file tree scrollbar, making pure mouse scrollbar dragging hard to use.

## Validation
- `pnpm --dir packages/app test src/components/MarkdownFileTreeDrawer.test.tsx` passed, 93 tests.
- `pnpm --dir packages/app test src/App.test.tsx` passed, 175 tests.

## Risk
- Low. The change is scoped to the file tree resize hitbox; keyboard resize behavior and AI/editor resize handles are unchanged.

Refs #385