### PR TITLE
fix(app): ignore empty headings in outline jumps

### DIFF
--- a/packages/app/src/hooks/useEditorController.test.ts
+++ b/packages/app/src/hooks/useEditorController.test.ts
@@ -3,8 +3,12 @@ import {
   markdownLinkInsertionForSelection,
   scrollElementToContainerTop,
   scrollElementsAboveContainerBottomInset,
-  selectionAnchorFromEditorView
+  selectionAnchorFromEditorView,
+  useEditorController
 } from "./useEditorController";
+import { act, renderHook } from "@testing-library/react";
+import type { Editor } from "@milkdown/kit/core";
+import { TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 
 function rect(overrides: Partial<DOMRect> = {}): DOMRect {
@@ -20,6 +24,30 @@ function rect(overrides: Partial<DOMRect> = {}): DOMRect {
     toJSON: () => ({}),
     ...overrides
   };
+}
+
+type MockOutlineNode = {
+  attrs: { level: number };
+  position: number;
+  textContent: string;
+  type: { name: string };
+};
+
+function mockOutlineHeading(position: number, level: number, textContent: string): MockOutlineNode {
+  return {
+    attrs: { level },
+    position,
+    textContent,
+    type: { name: "heading" }
+  };
+}
+
+function mockOutlineEditor(view: EditorView): Editor {
+  return {
+    action: (runner: (ctx: { get: () => EditorView }) => unknown) => runner({
+      get: () => view
+    })
+  } as unknown as Editor;
 }
 
 afterEach(() => {
@@ -127,6 +155,77 @@ describe("editor controller scrolling", () => {
 
     expect(scrollElementsAboveContainerBottomInset([target], container, 200, 24)).toBe(false);
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("editor controller outline navigation", () => {
+  it("selects outline headings by their non-empty outline index", () => {
+    const paperScroll = document.createElement("div");
+    const editorDom = document.createElement("div");
+    const targetHeading = document.createElement("h4");
+    const scrollTo = vi.fn();
+    const selection = { synthetic: "selection" };
+    const transaction = { synthetic: "transaction" };
+    const setSelection = vi.fn(() => transaction);
+    const dispatch = vi.fn();
+    const focus = vi.fn();
+    const nodeDOM = vi.fn(() => targetHeading);
+    const resolve = vi.fn(() => ({ synthetic: "resolved-position" }));
+    const nodes = [
+      mockOutlineHeading(0, 4, "One"),
+      mockOutlineHeading(20, 4, "Two"),
+      mockOutlineHeading(40, 4, ""),
+      mockOutlineHeading(60, 4, "Three")
+    ];
+
+    paperScroll.className = "paper-scroll";
+    paperScroll.append(editorDom);
+    Object.defineProperty(paperScroll, "scrollTop", {
+      configurable: true,
+      value: 0
+    });
+    Object.defineProperty(paperScroll, "scrollTo", {
+      configurable: true,
+      value: scrollTo
+    });
+    vi.spyOn(paperScroll, "getBoundingClientRect").mockReturnValue(rect({ height: 700, top: 0 }));
+    vi.spyOn(targetHeading, "getBoundingClientRect").mockReturnValue(rect({ height: 32, top: 120 }));
+    vi.spyOn(TextSelection, "near").mockReturnValue(selection as never);
+
+    const view = {
+      dispatch,
+      dom: editorDom,
+      focus,
+      nodeDOM,
+      state: {
+        doc: {
+          descendants(callback: (node: MockOutlineNode, position: number) => boolean | undefined) {
+            for (const node of nodes) {
+              callback(node, node.position);
+            }
+          },
+          resolve
+        },
+        tr: {
+          setSelection
+        }
+      }
+    } as unknown as EditorView;
+    const { result } = renderHook(() => useEditorController());
+
+    act(() => result.current.handleEditorReady(mockOutlineEditor(view)));
+    act(() => result.current.selectOutlineItem({ level: 4, title: "Three" }, 2));
+
+    expect(resolve).toHaveBeenCalledWith(61);
+    expect(TextSelection.near).toHaveBeenCalledWith({ synthetic: "resolved-position" });
+    expect(setSelection).toHaveBeenCalledWith(selection);
+    expect(dispatch).toHaveBeenCalledWith(transaction);
+    expect(nodeDOM).toHaveBeenCalledWith(60);
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: "auto",
+      top: 56
+    });
+    expect(focus).toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -1129,11 +1129,14 @@ export function useEditorController() {
       view.state.doc.descendants((node, position) => {
         if (node.type.name !== "heading") return true;
 
+        const headingTitle = node.textContent.trim();
+        if (!headingTitle) return true;
+
         headingIndex += 1;
         if (
           headingIndex === targetIndex &&
           Number(node.attrs.level) === targetItem.level &&
-          node.textContent.trim() === targetItem.title
+          headingTitle === targetItem.title
         ) {
           // Keep the cursor inside the matched heading while the DOM scroll aligns the heading itself.
           targetNodePosition = position;


### PR DESCRIPTION
## Summary
- Skip empty editor heading nodes when matching sidebar outline clicks to document headings.
- Add a regression test for outline navigation with an empty heading before later visible headings.

## Why
- `getMarkdownOutline` omits empty Markdown headings like `####`, but outline click navigation was counting every editor heading node.
- That index mismatch made later outline entries fail to jump after an empty heading.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useEditorController.test.ts` passed: 11 tests.
- `pnpm --filter @markra/app exec vitest run src/components/markdown-paper-plugins.test.ts src/hooks/useEditorController.test.ts` passed: 14 tests.
- `pnpm --filter @markra/markdown test -- src/markdown.test.ts` passed: 15 tests.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.

## Related Issues
- Closes #421
