### PR TITLE
fix(editor): render raw HTML badge rows inline

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -9163,6 +9163,40 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain('<img src="https://example.test/badges/version.svg" />');
   });
 
+  it("keeps GitHub README HTML badge rows together", async () => {
+    const source = [
+      '<p align="center">',
+      '  <img alt="Desktop" src="https://example.test/badges/desktop.svg" />',
+      '  <img alt="Web Editor" src="https://example.test/badges/web-editor.svg" />',
+      '  <a href="https://example.test/product">',
+      '    <img alt="Product" src="https://example.test/badges/product.svg" />',
+      "  </a>",
+      "</p>"
+    ].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+
+    const renderedHtml = container.querySelector<HTMLElement>(".ProseMirror .markra-html-node");
+    const centeredParagraph = renderedHtml?.querySelector<HTMLElement>('p[align="center"]');
+    const badgeImages = renderedHtml?.querySelectorAll("img");
+    const linkedBadge = renderedHtml?.querySelector<HTMLImageElement>(
+      'a[href="https://example.test/product"] img[src="https://example.test/badges/product.svg"]'
+    );
+
+    expect(renderedHtml).toBeInTheDocument();
+    expect(centeredParagraph).toBeInTheDocument();
+    expect(container.querySelectorAll(".ProseMirror .markra-html-node")).toHaveLength(1);
+    expect(Array.from(badgeImages ?? []).map((image) => image.alt)).toEqual([
+      "Desktop",
+      "Web Editor",
+      "Product"
+    ]);
+    expect(linkedBadge).toHaveAttribute("alt", "Product");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain('<p align="center">');
+    expect(serializeMarkdown(view.state.doc)).toContain('<a href="https://example.test/product">');
+  });
+
   it("hides empty Slidev wrapper tags without swallowing nearby markdown blocks", async () => {
     const source = [
       "<v-clicks>",

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2450,10 +2450,15 @@
 
   .markdown-paper .markra-html-node {
     @apply max-w-full outline-none;
+    white-space: normal;
   }
 
   .markdown-paper .markra-html-node img {
     @apply m-0 inline-block max-w-full rounded-none border-0 align-middle;
+  }
+
+  .markdown-paper .markra-html-node pre {
+    white-space: pre-wrap;
   }
 
   .markdown-paper .markra-html-node-source {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -274,6 +274,23 @@ describe("editor stylesheet", () => {
     expect(sourceSelectionStyles).toContain("background: color-mix(in srgb, var(--accent) 28%, transparent)");
   });
 
+  it("lets rendered raw HTML collapse source newlines like browser HTML", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const rawHtmlStart = styles.indexOf(".markdown-paper .markra-html-node {");
+    const rawHtmlEnd = styles.indexOf(".markdown-paper .markra-html-node img", rawHtmlStart);
+    const rawHtmlStyles = styles.slice(rawHtmlStart, rawHtmlEnd);
+    const rawHtmlPreStart = styles.indexOf(".markdown-paper .markra-html-node pre", rawHtmlEnd);
+    const rawHtmlPreEnd = styles.indexOf(".markdown-paper .markra-html-node-source", rawHtmlPreStart);
+    const rawHtmlPreStyles = styles.slice(rawHtmlPreStart, rawHtmlPreEnd);
+
+    expect(rawHtmlStart).toBeGreaterThanOrEqual(0);
+    expect(rawHtmlEnd).toBeGreaterThan(rawHtmlStart);
+    expect(rawHtmlStyles).toContain("white-space: normal");
+    expect(rawHtmlPreStart).toBeGreaterThanOrEqual(0);
+    expect(rawHtmlPreEnd).toBeGreaterThan(rawHtmlPreStart);
+    expect(rawHtmlPreStyles).toContain("white-space: pre-wrap");
+  });
+
   it("gives horizontal rules a forgiving hit target without heavy selected-node feedback", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const ruleStart = styles.indexOf(".markdown-paper hr {");


### PR DESCRIPTION
## Summary
- Restore browser-style whitespace collapsing inside rendered raw HTML previews.
- Keep raw HTML `<pre>` content pre-wrapped so preformatted snippets do not lose line breaks.
- Add regression coverage for GitHub README-style badge rows and the raw HTML whitespace rule.

## Why
README badge blocks often put each `<img>` on its own source line inside `<p align="center">`. Markra rendered raw HTML inside the visual editor while inheriting the editor surface `white-space: pre-wrap`, so those source newlines became visible line breaks and badge images stacked vertically instead of flowing inline like GitHub.

## Validation
- `pnpm --filter @markra/app test -- src/styles.test.ts -t "lets rendered raw HTML collapse source newlines like browser HTML"` passed
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t "keeps GitHub README HTML badge rows together"` passed
- `pnpm --filter @markra/app build` passed

## Risk
- Low. The style change is scoped to rendered raw HTML previews. Markdown image blocks keep their existing block layout, and raw HTML `<pre>` nodes explicitly preserve line breaks.