### PR TITLE
fix(editor): place cursor at formatted edge clicks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7564,7 +7564,7 @@ describe("MarkdownPaper editing", () => {
     );
 
     moveCursor(view, findLastTextBlockEndCursor(view));
-    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 158, clientY: 30 });
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 150, clientY: 30 });
     typeText(view, "X");
 
     expect(container.querySelector(".ProseMirror .markra-live-mark-strong")).toHaveTextContent("ABCX");
@@ -7654,7 +7654,7 @@ describe("MarkdownPaper editing", () => {
     });
 
     moveCursor(view, findLastTextBlockEndCursor(view));
-    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 158, clientY: 30 });
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 150, clientY: 30 });
     typeText(view, "X");
 
     expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("ABCX");

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7633,6 +7633,7 @@ describe("MarkdownPaper editing", () => {
 
     const mark = container.querySelector<HTMLElement>(".ProseMirror strong");
     const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+    const originalFocus = view.focus.bind(view);
 
     mark!.getBoundingClientRect = vi.fn(
       () =>
@@ -7647,6 +7648,10 @@ describe("MarkdownPaper editing", () => {
           y: 20
         }) as DOMRect
     );
+    view.focus = vi.fn(() => {
+      view.dispatch(view.state.tr.setStoredMarks(null));
+      originalFocus();
+    });
 
     moveCursor(view, findLastTextBlockEndCursor(view));
     fireEvent.mouseDown(paragraph!, { button: 0, clientX: 158, clientY: 30 });

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7481,6 +7481,64 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("places the cursor after live formatted text from clicks near the visible closing edge", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**ABC** tail");
+
+    const mark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+    const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+    const tailPosition = findTextPosition(view, " tail");
+
+    mark!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 160,
+          top: 20,
+          width: 60,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 162, clientY: 30 });
+
+    expect(view.state.selection.from).toBe(tailPosition);
+    await settleMarkdownListener();
+  });
+
+  it("places the cursor after finalized formatted text from clicks near the visible closing edge", async () => {
+    const { container, view } = await renderEditor("**ABC** tail");
+
+    const mark = container.querySelector<HTMLElement>(".ProseMirror strong");
+    const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+    const tailPosition = findTextPosition(view, " tail");
+
+    mark!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 160,
+          top: 20,
+          width: 60,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 162, clientY: 30 });
+
+    expect(view.state.selection.from).toBe(tailPosition);
+    await settleMarkdownListener();
+  });
+
   it("places the cursor before adjacent punctuation from folded closing delimiter clicks", async () => {
     const { container, view } = await renderEditor("**ABC**:");
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7458,6 +7458,61 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("places the cursor outside active live markdown delimiters from parent-targeted marker clicks", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**ABC**tail");
+
+    expectLiveMark(container, "strong", "ABC");
+
+    const sourceStart = findFirstTextBlockCursor(view);
+    const sourceEnd = findTextPosition(view, "tail");
+    const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+
+    moveCursor(view, findTextPosition(view, "ABC", 1));
+
+    const delimiters = Array.from(container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-delimiter"));
+    expect(delimiters).toHaveLength(2);
+    const [openingDelimiter, closingDelimiter] = delimiters;
+
+    openingDelimiter!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 128,
+          top: 20,
+          width: 28,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+    closingDelimiter!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 188,
+          right: 216,
+          top: 20,
+          width: 28,
+          x: 188,
+          y: 20
+        }) as DOMRect
+    );
+
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 104, clientY: 19.75 });
+
+    expect(view.state.selection.from).toBe(sourceStart);
+
+    moveCursor(view, findTextPosition(view, "ABC", 1));
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 212, clientY: 19.75 });
+
+    expect(view.state.selection.from).toBe(sourceEnd);
+    await settleMarkdownListener();
+  });
+
   it("places the cursor before adjacent punctuation from live closing delimiter clicks", async () => {
     const { container, view } = await renderEditor();
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7484,11 +7484,11 @@ describe("MarkdownPaper editing", () => {
   it("places the cursor after live formatted text from clicks near the visible closing edge", async () => {
     const { container, view } = await renderEditor();
 
-    typeText(view, "**ABC** tail");
+    typeText(view, "**ABC**tail");
 
     const mark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
     const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
-    const tailPosition = findTextPosition(view, " tail");
+    const tailPosition = findTextPosition(view, "tail");
 
     mark!.getBoundingClientRect = vi.fn(
       () =>
@@ -7511,12 +7511,73 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps text typed from direct live formatted edge clicks inside the mark", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**ABC**tail");
+
+    const mark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+
+    mark!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 160,
+          top: 20,
+          width: 60,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    fireEvent.mouseDown(mark!, { button: 0, clientX: 158, clientY: 30 });
+    typeText(view, "X");
+
+    expect(container.querySelector(".ProseMirror .markra-live-mark-strong")).toHaveTextContent("ABCX");
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("**ABCX**tail");
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed from parent-targeted live formatted inner edge clicks inside the mark", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**ABC**tail");
+
+    const mark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+    const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+
+    mark!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 160,
+          top: 20,
+          width: 60,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 158, clientY: 30 });
+    typeText(view, "X");
+
+    expect(container.querySelector(".ProseMirror .markra-live-mark-strong")).toHaveTextContent("ABCX");
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("**ABCX**tail");
+    await settleMarkdownListener();
+  });
+
   it("places the cursor after finalized formatted text from clicks near the visible closing edge", async () => {
-    const { container, view } = await renderEditor("**ABC** tail");
+    const { container, view } = await renderEditor("**ABC**tail");
 
     const mark = container.querySelector<HTMLElement>(".ProseMirror strong");
     const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
-    const tailPosition = findTextPosition(view, " tail");
+    const tailPosition = findTextPosition(view, "tail");
 
     mark!.getBoundingClientRect = vi.fn(
       () =>
@@ -7536,6 +7597,63 @@ describe("MarkdownPaper editing", () => {
     fireEvent.mouseDown(paragraph!, { button: 0, clientX: 162, clientY: 30 });
 
     expect(view.state.selection.from).toBe(tailPosition);
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed from direct finalized formatted edge clicks inside the mark", async () => {
+    const { container, view } = await renderEditor("**ABC**tail");
+
+    const mark = container.querySelector<HTMLElement>(".ProseMirror strong");
+
+    mark!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 160,
+          top: 20,
+          width: 60,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    fireEvent.mouseDown(mark!, { button: 0, clientX: 158, clientY: 30 });
+    typeText(view, "X");
+
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("ABCX");
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("ABCXtail");
+    await settleMarkdownListener();
+  });
+
+  it("keeps text typed from parent-targeted finalized formatted inner edge clicks inside the mark", async () => {
+    const { container, view } = await renderEditor("**ABC**tail");
+
+    const mark = container.querySelector<HTMLElement>(".ProseMirror strong");
+    const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+
+    mark!.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 40,
+          height: 20,
+          left: 100,
+          right: 160,
+          top: 20,
+          width: 60,
+          x: 100,
+          y: 20
+        }) as DOMRect
+    );
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    fireEvent.mouseDown(paragraph!, { button: 0, clientX: 158, clientY: 30 });
+    typeText(view, "X");
+
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("ABCX");
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("ABCXtail");
     await settleMarkdownListener();
   });
 

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -718,8 +718,8 @@ function selectVisibleFormattedEdge(view: EditorView, event: MouseEvent) {
   const transaction = view.state.tr
     .setSelection(TextSelection.create(view.state.doc, closestCandidate.position))
     .scrollIntoView();
-  view.dispatch(closestCandidate.marks ? transaction.setStoredMarks(closestCandidate.marks) : transaction);
   view.focus();
+  view.dispatch(closestCandidate.marks ? transaction.setStoredMarks(closestCandidate.marks) : transaction);
   return true;
 }
 

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -81,6 +81,7 @@ const liveMarkdownVisibleMarkSelector = [
 ].join("");
 const formattedInlineElementSelector = "strong, em, del, code";
 const visibleFormattedEdgeThreshold = 6;
+const maxVisibleFormattedEdgeThreshold = 14;
 type FormattedEdge = "left" | "right";
 type FormattedEdgePlacement = "inside" | "outside";
 
@@ -593,6 +594,14 @@ function rectContainsY(rect: DOMRect, y: number) {
   return rect.width > 0 && rect.height > 0 && y >= rect.top && y <= rect.bottom;
 }
 
+function visibleFormattedEdgeHitThreshold(target: HTMLElement, rect: DOMRect) {
+  const textLength = Array.from(target.textContent ?? "").length;
+  if (textLength === 0) return visibleFormattedEdgeThreshold;
+
+  const averageGlyphWidth = rect.width / textLength;
+  return Math.max(visibleFormattedEdgeThreshold, Math.min(maxVisibleFormattedEdgeThreshold, averageGlyphWidth * 0.75));
+}
+
 function formattedEdgePlacementFromCoordinates(rect: DOMRect, edge: FormattedEdge, x: number): FormattedEdgePlacement {
   if (edge === "left") return x > rect.left ? "inside" : "outside";
   return x < rect.right ? "inside" : "outside";
@@ -685,7 +694,7 @@ function visibleFormattedEdgeCandidate(
   const rightDistance = Math.abs(event.clientX - rect.right);
   const edge = leftDistance <= rightDistance ? "left" : "right";
   const distance = Math.min(leftDistance, rightDistance);
-  if (distance > visibleFormattedEdgeThreshold) return null;
+  if (distance > visibleFormattedEdgeHitThreshold(target, rect)) return null;
 
   const placement = formattedEdgePlacementFromCoordinates(rect, edge, event.clientX);
   const position = edgePositionFromVisibleFormattedTarget(view, target, edge, placement);

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -82,6 +82,8 @@ const liveMarkdownVisibleMarkSelector = [
 const formattedInlineElementSelector = "strong, em, del, code";
 const visibleFormattedEdgeThreshold = 6;
 const maxVisibleFormattedEdgeThreshold = 14;
+const visibleDelimiterHitThreshold = 6;
+const visibleInlineYSlop = 2;
 type FormattedEdge = "left" | "right";
 type FormattedEdgePlacement = "inside" | "outside";
 
@@ -591,7 +593,7 @@ function numericDataAttribute(target: HTMLElement, name: string) {
 }
 
 function rectContainsY(rect: DOMRect, y: number) {
-  return rect.width > 0 && rect.height > 0 && y >= rect.top && y <= rect.bottom;
+  return rect.width > 0 && rect.height > 0 && y >= rect.top - visibleInlineYSlop && y <= rect.bottom + visibleInlineYSlop;
 }
 
 function visibleFormattedEdgeHitThreshold(target: HTMLElement, rect: DOMRect) {
@@ -605,6 +607,47 @@ function visibleFormattedEdgeHitThreshold(target: HTMLElement, rect: DOMRect) {
 function formattedEdgePlacementFromCoordinates(rect: DOMRect, edge: FormattedEdge, x: number): FormattedEdgePlacement {
   if (edge === "left") return x > rect.left ? "inside" : "outside";
   return x < rect.right ? "inside" : "outside";
+}
+
+function rectHorizontalDistance(rect: DOMRect, x: number) {
+  if (x >= rect.left && x <= rect.right) return 0;
+  return Math.min(Math.abs(x - rect.left), Math.abs(x - rect.right));
+}
+
+function visibleDelimiterCandidate(target: HTMLElement, event: MouseEvent) {
+  const rect = target.getBoundingClientRect();
+  if (!rectContainsY(rect, event.clientY)) return null;
+
+  const distance = rectHorizontalDistance(rect, event.clientX);
+  if (distance > visibleDelimiterHitThreshold) return null;
+
+  const position = liveMarkdownDelimiterPosition(target);
+  return position === null ? null : { distance, position };
+}
+
+function selectLiveMarkdownDelimiterByCoordinates(view: EditorView, event: MouseEvent) {
+  const targets = Array.from(view.dom.querySelectorAll<HTMLElement>(liveMarkdownDelimiterSelector));
+  let closestCandidate: { distance: number; position: number } | null = null;
+
+  for (const target of targets) {
+    const candidate = visibleDelimiterCandidate(target, event);
+    if (!candidate) continue;
+    if (!closestCandidate || candidate.distance < closestCandidate.distance) {
+      closestCandidate = candidate;
+    }
+  }
+
+  if (!closestCandidate || closestCandidate.position > view.state.doc.content.size) return false;
+
+  event.preventDefault();
+  event.stopPropagation();
+  view.focus();
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, closestCandidate.position))
+      .scrollIntoView()
+  );
+  return true;
 }
 
 function edgePositionFromLiveMarkdownMark(
@@ -694,7 +737,8 @@ function visibleFormattedEdgeCandidate(
   const rightDistance = Math.abs(event.clientX - rect.right);
   const edge = leftDistance <= rightDistance ? "left" : "right";
   const distance = Math.min(leftDistance, rightDistance);
-  if (distance > visibleFormattedEdgeHitThreshold(target, rect)) return null;
+  const threshold = visibleFormattedEdgeHitThreshold(target, rect);
+  if (distance > threshold) return null;
 
   const placement = formattedEdgePlacementFromCoordinates(rect, edge, event.clientX);
   const position = edgePositionFromVisibleFormattedTarget(view, target, edge, placement);
@@ -737,7 +781,7 @@ function selectLiveMarkdownDelimiterEdge(view: EditorView, event: Event) {
   if (event.button !== 0) return false;
 
   const target = liveMarkdownDelimiterTarget(event.target);
-  if (!target) return selectVisibleFormattedEdge(view, event);
+  if (!target) return selectLiveMarkdownDelimiterByCoordinates(view, event) || selectVisibleFormattedEdge(view, event);
 
   const position = liveMarkdownDelimiterPosition(target);
   if (position === null || position > view.state.doc.content.size) return false;

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -72,10 +72,17 @@ type LiveMarkdownPluginState = {
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
 const liveMarkdownDelimiterSelector = ".markra-md-delimiter[data-markra-live-delimiter-position]";
-const liveMarkdownVisibleMarkSelector =
-  ".markra-live-mark[data-markra-live-mark-from][data-markra-live-mark-to]";
+const liveMarkdownVisibleMarkSelector = [
+  ".markra-live-mark",
+  "[data-markra-live-mark-from]",
+  "[data-markra-live-mark-to]",
+  "[data-markra-live-mark-content-from]",
+  "[data-markra-live-mark-content-to]"
+].join("");
 const formattedInlineElementSelector = "strong, em, del, code";
 const visibleFormattedEdgeThreshold = 6;
+type FormattedEdge = "left" | "right";
+type FormattedEdgePlacement = "inside" | "outside";
 
 function getLiveMarkdownKinds(spec: LiveMarkdownSpec) {
   return spec.kinds ?? spec.marks.map((mark) => mark.kind);
@@ -548,9 +555,11 @@ function createDelimiterWidget(marker: string, position: number | null = null) {
   return delimiter;
 }
 
-function liveMarkdownMarkAttrs(className: string, from: number, to: number) {
+function liveMarkdownMarkAttrs(className: string, from: number, to: number, contentFrom: number, contentTo: number) {
   return {
     class: className,
+    "data-markra-live-mark-content-from": String(contentFrom),
+    "data-markra-live-mark-content-to": String(contentTo),
     "data-markra-live-mark-from": String(from),
     "data-markra-live-mark-to": String(to)
   };
@@ -584,11 +593,28 @@ function rectContainsY(rect: DOMRect, y: number) {
   return rect.width > 0 && rect.height > 0 && y >= rect.top && y <= rect.bottom;
 }
 
-function edgePositionFromLiveMarkdownMark(target: HTMLElement, edge: "left" | "right") {
-  return numericDataAttribute(target, edge === "left" ? "markraLiveMarkFrom" : "markraLiveMarkTo");
+function formattedEdgePlacementFromCoordinates(rect: DOMRect, edge: FormattedEdge, x: number): FormattedEdgePlacement {
+  if (edge === "left") return x > rect.left ? "inside" : "outside";
+  return x < rect.right ? "inside" : "outside";
 }
 
-function edgeTextNode(target: Node, edge: "left" | "right"): Text | null {
+function edgePositionFromLiveMarkdownMark(
+  target: HTMLElement,
+  edge: FormattedEdge,
+  placement: FormattedEdgePlacement
+) {
+  const attribute =
+    placement === "inside"
+      ? edge === "left"
+        ? "markraLiveMarkContentFrom"
+        : "markraLiveMarkContentTo"
+      : edge === "left"
+        ? "markraLiveMarkFrom"
+        : "markraLiveMarkTo";
+  return numericDataAttribute(target, attribute);
+}
+
+function edgeTextNode(target: Node, edge: FormattedEdge): Text | null {
   if (target.nodeType === Node.TEXT_NODE) return target as Text;
 
   const children = Array.from(target.childNodes);
@@ -602,26 +628,56 @@ function edgeTextNode(target: Node, edge: "left" | "right"): Text | null {
   return null;
 }
 
-function edgePositionFromFormattedElement(view: EditorView, target: HTMLElement, edge: "left" | "right") {
+function formattedElementEdgeMarks(view: EditorView, position: number, edge: FormattedEdge) {
+  const $position = view.state.doc.resolve(position);
+  return edge === "left" ? ($position.nodeAfter?.marks ?? []) : ($position.nodeBefore?.marks ?? []);
+}
+
+function edgePositionFromFormattedElement(
+  view: EditorView,
+  target: HTMLElement,
+  edge: FormattedEdge,
+  placement: FormattedEdgePlacement
+) {
   if (target.closest("pre")) return null;
 
   const textNode = edgeTextNode(target, edge);
   if (!textNode) return null;
 
   try {
-    return view.posAtDOM(textNode, edge === "left" ? 0 : (textNode.textContent?.length ?? 0));
+    const position = view.posAtDOM(textNode, edge === "left" ? 0 : (textNode.textContent?.length ?? 0));
+    return {
+      marks: placement === "inside" ? formattedElementEdgeMarks(view, position, edge) : null,
+      position
+    };
   } catch {
     return null;
   }
 }
 
-function edgePositionFromVisibleFormattedTarget(view: EditorView, target: HTMLElement, edge: "left" | "right") {
-  if (target.matches(liveMarkdownVisibleMarkSelector)) return edgePositionFromLiveMarkdownMark(target, edge);
-  if (target.matches(formattedInlineElementSelector)) return edgePositionFromFormattedElement(view, target, edge);
+function edgePositionFromVisibleFormattedTarget(
+  view: EditorView,
+  target: HTMLElement,
+  edge: FormattedEdge,
+  placement: FormattedEdgePlacement
+) {
+  if (target.matches(liveMarkdownVisibleMarkSelector)) {
+    const position = edgePositionFromLiveMarkdownMark(target, edge, placement);
+    return position === null ? null : { marks: null, position };
+  }
+
+  if (target.matches(formattedInlineElementSelector)) {
+    return edgePositionFromFormattedElement(view, target, edge, placement);
+  }
+
   return null;
 }
 
-function visibleFormattedEdgeCandidate(view: EditorView, target: HTMLElement, event: MouseEvent) {
+function visibleFormattedEdgeCandidate(
+  view: EditorView,
+  target: HTMLElement,
+  event: MouseEvent
+) {
   const rect = target.getBoundingClientRect();
   if (!rectContainsY(rect, event.clientY)) return null;
 
@@ -631,10 +687,11 @@ function visibleFormattedEdgeCandidate(view: EditorView, target: HTMLElement, ev
   const distance = Math.min(leftDistance, rightDistance);
   if (distance > visibleFormattedEdgeThreshold) return null;
 
-  const position = edgePositionFromVisibleFormattedTarget(view, target, edge);
-  if (position === null || position > view.state.doc.content.size) return null;
+  const placement = formattedEdgePlacementFromCoordinates(rect, edge, event.clientX);
+  const position = edgePositionFromVisibleFormattedTarget(view, target, edge, placement);
+  if (!position || position.position > view.state.doc.content.size) return null;
 
-  return { distance, position };
+  return { distance, ...position };
 }
 
 // Browser hit testing can land on the parent textblock just outside a formatted inline node.
@@ -644,7 +701,7 @@ function selectVisibleFormattedEdge(view: EditorView, event: MouseEvent) {
   const targets = Array.from(
     view.dom.querySelectorAll<HTMLElement>(`${liveMarkdownVisibleMarkSelector}, ${formattedInlineElementSelector}`)
   );
-  let closestCandidate: { distance: number; position: number } | null = null;
+  let closestCandidate: { distance: number; marks: readonly Mark[] | null; position: number } | null = null;
 
   for (const target of targets) {
     const candidate = visibleFormattedEdgeCandidate(view, target, event);
@@ -658,11 +715,10 @@ function selectVisibleFormattedEdge(view: EditorView, event: MouseEvent) {
 
   event.preventDefault();
   event.stopPropagation();
-  view.dispatch(
-    view.state.tr
-      .setSelection(TextSelection.create(view.state.doc, closestCandidate.position))
-      .scrollIntoView()
-  );
+  const transaction = view.state.tr
+    .setSelection(TextSelection.create(view.state.doc, closestCandidate.position))
+    .scrollIntoView();
+  view.dispatch(closestCandidate.marks ? transaction.setStoredMarks(closestCandidate.marks) : transaction);
   view.focus();
   return true;
 }
@@ -733,7 +789,9 @@ function buildLiveMarkdownDecorations(
             liveMarkdownMarkAttrs(
               ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" "),
               from,
-              to
+              to,
+              contentFrom,
+              contentTo
             )
           )
         );

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -72,6 +72,10 @@ type LiveMarkdownPluginState = {
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
 const liveMarkdownDelimiterSelector = ".markra-md-delimiter[data-markra-live-delimiter-position]";
+const liveMarkdownVisibleMarkSelector =
+  ".markra-live-mark[data-markra-live-mark-from][data-markra-live-mark-to]";
+const formattedInlineElementSelector = "strong, em, del, code";
+const visibleFormattedEdgeThreshold = 6;
 
 function getLiveMarkdownKinds(spec: LiveMarkdownSpec) {
   return spec.kinds ?? spec.marks.map((mark) => mark.kind);
@@ -544,6 +548,14 @@ function createDelimiterWidget(marker: string, position: number | null = null) {
   return delimiter;
 }
 
+function liveMarkdownMarkAttrs(className: string, from: number, to: number) {
+  return {
+    class: className,
+    "data-markra-live-mark-from": String(from),
+    "data-markra-live-mark-to": String(to)
+  };
+}
+
 function liveMarkdownDelimiterAttrs(className: string, position: number | null) {
   if (position === null) return { class: className };
 
@@ -563,12 +575,104 @@ function liveMarkdownDelimiterPosition(target: HTMLElement) {
   return Number.isInteger(value) && value >= 0 ? value : null;
 }
 
+function numericDataAttribute(target: HTMLElement, name: string) {
+  const value = Number(target.dataset[name]);
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function rectContainsY(rect: DOMRect, y: number) {
+  return rect.width > 0 && rect.height > 0 && y >= rect.top && y <= rect.bottom;
+}
+
+function edgePositionFromLiveMarkdownMark(target: HTMLElement, edge: "left" | "right") {
+  return numericDataAttribute(target, edge === "left" ? "markraLiveMarkFrom" : "markraLiveMarkTo");
+}
+
+function edgeTextNode(target: Node, edge: "left" | "right"): Text | null {
+  if (target.nodeType === Node.TEXT_NODE) return target as Text;
+
+  const children = Array.from(target.childNodes);
+  const orderedChildren = edge === "left" ? children : children.reverse();
+
+  for (const child of orderedChildren) {
+    const textNode = edgeTextNode(child, edge);
+    if (textNode) return textNode;
+  }
+
+  return null;
+}
+
+function edgePositionFromFormattedElement(view: EditorView, target: HTMLElement, edge: "left" | "right") {
+  if (target.closest("pre")) return null;
+
+  const textNode = edgeTextNode(target, edge);
+  if (!textNode) return null;
+
+  try {
+    return view.posAtDOM(textNode, edge === "left" ? 0 : (textNode.textContent?.length ?? 0));
+  } catch {
+    return null;
+  }
+}
+
+function edgePositionFromVisibleFormattedTarget(view: EditorView, target: HTMLElement, edge: "left" | "right") {
+  if (target.matches(liveMarkdownVisibleMarkSelector)) return edgePositionFromLiveMarkdownMark(target, edge);
+  if (target.matches(formattedInlineElementSelector)) return edgePositionFromFormattedElement(view, target, edge);
+  return null;
+}
+
+function visibleFormattedEdgeCandidate(view: EditorView, target: HTMLElement, event: MouseEvent) {
+  const rect = target.getBoundingClientRect();
+  if (!rectContainsY(rect, event.clientY)) return null;
+
+  const leftDistance = Math.abs(event.clientX - rect.left);
+  const rightDistance = Math.abs(event.clientX - rect.right);
+  const edge = leftDistance <= rightDistance ? "left" : "right";
+  const distance = Math.min(leftDistance, rightDistance);
+  if (distance > visibleFormattedEdgeThreshold) return null;
+
+  const position = edgePositionFromVisibleFormattedTarget(view, target, edge);
+  if (position === null || position > view.state.doc.content.size) return null;
+
+  return { distance, position };
+}
+
+// Browser hit testing can land on the parent textblock just outside a formatted inline node.
+function selectVisibleFormattedEdge(view: EditorView, event: MouseEvent) {
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) return false;
+
+  const targets = Array.from(
+    view.dom.querySelectorAll<HTMLElement>(`${liveMarkdownVisibleMarkSelector}, ${formattedInlineElementSelector}`)
+  );
+  let closestCandidate: { distance: number; position: number } | null = null;
+
+  for (const target of targets) {
+    const candidate = visibleFormattedEdgeCandidate(view, target, event);
+    if (!candidate) continue;
+    if (!closestCandidate || candidate.distance < closestCandidate.distance) {
+      closestCandidate = candidate;
+    }
+  }
+
+  if (!closestCandidate) return false;
+
+  event.preventDefault();
+  event.stopPropagation();
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, closestCandidate.position))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
 function selectLiveMarkdownDelimiterEdge(view: EditorView, event: Event) {
   if (!(event instanceof MouseEvent)) return false;
   if (event.button !== 0) return false;
 
   const target = liveMarkdownDelimiterTarget(event.target);
-  if (!target) return false;
+  if (!target) return selectVisibleFormattedEdge(view, event);
 
   const position = liveMarkdownDelimiterPosition(target);
   if (position === null || position > view.state.doc.content.size) return false;
@@ -623,9 +727,15 @@ function buildLiveMarkdownDecorations(
 
       if (range.contentFrom < range.contentTo) {
         decorations.push(
-          Decoration.inline(contentFrom, contentTo, {
-            class: ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ")
-          })
+          Decoration.inline(
+            contentFrom,
+            contentTo,
+            liveMarkdownMarkAttrs(
+              ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" "),
+              from,
+              to
+            )
+          )
         );
       }
     }


### PR DESCRIPTION
## Summary
- Place the cursor on the nearest formatted inline edge when browser hit testing lands on the parent paragraph.
- Distinguish inner-edge clicks from outer-edge clicks by coordinates, so direct clicks after formatted text can keep typing inside the mark while clicks past the visual edge land before following text.
- Widen formatted-edge hit testing based on the rendered text's average glyph width, capped at a narrow 14px, to cover desktop WebView/CJK edge coordinates that land inside the final glyph but more than 6px from the DOM rect edge.
- Preserve live Markdown source/content edge positions on visible live marks.
- Focus before dispatching formatted-edge selection so desktop WebView focus/selection sync cannot clear the stored marks needed for finalized strong/em/del/code edge typing.
- Add regression coverage for live, finalized, direct-target, parent-target, focus-cleared, and wider inner-edge formatted text clicks without whitespace after the mark.

## Why
Chrome and desktop WebViews can report different `mousedown.target` values for the same visual click near formatted text. Chrome may target the bold span, while desktop WebView can target the parent paragraph. Relying on the event target made the web build look fixed while the desktop app still treated inner-edge clicks as outside the mark.

After retesting through `npm run tauri dev`, there was still a remaining gap: the previous fixed 6px edge threshold was too narrow for desktop WebView/font rendering. A click that feels like “after the final bold character” can still land inside that final glyph, more than 6px from the inline rect edge, so the custom handler never ran and ProseMirror fell back to native selection. The handler now derives the hit area from rendered glyph width and caps it to keep normal text clicks unaffected.

Desktop focus/selection sync can also clear ProseMirror stored marks after the edge click. The handler focuses first, then dispatches the selection and stored marks, so typing at a finalized formatted edge remains formatted.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t "parent-targeted"` failed before the latest threshold change, then passed after it
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed, including `verify:chunks`
- `git diff --check` passed
- Browser QA: reproduced the edge click insertion issue locally, then verified typed text inserts after the bold segment and before following plain text
- Not run after the latest threshold commit: manual Tauri click QA, because this run cannot directly exercise the user's desktop pointer path

## Risk
- Low-to-moderate: adjusts mouse down handling around inline formatted text edges. The hit area remains capped and glyph-relative so normal clicks inside text continue through ProseMirror.

Closes #419