### PR TITLE
fix(app): keep equivalent visual saves clean

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -720,6 +720,62 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("clears dirty state when save resolves after equivalent visual serialization", async () => {
+    let editorMarkdown = "# Guide\n\nSaved";
+    let resolveSave: (savedFile: { name: string; path: string }) => unknown = () => {};
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "# Guide\n\nOriginal",
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    mockedSaveNativeMarkdownFile.mockReturnValue(new Promise((resolve) => {
+      resolveSave = resolve;
+    }));
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: (markdown) =>
+          markdown === editorMarkdown ||
+          (markdown === "# Guide\n\nSaved" && editorMarkdown === "Guide\n=====\n\nSaved"),
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+    const savePromise = result.current.saveCurrentDocument();
+    act(() => {
+      editorMarkdown = "Guide\n=====\n\nSaved";
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+    await act(async () => {
+      resolveSave({
+        name: "guide.md",
+        path: "/mock-files/guide.md"
+      });
+      await savePromise;
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "# Guide\n\nSaved",
+      dirty: false,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+  });
+
   it("opens folder files as tabs and keeps dirty tab content when switching", async () => {
     const confirmDiscardUnsavedChanges = vi.fn(() => true);
     mockedReadNativeMarkdownFile.mockImplementation(async (path) => {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -1138,8 +1138,12 @@ export function useMarkdownDocument({
           ? documentFromTab(targetTab)
           : documentRef.current;
     const sourceContent = options.sourceContent ?? contents;
+    const activeEditorMatchesSavedContent =
+      targetTabId === activeTabIdRef.current && isActiveEditorMarkdownEquivalent(contents) === true;
     const contentChangedAfterSaveStarted =
-      targetDocument.content !== sourceContent && targetDocument.content !== contents;
+      targetDocument.content !== sourceContent &&
+      targetDocument.content !== contents &&
+      !activeEditorMatchesSavedContent;
     const nextDocument = {
       ...targetDocument,
       path: savedFile.path,
@@ -1180,6 +1184,7 @@ export function useMarkdownDocument({
   }, [
     documentTabsEnabled,
     editorSyncState,
+    isActiveEditorMarkdownEquivalent,
     onTreeRootFromFilePath,
     registerWindowRestoreState,
     rememberRecentMarkdownFile


### PR DESCRIPTION
## Summary
- Treat active visual editor content as clean when it is equivalent to the saved markdown after an async save resolves.
- Add coverage for equivalent visual serialization arriving while save is in flight.

## Why
- Fixes a dirty-state false positive where saving succeeds, but Milkdown emits equivalent markdown with different source formatting before the save promise resolves.
- This can leave the document marked dirty and trigger an unsaved-changes prompt on close even though the saved content is current.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx src/hooks/markdown-document/editor-sync.test.ts` passed: 54 tests.
- `pnpm --filter @markra/app build` passed.
- `git diff --check` passed.

## Risk
- Low. The change only clears dirty state when the active visual editor reports the saved content as equivalent; real edits made during save remain dirty.

Refs #308