### PR TITLE
fix(app): preserve externally deleted document tabs

### DIFF
--- a/packages/app/src/components/MarkdownTabsBar.test.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.test.tsx
@@ -89,6 +89,30 @@ describe("MarkdownTabsBar", () => {
     expect(newTabButton.closest(".document-tabs-controls")).toBeInTheDocument();
   });
 
+  it("renders deleted document tab labels with a strikethrough", () => {
+    render(
+      <MarkdownTabsBar
+        activeTabId="tab-a"
+        items={[
+          {
+            deleted: true,
+            dirty: false,
+            id: "tab-a",
+            name: "Alpha.md",
+            path: "/synthetic/alpha.md"
+          }
+        ]}
+        placement="titlebar"
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        onSelectTab={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("tab", { name: /Alpha\.md/ })).toBeInTheDocument();
+    expect(screen.getByText("Alpha.md")).toHaveClass("line-through");
+  });
+
   it("scrolls overflowing tabs horizontally with a vertical mouse wheel", () => {
     render(
       <MarkdownTabsBar

--- a/packages/app/src/components/MarkdownTabsBar.tsx
+++ b/packages/app/src/components/MarkdownTabsBar.tsx
@@ -13,7 +13,7 @@ import { t, type AppLanguage } from "@markra/shared";
 import type { MarkdownDocumentTab } from "../hooks/useMarkdownDocument";
 import { ContextMenu, type ContextMenuEntry } from "./ContextMenu";
 
-export type MarkdownTabsBarDocumentItem = Pick<MarkdownDocumentTab, "dirty" | "id" | "name"> & {
+export type MarkdownTabsBarDocumentItem = Pick<MarkdownDocumentTab, "deleted" | "dirty" | "id" | "name"> & {
   displayKind?: "image" | "markdown";
   path?: string | null;
 };
@@ -536,7 +536,9 @@ export function MarkdownTabsBar({
           onPointerDown={(event) => handleTabPointerDown(event, tab)}
         >
           <TabIcon aria-hidden="true" className="shrink-0 opacity-65" size={13} />
-          <span className="min-w-0 truncate">{tab.name || "Untitled.md"}</span>
+          <span className={`min-w-0 truncate ${tab.deleted ? "line-through decoration-(--text-tertiary) decoration-1" : ""}`}>
+            {tab.name || "Untitled.md"}
+          </span>
           {tab.dirty ? (
             <span className="size-1.25 shrink-0 rounded-full bg-(--accent)" aria-label={label("app.unsavedChanges")} />
           ) : null}

--- a/packages/app/src/hooks/markdown-document/document-model.ts
+++ b/packages/app/src/hooks/markdown-document/document-model.ts
@@ -14,6 +14,7 @@ export function createInitialDocumentState(): DocumentState {
     path: null,
     name: "Untitled.md",
     content: "",
+    deleted: false,
     dirty: false,
     open: true,
     revision: 0
@@ -38,6 +39,7 @@ export function documentFromTab(tab: MarkdownDocumentTab): DocumentState {
     name: tab.name,
     content: tab.content,
     sizeBytes: tab.sizeBytes,
+    deleted: tab.deleted,
     dirty: tab.dirty,
     open: tab.open,
     revision: tab.revision
@@ -49,6 +51,7 @@ export function documentFromDraftTab(draft: StoredWorkspaceDraftTab, revision: n
     path: draft.path,
     name: draft.name,
     content: draft.content,
+    deleted: false,
     dirty: true,
     open: true,
     revision

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1520,6 +1520,126 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("marks an externally deleted active document tab without closing it", async () => {
+    let emitExternalChange: (path: string) => unknown | Promise<unknown> = () => {};
+    let deletedExternally = false;
+    mockedWatchNativeMarkdownFile.mockImplementation(async (_path, onChange) => {
+      emitExternalChange = onChange;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (deletedExternally) throw new Error("No such file or directory");
+
+      return {
+        content: "# Guide",
+        name: "guide.md",
+        path
+      };
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+    await waitFor(() => expect(mockedWatchNativeMarkdownFile).toHaveBeenCalled());
+    const activeTabId = result.current.activeTabId;
+
+    deletedExternally = true;
+    await act(async () => {
+      await emitExternalChange("/mock-files/guide.md");
+    });
+
+    expect(result.current.activeTabId).toBe(activeTabId);
+    expect(result.current.document).toMatchObject({
+      deleted: true,
+      name: "guide.md",
+      open: true,
+      path: "/mock-files/guide.md"
+    });
+    expect(result.current.tabs).toMatchObject([
+      {
+        deleted: true,
+        name: "guide.md",
+        path: "/mock-files/guide.md"
+      }
+    ]);
+  });
+
+  it("saves an externally deleted active document through a new target path", async () => {
+    let emitExternalChange: (path: string) => unknown | Promise<unknown> = () => {};
+    let deletedExternally = false;
+    mockedWatchNativeMarkdownFile.mockImplementation(async (_path, onChange) => {
+      emitExternalChange = onChange;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (deletedExternally) throw new Error("No such file or directory");
+
+      return {
+        content: "# Guide",
+        name: "guide.md",
+        path
+      };
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValue({
+      name: "guide-restored.md",
+      path: "/mock-files/restored/guide-restored.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+    await waitFor(() => expect(mockedWatchNativeMarkdownFile).toHaveBeenCalled());
+
+    deletedExternally = true;
+    await act(async () => {
+      await emitExternalChange("/mock-files/guide.md");
+    });
+    mockedSaveNativeMarkdownFile.mockClear();
+
+    await act(async () => {
+      await result.current.saveCurrentDocument();
+    });
+
+    expect(mockedSaveNativeMarkdownFile).toHaveBeenCalledWith(expect.objectContaining({
+      contents: "# Guide",
+      path: null,
+      suggestedName: "guide.md"
+    }));
+    expect(result.current.document).toMatchObject({
+      deleted: false,
+      name: "guide-restored.md",
+      path: "/mock-files/restored/guide-restored.md"
+    });
+  });
+
   it("updates open tree document paths when their containing folder is moved", async () => {
     mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
       content: path.endsWith("guide.md") ? "# Guide" : "# Notes",

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -118,6 +118,11 @@ function markdownDocumentSummaryKey(document: DocumentState) {
   ].join(":");
 }
 
+function isMissingMarkdownFileReadError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /(?:cannot find|no longer exists|no such file|not found)/iu.test(message);
+}
+
 function calculateMarkdownDocumentSummary(
   content: string,
   detail: Record<string, unknown>
@@ -441,6 +446,7 @@ export function useMarkdownDocument({
         path: null,
         name: "",
         content: "",
+        deleted: false,
         dirty: false,
         open: false,
         revision: documentRef.current.revision + 1
@@ -645,6 +651,7 @@ export function useMarkdownDocument({
       path: null,
       name: blankDocumentName(options.name),
       content: options.content ?? "",
+      deleted: false,
       dirty: true,
       open: true,
       revision: documentRef.current.revision + 1
@@ -696,6 +703,7 @@ export function useMarkdownDocument({
       path: null,
       name: "",
       content: "",
+      deleted: false,
       dirty: false,
       open: false,
       revision: documentRef.current.revision + 1
@@ -742,7 +750,7 @@ export function useMarkdownDocument({
         targetTab.revision !== expectedTab.revision ||
         targetTab.content !== expectedTab.content
       );
-    if (!targetTab || staleRequest || targetTab.dirty || targetTab.content === file.content) {
+    if (!targetTab || staleRequest || targetTab.dirty || (!targetTab.deleted && targetTab.content === file.content)) {
       debug(() => ["[markra-history] disk file event ignored", {
         diskPath: file.path,
         reason: !targetTab
@@ -751,7 +759,9 @@ export function useMarkdownDocument({
             ? "stale request"
             : targetTab.dirty
               ? "tab dirty"
-              : "contents unchanged",
+              : !targetTab.deleted && targetTab.content === file.content
+                ? "contents unchanged"
+                : "unknown",
         source: reason,
         tabId: targetTab?.id ?? null
       }]);
@@ -763,6 +773,7 @@ export function useMarkdownDocument({
       name: file.name,
       content: file.content,
       sizeBytes: file.sizeBytes,
+      deleted: false,
       dirty: false,
       open: true,
       revision: targetTab.revision + 1
@@ -816,6 +827,7 @@ export function useMarkdownDocument({
           name: file.name,
           content: file.content,
           sizeBytes: file.sizeBytes,
+          deleted: false,
           dirty: false,
           open: true,
           revision: documentRef.current.revision + 1
@@ -932,6 +944,7 @@ export function useMarkdownDocument({
             name: file.name,
             content: file.content,
             sizeBytes: file.sizeBytes,
+            deleted: false,
             dirty: false,
             open: true,
             revision: documentRef.current.revision + 1
@@ -945,6 +958,7 @@ export function useMarkdownDocument({
           name: activeFile.name,
           content: activeFile.content,
           sizeBytes: activeFile.sizeBytes,
+          deleted: false,
           dirty: false,
           open: true,
           revision: documentRef.current.revision + 1
@@ -1051,6 +1065,7 @@ export function useMarkdownDocument({
           name: nativeFile.name,
           content: nativeFile.content,
           sizeBytes: nativeFile.sizeBytes,
+          deleted: false,
           dirty: false,
           open: true,
           revision: documentRef.current.revision + 1
@@ -1090,6 +1105,7 @@ export function useMarkdownDocument({
     if (current.path === previousPath) {
       setActiveDocument({
         ...current,
+        deleted: false,
         name: file.name,
         path: file.path
       });
@@ -1100,6 +1116,7 @@ export function useMarkdownDocument({
 
       return {
         ...tab,
+        deleted: false,
         name: file.name,
         path: file.path
       };
@@ -1128,6 +1145,7 @@ export function useMarkdownDocument({
       if (nextPath !== current.path) {
         setActiveDocument({
           ...current,
+          deleted: false,
           name: current.path === previousPath ? file.name : current.name,
           path: nextPath
         });
@@ -1140,6 +1158,7 @@ export function useMarkdownDocument({
 
       return {
         ...tab,
+        deleted: false,
         name: tab.path === previousPath ? file.name : tab.name,
         path: nextPath
       };
@@ -1197,6 +1216,39 @@ export function useMarkdownDocument({
     return true;
   }, [documentTabsEnabled, registerWindowRestoreState, setActiveDocument, setActiveTabState]);
 
+  const markExternallyDeletedDocumentFile = useCallback((path: string) => {
+    const matchesDeletedPath = (documentPath: string | null) =>
+      documentPath !== null && isDeletedDocumentPath(documentPath, path);
+    const currentTabs = tabsRef.current;
+    const current = documentRef.current;
+    const activeTabId = activeTabIdRef.current;
+    const affectsCurrent = matchesDeletedPath(current.path);
+    const affectsTabs = currentTabs.some((tab) => matchesDeletedPath(tab.path));
+
+    if (!affectsCurrent && !affectsTabs) return false;
+
+    const nextDocument = affectsCurrent ? { ...current, deleted: true } : current;
+    const nextTabs = currentTabs.map((tab) => {
+      if (affectsCurrent && tab.id === activeTabId) return createDocumentTab(nextDocument, tab.id);
+      if (matchesDeletedPath(tab.path)) return { ...tab, deleted: true };
+      return tab;
+    });
+
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    if (affectsCurrent) {
+      documentRef.current = nextDocument;
+      setDocument(nextDocument);
+    }
+    persistWorkspaceState({
+      ...draftWorkspacePatchFromTabs(nextTabs, activeTabId),
+      filePath: activeFilePathFromTabs(nextTabs, activeTabId),
+      openFilePaths: openFilePathsFromTabs(nextTabs)
+    });
+    registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabId), openFilePathsFromTabs(nextTabs));
+    return true;
+  }, [registerWindowRestoreState]);
+
   const applySavedCurrentDocument = useCallback((
     savedFile: { name: string; path: string },
     contents: string,
@@ -1228,6 +1280,7 @@ export function useMarkdownDocument({
       path: savedFile.path,
       name: savedFile.name,
       content: contentChangedAfterSaveStarted ? targetDocument.content : contents,
+      deleted: false,
       dirty: contentChangedAfterSaveStarted ? true : false,
       revision: targetDocument.revision
     };
@@ -1276,7 +1329,7 @@ export function useMarkdownDocument({
 
       const targetTabId = activeTabIdRef.current;
       const contents = currentMarkdownForSave(current, targetTabId);
-      const savePath = saveAs ? null : current.path;
+      const savePath = saveAs || current.deleted ? null : current.path;
       const savedFile = await saveNativeMarkdownFile({
         ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
         path: savePath,
@@ -1287,7 +1340,7 @@ export function useMarkdownDocument({
       if (!savedFile) return null;
 
       applySavedCurrentDocument(savedFile, contents, {
-        retargetWorkspaceRoot: saveAs || current.path === null,
+        retargetWorkspaceRoot: saveAs || current.path === null || current.deleted === true,
         sourceContent: current.content,
         targetTabId
       });
@@ -1302,7 +1355,7 @@ export function useMarkdownDocument({
       contents: string,
       options: SaveCurrentDocumentContentOptions = {}
     ) => {
-      const savePath = tab.path;
+      const savePath = tab.deleted ? null : tab.path;
       const savedFile = await saveNativeMarkdownFile({
         ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
         historyCursorId: options.historyCursorId,
@@ -1315,7 +1368,7 @@ export function useMarkdownDocument({
       if (!savedFile) return null;
 
       applySavedCurrentDocument(savedFile, contents, {
-        retargetWorkspaceRoot: tab.path === null,
+        retargetWorkspaceRoot: tab.path === null || tab.deleted === true,
         sourceContent: tab.content,
         targetTabId: tab.id
       });
@@ -1345,7 +1398,7 @@ export function useMarkdownDocument({
         suggestedName: current.name || "Untitled.md"
       }]);
 
-      const savePath = current.path;
+      const savePath = current.deleted ? null : current.path;
       let savedFile: Awaited<ReturnType<typeof saveNativeMarkdownFile>>;
       try {
         savedFile = await saveNativeMarkdownFile({
@@ -1372,7 +1425,7 @@ export function useMarkdownDocument({
       }
 
       applySavedCurrentDocument(savedFile, contents, {
-        retargetWorkspaceRoot: current.path === null,
+        retargetWorkspaceRoot: current.path === null || current.deleted === true,
         sourceContent: current.content,
         targetTabId
       });
@@ -1395,7 +1448,7 @@ export function useMarkdownDocument({
       const contents = tab.id === activeTabIdRef.current
         ? currentMarkdownForSave(documentFromTab(tab), tab.id)
         : tab.content;
-      const savePath = saveAs ? null : tab.path;
+      const savePath = saveAs || tab.deleted ? null : tab.path;
       const savedFile = await saveNativeMarkdownFile({
         ...defaultSaveDirectoryInput(defaultSaveDirectory, savePath),
         path: savePath,
@@ -1411,6 +1464,7 @@ export function useMarkdownDocument({
         path: savedFile.path,
         name: savedFile.name,
         content: contents,
+        deleted: false,
         dirty: false,
         revision: sourceDocument.revision
       };
@@ -1431,14 +1485,14 @@ export function useMarkdownDocument({
         setDocument(nextDocument);
       }
 
-      if (saveAs || tab.path === null) onTreeRootFromFilePath(savedFile.path);
+      if (saveAs || tab.path === null || tab.deleted) onTreeRootFromFilePath(savedFile.path);
       rememberRecentMarkdownFile(savedFile);
       registerWindowRestoreState(activeFilePathFromTabs(nextTabs, activeTabIdRef.current), openFilePathsFromTabs(nextTabs));
       persistWorkspaceState({
         ...draftWorkspacePatchFromTabs(nextTabs, activeTabIdRef.current),
         filePath: activeFilePathFromTabs(nextTabs, activeTabIdRef.current),
         openFilePaths: openFilePathsFromTabs(nextTabs),
-        ...(saveAs || tab.path === null ? { folderName: null, folderPath: null } : {})
+        ...(saveAs || tab.path === null || tab.deleted ? { folderName: null, folderPath: null } : {})
       });
       return savedFile;
     },
@@ -1462,7 +1516,7 @@ export function useMarkdownDocument({
 
     const savePromise = (async () => {
       syncActiveDocumentFromEditor();
-      const dirtyTabs = tabsRef.current.filter((tab) => tab.open && tab.dirty && tab.path !== null);
+      const dirtyTabs = tabsRef.current.filter((tab) => tab.open && tab.dirty && tab.path !== null && !tab.deleted);
       for (const tab of dirtyTabs) {
         await saveMarkdownTabContent(tab, tab.content, { skipHistorySnapshot: true });
       }
@@ -1936,7 +1990,28 @@ export function useMarkdownDocument({
           changedPath,
           watchedPath
         }]);
-        const file = await readMarkdownFileWithPerformance(changedPath, "watcher");
+        let file: NativeMarkdownFile;
+        try {
+          file = await readMarkdownFileWithPerformance(changedPath, "watcher");
+        } catch (error: unknown) {
+          if (active && isMissingMarkdownFileReadError(error)) {
+            const markedDeleted = markExternallyDeletedDocumentFile(changedPath);
+            debug(() => ["[markra-history] watcher marked missing file", {
+              changedPath,
+              markedDeleted,
+              watchedPath
+            }]);
+            onMarkdownTreeChange?.(changedPath);
+            return;
+          }
+
+          debug(() => ["[markra-history] watcher read failed", {
+            changedPath,
+            error: error instanceof Error ? error.message : String(error),
+            watchedPath
+          }]);
+          return;
+        }
         if (!active) return;
 
         applyDiskFileToCleanOpenTab(file, "watcher");
@@ -1970,6 +2045,7 @@ export function useMarkdownDocument({
   }, [
     applyDiskFileToCleanOpenTab,
     document.path,
+    markExternallyDeletedDocumentFile,
     onMarkdownTreeChange,
     readMarkdownFileWithPerformance,
     watchedMarkdownFilePathsKey

--- a/packages/shared/src/document.ts
+++ b/packages/shared/src/document.ts
@@ -3,6 +3,7 @@ export type DocumentState = {
   name: string;
   content: string;
   sizeBytes?: number;
+  deleted?: boolean;
   dirty: boolean;
   open: boolean;
   revision: number;


### PR DESCRIPTION
## Summary
- Keep document tabs open when an already-open markdown file is deleted outside Markra.
- Mark externally deleted tabs with a strikethrough while preserving the original path/name/content.
- Route Ctrl+S on an externally deleted document through the save-as/new-target flow and clear the deleted state after saving.

## Why
Externally deleted files were previously treated like normal disk refreshes: the watcher attempted to reread the missing path and did not give the tab a recoverable deleted state. This made the UI diverge from editor behavior users expect from tools like VS Code.

Internal deletes still use the existing detach flow and close/remove the matching tab.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx src/components/MarkdownTabsBar.test.tsx` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/shared build` passed
- `pnpm --filter @markra/app build` passed

## Risk
- Low-to-medium: touches document tab state and save routing, but the new behavior is scoped to watcher read failures that indicate a missing external file.
