### PR TITLE
fix(editor): stabilize formatted text edge selection

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -232,6 +232,30 @@ function clickFinalizedImage(target: Element) {
   return mouseDownResult;
 }
 
+function testRect(rect: Pick<DOMRect, "bottom" | "left" | "right" | "top">): DOMRect {
+  return {
+    ...rect,
+    height: rect.bottom - rect.top,
+    width: rect.right - rect.left,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => ({})
+  } as DOMRect;
+}
+
+function mockInlineElementRect(element: HTMLElement, rect: Pick<DOMRect, "bottom" | "left" | "right" | "top">) {
+  const domRect = testRect(rect);
+
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => domRect
+  });
+  Object.defineProperty(element, "getClientRects", {
+    configurable: true,
+    value: () => [domRect]
+  });
+}
+
 function findFirstTextBlockCursor(view: EditorView) {
   let position: number | null = null;
 
@@ -7353,6 +7377,150 @@ describe("MarkdownPaper editing", () => {
       expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
     }
 
+    await settleMarkdownListener();
+  });
+
+  it("snaps finalized formatting edge clicks to the mark boundary", async () => {
+    const { container, editor, unmount, view } = await renderEditor("alpha **bold** omega");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+
+    expect(strong).toHaveTextContent("bold");
+    mockInlineElementRect(strong!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    moveCursor(view, findFirstTextBlockCursor(view));
+
+    const rightEdgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(rightEdgeClick, "target", {
+      configurable: true,
+      value: strong
+    });
+    const handled = view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, rightEdgeClick));
+
+    expect(handled).toBe(true);
+    expect(rightEdgeClick.defaultPrevented).toBe(true);
+    expect(view.state.selection.from).toBe(findTextPosition(view, " omega"));
+
+    typeText(view, "!");
+
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
+    unmount();
+
+    const before = await renderEditor("alpha **bold** omega");
+    const beforeSerializer = before.editor.action((ctx) => ctx.get(serializerCtx));
+    const beforeStrong = before.container.querySelector<HTMLElement>(".ProseMirror strong");
+    expect(beforeStrong).toHaveTextContent("bold");
+    mockInlineElementRect(beforeStrong!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    const leftEdgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 101,
+      clientY: 22
+    });
+    Object.defineProperty(leftEdgeClick, "target", {
+      configurable: true,
+      value: beforeStrong
+    });
+    const leftHandled = before.view.someProp(
+      "handleDOMEvents",
+      (handlers) => handlers.mousedown?.(before.view, leftEdgeClick)
+    );
+
+    expect(leftHandled).toBe(true);
+    expect(before.view.state.selection.from).toBe(findTextPosition(before.view, "bold"));
+
+    typeText(before.view, "!");
+
+    expect(before.container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(beforeSerializer(before.view.state.doc).trimEnd()).toBe("alpha !**bold** omega");
+    await settleMarkdownListener();
+  });
+
+  it("leaves finalized formatting center clicks to the browser selection handler", async () => {
+    const { container, view } = await renderEditor("alpha **bold** omega");
+    const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+
+    expect(strong).toHaveTextContent("bold");
+    mockInlineElementRect(strong!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    const centerClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 124,
+      clientY: 22
+    });
+    Object.defineProperty(centerClick, "target", {
+      configurable: true,
+      value: strong
+    });
+
+    const handled = view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, centerClick));
+
+    expect(handled).toBeUndefined();
+    expect(centerClick.defaultPrevented).toBe(false);
+    await settleMarkdownListener();
+  });
+
+  it("snaps finalized formatting edge clicks when the WebView reports a surrounding target", async () => {
+    const { container, editor, view } = await renderEditor("alpha **bold** omega");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+    const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+
+    expect(paragraph).toBeInTheDocument();
+    expect(strong).toHaveTextContent("bold");
+    mockInlineElementRect(strong!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", {
+      configurable: true,
+      value: paragraph
+    });
+
+    const handled = view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick));
+
+    expect(handled).toBe(true);
+    expect(view.state.selection.from).toBe(findTextPosition(view, " omega"));
+
+    typeText(view, "!");
+
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2674,7 +2674,14 @@
   }
 
   .markdown-paper .markra-md-hidden-delimiter {
-    @apply hidden;
+    display: inline-block;
+    width: 0;
+    max-width: 0;
+    overflow: hidden;
+    color: transparent;
+    vertical-align: baseline;
+    white-space: pre;
+    -webkit-text-fill-color: transparent;
   }
 
   .markdown-paper .markra-math-source-hidden-display.markra-md-hidden-delimiter {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -331,6 +331,21 @@ describe("editor stylesheet", () => {
     expect(anchorStyles).not.toContain("opacity: 0");
   });
 
+  it("keeps hidden markdown delimiters available as zero-width caret anchors", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const delimiterStart = styles.indexOf(".markdown-paper .markra-md-hidden-delimiter {");
+    const delimiterEnd = styles.indexOf(".markdown-paper .markra-math-source-hidden-display.markra-md-hidden-delimiter {");
+    const delimiterStyles = styles.slice(delimiterStart, delimiterEnd);
+
+    expect(delimiterStart).toBeGreaterThanOrEqual(0);
+    expect(delimiterEnd).toBeGreaterThan(delimiterStart);
+    expect(delimiterStyles).toContain("display: inline-block");
+    expect(delimiterStyles).toContain("width: 0");
+    expect(delimiterStyles).toContain("overflow: hidden");
+    expect(delimiterStyles).toContain("-webkit-text-fill-color: transparent");
+    expect(delimiterStyles).not.toContain("@apply hidden");
+  });
+
   it("keeps hidden display math source available for the native caret", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const sourceStart = styles.indexOf(".markdown-paper .markra-math-source-hidden-display.markra-md-hidden-delimiter {");

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -72,6 +72,17 @@ type LiveMarkdownPluginState = {
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
 const liveMarkdownDelimiterSelector = ".markra-md-delimiter[data-markra-live-delimiter-position]";
+const formattedMarkEdgeSelector = "strong, em, del, code";
+const formattedMarkEdgeSnapPixels = 6;
+const formattedMarkEdgeVerticalTolerancePixels = 4;
+
+type FormattedMarkEdge = "start" | "end";
+
+type FormattedMarkEdgeHit = {
+  distance: number;
+  edge: FormattedMarkEdge;
+  element: HTMLElement;
+};
 
 function getLiveMarkdownKinds(spec: LiveMarkdownSpec) {
   return spec.kinds ?? spec.marks.map((mark) => mark.kind);
@@ -584,6 +595,113 @@ function selectLiveMarkdownDelimiterEdge(view: EditorView, event: Event) {
   return true;
 }
 
+function formattedMarkEdgeElement(target: EventTarget | null, root: HTMLElement) {
+  const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+  const markElement = element?.closest<HTMLElement>(formattedMarkEdgeSelector) ?? null;
+
+  return formattedMarkElementCandidate(markElement, root);
+}
+
+function formattedMarkElementCandidate(element: HTMLElement | null, root: HTMLElement) {
+  if (!element || !root.contains(element)) return null;
+  if (element.closest("pre")) return null;
+
+  return element;
+}
+
+function visibleClientRects(element: HTMLElement) {
+  const rects = Array.from(element.getClientRects()).filter((rect) => rect.width > 0 && rect.height > 0);
+  if (rects.length > 0) return rects;
+
+  const fallback = element.getBoundingClientRect();
+  return fallback.width > 0 && fallback.height > 0 ? [fallback] : [];
+}
+
+function pointIsVerticallyNearRect(event: MouseEvent, rect: DOMRect) {
+  return (
+    event.clientY >= rect.top - formattedMarkEdgeVerticalTolerancePixels &&
+    event.clientY <= rect.bottom + formattedMarkEdgeVerticalTolerancePixels
+  );
+}
+
+function horizontalEdgeDistance(event: MouseEvent, rect: DOMRect, edge: "left" | "right") {
+  if (!pointIsVerticallyNearRect(event, rect)) return null;
+
+  const edgePosition = edge === "left" ? rect.left : rect.right;
+  const tolerance = Math.min(formattedMarkEdgeSnapPixels, Math.max(2, rect.width / 3));
+  const distance = Math.abs(event.clientX - edgePosition);
+
+  return distance <= tolerance ? distance : null;
+}
+
+function formattedMarkEdgeHitFromElement(event: MouseEvent, element: HTMLElement): FormattedMarkEdgeHit | null {
+  const rects = visibleClientRects(element);
+  const firstRect = rects[0];
+  const lastRect = rects[rects.length - 1];
+  const startDistance = firstRect ? horizontalEdgeDistance(event, firstRect, "left") : null;
+  const endDistance = lastRect ? horizontalEdgeDistance(event, lastRect, "right") : null;
+
+  if (startDistance === null && endDistance === null) return null;
+  if (endDistance !== null && (startDistance === null || endDistance < startDistance)) {
+    return { distance: endDistance, edge: "end", element };
+  }
+
+  return { distance: startDistance ?? 0, edge: "start", element };
+}
+
+function directFormattedMarkEdgeHit(view: EditorView, event: MouseEvent) {
+  const target = formattedMarkEdgeElement(event.target, view.dom);
+  return target ? formattedMarkEdgeHitFromElement(event, target) : null;
+}
+
+function nearbyFormattedMarkEdgeHit(view: EditorView, event: MouseEvent) {
+  let bestHit: FormattedMarkEdgeHit | null = null;
+
+  for (const element of Array.from(view.dom.querySelectorAll<HTMLElement>(formattedMarkEdgeSelector))) {
+    const candidate = formattedMarkElementCandidate(element, view.dom);
+    if (!candidate) continue;
+
+    const hit = formattedMarkEdgeHitFromElement(event, candidate);
+    if (!hit) continue;
+    if (!bestHit || hit.distance < bestHit.distance) bestHit = hit;
+  }
+
+  return bestHit;
+}
+
+function formattedMarkEdgePosition(view: EditorView, element: HTMLElement, edge: FormattedMarkEdge) {
+  try {
+    const offset = edge === "start" ? 0 : element.childNodes.length;
+    const bias = edge === "start" ? -1 : 1;
+    const position = view.posAtDOM(element, offset, bias);
+
+    return position >= 0 && position <= view.state.doc.content.size ? position : null;
+  } catch {
+    return null;
+  }
+}
+
+function selectFormattedMarkEdge(view: EditorView, event: Event) {
+  if (!(event instanceof MouseEvent)) return false;
+  if (event.button !== 0) return false;
+
+  const hit = directFormattedMarkEdgeHit(view, event) ?? nearbyFormattedMarkEdgeHit(view, event);
+  if (!hit) return false;
+
+  const position = formattedMarkEdgePosition(view, hit.element, hit.edge);
+  if (position === null) return false;
+
+  event.preventDefault();
+  event.stopPropagation();
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, position))
+      .scrollIntoView()
+  );
+  view.focus();
+  return true;
+}
+
 function buildLiveMarkdownDecorations(
   doc: ProseNode,
   specs: LiveMarkdownSpec[],
@@ -1009,7 +1127,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
     },
     props: {
       handleDOMEvents: {
-        mousedown: selectLiveMarkdownDelimiterEdge
+        mousedown: (view, event) =>
+          selectLiveMarkdownDelimiterEdge(view, event) || selectFormattedMarkEdge(view, event)
       },
       decorations: (state) => {
         const pluginState = liveMarkdownKey.getState(state) as LiveMarkdownPluginState | undefined;


### PR DESCRIPTION
## Summary
- Keep hidden Markdown delimiters as zero-width caret anchors instead of removing them from layout with `display: none`.
- Snap clicks near finalized inline formatting edges to the corresponding ProseMirror mark boundary.
- Add a WebView-target fallback that finds the nearest formatted mark edge by coordinates when the event target is a surrounding paragraph/editor node.
- Cover left edge, right edge, center-click passthrough, surrounding-target clicks, and delimiter style behavior with regression tests.

## Why
Windows Tauri uses WebView2, which can map clicks around hidden inline decorations and formatted mark boundaries differently than a regular browser. The previous behavior could leave users unable to place the cursor immediately before or after formatted text such as `**bold**` in WYSIWYG mode.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx src/styles.test.ts` passed: 465 tests
- `pnpm --filter @markra/editor test` passed: 11 tests
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed, including vendor chunk verification
- `git diff --check` passed

## Risk
- Native Windows WebView2 behavior still needs manual confirmation on Windows 11 with a sample like `这是**测试内容**为格式文本的编辑。`
- The edge snapping is limited to clicks near inline formatted mark edges and leaves center clicks to the browser selection handler.

## Related Issues
Refs #406 #419
