### PR TITLE
ci(release): add Linux ARM64 bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,19 @@ jobs:
             asset_platform: linux
             asset_arch: x64
             updater_platform: linux-x86_64
+            appimagetool_arch: x86_64
+            appimage_arch: x86_64
             args: --target x86_64-unknown-linux-gnu
+          - name: Linux (ARM64)
+            artifact_name: Linux-arm64
+            os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset_platform: linux
+            asset_arch: arm64
+            updater_platform: linux-aarch64
+            appimagetool_arch: aarch64
+            appimage_arch: aarch64
+            args: --target aarch64-unknown-linux-gnu
           - name: Windows (x64)
             artifact_name: Windows-x64
             os: windows-latest
@@ -150,7 +162,7 @@ jobs:
           cache-bin: false
 
       - name: Install Linux system dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.asset_platform == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -291,9 +303,11 @@ jobs:
           args: ${{ steps.tauri_args.outputs.args }} --config tauri.updater.conf.json
 
       - name: Rebuild Linux AppImage library policy
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.asset_platform == 'linux'
         shell: bash
         env:
+          APPIMAGETOOL_ARCH: ${{ matrix.appimagetool_arch }}
+          APPIMAGE_ARCH: ${{ matrix.appimage_arch }}
           APPIMAGE_APPDIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/${{ env.APP_PRODUCT_NAME }}.AppDir
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -315,17 +329,17 @@ jobs:
 
           rm -f "${appimage_path}.sig" "${appimage_path}.tar.gz" "${appimage_path}.tar.gz.sig"
 
-          appimagetool="${RUNNER_TEMP}/appimagetool-x86_64.AppImage"
+          appimagetool="${RUNNER_TEMP}/appimagetool-${APPIMAGETOOL_ARCH}.AppImage"
           curl -fsSL \
-            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+            "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${APPIMAGETOOL_ARCH}.AppImage" \
             -o "${appimagetool}"
           chmod +x "${appimagetool}"
 
-          APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 "${appimagetool}" "${APPIMAGE_APPDIR}" "${appimage_path}"
+          APPIMAGE_EXTRACT_AND_RUN=1 ARCH="${APPIMAGE_ARCH}" "${appimagetool}" "${APPIMAGE_APPDIR}" "${appimage_path}"
           "${DESKTOP_DIR}/node_modules/.bin/tauri" signer sign "${appimage_path}" > "${appimage_path}.sig"
 
       - name: Verify Linux AppImage library policy
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.asset_platform == 'linux'
         shell: bash
         env:
           APPIMAGE_APPDIR: ${{ env.DESKTOP_DIR }}/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/${{ env.APP_PRODUCT_NAME }}.AppDir
@@ -536,7 +550,7 @@ jobs:
 
       - name: Generate updater manifest
         env:
-          EXPECTED_UPDATER_PLATFORMS: darwin-aarch64,darwin-x86_64,linux-x86_64,windows-x86_64
+          EXPECTED_UPDATER_PLATFORMS: darwin-aarch64,darwin-x86_64,linux-aarch64,linux-x86_64,windows-x86_64
           GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_ASSETS_ROOT: release-assets
           RELEASE_NOTES_PATH: release-notes.md

--- a/scripts/release/generate-updater-manifest.test.mjs
+++ b/scripts/release/generate-updater-manifest.test.mjs
@@ -50,6 +50,7 @@ test("generate-updater-manifest writes latest.json for every updater platform", 
 
   writeArtifact(rootDir, "darwin-aarch64", "Markra_0.0.8_macos_arm64_updater.app.tar.gz", "mac-arm-signature");
   writeArtifact(rootDir, "darwin-x86_64", "Markra_0.0.8_macos_x64_updater.app.tar.gz", "mac-intel-signature");
+  writeArtifact(rootDir, "linux-aarch64", "Markra_0.0.8_linux_arm64.AppImage", "linux-arm-signature");
   writeArtifact(rootDir, "linux-x86_64", "Markra_0.0.8_linux_x64.AppImage", "linux-signature");
   writeArtifact(rootDir, "windows-x86_64", "Markra_0.0.8_windows_x64_setup.exe", "windows-signature");
   fs.writeFileSync(notesPath, "Release notes");
@@ -75,6 +76,10 @@ test("generate-updater-manifest writes latest.json for every updater platform", 
     "darwin-x86_64": {
       signature: "mac-intel-signature",
       url: "https://github.com/markrahq/markra/releases/latest/download/Markra_0.0.8_macos_x64_updater.app.tar.gz",
+    },
+    "linux-aarch64": {
+      signature: "linux-arm-signature",
+      url: "https://github.com/markrahq/markra/releases/latest/download/Markra_0.0.8_linux_arm64.AppImage",
     },
     "linux-x86_64": {
       signature: "linux-signature",

--- a/scripts/release/normalize-release-artifacts.test.mjs
+++ b/scripts/release/normalize-release-artifacts.test.mjs
@@ -61,6 +61,18 @@ test("release workflow uses arm64 in Apple Silicon file names while keeping the 
   assert.doesNotMatch(appleSiliconEntry, /asset_arch:\s*aarch64/);
 });
 
+test("release workflow builds Linux ARM64 bundles", () => {
+  const linuxArm64Entry = readReleaseMatrixEntry("Linux (ARM64)");
+
+  assert.match(linuxArm64Entry, /artifact_name:\s*Linux-arm64/);
+  assert.match(linuxArm64Entry, /os:\s*ubuntu-22\.04-arm/);
+  assert.match(linuxArm64Entry, /target:\s*aarch64-unknown-linux-gnu/);
+  assert.match(linuxArm64Entry, /asset_platform:\s*linux/);
+  assert.match(linuxArm64Entry, /asset_arch:\s*arm64/);
+  assert.match(linuxArm64Entry, /updater_platform:\s*linux-aarch64/);
+  assert.match(linuxArm64Entry, /args:\s*--target aarch64-unknown-linux-gnu/);
+});
+
 test("release workflow validates the web package version", () => {
   const validateStep = readReleaseStep("Validate release version");
 
@@ -74,12 +86,15 @@ test("release workflow excludes Wayland client from Linux AppImage bundling", ()
   const verifyStep = readReleaseStep("Verify Linux AppImage library policy");
 
   assert.match(buildStep, /LINUXDEPLOY_EXCLUDED_LIBRARIES:\s*libwayland-client\.so\*/);
-  assert.match(rebuildStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
+  assert.match(rebuildStep, /if:\s*matrix\.asset_platform == 'linux'/);
   assert.match(rebuildStep, /repair-linux-appimage-libraries\.mjs/);
   assert.match(rebuildStep, /repair-linux-appimage-gtk-ime\.mjs/);
-  assert.match(rebuildStep, /appimagetool-x86_64\.AppImage/);
+  assert.match(rebuildStep, /APPIMAGETOOL_ARCH:\s*\$\{\{ matrix\.appimagetool_arch \}\}/);
+  assert.match(rebuildStep, /APPIMAGE_ARCH:\s*\$\{\{ matrix\.appimage_arch \}\}/);
+  assert.match(rebuildStep, /appimagetool-\$\{APPIMAGETOOL_ARCH\}\.AppImage/);
+  assert.match(rebuildStep, /ARCH="\$\{APPIMAGE_ARCH\}"/);
   assert.match(rebuildStep, /tauri" signer sign/);
-  assert.match(verifyStep, /if:\s*matrix\.os == 'ubuntu-22\.04'/);
+  assert.match(verifyStep, /if:\s*matrix\.asset_platform == 'linux'/);
   assert.match(verifyStep, /verify-linux-appimage-libraries\.mjs/);
   assert.match(verifyStep, /verify-linux-appimage-gtk-ime\.mjs/);
 });


### PR DESCRIPTION
## Summary
- Add a Linux ARM64 release matrix entry using the ubuntu-22.04-arm runner.
- Parameterize Linux AppImage rebuilding so x64 and ARM64 use the matching appimagetool and ARCH value.
- Include linux-aarch64 in updater manifest expectations and release tests.

## Validation
- `pnpm test:release` passed.
- `git diff --check` passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"'` passed.\n\n## Risk\n- Linux ARM64 packaging has not been exercised by a live GitHub Actions release run in this branch yet.