### PR TITLE
fix(app): keep split source pane synced

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,5 +1,8 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { EditorView } from "@codemirror/view";
+import { Editor as MilkdownEditor, editorViewCtx } from "@milkdown/kit/core";
+import { TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorView as ProseMirrorEditorView } from "@milkdown/kit/prose/view";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import desktopPackage from "../package.json";
 import { defaultAiQuickActionPrompts } from "./lib/ai-actions";
@@ -261,6 +264,20 @@ function replaceMarkdownSource(sourceEditor: HTMLElement, value: string) {
         to: view.state.doc.length
       }
     });
+  });
+}
+
+function typeVisualText(view: ProseMirrorEditorView, text: string) {
+  act(() => {
+    for (const char of text) {
+      const { from, to } = view.state.selection;
+      const insertText = () => view.state.tr.insertText(char, from, to).scrollIntoView();
+      const handled = view.someProp("handleTextInput", (handler) => handler(view, from, to, char, insertText));
+
+      if (!handled) {
+        view.dispatch(insertText());
+      }
+    }
   });
 }
 
@@ -5982,6 +5999,115 @@ describe("Markra workspace", () => {
       expect(currentSource).not.toContain("Column 1");
       expect(currentSource).not.toContain("Column 2");
     });
+  });
+
+  it("keeps a visual update that arrives after source pane focus in split mode", async () => {
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+    const { container } = renderApp();
+
+    try {
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+      await settleEditorUpdates();
+
+      await selectEditorViewMode("Preview + Source");
+
+      const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+      await act(async () => {
+        fireEvent.focusIn(sourceEditor);
+      });
+
+      const visualView = createdEditors.reduce<ProseMirrorEditorView | null>((visibleView, editor) => {
+        if (visibleView) return visibleView;
+
+        try {
+          const view = editor.action((ctx) => ctx.get(editorViewCtx));
+          return container.contains(view.dom) && !view.dom.closest("[hidden]") ? view : null;
+        } catch {
+          return null;
+        }
+      }, null);
+      if (!visualView) throw new Error("Expected a visible Milkdown editor view.");
+
+      act(() => {
+        visualView.dispatch(
+          visualView.state.tr
+            .setSelection(TextSelection.atEnd(visualView.state.doc))
+            .insertText("\n\nDelayed visual sync.")
+        );
+      });
+
+      await waitFor(() => {
+        expect(readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }))).toContain(
+          "Delayed visual sync."
+        );
+      });
+    } finally {
+      makeSpy.mockRestore();
+    }
+  });
+
+  it("keeps a synced visual edit in source after focusing the source pane in split mode", async () => {
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+    const { container } = renderApp();
+
+    try {
+      expect(await screen.findByText("Welcome to Markra")).toBeInTheDocument();
+      await settleEditorUpdates();
+
+      await selectEditorViewMode("Preview + Source");
+
+      const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+      const originalSource = readMarkdownSource(sourceEditor);
+      const visualView = createdEditors.reduce<ProseMirrorEditorView | null>((visibleView, editor) => {
+        if (visibleView) return visibleView;
+
+        try {
+          const view = editor.action((ctx) => ctx.get(editorViewCtx));
+          return container.contains(view.dom) && !view.dom.closest("[hidden]") ? view : null;
+        } catch {
+          return null;
+        }
+      }, null);
+      if (!visualView) throw new Error("Expected a visible Milkdown editor view.");
+
+      await act(async () => {
+        fireEvent.focusIn(visualView.dom);
+      });
+      act(() => {
+        visualView.dispatch(visualView.state.tr.setSelection(TextSelection.atStart(visualView.state.doc)));
+      });
+      typeVisualText(visualView, "Visual typed before source focus. ");
+
+      await waitFor(() => {
+        expect(readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }))).toContain(
+          "Visual typed before source focus."
+        );
+      });
+
+      await act(async () => {
+        fireEvent.focusIn(screen.getByRole("textbox", { name: "Markdown source" }));
+      });
+
+      await waitFor(() => {
+        const currentSource = readMarkdownSource(screen.getByRole("textbox", { name: "Markdown source" }));
+        expect(currentSource).toContain("Visual typed before source focus.");
+        expect(currentSource).not.toBe(originalSource);
+      });
+    } finally {
+      makeSpy.mockRestore();
+    }
   });
 
   it("places the visual pane before the source pane in split mode", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -378,6 +378,9 @@ function WorkspaceApp() {
   const splitScrollSyncFrameRef = useRef<number | null>(null);
   const splitPaneResizeCleanupRef = useRef<(() => unknown) | null>(null);
   const sideDocumentPaneResizeCleanupRef = useRef<(() => unknown) | null>(null);
+  // Late visual-editor updates may arrive after focus moves to source; source edits after that focus win.
+  const sourceEditSequenceRef = useRef(0);
+  const sourceFocusSourceEditSequenceRef = useRef(0);
   const exportContextRef = useRef({
     activeImageFile: false,
     content: "",
@@ -2560,6 +2563,11 @@ function WorkspaceApp() {
   const titleDocumentKind = activeImageFile ? "image" : hasOpenDocument ? "file" : "folder";
   const sourceModeAvailable = hasOpenDocument && !activeImageFile;
   const supportsAiThinking = selectedInlineAiModel?.capabilities.includes("reasoning") ?? false;
+  useEffect(() => {
+    if (activeEditorSurface !== "source") return;
+
+    sourceFocusSourceEditSequenceRef.current = sourceEditSequenceRef.current;
+  }, [activeEditorSurface, activeTabId, document.path, document.revision]);
   const handleMainDocumentPaneFocus = useCallback(() => {
     setDocumentOperationTarget("main");
   }, []);
@@ -2569,6 +2577,7 @@ function WorkspaceApp() {
   }, []);
   const handleSourcePaneFocus = useCallback(() => {
     setDocumentOperationTarget("main");
+    sourceFocusSourceEditSequenceRef.current = sourceEditSequenceRef.current;
     setActiveEditorSurface("source");
     updateActiveAiSelection(null);
   }, [updateActiveAiSelection]);
@@ -2577,19 +2586,46 @@ function WorkspaceApp() {
   }, []);
   const handleVisualMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (isApplyingSourceToVisualSync()) return;
-    if (sourceSurfaceActive) return;
+    if (sourceMode) return;
     if (readOnlyMode) return;
+    if (
+      splitMode &&
+      activeEditorSurface === "source" &&
+      sourceEditSequenceRef.current !== sourceFocusSourceEditSequenceRef.current
+    ) {
+      return;
+    }
 
-    if (splitMode) setActiveEditorSurface("visual");
+    if (splitMode && activeEditorSurface !== "source") setActiveEditorSurface("visual");
     handleMarkdownChange(content, { ...options, surface: "visual" });
-  }, [handleMarkdownChange, isApplyingSourceToVisualSync, readOnlyMode, sourceSurfaceActive, splitMode]);
+  }, [
+    activeEditorSurface,
+    handleMarkdownChange,
+    isApplyingSourceToVisualSync,
+    readOnlyMode,
+    sourceMode,
+    splitMode
+  ]);
   const handleSourceMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (readOnlyMode) return;
+    if (
+      content !== document.content &&
+      (options?.documentRevision === undefined || options.documentRevision === document.revision)
+    ) {
+      sourceEditSequenceRef.current += 1;
+    }
 
     markSourceEditForHistory(content, options);
     if (splitMode) setActiveEditorSurface("source");
     handleMarkdownChange(content, { ...options, surface: "source" });
-  }, [handleMarkdownChange, markSourceEditForHistory, readOnlyMode, splitMode]);
+  }, [
+    document.content,
+    document.revision,
+    handleMarkdownChange,
+    markSourceEditForHistory,
+    readOnlyMode,
+    splitMode
+  ]);
   const syncSplitPaneScrollPosition = useCallback((sourceSurface: EditorSurface, sourceElement: HTMLElement) => {
     if (!splitMode) return false;
 

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -133,6 +133,34 @@ describe("MarkdownSourceEditor", () => {
     expect(view.state.doc.toString()).toBe("# External");
   });
 
+  it("keeps externally synced content when autofocus changes", () => {
+    const { container, rerender } = render(
+      <MarkdownSourceEditor
+        content="# First"
+        onChange={() => {}}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    rerender(
+      <MarkdownSourceEditor
+        content="# External"
+        onChange={() => {}}
+      />
+    );
+    expect(view.state.doc.toString()).toBe("# External");
+
+    rerender(
+      <MarkdownSourceEditor
+        autoFocus
+        content="# External"
+        onChange={() => {}}
+      />
+    );
+
+    expect(getMarkdownSourceView(container).state.doc.toString()).toBe("# External");
+  });
+
   it("notifies selected source text changes", () => {
     const handleSelectionTextChange = vi.fn();
     const { container } = render(

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -198,7 +198,7 @@ export function MarkdownSourceEditor({
   topInset = "titlebar"
 }: MarkdownSourceEditorProps) {
   const editorContainerRef = useRef<HTMLDivElement | null>(null);
-  const initialContentRef = useRef(content);
+  const contentRef = useRef(content);
   const onChangeRef = useRef(onChange);
   const onRedoRef = useRef(onRedo);
   const onSelectionTextChangeRef = useRef(onSelectionTextChange);
@@ -275,7 +275,7 @@ export function MarkdownSourceEditor({
     const view = new EditorView({
       parent: container,
       state: EditorState.create({
-        doc: initialContentRef.current,
+        doc: contentRef.current,
         extensions
       })
     });
@@ -288,7 +288,13 @@ export function MarkdownSourceEditor({
       view.destroy();
       viewRef.current = null;
     };
-  }, [autoFocus, extensions]);
+  }, [extensions]);
+
+  useEffect(() => {
+    if (!autoFocus) return;
+
+    viewRef.current?.focus();
+  }, [autoFocus]);
 
   useEffect(() => {
     const view = viewRef.current;
@@ -304,6 +310,7 @@ export function MarkdownSourceEditor({
 
   useEffect(() => {
     const view = viewRef.current;
+    contentRef.current = content;
     if (!view) return;
 
     const currentContent = view.state.doc.toString();

--- a/packages/app/src/hooks/useSharedEditorHistory.test.tsx
+++ b/packages/app/src/hooks/useSharedEditorHistory.test.tsx
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSharedEditorHistory } from "./useSharedEditorHistory";
+
+describe("useSharedEditorHistory", () => {
+  it("does not sync source to visual just because the source pane received focus", () => {
+    const replaceEditorMarkdown = vi.fn(() => true);
+    const { rerender } = renderHook(
+      ({ sourceSurfaceActive }) => useSharedEditorHistory({
+        documentContent: "# Split\n\nEdited from visual.",
+        documentRevision: 1,
+        largeMarkdownVisualBlocked: false,
+        replaceEditorMarkdown,
+        sourceSurfaceActive,
+        syncSourceToVisual: sourceSurfaceActive,
+        visualEditorReadySequence: 1
+      }),
+      { initialProps: { sourceSurfaceActive: false } }
+    );
+
+    rerender({ sourceSurfaceActive: true });
+
+    expect(replaceEditorMarkdown).not.toHaveBeenCalled();
+  });
+
+  it("syncs pending source edits to visual history when the source pane is active", () => {
+    const replaceEditorMarkdown = vi.fn(() => true);
+    const { result, rerender } = renderHook(
+      ({ documentContent, sourceSurfaceActive }) => useSharedEditorHistory({
+        documentContent,
+        documentRevision: 1,
+        largeMarkdownVisualBlocked: false,
+        replaceEditorMarkdown,
+        sourceSurfaceActive,
+        syncSourceToVisual: sourceSurfaceActive,
+        visualEditorReadySequence: 1
+      }),
+      {
+        initialProps: {
+          documentContent: "# Split\n\nOriginal.",
+          sourceSurfaceActive: false
+        }
+      }
+    );
+
+    act(() => {
+      result.current.markSourceEditForHistory("# Split\n\nEdited from source.", { documentRevision: 1 });
+    });
+    rerender({
+      documentContent: "# Split\n\nEdited from source.",
+      sourceSurfaceActive: true
+    });
+
+    expect(replaceEditorMarkdown).toHaveBeenCalledWith("# Split\n\nEdited from source.", {
+      addToHistory: true,
+      historyBaselineMarkdown: "# Split\n\nOriginal."
+    });
+  });
+});

--- a/packages/app/src/hooks/useSharedEditorHistory.ts
+++ b/packages/app/src/hooks/useSharedEditorHistory.ts
@@ -52,12 +52,15 @@ export function useSharedEditorHistory({
 
   const syncSourceEditsToVisualHistory = useCallback(() => {
     if (largeMarkdownVisualBlocked) return false;
+    const pendingSourceHistory = pendingSourceHistoryRef.current;
+    // Source focus after a visual edit should not reapply the visual editor; only source edits need history repair.
+    if (!pendingSourceHistory) return false;
+
     syncingSourceToVisualRef.current = true;
     try {
-      const pendingSourceHistory = pendingSourceHistoryRef.current;
       const synced = replaceEditorMarkdown(documentContent, {
-        addToHistory: Boolean(pendingSourceHistory),
-        historyBaselineMarkdown: pendingSourceHistory?.previousContent
+        addToHistory: true,
+        historyBaselineMarkdown: pendingSourceHistory.previousContent
       });
       if (synced) pendingSourceHistoryRef.current = null;
       return synced;


### PR DESCRIPTION
## Summary
- Keep split preview/source mode accepting late visual-editor updates after focus moves to the source pane.
- Track source edits after source focus so real source changes still win over stale visual updates.
- Avoid source-to-visual history repair when the source pane only receives focus and has no pending source edits.
- Keep the CodeMirror source editor mounted when split source autofocus changes, so focusing source does not recreate it with stale initial content.
- Add regression coverage for split-pane sync and source editor autofocus/content retention.

## Why
Issue #440 reported that Preview + Source mode could show different content between panes, including stale or cross-document-looking source content after editing in the preview and then focusing source.

A manual browser repro showed the remaining failure: after a real visual-editor text input, the source pane first synced correctly, then clicking source recreated CodeMirror from its original `initialContentRef` because the source editor creation effect depended on `autoFocus`. The source editor now focuses in a separate effect instead of remounting on focus changes.

## Validation
- Manual browser check at `http://127.0.0.1:5175/?blank=1`: typed in the left visual pane, observed the right source pane sync, focused the right source pane, and confirmed the source content stayed unchanged.
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownSourceEditor.test.tsx` passed: 12 tests
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "keeps a synced visual edit in source after focusing|keeps a visual update that arrives after source pane focus|keeps source and visual editors synchronized in split mode"` passed: 3 tests
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx -t "keeps a synced visual edit in source after focusing|keeps a visual update that arrives after source pane focus|keeps source and visual editors synchronized in split mode|source mode|split mode|source edits undoable|visual undo history"` passed: 19 tests
- `pnpm --filter @markra/app test` passed: 103 files, 1550 tests
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed

## Risk
- Low. The change is scoped to split/source synchronization and source editor lifecycle. Source focus no longer remounts CodeMirror, while source edits and undo/redo coverage still pass.

## Related Issues
Closes #440