### PR TITLE
fix(editor): render Mermaid HTML label breaks

### DIFF
--- a/packages/editor/src/mermaid.test.ts
+++ b/packages/editor/src/mermaid.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async (id: string) => ({
+      svg: `<svg id="${id}"><g></g></svg>`
+    }))
+  }
+}));
+
+import mermaid from "mermaid";
+import { renderMermaidToSvg } from "./mermaid";
+
+describe("renderMermaidToSvg", () => {
+  it("configures Mermaid to render safe HTML label line breaks", async () => {
+    await renderMermaidToSvg(["flowchart TD", "  A[Global<br/>Rules] --> B[Project]"].join("\n"), {
+      theme: "neutral"
+    });
+
+    expect(mermaid.initialize).toHaveBeenCalledWith(expect.objectContaining({
+      flowchart: expect.objectContaining({
+        htmlLabels: true
+      }),
+      securityLevel: "antiscript"
+    }));
+  });
+});

--- a/packages/editor/src/mermaid.ts
+++ b/packages/editor/src/mermaid.ts
@@ -51,7 +51,10 @@ function configureMermaid(renderer: MermaidRenderer, theme: MarkraMermaidTheme) 
   if (configuredTheme === theme) return;
 
   renderer.initialize({
-    securityLevel: "strict",
+    flowchart: {
+      htmlLabels: true
+    },
+    securityLevel: "antiscript",
     startOnLoad: false,
     theme
   });


### PR DESCRIPTION
## Summary
- configure Mermaid flowcharts to render HTML labels, including `<br/>` line breaks in node labels
- use Mermaid's `antiscript` security level rather than `strict` so labels can render while scripts remain stripped
- add an editor package test for the Mermaid renderer configuration

## Why
Issue #432 includes a Mermaid diagram from a Slidev deck with labels such as `A[Global<br/>Rules]`. GitHub renders those labels as multi-line nodes, while Markra initialized Mermaid with `securityLevel: "strict"`, which encodes HTML tags instead of rendering label breaks.

## Validation
- `pnpm --filter @markra/editor test -- src/mermaid.test.ts` passed: 6 files / 12 tests
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app test -- packages/app/src/components/MarkdownPaper.test.tsx -t "Mermaid"` passed: 100 files / 1505 tests
- `pnpm --filter @markra/editor typecheck:test` passed

## Risk
- Low to moderate: Mermaid labels can now render safe HTML such as `<br/>`. The configuration uses `antiscript` instead of `loose` to keep script content stripped.

## Related Issues
Refs #432