### PR TITLE
ci(release): sign macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,62 @@ jobs:
           tauri_args="$(node .release-scripts/scripts/release/resolve-tauri-build-args.mjs)"
           echo "args=${tauri_args}" >> "${GITHUB_OUTPUT}"
 
+      - name: Import Apple Developer ID certificate
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          : "${APPLE_CERTIFICATE:?Missing APPLE_CERTIFICATE secret}"
+          : "${APPLE_CERTIFICATE_PASSWORD:?Missing APPLE_CERTIFICATE_PASSWORD secret}"
+          : "${APPLE_SIGNING_IDENTITY:?Missing APPLE_SIGNING_IDENTITY secret}"
+          : "${KEYCHAIN_PASSWORD:?Missing KEYCHAIN_PASSWORD secret}"
+
+          certificate_path="${RUNNER_TEMP}/developer-id.p12"
+          keychain_path="${RUNNER_TEMP}/app-signing.keychain-db"
+
+          echo "${APPLE_CERTIFICATE}" | base64 --decode > "${certificate_path}"
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${keychain_path}"
+          security set-keychain-settings -lut 21600 "${keychain_path}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${keychain_path}"
+          security import "${certificate_path}" -k "${keychain_path}" -P "${APPLE_CERTIFICATE_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/security
+          security list-keychains -d user -s "${keychain_path}"
+          security default-keychain -s "${keychain_path}"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PASSWORD}" "${keychain_path}"
+
+          if ! security find-identity -v -p codesigning "${keychain_path}" | grep -F "${APPLE_SIGNING_IDENTITY}"; then
+            echo "Apple signing identity was not found in the imported keychain." >&2
+            exit 1
+          fi
+
+          echo "APPLE_SIGNING_IDENTITY=${APPLE_SIGNING_IDENTITY}" >> "${GITHUB_ENV}"
+
+      - name: Prepare Apple notarization key
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PRIVATE_KEY: ${{ secrets.APPLE_API_KEY_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          : "${APPLE_API_ISSUER:?Missing APPLE_API_ISSUER secret}"
+          : "${APPLE_API_KEY:?Missing APPLE_API_KEY secret}"
+          : "${APPLE_API_KEY_PRIVATE_KEY:?Missing APPLE_API_KEY_PRIVATE_KEY secret}"
+
+          api_key_path="${RUNNER_TEMP}/AuthKey_${APPLE_API_KEY}.p8"
+          printf "%s" "${APPLE_API_KEY_PRIVATE_KEY}" > "${api_key_path}"
+          chmod 600 "${api_key_path}"
+          echo "APPLE_API_ISSUER=${APPLE_API_ISSUER}" >> "${GITHUB_ENV}"
+          echo "APPLE_API_KEY=${APPLE_API_KEY}" >> "${GITHUB_ENV}"
+          echo "APPLE_API_KEY_PATH=${api_key_path}" >> "${GITHUB_ENV}"
+
       - name: Build and bundle app
         id: tauri_build
         uses: tauri-apps/tauri-action@v0.6.0
@@ -276,20 +332,6 @@ jobs:
         run: |
           node .release-scripts/scripts/release/verify-linux-appimage-libraries.mjs
           node .release-scripts/scripts/release/verify-linux-appimage-gtk-ime.mjs
-
-      - name: Add macOS open helper to DMG
-        if: startsWith(matrix.os, 'macos-')
-        shell: bash
-        env:
-          APP_PRODUCT_NAME: ${{ env.APP_PRODUCT_NAME }}
-          DMG_DIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/dmg
-          HELPER_PATH: ${{ runner.temp }}/Markra-macOS-Open-Anyway.command
-          MACOS_BUNDLE_DIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/macos
-        run: |
-          set -euo pipefail
-
-          OUTPUT_PATH="${HELPER_PATH}" node .release-scripts/scripts/release/create-macos-open-helper.mjs
-          node .release-scripts/scripts/release/rebuild-macos-dmg-with-helper.mjs
 
       - name: Normalize release asset names
         shell: bash
@@ -485,9 +527,6 @@ jobs:
               echo "- Release ${RELEASE_TAG}"
             } > release-notes.md
           fi
-
-      - name: Add macOS unsigned app notice
-        run: node .release-scripts/scripts/release/prepend-macos-unsigned-notice.mjs
 
       - name: Download bundled artifacts
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.0.0-rc.0](https://github.com/markrahq/markra/compare/v0.17.1...v1.0.0-rc.0) (2026-07-01)
+
 ## [0.17.1](https://github.com/markrahq/markra/compare/v0.17.0...v0.17.1) (2026-07-01)
 
 ### Bug Fixes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markra/desktop",
-  "version": "0.17.1",
+  "version": "1.0.0-rc.0",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markra"
-version = "0.17.1"
+version = "1.0.0-rc.0"
 dependencies = [
  "arboard",
  "core-foundation",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markra"
-version = "0.17.1"
+version = "1.0.0-rc.0"
 description = "AI-native Markdown editor"
 authors = ["Markra contributors"]
 license = "AGPL-3.0-only"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markra",
-  "version": "0.17.1",
+  "version": "1.0.0-rc.0",
   "identifier": "dev.markra.app",
   "build": {
     "beforeDevCommand": "pnpm dev --host 127.0.0.1 --port 1420 --strictPort",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markra/web",
-  "version": "0.17.1",
+  "version": "1.0.0-rc.0",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markra-workspace",
-  "version": "0.17.1",
+  "version": "1.0.0-rc.0",
   "license": "AGPL-3.0-only",
   "private": true,
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
## Summary
- Import the Developer ID `.p12` certificate into a temporary macOS CI keychain before Tauri release builds.
- Prepare the App Store Connect `.p8` API key for Tauri notarization and remove the unsigned macOS DMG helper/notice flow.
- Bump the release version to `1.0.0-rc.0` so `v1.0.0-rc.0` can be used as a signed prerelease test.

## Why
This lets the GitHub Actions release workflow exercise Apple Developer ID signing and notarization on the next macOS prerelease build.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parses"'` passed\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml` passed\n- `pnpm test:release` passed, 34 tests\n\n## Release Test\nAfter merge, create and push tag `v1.0.0-rc.0` to trigger the Release workflow as a prerelease.\n\n## Risk\nThe local checks validate workflow syntax and release scripts, but the actual Apple notarization path still needs to be verified by GitHub Actions because it depends on repository secrets.