### PR TITLE
fix(app): refresh open document panes from disk

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3494,6 +3494,165 @@ describe("Markra workspace", () => {
     await waitFor(() => expect(queryVisibleMilkdownTable(container)).toBeInTheDocument());
   });
 
+  it("refreshes a clean inactive document tab from disk when selecting it", async () => {
+    const mainPath = "/mock-files/vault/main.md";
+    const sidePath = "/mock-files/vault/side.md";
+    const diskContent = new Map([
+      [mainPath, "# Main\n\nCurrent text"],
+      [sidePath, "# Side\n\nCached text"]
+    ]);
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "main.md", path: mainPath, relativePath: "main.md" },
+      { name: "side.md", path: sidePath, relativePath: "side.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
+      content: diskContent.get(path) ?? "",
+      name: path === mainPath ? "main.md" : "side.md",
+      path
+    }));
+
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "main.md" }));
+    await expectVisibleMilkdownText(container, "Current text");
+
+    fireEvent.click(await screen.findByRole("button", { name: "side.md" }));
+    await expectVisibleMilkdownText(container, "Cached text");
+
+    fireEvent.click(screen.getByRole("tab", { name: /main\.md/ }));
+    await expectVisibleMilkdownText(container, "Current text");
+
+    diskContent.set(sidePath, "# Side\n\nFresh disk text");
+    fireEvent.click(screen.getByRole("tab", { name: /side\.md/ }));
+
+    await expectVisibleMilkdownText(container, "Fresh disk text");
+  });
+
+  it("shows document status for both panes in side-by-side mode", async () => {
+    const mainPath = "/mock-files/vault/main.md";
+    const sidePath = "/mock-files/vault/side.md";
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "main.md", path: mainPath, relativePath: "main.md" },
+      { name: "side.md", path: sidePath, relativePath: "side.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === mainPath) {
+        return {
+          content: "main words",
+          name: "main.md",
+          path: mainPath
+        };
+      }
+
+      return {
+        content: "side pane words",
+        name: "side.md",
+        path: sidePath
+      };
+    });
+
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "main.md" }));
+    await expectVisibleMilkdownText(container, "main words");
+
+    fireEvent.click(await screen.findByRole("button", { name: "side.md" }));
+    await expectVisibleMilkdownText(container, "side pane words");
+
+    fireEvent.click(screen.getByRole("tab", { name: /main\.md/ }));
+    await expectVisibleMilkdownText(container, "main words");
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /side\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
+
+    const mainPane = container.querySelector(".editor-side-by-side-surface > div:first-child") as HTMLElement;
+    const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
+    const mainStatus = mainPane.querySelector(".quiet-status");
+    const sideStatus = sidePane.querySelector(".quiet-status");
+
+    expect(mainStatus).toHaveTextContent("2 words");
+    expect(mainStatus).toHaveTextContent("saved");
+    expect(sideStatus).toHaveTextContent("3 words");
+    expect(sideStatus).toHaveTextContent("saved");
+  });
+
+  it("reloads a clean side document when its native watcher reports an external change", async () => {
+    const mainPath = "/mock-files/vault/main.md";
+    const sidePath = "/mock-files/vault/side.md";
+    const diskContent = new Map([
+      [mainPath, "# Main\n\nPrimary text"],
+      [sidePath, "# Side\n\nBefore agent edit"]
+    ]);
+    const watchHandlers = new Map<string, (path: string) => unknown | Promise<unknown>>();
+    mockedOpenNativeMarkdownPath.mockResolvedValue({
+      kind: "folder",
+      folder: {
+        path: mockFolderPath,
+        name: "vault"
+      }
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "main.md", path: mainPath, relativePath: "main.md" },
+      { name: "side.md", path: sidePath, relativePath: "side.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
+      content: diskContent.get(path) ?? "",
+      name: path === mainPath ? "main.md" : "side.md",
+      path
+    }));
+    mockedWatchNativeMarkdownFile.mockImplementation(async (path, onChange) => {
+      watchHandlers.set(path, onChange);
+      return () => {
+        watchHandlers.delete(path);
+      };
+    });
+
+    const { container } = renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByRole("heading", { name: "vault" })).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("button", { name: "main.md" }));
+    await expectVisibleMilkdownText(container, "Primary text");
+
+    fireEvent.click(await screen.findByRole("button", { name: "side.md" }));
+    await expectVisibleMilkdownText(container, "Before agent edit");
+
+    fireEvent.click(screen.getByRole("tab", { name: /main\.md/ }));
+    await expectVisibleMilkdownText(container, "Primary text");
+    fireEvent.contextMenu(screen.getByRole("tab", { name: /side\.md/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open to side" }));
+
+    await waitFor(() => expect(watchHandlers.has(sidePath)).toBe(true));
+
+    diskContent.set(sidePath, "# Side\n\nAfter agent edit");
+    await act(async () => {
+      await watchHandlers.get(sidePath)?.(sidePath);
+    });
+
+    const sidePane = container.querySelector(".side-document-pane") as HTMLElement;
+    await waitFor(() => expect(within(sidePane).getByText("After agent edit")).toBeInTheDocument());
+  });
+
   it("opens a document tab to a side editor, toggles both panes to source mode, and closes the side tab from the titlebar", async () => {
     const guidePath = "/mock-files/vault/docs/guide.md";
     const notesPath = "/mock-files/vault/docs/notes.md";

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2541,6 +2541,10 @@ function WorkspaceApp() {
     () => createMarkdownImageSrcResolver(sideDocumentTab?.path ?? null),
     [sideDocumentTab?.path]
   );
+  const sideDocumentWordCount = useMemo(
+    () => sideDocumentTab ? getWordCount(sideDocumentTab.content) : 0,
+    [sideDocumentTab?.content]
+  );
   const documentTabsVisible =
     editorPreferences.preferences.showDocumentTabs &&
     (hasOpenDocument || Boolean(activeImageFile)) &&
@@ -4149,6 +4153,7 @@ function WorkspaceApp() {
                         <span className="pointer-events-none absolute top-10 bottom-5 left-1/2 w-px -translate-x-1/2 bg-(--border-default) transition-colors duration-150 ease-out group-hover/side-resizer:bg-(--accent) group-focus/side-resizer:bg-(--accent)" />
                       </div>
                       <SideDocumentPane
+                        bottomOverlayInset={quietStatusOverlayInset}
                         bodyFontSize={editorPreferences.preferences.bodyFontSize}
                         content={sideDocumentTab.content}
                         contentWidth={activeEditorContentWidth}
@@ -4172,6 +4177,15 @@ function WorkspaceApp() {
                         spellcheckEnabled={spellcheckFeatureEnabled && editorPreferences.preferences.spellcheckEnabled}
                         spellcheckIgnoredWords={editorPreferences.preferences.spellcheckIgnoredWords}
                         spellchecker={appSpellchecker}
+                        status={(
+                          <QuietStatus
+                            dirty={sideDocumentTab.dirty}
+                            language={appLanguage.language}
+                            readOnly={readOnlyMode}
+                            showWordCount={editorPreferences.preferences.showWordCount}
+                            wordCount={sideDocumentWordCount}
+                          />
+                        )}
                         tableColumnWidthMode={editorPreferences.preferences.tableColumnWidthMode}
                         onAddSpellcheckIgnoredWord={handleAddSpellcheckIgnoredWord}
                         workspaceFiles={fileTreeFiles}

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1145,7 +1145,7 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(container.querySelector(".markdown-file-tree-resizer-indicator")).not.toBeInTheDocument();
   });
 
-  it("keeps the file tree resize handle narrow so scrollbar clicks remain available", () => {
+  it("keeps the file tree resize handle forgiving without covering the whole scrollbar", () => {
     const { container } = render(
       <MarkdownFileTreeDrawer
         currentPath={null}
@@ -1162,7 +1162,8 @@ describe("MarkdownFileTreeDrawer", () => {
 
     const resizeHandle = container.querySelector(".markdown-file-tree-resizer");
 
-    expect(resizeHandle).toHaveClass("w-px");
+    expect(resizeHandle).toHaveClass("w-1");
+    expect(resizeHandle).not.toHaveClass("w-px");
     expect(resizeHandle).not.toHaveClass("w-2");
   });
 

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -2596,7 +2596,7 @@ export function MarkdownFileTreeDrawer({
         {renderSidebarPanelTabs()}
         {open && onResize && resolvedWidth !== null ? (
           <div
-            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-px cursor-col-resize touch-none outline-none"
+            className="markdown-file-tree-resizer absolute top-10 right-0 bottom-0 z-30 w-1 cursor-col-resize touch-none outline-none"
             role="separator"
             tabIndex={0}
             aria-label={label("app.resizeMarkdownFiles")}

--- a/packages/app/src/components/SideDocumentPane.tsx
+++ b/packages/app/src/components/SideDocumentPane.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { t, type AppLanguage } from "@markra/shared";
 import type { MarkdownShortcutMap, Spellchecker } from "@markra/editor";
 import type { EditorContentWidth } from "../lib/editor-width";
@@ -11,6 +12,7 @@ import { MarkdownPaper } from "./MarkdownPaper";
 
 type SideDocumentPaneProps = {
   bodyFontSize: number;
+  bottomOverlayInset?: number;
   content: string;
   contentWidth: EditorContentWidth;
   contentWidthPx: number | null;
@@ -32,6 +34,7 @@ type SideDocumentPaneProps = {
   spellcheckEnabled?: boolean;
   spellcheckIgnoredWords?: readonly string[];
   spellchecker?: Spellchecker;
+  status?: ReactNode;
   tableColumnWidthMode?: TableColumnWidthModePreference;
   onAddSpellcheckIgnoredWord?: (word: string) => unknown;
   onSaveClipboardAttachment?: (attachment: File) => Promise<{ label: string; src: string } | null>;
@@ -49,6 +52,7 @@ function ignoreSideEditorReady() {
 
 export function SideDocumentPane({
   bodyFontSize,
+  bottomOverlayInset = 0,
   content,
   contentWidth,
   contentWidthPx,
@@ -70,6 +74,7 @@ export function SideDocumentPane({
   spellcheckEnabled = false,
   spellcheckIgnoredWords,
   spellchecker,
+  status = null,
   tableColumnWidthMode = "auto",
   onAddSpellcheckIgnoredWord,
   onSaveClipboardAttachment,
@@ -91,6 +96,7 @@ export function SideDocumentPane({
     >
       {mode === "source" ? (
         <LazyMarkdownSourceEditor
+          bottomOverlayInset={bottomOverlayInset}
           bodyFontSize={bodyFontSize}
           content={content}
           contentWidth={contentWidth}
@@ -110,6 +116,7 @@ export function SideDocumentPane({
       ) : (
         <MarkdownPaper
           autoFocus={false}
+          bottomOverlayInset={bottomOverlayInset}
           bodyFontSize={bodyFontSize}
           contentWidth={contentWidth}
           contentWidthPx={contentWidthPx}
@@ -142,6 +149,7 @@ export function SideDocumentPane({
           wrapCodeBlocks={wrapCodeBlocks}
         />
       )}
+      {status}
     </section>
   );
 }

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -290,6 +290,7 @@ export function useMarkdownDocument({
   const wordCount = markdownSummaryDeferred
     ? currentDeferredMarkdownSummary?.wordCount ?? emptyMarkdownDocumentSummary.wordCount
     : immediateMarkdownSummary.wordCount;
+  const watchedMarkdownFilePathsKey = useMemo(() => openFilePathsFromTabs(tabs).join("\n"), [tabs]);
 
   useEffect(() => {
     if (!markdownSummaryDeferred) return;
@@ -725,6 +726,84 @@ export function useMarkdownDocument({
       }),
     []
   );
+
+  const applyDiskFileToCleanOpenTab = useCallback((
+    file: NativeMarkdownFile,
+    reason: string,
+    expectedTab?: { content: string; id: string; revision: number }
+  ) => {
+    const currentTabs = tabsRef.current;
+    const targetTab = currentTabs.find((tab) => tab.path !== null && sameNativePath(tab.path, file.path));
+    // Tab-selection refreshes are async; ignore disk reads if the tab changed while the read was in flight.
+    const staleRequest =
+      expectedTab &&
+      (
+        targetTab?.id !== expectedTab.id ||
+        targetTab.revision !== expectedTab.revision ||
+        targetTab.content !== expectedTab.content
+      );
+    if (!targetTab || staleRequest || targetTab.dirty || targetTab.content === file.content) {
+      debug(() => ["[markra-history] disk file event ignored", {
+        diskPath: file.path,
+        reason: !targetTab
+          ? "tab missing"
+          : staleRequest
+            ? "stale request"
+            : targetTab.dirty
+              ? "tab dirty"
+              : "contents unchanged",
+        source: reason,
+        tabId: targetTab?.id ?? null
+      }]);
+      return false;
+    }
+
+    const nextDocument = {
+      path: file.path,
+      name: file.name,
+      content: file.content,
+      sizeBytes: file.sizeBytes,
+      dirty: false,
+      open: true,
+      revision: targetTab.revision + 1
+    };
+    const nextTabs = currentTabs.map((tab) =>
+      tab.id === targetTab.id ? createDocumentTab(nextDocument, tab.id) : tab
+    );
+
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    if (targetTab.id === activeTabIdRef.current) {
+      documentRef.current = nextDocument;
+      setDocument(nextDocument);
+    }
+
+    debug(() => ["[markra-history] disk file content applied", {
+      contentsChars: file.content.length,
+      diskPath: file.path,
+      nextRevision: nextDocument.revision,
+      source: reason,
+      tabId: targetTab.id
+    }]);
+    return true;
+  }, []);
+
+  const refreshCleanOpenTabFromDisk = useCallback((path: string, reason: string) => {
+    const currentTab = tabsRef.current.find((tab) => tab.path !== null && sameNativePath(tab.path, path));
+    if (!currentTab || currentTab.dirty) return;
+
+    const expectedTab = {
+      content: currentTab.content,
+      id: currentTab.id,
+      revision: currentTab.revision
+    };
+
+    readMarkdownFileWithPerformance(path, reason)
+      .then((file) => {
+        applyDiskFileToCleanOpenTab(file, reason, expectedTab);
+      })
+      .catch(() => {});
+  }, [applyDiskFileToCleanOpenTab, readMarkdownFileWithPerformance]);
 
   const applyNativeMarkdownFile = useCallback(
     (file: NativeMarkdownFile, updateTreeRoot = true, preferredSessionId?: string | null) => {
@@ -1411,6 +1490,7 @@ export function useMarkdownDocument({
     if (!tab) return false;
 
     setActiveTabState(tabsRef.current, tab.id);
+    if (tab.path && !tab.dirty) refreshCleanOpenTabFromDisk(tab.path, "select-tab");
     registerWindowRestoreState(tab.path, openFilePathsFromTabs(tabsRef.current));
     persistWorkspaceState({
       ...draftWorkspacePatchFromTabs(tabsRef.current, tab.id),
@@ -1418,7 +1498,7 @@ export function useMarkdownDocument({
       openFilePaths: openFilePathsFromTabs(tabsRef.current)
     });
     return true;
-  }, [registerWindowRestoreState, setActiveTabState, syncActiveDocumentFromEditor]);
+  }, [refreshCleanOpenTabFromDisk, registerWindowRestoreState, setActiveTabState, syncActiveDocumentFromEditor]);
 
   const closeMarkdownTab = useCallback(async (tabId: string) => {
     syncActiveDocumentFromEditor();
@@ -1827,104 +1907,73 @@ export function useMarkdownDocument({
   ]);
 
   useEffect(() => {
-    if (!document.path) return;
+    const watchedPaths = watchedMarkdownFilePathsKey.split("\n").filter((path) => path.trim().length > 0);
+    if (watchedPaths.length === 0) return;
 
     let active = true;
-    let unwatch: (() => unknown) | null = null;
-    const watchedDocumentPath = document.path;
+    const stopWatchers: Array<() => unknown> = [];
 
-    debug(() => ["[markra-history] watcher start", {
-      path: watchedDocumentPath
-    }]);
-
-    watchNativeMarkdownFile(document.path, async (changedPath) => {
-      if (!active) return;
-
-      debug(() => ["[markra-history] watcher file event", {
-        changedPath
+    watchedPaths.forEach((watchedPath) => {
+      debug(() => ["[markra-history] watcher start", {
+        path: watchedPath
       }]);
-      // External edits rebuild the editor so the visible document mirrors disk.
-      const file = await readMarkdownFileWithPerformance(changedPath, "watcher");
-      const current = documentRef.current;
-      if (!active || current.path !== file.path || current.dirty || current.content === file.content) {
-        debug(() => ["[markra-history] watcher file event ignored", {
-          active,
-          changedPath,
-          currentDirty: current.dirty,
-          currentPath: current.path,
-          diskPath: file.path,
-          reason: !active
-            ? "inactive"
-            : current.path !== file.path
-              ? "path mismatch"
-              : current.dirty
-                ? "current dirty"
-                : "contents unchanged"
-        }]);
-        return;
-      }
 
-      const latest = documentRef.current;
-      if (latest.path !== file.path || latest.dirty || latest.content === file.content) {
-        debug(() => ["[markra-history] watcher latest event ignored", {
-          changedPath,
-          diskPath: file.path,
-          latestDirty: latest.dirty,
-          latestPath: latest.path,
-          reason: latest.path !== file.path
-            ? "path mismatch"
-            : latest.dirty
-              ? "latest dirty"
-              : "contents unchanged"
-        }]);
-        return;
-      }
+      const treeChangeHandler = sameNativePath(watchedPath, document.path)
+        ? (changedPath: string) => {
+            if (!active) return;
+            debug(() => ["[markra-history] watcher tree event", {
+              changedPath,
+              watchedPath
+            }]);
+            onMarkdownTreeChange?.(changedPath);
+          }
+        : undefined;
 
-      setActiveDocument({
-        path: file.path,
-        name: file.name,
-        content: file.content,
-        sizeBytes: file.sizeBytes,
-        dirty: false,
-        open: true,
-        revision: latest.revision + 1
+      watchNativeMarkdownFile(watchedPath, async (changedPath) => {
+        if (!active) return;
+
+        debug(() => ["[markra-history] watcher file event", {
+          changedPath,
+          watchedPath
+        }]);
+        const file = await readMarkdownFileWithPerformance(changedPath, "watcher");
+        if (!active) return;
+
+        applyDiskFileToCleanOpenTab(file, "watcher");
+      }, treeChangeHandler).then((stopWatching) => {
+        if (!active) {
+          stopWatching();
+          return;
+        }
+
+        stopWatchers.push(stopWatching);
+        debug(() => ["[markra-history] watcher ready", {
+          path: watchedPath
+        }]);
+      }).catch((error: unknown) => {
+        debug(() => ["[markra-history] watcher failed", {
+          error: error instanceof Error ? error.message : String(error),
+          path: watchedPath
+        }]);
       });
-      debug(() => ["[markra-history] watcher applied disk content", {
-        changedPath,
-        contentsChars: file.content.length,
-        nextRevision: latest.revision + 1
-      }]);
-    }, (changedPath) => {
-      if (!active) return;
-      debug(() => ["[markra-history] watcher tree event", {
-        changedPath
-      }]);
-      onMarkdownTreeChange?.(changedPath);
-    }).then((stopWatching) => {
-      if (!active) {
-        stopWatching();
-        return;
-      }
-
-      unwatch = stopWatching;
-      debug(() => ["[markra-history] watcher ready", {
-        path: watchedDocumentPath
-      }]);
-    }).catch((error: unknown) => {
-      debug(() => ["[markra-history] watcher failed", {
-        error: error instanceof Error ? error.message : String(error),
-        path: watchedDocumentPath
-      }]);
     });
 
     return () => {
       active = false;
-      debug(() => ["[markra-history] watcher stop", {
-        path: watchedDocumentPath
-      }]);
-      unwatch?.();
+      watchedPaths.forEach((watchedPath) => {
+        debug(() => ["[markra-history] watcher stop", {
+          path: watchedPath
+        }]);
+      });
+      stopWatchers.forEach((stopWatching) => stopWatching());
     };
-  }, [document.path, onMarkdownTreeChange, readMarkdownFileWithPerformance, setActiveDocument]);
+  }, [
+    applyDiskFileToCleanOpenTab,
+    document.path,
+    onMarkdownTreeChange,
+    readMarkdownFileWithPerformance,
+    watchedMarkdownFilePathsKey
+  ]);
 
   return {
     clearRecentMarkdownFiles,


### PR DESCRIPTION

## Summary
- Refresh clean open Markdown tabs from disk when switching tabs or when watched files change, including side-by-side panes.
- Show the quiet status overlay for side-by-side document panes with the same bottom inset as the main pane.
- Restore a wider but non-overlapping file tree resize hitbox.

## Why
- Fixes the UI/control issues reported in #430 where side panes and inactive clean tabs could show stale content or missing document status, and the file tree resizer was too hard to grab.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownFileTreeDrawer.test.tsx`
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx`
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx`
- `pnpm --filter @markra/app exec vitest run`
- `pnpm --filter @markra/app typecheck:test`
- `pnpm --filter @markra/app build`

## Risk
- Watcher fan-out now tracks all open Markdown file paths; stale and dirty tab guards prevent overwriting local edits, with regression coverage for delayed reads.

Closes #430
