### PR TITLE
fix(editor): hide raw HTML wrapper boundaries

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -9194,6 +9194,30 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("</v-clicks>");
   });
 
+  it("hides empty raw HTML wrapper boundary tags without swallowing markdown blocks", async () => {
+    const source = [
+      '<div class="text-center">',
+      "",
+      "## Synthetic questions?",
+      "",
+      "**Example Presenter**",
+      "",
+      "</div>"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+
+    const surfaceText = container.querySelector(".ProseMirror")?.textContent ?? "";
+
+    expect(surfaceText).toContain("Synthetic questions?");
+    expect(surfaceText).toContain("Example Presenter");
+    expect(surfaceText).not.toContain('<div class="text-center">');
+    expect(surfaceText).not.toContain("</div>");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain('<div class="text-center">');
+    expect(serializeMarkdown(view.state.doc)).toContain("</div>");
+  });
+
   it("keeps raw HTML class attributes out of preview layout while preserving source", async () => {
     const source = [
       '<div class="text-center mt-20">',

--- a/packages/editor/src/raw-html.ts
+++ b/packages/editor/src/raw-html.ts
@@ -272,14 +272,32 @@ function firstRawHtmlElementTagName(rawHtml: string, ownerDocument: Document) {
   return firstElement instanceof HTMLElement ? firstElement.tagName.toLowerCase() : null;
 }
 
-function rawHtmlIsCustomComponentBoundary(rawHtml: string) {
+function rawHtmlBoundaryTagName(rawHtml: string) {
   const match = /^<\/?\s*([A-Za-z][\w:.-]*)(?:\s[^<>]*)?\/?\s*>$/u.exec(rawHtml.trim());
-  if (!match) return false;
+  return match?.[1]?.toLowerCase() ?? null;
+}
 
-  const tagName = match[1]?.toLowerCase() ?? "";
+function rawHtmlIsSelfClosingBoundary(rawHtml: string) {
+  return /\/\s*>$/u.test(rawHtml.trim());
+}
+
+function rawHtmlIsCustomComponentBoundary(rawHtml: string) {
+  const tagName = rawHtmlBoundaryTagName(rawHtml);
+  if (!tagName) return false;
   if (allowedRawHtmlTags.has(tagName) || droppedRawHtmlTags.has(tagName)) return false;
 
   return tagName.includes("-") || tagName.includes(":");
+}
+
+function rawHtmlIsBlockWrapperBoundary(rawHtml: string) {
+  const tagName = rawHtmlBoundaryTagName(rawHtml);
+  if (!tagName || !blockRawHtmlTags.has(tagName)) return false;
+
+  return rawHtml.trim().startsWith("</") || !rawHtmlIsSelfClosingBoundary(rawHtml);
+}
+
+function rawHtmlIsHiddenBoundary(rawHtml: string) {
+  return rawHtmlIsCustomComponentBoundary(rawHtml) || rawHtmlIsBlockWrapperBoundary(rawHtml);
 }
 
 function createRawHtmlRoot(rawHtml: string, ownerDocument: Document) {
@@ -313,7 +331,7 @@ function renderRawHtmlPreviewInto(root: HTMLElement, rawHtml: string, ownerDocum
   }
 
   if (!root.childNodes.length) {
-    if (!rawHtmlIsCustomComponentBoundary(rawHtml)) {
+    if (!rawHtmlIsHiddenBoundary(rawHtml)) {
       root.replaceChildren(createRawHtmlFallback(rawHtml, ownerDocument));
     }
   }


### PR DESCRIPTION
## Summary
- hide standalone raw HTML block wrapper boundaries such as `<div ...>` and `</div>` in the visual preview
- keep the wrapped Markdown content visible and editable
- preserve the original HTML boundary tags when serializing Markdown

## Why
The Slidev repro in #432 still had plain HTML wrapper lines rendered as visible text in Markra, for example `<div class="text-center">` around ordinary Markdown content. GitHub treats those as HTML wrappers rather than text.

## Validation
- `pnpm exec vitest run src/components/MarkdownPaper.test.tsx -t "hides empty raw HTML wrapper boundary"` passed
- `pnpm exec vitest run src/components/MarkdownPaper.test.tsx` passed: 430 tests
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app typecheck:test` passed

## Risk
- Standalone allowed block wrapper tags no longer show as literal preview text when they have no preview children. The original Markdown source is still preserved, and complete HTML blocks with rendered children continue to render normally.

Refs #432