### PR TITLE
fix(export): render table cell br tags in exports

### DIFF
--- a/packages/app/src/components/MarkdownExportDocument.test.tsx
+++ b/packages/app/src/components/MarkdownExportDocument.test.tsx
@@ -35,6 +35,30 @@ describe("MarkdownExportDocument", () => {
     expect(bodyHtml).not.toContain("&lt;br");
   });
 
+  it("renders raw br markers in GFM table cells as line breaks before exporting HTML", async () => {
+    const onRendered = vi.fn();
+
+    render(
+      <MarkdownExportDocument
+        onRendered={onRendered}
+        snapshot={{
+          id: 1,
+          kind: "html",
+          markdown: ["| Setting | Value |", "| --- | --- |", "| Mock | First<br>Second |"].join("\n"),
+          title: "table-breaks.md"
+        }}
+      />
+    );
+
+    await waitFor(() => expect(onRendered).toHaveBeenCalledTimes(1));
+
+    const bodyHtml = onRendered.mock.calls[0]?.[0].bodyHtml as string;
+    expect(bodyHtml).toContain("<table>");
+    expect(bodyHtml).toContain("First<br");
+    expect(bodyHtml).toContain("Second");
+    expect(bodyHtml).not.toContain("&lt;br");
+  });
+
   it("renders inline and display math before exporting HTML", async () => {
     const onRendered = vi.fn();
 

--- a/packages/app/src/components/MarkdownExportDocument.tsx
+++ b/packages/app/src/components/MarkdownExportDocument.tsx
@@ -44,6 +44,31 @@ function childrenToText(children: ReactNode) {
     .join("");
 }
 
+type MarkdownAstNode = {
+  children?: MarkdownAstNode[];
+  type?: string;
+  value?: string;
+};
+
+function replaceHtmlBreakNodes(node: MarkdownAstNode) {
+  if (!Array.isArray(node.children)) return;
+
+  node.children = node.children.map((child) => {
+    if (child.type === "html" && typeof child.value === "string" && /^\s*<br\s*\/?>\s*$/iu.test(child.value)) {
+      return { type: "break" };
+    }
+
+    replaceHtmlBreakNodes(child);
+    return child;
+  });
+}
+
+function remarkMarkraHtmlBreaks() {
+  return (tree: MarkdownAstNode) => {
+    replaceHtmlBreakNodes(tree);
+  };
+}
+
 function hasMathClass(className: unknown, kind: "display" | "inline") {
   return typeof className === "string" && className.split(/\s+/u).includes(`math-${kind}`);
 }
@@ -242,7 +267,7 @@ export function MarkdownExportDocument({
     >
       <article className="markdown-paper markdown-export-paper" ref={articleRef}>
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkHugoMath]}
+          remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkHugoMath, remarkMarkraHtmlBreaks]}
           components={{
             a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
             blockquote: ({ node: _node, ...props }) =>


### PR DESCRIPTION
## Summary
- Convert Markdown raw `<br>` markers into hard breaks during export rendering.
- Add a regression test for GFM table cells containing `<br>` before HTML/PDF export.

## Why
- Fixes exported HTML/PDF showing literal `<br>` text in table cells instead of preserving the Markdown line break behavior.
- Keeps the export path narrow by handling only `<br>` markers instead of enabling all raw HTML rendering.

## Validation
- `pnpm --filter @markra/app test -- MarkdownExportDocument.test.tsx` passed; observed 100 test files and 1504 tests passing.
- `pnpm --filter @markra/app typecheck:test` passed.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low. The change is scoped to export rendering and only rewrites raw HTML nodes that are standalone `<br>` tags.

Closes #426
