### PR TITLE
feat(editor): add Vim mode support

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,6 +46,7 @@
     "@milkdown/kit": "^7.20.0",
     "@milkdown/react": "^7.20.0",
     "@noble/hashes": "^2.2.0",
+    "@replit/codemirror-vim": "6.3.0",
     "@tanstack/react-virtual": "3.14.2",
     "codemirror": "6.0.2",
     "cspell-trie-lib": "10.0.1",

--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -238,6 +238,7 @@ describe("Markra AI workspace", () => {
       showWordCount: true,
       suggestAiPanelForComplexInlinePrompts: true,
       tableColumnWidthMode: "even",
+      vimModeEnabled: false,
       wrapCodeBlocks: true,
       titlebarActions: [
         { id: "aiAgent", visible: true },
@@ -349,6 +350,7 @@ describe("Markra AI workspace", () => {
       showWordCount: true,
       suggestAiPanelForComplexInlinePrompts: false,
       tableColumnWidthMode: "even",
+      vimModeEnabled: false,
       wrapCodeBlocks: true,
       titlebarActions: [
         { id: "aiAgent", visible: true },

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -399,6 +399,7 @@ function createStoredEditorPreferences(
       viewModeToggle: "visible",
       wordCount: "visible"
     },
+    vimModeEnabled: overrides.vimModeEnabled ?? false,
     wrapCodeBlocks: overrides.wrapCodeBlocks ?? true
   };
 }
@@ -904,7 +905,10 @@ describe("Markra workspace", () => {
         { id: "sourceMode", visible: true },
         { id: "save", visible: true },
         { id: "theme", visible: true }
-      ]
+      ],
+      showWordCount: true,
+      vimModeEnabled: false,
+      wrapCodeBlocks: true
     }));
     renderApp();
 
@@ -981,6 +985,7 @@ describe("Markra workspace", () => {
           wordCount: "visible"
         },
         showWordCount: true,
+        vimModeEnabled: false,
         wrapCodeBlocks: true
       })
     );
@@ -1046,6 +1051,7 @@ describe("Markra workspace", () => {
           wordCount: "visible"
         },
         showWordCount: true,
+        vimModeEnabled: false,
         wrapCodeBlocks: true
       })
     );
@@ -2094,7 +2100,10 @@ describe("Markra workspace", () => {
         { id: "sourceMode" as const, visible: true },
         { id: "save" as const, visible: true },
         { id: "theme" as const, visible: true }
-      ]
+      ],
+      showWordCount: true,
+      vimModeEnabled: false,
+      wrapCodeBlocks: true
     });
     mockedGetStoredEditorPreferences.mockResolvedValue(initialPreferences);
     window.history.pushState({}, "", "/?settings=1");
@@ -2248,6 +2257,7 @@ describe("Markra workspace", () => {
         wordCount: "visible"
       },
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
     window.history.pushState({}, "", "/?settings=1");
@@ -5284,6 +5294,7 @@ describe("Markra workspace", () => {
         wordCount: "visible"
       },
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
     mockedOpenNativeMarkdownPath.mockResolvedValue({
@@ -5448,6 +5459,7 @@ describe("Markra workspace", () => {
         wordCount: "visible"
       },
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
     mockOpenMarkdownFile({

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4012,6 +4012,7 @@ function WorkspaceApp() {
               tableColumnWidthMode={editorPreferences.preferences.tableColumnWidthMode}
               onAddSpellcheckIgnoredWord={handleAddSpellcheckIgnoredWord}
               topInset="titlebar"
+              vimModeEnabled={editorPreferences.preferences.vimModeEnabled}
               workspaceFiles={fileTreeFiles}
               wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
             />
@@ -4364,6 +4365,7 @@ function WorkspaceApp() {
                           searchMatches={visibleSourceDocumentSearchMatches}
                           scrollRef={sourceScrollRef}
                           topInset="titlebar"
+                          vimModeEnabled={editorPreferences.preferences.vimModeEnabled}
                         />
                       </div>
                     </div>
@@ -4394,6 +4396,7 @@ function WorkspaceApp() {
                           searchMatches={visibleSourceDocumentSearchMatches}
                           scrollRef={sourceScrollRef}
                           topInset="titlebar"
+                          vimModeEnabled={editorPreferences.preferences.vimModeEnabled}
                         />
                       ) : null}
                     </div>
@@ -4468,6 +4471,7 @@ function WorkspaceApp() {
                         onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
                         onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
                         onFocus={handleSideDocumentPaneFocus}
+                        vimModeEnabled={editorPreferences.preferences.vimModeEnabled}
                         wrapCodeBlocks={editorPreferences.preferences.wrapCodeBlocks}
                       />
                     </>

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -73,6 +73,7 @@ async function renderEditor(
     readOnly?: boolean;
     resolveImageSrc?: (src: string) => string;
     markdownShortcuts?: MarkdownShortcutMap;
+    vimModeEnabled?: boolean;
     extendedSyntax?: ExtendedSyntaxPreferences;
     workspaceFiles?: Array<{
       kind?: "asset" | "attachment" | "folder";
@@ -101,6 +102,7 @@ async function renderEditor(
       }}
       extendedSyntax={options.extendedSyntax}
       markdownShortcuts={options.markdownShortcuts}
+      vimModeEnabled={options.vimModeEnabled}
       onMarkdownChange={options.onMarkdownChange ?? (() => {})}
       onSaveClipboardAttachment={options.onSaveClipboardAttachment}
       onSaveClipboardImage={options.onSaveClipboardImage}
@@ -1048,6 +1050,65 @@ describe("MarkdownPaper editing", () => {
     expect(caret?.style.left).toBe("24px");
     expect(caret?.style.top).toBe("17px");
     expect(caret?.style.height).toBe("18px");
+
+    coordsSpy.mockRestore();
+    await settleMarkdownListener();
+  });
+
+  it("enables Vim normal and insert modes in the visual editor", async () => {
+    const { view } = await renderEditor("alpha", { vimModeEnabled: true });
+
+    focusEditor(view);
+    moveCursor(view, findTextPosition(view, "alpha", 2));
+
+    expect(pressShortcut(view, "Escape")).toBe(true);
+    typeText(view, "z");
+    expect(view.state.doc.textBetween(0, view.state.doc.content.size, "\n")).toBe("alpha");
+
+    expect(pressShortcut(view, "i")).toBe(true);
+    typeText(view, "z");
+    expect(view.state.doc.textBetween(0, view.state.doc.content.size, "\n")).toBe("azlpha");
+
+    await settleMarkdownListener();
+  });
+
+  it("uses a block custom caret in visual Vim normal mode", async () => {
+    const { view } = await renderEditor("alpha", { vimModeEnabled: true });
+    const alphaPosition = findTextPosition(view, "alpha");
+    const blockPosition = alphaPosition + 1;
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockImplementation((position) => {
+      if (position === blockPosition + 1) {
+        return {
+          bottom: 42,
+          left: 32,
+          right: 33,
+          top: 10
+        };
+      }
+
+      return {
+        bottom: 42,
+        left: 24,
+        right: 25,
+        top: 10
+      };
+    });
+
+    focusEditor(view);
+    moveCursor(view, alphaPosition + 2);
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+    expect(caret).toBeInTheDocument();
+    expect(caret).not.toHaveClass("markra-prosemirror-caret-block");
+    expect(caret?.style.width).toBe("1px");
+
+    expect(pressShortcut(view, "Escape")).toBe(true);
+    expect(caret).toHaveClass("markra-prosemirror-caret-block");
+    expect(caret?.style.width).toBe("8px");
+
+    expect(pressShortcut(view, "i")).toBe(true);
+    expect(caret).not.toHaveClass("markra-prosemirror-caret-block");
+    expect(caret?.style.width).toBe("1px");
 
     coordsSpy.mockRestore();
     await settleMarkdownListener();

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -1055,6 +1055,30 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps the custom caret visible when the editor DOM remains active without ProseMirror focus markers", async () => {
+    const { view } = await renderEditor("Alpha");
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 42,
+      left: 24,
+      right: 25,
+      top: 10
+    });
+    const hasFocusSpy = vi.spyOn(view, "hasFocus").mockReturnValue(false);
+
+    focusEditor(view);
+    view.dom.classList.remove("ProseMirror-focused");
+    moveCursor(view, findTextPosition(view, "Alpha", 2));
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+
+    expect(view.dom.ownerDocument.activeElement).toBe(view.dom);
+    expect(caret?.style.display).toBe("block");
+
+    hasFocusSpy.mockRestore();
+    coordsSpy.mockRestore();
+    await settleMarkdownListener();
+  });
+
   it("enables Vim normal and insert modes in the visual editor", async () => {
     const { view } = await renderEditor("alpha", { vimModeEnabled: true });
 
@@ -1109,6 +1133,82 @@ describe("MarkdownPaper editing", () => {
     expect(pressShortcut(view, "i")).toBe(true);
     expect(caret).not.toHaveClass("markra-prosemirror-caret-block");
     expect(caret?.style.width).toBe("1px");
+
+    coordsSpy.mockRestore();
+    await settleMarkdownListener();
+  });
+
+  it("keeps the custom Vim caret visible after line motions scroll the selection", async () => {
+    const { view } = await renderEditor("alpha\n\nbeta", { vimModeEnabled: true });
+    const alphaPosition = findTextPosition(view, "alpha");
+    const betaPosition = findTextPosition(view, "beta");
+    const alphaCaret = alphaPosition + 1;
+    const betaCaret = betaPosition + 1;
+    let selectionHasScrolled = false;
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockImplementation((position) => {
+      const betaTop = selectionHasScrolled ? 50 : 210;
+      const betaBottom = selectionHasScrolled ? 82 : 242;
+
+      if (position === betaCaret + 1) {
+        return {
+          bottom: betaBottom,
+          left: 56,
+          right: 57,
+          top: betaTop
+        };
+      }
+
+      if (position === betaCaret) {
+        return {
+          bottom: betaBottom,
+          left: 48,
+          right: 49,
+          top: betaTop
+        };
+      }
+
+      if (position === alphaCaret + 1) {
+        return {
+          bottom: 42,
+          left: 32,
+          right: 33,
+          top: 10
+        };
+      }
+
+      return {
+        bottom: 42,
+        left: 24,
+        right: 25,
+        top: 10
+      };
+    });
+
+    focusEditor(view);
+    moveCursor(view, alphaPosition + 2);
+    expect(pressShortcut(view, "Escape")).toBe(true);
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+    expect(caret).toBeInTheDocument();
+    expect(caret).toHaveClass("markra-prosemirror-caret-block");
+    expect(caret?.style.display).toBe("block");
+    expect(caret?.style.left).toBe("24px");
+    expect(caret?.style.top).toBe("17px");
+
+    expect(pressShortcut(view, "j")).toBe(true);
+    expect(view.state.selection.from).toBe(betaCaret);
+    expect(caret).toHaveClass("markra-prosemirror-caret-block");
+    expect(caret?.style.display).toBe("block");
+    expect(caret?.style.left).toBe("48px");
+    expect(caret?.style.top).toBe("217px");
+
+    selectionHasScrolled = true;
+    const scrollRoot = view.dom.closest(".paper-scroll");
+    expect(scrollRoot).toBeInstanceOf(HTMLElement);
+    fireEvent.scroll(scrollRoot as HTMLElement);
+
+    expect(caret?.style.top).toBe("57px");
+    expect(caret?.style.width).toBe("8px");
 
     coordsSpy.mockRestore();
     await settleMarkdownListener();

--- a/packages/app/src/components/MarkdownPaper.tsx
+++ b/packages/app/src/components/MarkdownPaper.tsx
@@ -61,6 +61,7 @@ type MarkdownPaperProps = {
   spellchecker?: MarkdownPaperSurfaceProps["spellchecker"];
   tableColumnWidthMode?: TableColumnWidthModePreference;
   topInset?: "tabs" | "titlebar";
+  vimModeEnabled?: MarkdownPaperSurfaceProps["vimModeEnabled"];
   workspaceFiles?: MarkdownPaperSurfaceProps["workspaceFiles"];
   wrapCodeBlocks?: boolean;
 };
@@ -126,6 +127,7 @@ export function MarkdownPaper({
   spellchecker,
   tableColumnWidthMode = "auto",
   topInset = "titlebar",
+  vimModeEnabled,
   workspaceFiles,
   wrapCodeBlocks = true
 }: MarkdownPaperProps) {
@@ -195,6 +197,7 @@ export function MarkdownPaper({
             spellcheckIgnoredWords={spellcheckIgnoredWords}
             spellchecker={spellchecker}
             tableColumnWidthMode={tableColumnWidthMode}
+            vimModeEnabled={vimModeEnabled}
             workspaceFiles={workspaceFiles}
           />
         </Suspense>

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -52,6 +52,7 @@ import {
   markraTaskListPlugin,
   markraTrailingParagraphPlugin,
   markraTaskListSchema,
+  markraVimModePlugin,
   getActiveSpellcheckMatch,
   normalizeMarkdownShortcuts,
   replaceSpellcheckMatch,
@@ -87,6 +88,7 @@ export type MarkdownPaperSurfaceProps = {
   language: AppLanguage;
   extendedSyntax?: ExtendedSyntaxPreferences;
   markdownShortcuts?: MarkdownShortcutMap;
+  vimModeEnabled?: boolean;
   onEditorReady: (editor: Editor | null, options?: { autoFocus?: boolean }) => unknown;
   onActiveOutlineIndexChange?: (index: number | null) => unknown;
   onMarkdownChange: (content: string) => unknown;
@@ -214,6 +216,7 @@ function MilkdownEditorSurface({
   initialContent,
   language,
   markdownShortcuts,
+  vimModeEnabled = false,
   onEditorReady,
   onActiveOutlineIndexChange,
   onMarkdownChange,
@@ -245,6 +248,7 @@ function MilkdownEditorSurface({
   const readOnlyRef = useRef(readOnly);
   const resolveImageSrcRef = useRef(resolveImageSrc);
   const spellcheckEnabledRef = useRef(spellcheckEnabled);
+  const vimModeEnabledRef = useRef(vimModeEnabled);
   const spellcheckIgnoredWordsRef = useRef(spellcheckIgnoredWords);
   const tableColumnWidthModeRef = useRef(tableColumnWidthMode ?? "auto");
   const spellcheckMenuViewRef = useRef<EditorView | null>(null);
@@ -356,6 +360,10 @@ function MilkdownEditorSurface({
   useEffect(() => {
     readOnlyRef.current = readOnly;
   }, [readOnly]);
+
+  useEffect(() => {
+    vimModeEnabledRef.current = vimModeEnabled;
+  }, [vimModeEnabled]);
 
   useEffect(() => {
     resolveImageSrcRef.current = resolveImageSrc;
@@ -515,6 +523,7 @@ function MilkdownEditorSurface({
       editor
         .use(markraSlashCommands(slashCommandLabels, { callout: githubAlertsEnabled }))
         .use(markraMathSourcePlugin)
+        .use(markraVimModePlugin({ enabled: () => vimModeEnabledRef.current && !readOnlyRef.current }))
         .use(markraMarkdownShortcuts(normalizedMarkdownShortcuts))
         .use(markraMarkdownSourcePastePlugin)
         .use(markraCodeBlockPlugin)

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -267,6 +267,29 @@ describe("MarkdownSourceEditor", () => {
     expect(handleRedo).toHaveBeenCalledTimes(1);
   });
 
+  it("enables Vim commands in source mode when requested", () => {
+    const handleChange = vi.fn();
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="alpha"
+        onChange={handleChange}
+        vimModeEnabled
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    act(() => {
+      view.dispatch({ selection: { anchor: 0 } });
+      view.focus();
+    });
+
+    fireEvent.keyDown(view.contentDOM, { key: "Escape" });
+    fireEvent.keyDown(view.contentDOM, { key: "x" });
+
+    expect(view.state.doc.toString()).toBe("lpha");
+    expect(handleChange).toHaveBeenLastCalledWith("lpha");
+  });
+
   it("keeps source mode read-only when requested", () => {
     const { container } = render(
       <MarkdownSourceEditor

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, type CSSProperties, type Ref, type UIEvent 
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { Annotation, Compartment, EditorSelection, EditorState, Prec, Transaction, type Extension } from "@codemirror/state";
 import { Decoration, EditorView, keymap } from "@codemirror/view";
+import { vim } from "@replit/codemirror-vim";
 import { minimalSetup } from "codemirror";
 import { t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
@@ -43,6 +44,7 @@ export type MarkdownSourceEditorProps = {
   searchMatches?: SearchRange[];
   scrollRef?: Ref<HTMLElement>;
   topInset?: "none" | "tabs" | "titlebar";
+  vimModeEnabled?: boolean;
 };
 
 type MarkdownSourcePaperStyle = CSSProperties & {
@@ -50,6 +52,10 @@ type MarkdownSourcePaperStyle = CSSProperties & {
 };
 
 const externalSourceUpdate = Annotation.define<boolean>();
+
+function markdownSourceVimExtension(enabled: boolean): Extension {
+  return enabled ? vim() : [];
+}
 
 function markdownSourceContentAttributes(label: string, readOnly: boolean): Extension {
   return EditorView.contentAttributes.of({
@@ -195,7 +201,8 @@ export function MarkdownSourceEditor({
   searchActiveIndex = -1,
   searchMatches = [],
   scrollRef,
-  topInset = "titlebar"
+  topInset = "titlebar",
+  vimModeEnabled = false
 }: MarkdownSourceEditorProps) {
   const editorContainerRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef(content);
@@ -209,6 +216,7 @@ export function MarkdownSourceEditor({
   const searchCompartmentRef = useRef(new Compartment());
   const externalContentScrollSuppressedRef = useRef(false);
   const externalContentScrollRestoreFrameRef = useRef<number | null>(null);
+  const vimCompartmentRef = useRef(new Compartment());
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const editorFontFamilyCss = editorFontFamilyCssValue(editorFontFamily);
   const sourceLabel = t(language, "app.markdownSource");
@@ -259,6 +267,7 @@ export function MarkdownSourceEditor({
 
   const extensions = useMemo(
     () => [
+      vimCompartmentRef.current.of(markdownSourceVimExtension(vimModeEnabled && !readOnly)),
       minimalSetup,
       markdownSourceSharedHistoryExtension(onUndoRef, onRedoRef),
       markdown({
@@ -324,6 +333,15 @@ export function MarkdownSourceEditor({
       ]
     });
   }, [readOnly, sourceLabel]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    view.dispatch({
+      effects: vimCompartmentRef.current.reconfigure(markdownSourceVimExtension(vimModeEnabled && !readOnly))
+    });
+  }, [readOnly, vimModeEnabled]);
 
   useEffect(() => {
     const view = viewRef.current;

--- a/packages/app/src/components/SideDocumentPane.tsx
+++ b/packages/app/src/components/SideDocumentPane.tsx
@@ -36,6 +36,7 @@ type SideDocumentPaneProps = {
   spellchecker?: Spellchecker;
   status?: ReactNode;
   tableColumnWidthMode?: TableColumnWidthModePreference;
+  vimModeEnabled?: boolean;
   onAddSpellcheckIgnoredWord?: (word: string) => unknown;
   onSaveClipboardAttachment?: (attachment: File) => Promise<{ label: string; src: string } | null>;
   workspaceFiles?: MarkdownDocumentLinkFile[];
@@ -76,6 +77,7 @@ export function SideDocumentPane({
   spellchecker,
   status = null,
   tableColumnWidthMode = "auto",
+  vimModeEnabled = false,
   onAddSpellcheckIgnoredWord,
   onSaveClipboardAttachment,
   workspaceFiles,
@@ -110,6 +112,7 @@ export function SideDocumentPane({
           onContentWidthResizeEnd={onContentWidthResizeEnd}
           readOnly={readOnly}
           topInset="titlebar"
+          vimModeEnabled={vimModeEnabled}
         />
       ) : visualBlocked ? (
         <LargeMarkdownNotice language={language} />
@@ -145,6 +148,7 @@ export function SideDocumentPane({
           tableColumnWidthMode={tableColumnWidthMode}
           onAddSpellcheckIgnoredWord={onAddSpellcheckIgnoredWord}
           topInset="titlebar"
+          vimModeEnabled={vimModeEnabled}
           workspaceFiles={workspaceFiles}
           wrapCodeBlocks={wrapCodeBlocks}
         />

--- a/packages/app/src/components/settings/EditorSettings.test.tsx
+++ b/packages/app/src/components/settings/EditorSettings.test.tsx
@@ -126,6 +126,28 @@ describe("EditorSettings", () => {
     });
   });
 
+  it("toggles Vim mode from the editor settings", () => {
+    const onUpdatePreferences = vi.fn();
+
+    render(
+      <EditorSettings
+        preferences={{
+          ...defaultEditorPreferences,
+          vimModeEnabled: false
+        }}
+        translate={translate}
+        onUpdatePreferences={onUpdatePreferences}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "Vim mode" }));
+
+    expect(onUpdatePreferences).toHaveBeenCalledWith({
+      ...defaultEditorPreferences,
+      vimModeEnabled: true
+    });
+  });
+
   it("toggles document links from the editor settings", () => {
     const onUpdatePreferences = vi.fn();
 

--- a/packages/app/src/components/settings/EditorSettings.tsx
+++ b/packages/app/src/components/settings/EditorSettings.tsx
@@ -814,6 +814,22 @@ export function EditorSettings({
           }
         />
         <SettingsRow
+          title={translate("settings.editor.vimMode")}
+          description={translate("settings.editor.vimModeDescription")}
+          action={
+            <SettingsSwitch
+              checked={preferences.vimModeEnabled}
+              label={translate("settings.editor.vimMode")}
+              onChange={() =>
+                onUpdatePreferences({
+                  ...preferences,
+                  vimModeEnabled: !preferences.vimModeEnabled
+                })
+              }
+            />
+          }
+        />
+        <SettingsRow
           title={translate("settings.editor.sidebarLayoutMode")}
           description={translate("settings.editor.sidebarLayoutModeDescription")}
           action={

--- a/packages/app/src/hooks/useEditorPreferences.test.tsx
+++ b/packages/app/src/hooks/useEditorPreferences.test.tsx
@@ -228,6 +228,7 @@ describe("useEditorPreferences", () => {
       viewMode: "daily",
       viewModeCustomizations: defaultViewModeCustomizations,
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
     mockedListenAppEditorPreferencesChanged.mockImplementation(async (listener) => {
@@ -337,6 +338,7 @@ describe("useEditorPreferences", () => {
         viewMode: "daily",
         viewModeCustomizations: defaultViewModeCustomizations,
         showWordCount: false,
+        vimModeEnabled: false,
         wrapCodeBlocks: false
       });
     });

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -387,6 +387,7 @@ export type EditorPreferences = {
   viewMode: ViewMode;
   viewModeCustomizations: ViewModeCustomizations;
   showWordCount: boolean;
+  vimModeEnabled: boolean;
   wrapCodeBlocks: boolean;
 };
 export type { AppLanguage };
@@ -513,6 +514,7 @@ export const defaultEditorPreferences: EditorPreferences = {
   viewMode: "daily",
   viewModeCustomizations: { ...defaultViewModeCustomizations },
   showWordCount: true,
+  vimModeEnabled: false,
   wrapCodeBlocks: true
 };
 
@@ -1647,6 +1649,8 @@ export function normalizeEditorPreferences(value: unknown): EditorPreferences {
     viewModeCustomizations: normalizeViewModeCustomizations(preferences.viewModeCustomizations),
     showWordCount:
       typeof preferences.showWordCount === "boolean" ? preferences.showWordCount : defaultEditorPreferences.showWordCount,
+    vimModeEnabled:
+      typeof preferences.vimModeEnabled === "boolean" ? preferences.vimModeEnabled : defaultEditorPreferences.vimModeEnabled,
     wrapCodeBlocks:
       typeof preferences.wrapCodeBlocks === "boolean" ? preferences.wrapCodeBlocks : defaultEditorPreferences.wrapCodeBlocks
   };

--- a/packages/app/src/lib/settings/editor-preferences.test.ts
+++ b/packages/app/src/lib/settings/editor-preferences.test.ts
@@ -109,6 +109,7 @@ describe("editor preferences", () => {
         wordCount: "visible"
       },
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
 
@@ -161,7 +162,8 @@ describe("editor preferences", () => {
       sidebarLayoutMode: "stacked",
       showAiQuickInputOnSelection: false,
       showAiSelectionToolbarOnSelection: true,
-      showWordCount: false
+      showWordCount: false,
+      vimModeEnabled: true
     });
 
     await expect(getStoredEditorPreferences()).resolves.toEqual({
@@ -259,6 +261,7 @@ describe("editor preferences", () => {
         wordCount: "visible"
       },
       showWordCount: false,
+      vimModeEnabled: true,
       wrapCodeBlocks: true
     });
   });
@@ -372,6 +375,12 @@ describe("editor preferences", () => {
     expect(normalizeEditorPreferences({}).wrapCodeBlocks).toBe(true);
     expect(normalizeEditorPreferences({ wrapCodeBlocks: false }).wrapCodeBlocks).toBe(false);
     expect(normalizeEditorPreferences({ wrapCodeBlocks: "no" }).wrapCodeBlocks).toBe(true);
+  });
+
+  it("normalizes the Vim mode preference", () => {
+    expect(normalizeEditorPreferences({}).vimModeEnabled).toBe(false);
+    expect(normalizeEditorPreferences({ vimModeEnabled: true }).vimModeEnabled).toBe(true);
+    expect(normalizeEditorPreferences({ vimModeEnabled: "yes" }).vimModeEnabled).toBe(false);
   });
 
   it("migrates the old AI selection display mode into independent switches", () => {
@@ -768,6 +777,7 @@ describe("editor preferences", () => {
         wordCount: "visible"
       },
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
   });
@@ -868,6 +878,7 @@ describe("editor preferences", () => {
         wordCount: "visible"
       },
       showWordCount: false,
+      vimModeEnabled: true,
       wrapCodeBlocks: false
     });
 
@@ -966,6 +977,7 @@ describe("editor preferences", () => {
         wordCount: "visible"
       },
       showWordCount: false,
+      vimModeEnabled: true,
       wrapCodeBlocks: false
     });
     expect(store.save).toHaveBeenCalledTimes(1);

--- a/packages/app/src/lib/settings/settings-events.test.ts
+++ b/packages/app/src/lib/settings/settings-events.test.ts
@@ -246,6 +246,7 @@ describe("settings events", () => {
         wordCount: "visible"
       },
       showWordCount: false,
+      vimModeEnabled: false,
       wrapCodeBlocks: false
     };
 

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -861,6 +861,12 @@
     animation: markra-prosemirror-caret-blink 1.05s steps(1, end) infinite;
   }
 
+  .markdown-paper .markra-prosemirror-caret.markra-prosemirror-caret-block {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 52%, transparent);
+    border-radius: 3px;
+  }
+
   .editor-content-slot[data-document-search-open="true"] .markdown-paper .markra-prosemirror-caret {
     display: none !important;
   }

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -31,6 +31,22 @@ describe("editor stylesheet", () => {
     expect(surfaceRule).toContain("font-family: var(--editor-font-family);");
   });
 
+  it("styles the visual Vim normal mode caret as a block", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const blockCaretRuleStart = styles.indexOf(
+      ".markdown-paper .markra-prosemirror-caret.markra-prosemirror-caret-block"
+    );
+    const blockCaretRuleEnd = styles.indexOf(".editor-content-slot[data-document-search-open=\"true\"]", blockCaretRuleStart);
+    const blockCaretRule = styles.slice(blockCaretRuleStart, blockCaretRuleEnd);
+
+    expect(blockCaretRuleStart).toBeGreaterThanOrEqual(0);
+    expect(blockCaretRuleEnd).toBeGreaterThan(blockCaretRuleStart);
+    expect(blockCaretRule).toContain("border: 1px solid color-mix(in srgb, var(--accent) 52%, transparent);");
+    expect(blockCaretRule).toContain("background: color-mix(in srgb, var(--accent) 10%, transparent);");
+    expect(blockCaretRule).toContain("border-radius: 3px;");
+    expect(blockCaretRule).not.toContain("opacity:");
+  });
+
   it("forces a grabbing cursor during document tab pointer drags", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -352,6 +352,7 @@ vi.mock("../lib/settings/app-settings", () => ({
       viewModeToggle: "visible"
     },
     showWordCount: true,
+    vimModeEnabled: false,
     wrapCodeBlocks: true
   },
   appThemeOptions: [
@@ -634,6 +635,7 @@ vi.mock("../lib/settings/app-settings", () => ({
       viewModeToggle: "visible"
     },
     showWordCount: true,
+    vimModeEnabled: preferences?.vimModeEnabled ?? false,
     ...preferences,
     wrapCodeBlocks: preferences?.wrapCodeBlocks ?? true
   })),
@@ -1422,6 +1424,7 @@ export function installAppTestHarness() {
         wordCount: "visible"
       },
       showWordCount: true,
+      vimModeEnabled: false,
       wrapCodeBlocks: true
     });
     mockedGetStoredExportSettings.mockResolvedValue({

--- a/packages/editor/src/caret.ts
+++ b/packages/editor/src/caret.ts
@@ -1,9 +1,11 @@
 import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
+import { vimNormalClassName } from "./vim-mode";
 
 const customCaretClassName = "markra-prosemirror-custom-caret";
 const caretClassName = "markra-prosemirror-caret";
+const blockCaretClassName = "markra-prosemirror-caret-block";
 
 function focused(view: EditorView) {
   return view.hasFocus() || view.dom.classList.contains("ProseMirror-focused");
@@ -18,6 +20,27 @@ function caretFontSize(view: EditorView) {
 function caretHeight(view: EditorView, lineHeight: number) {
   const targetHeight = Math.round(caretFontSize(view) * 1.125);
   return Math.max(1, Math.min(targetHeight, lineHeight > 0 ? lineHeight : targetHeight));
+}
+
+function caretWidth(view: EditorView) {
+  if (!view.dom.classList.contains(vimNormalClassName)) return "1px";
+
+  return `${Math.max(3, Math.round(caretFontSize(view) * 0.44))}px`;
+}
+
+function blockCaretWidth(view: EditorView, left: number) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return caretWidth(view);
+
+  try {
+    const next = view.coordsAtPos(selection.from + 1, -1);
+    const measuredWidth = Math.round(next.left - left);
+    if (measuredWidth > 1) return `${measuredWidth}px`;
+  } catch {
+    return caretWidth(view);
+  }
+
+  return caretWidth(view);
 }
 
 function hideCaret(caret: HTMLElement) {
@@ -100,11 +123,14 @@ class VisualCaretView {
     const lineHeight = coords.bottom - coords.top;
     const height = caretHeight(view, lineHeight);
     const top = coords.top + Math.max(0, lineHeight - height) / 2;
+    const block = view.dom.classList.contains(vimNormalClassName);
 
     this.caret.style.display = "block";
     this.caret.style.left = `${Math.round(coords.left)}px`;
     this.caret.style.top = `${Math.round(top)}px`;
     this.caret.style.height = `${height}px`;
+    this.caret.style.width = block ? blockCaretWidth(view, coords.left) : caretWidth(view);
+    this.caret.classList.toggle(blockCaretClassName, block);
   }
 
   destroy() {

--- a/packages/editor/src/caret.ts
+++ b/packages/editor/src/caret.ts
@@ -8,7 +8,13 @@ const caretClassName = "markra-prosemirror-caret";
 const blockCaretClassName = "markra-prosemirror-caret-block";
 
 function focused(view: EditorView) {
-  return view.hasFocus() || view.dom.classList.contains("ProseMirror-focused");
+  const activeElement = view.dom.ownerDocument.activeElement;
+  return (
+    view.hasFocus() ||
+    view.dom.classList.contains("ProseMirror-focused") ||
+    activeElement === view.dom ||
+    Boolean(activeElement && view.dom.contains(activeElement))
+  );
 }
 
 function caretFontSize(view: EditorView) {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -25,3 +25,4 @@ export * from "./spellcheck.ts";
 export * from "./table-controls.ts";
 export * from "./task-list.ts";
 export * from "./trailing-paragraph.ts";
+export * from "./vim-mode.ts";

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -276,6 +276,24 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("changes the current text block with cc and enters insert mode", () => {
+    const view = createView(["alpha", "beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["c", "c"])).toEqual([true, true]);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(textContent(view)).toBe("\nbeta");
+
+      expect(typeText(view, "X")).toBe(false);
+      expect(textContent(view)).toBe("X\nbeta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("moves w and b across text blocks", () => {
     const view = createView(["alpha", "beta gamma"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -206,6 +206,24 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("appends after the current character at the end of a text block", () => {
+    const view = createView(["abc"]);
+
+    try {
+      const start = findTextPosition(view, "abc");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "$")).toBe(true);
+      expect(pressKey(view, "a")).toBe(true);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(typeText(view, "X")).toBe(false);
+      expect(textContent(view)).toBe("abcX");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("supports word and line operator motions", () => {
     const view = createView(["alpha beta gamma"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -753,6 +753,47 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("searches with / and repeats matches with n and N", () => {
+    const view = createView(["alpha beta", "gamma beta", "beta delta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["/", "b", "e", "t", "a", "Enter"])).toEqual([true, true, true, true, true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha beta", "alpha ".length));
+      expect(textContent(view)).toBe("alpha beta\ngamma beta\nbeta delta");
+
+      expect(pressKey(view, "n")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "gamma beta", "gamma ".length));
+
+      expect(pressKey(view, "n")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta delta"));
+
+      expect(pressKey(view, "N")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "gamma beta", "gamma ".length));
+
+      expect(pressKey(view, "n")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta delta"));
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("supports reverse Vim searches with ?", () => {
+    const view = createView(["alpha beta", "gamma beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "gamma"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["?", "b", "e", "t", "a", "Enter"])).toEqual([true, true, true, true, true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha beta", "alpha ".length));
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("uses % as a Vim operator motion", () => {
     const view = createView(["alpha (beta) gamma"]);
     const backward = createView(["alpha (beta) gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -1,0 +1,324 @@
+import { Schema } from "@milkdown/kit/prose/model";
+import { history } from "@milkdown/kit/prose/history";
+import { EditorState, TextSelection } from "@milkdown/kit/prose/state";
+import { EditorView } from "@milkdown/kit/prose/view";
+import {
+  createVimModePlugin,
+  getVimMode
+} from "./vim-mode";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      content: "inline*",
+      group: "block",
+      parseDOM: [{ tag: "p" }],
+      toDOM: () => ["p", 0]
+    },
+    text: { group: "inline" }
+  }
+});
+
+function paragraph(text: string) {
+  return schema.node("paragraph", null, text ? [schema.text(text)] : []);
+}
+
+function createView(texts: readonly string[], enabled = true) {
+  const parent = document.createElement("div");
+  parent.className = "markdown-paper";
+  document.body.append(parent);
+
+  const view = new EditorView(parent, {
+    state: EditorState.create({
+      doc: schema.node("doc", null, texts.map(paragraph)),
+      plugins: [history(), createVimModePlugin({ enabled: () => enabled })]
+    })
+  });
+
+  return view;
+}
+
+function destroyView(view: EditorView) {
+  view.destroy();
+  view.dom.parentElement?.remove();
+}
+
+function textContent(view: EditorView) {
+  return view.state.doc.textBetween(0, view.state.doc.content.size, "\n");
+}
+
+function findTextPosition(view: EditorView, text: string, offset = 0) {
+  let position: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (!node.isText || typeof node.text !== "string") return true;
+
+    const textOffset = node.text.indexOf(text);
+    if (textOffset < 0) return true;
+
+    position = nodePosition + textOffset + offset;
+    return false;
+  });
+
+  if (position === null) throw new Error(`Could not find text "${text}".`);
+
+  return position;
+}
+
+function moveCursor(view: EditorView, position: number) {
+  view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, position)));
+}
+
+function pressKey(view: EditorView, key: string, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+    ...init
+  });
+
+  return Boolean(view.someProp("handleKeyDown", (handler) => handler(view, event)));
+}
+
+function pressKeys(view: EditorView, keys: readonly string[]) {
+  return keys.map((key) => pressKey(view, key));
+}
+
+function typeText(view: EditorView, text: string) {
+  const { from, to } = view.state.selection;
+  const insertText = () => view.state.tr.insertText(text, from, to);
+  const handled = view.someProp("handleTextInput", (handler) => handler(view, from, to, text, insertText));
+
+  if (!handled) {
+    view.dispatch(insertText());
+  }
+
+  return Boolean(handled);
+}
+
+describe("vim mode plugin", () => {
+  it("marks the editor DOM with the active Vim mode", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      const paper = view.dom.closest(".markdown-paper");
+
+      expect(view.dom.classList.contains("markra-vim-mode")).toBe(true);
+      expect(view.dom.classList.contains("markra-vim-insert")).toBe(true);
+      expect(view.dom.classList.contains("markra-vim-normal")).toBe(false);
+      expect(paper?.classList.contains("markra-vim-mode")).toBe(true);
+      expect(paper?.classList.contains("markra-vim-insert")).toBe(true);
+
+      pressKey(view, "Escape");
+      expect(view.dom.classList.contains("markra-vim-normal")).toBe(true);
+      expect(view.dom.classList.contains("markra-vim-insert")).toBe(false);
+      expect(paper?.classList.contains("markra-vim-normal")).toBe(true);
+      expect(paper?.classList.contains("markra-vim-insert")).toBe(false);
+
+      pressKey(view, "i");
+      expect(view.dom.classList.contains("markra-vim-insert")).toBe(true);
+      expect(view.dom.classList.contains("markra-vim-normal")).toBe(false);
+      expect(paper?.classList.contains("markra-vim-insert")).toBe(true);
+      expect(paper?.classList.contains("markra-vim-normal")).toBe(false);
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("blocks text input in normal mode and resumes text input from insert mode", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+
+      expect(pressKey(view, "Escape")).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha", 1));
+      expect(typeText(view, "z")).toBe(true);
+      expect(textContent(view)).toBe("alpha");
+
+      expect(pressKey(view, "i")).toBe(true);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(typeText(view, "z")).toBe(false);
+      expect(textContent(view)).toBe("azlpha");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("moves the cursor and deletes the character under the cursor in normal mode", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      const start = findTextPosition(view, "alpha");
+      moveCursor(view, start + 1);
+
+      pressKey(view, "Escape");
+      expect(pressKey(view, "l")).toBe(true);
+      expect(view.state.selection.from).toBe(start + 1);
+
+      expect(pressKey(view, "h")).toBe(true);
+      expect(view.state.selection.from).toBe(start);
+
+      moveCursor(view, start);
+      expect(pressKey(view, "x")).toBe(true);
+      expect(textContent(view)).toBe("lpha");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("moves between text blocks with j and k", () => {
+    const view = createView(["alpha", "beta"]);
+
+    try {
+      const alphaOffset = 2;
+      moveCursor(view, findTextPosition(view, "alpha", alphaOffset));
+
+      pressKey(view, "Escape");
+      expect(pressKey(view, "j")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta", alphaOffset - 1));
+
+      expect(pressKey(view, "k")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha", alphaOffset - 1));
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("applies counts to motions and character deletes", () => {
+    const view = createView(["abcdef"]);
+
+    try {
+      const start = findTextPosition(view, "abcdef");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["3", "l"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(start + 3);
+
+      expect(pressKeys(view, ["2", "x"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("abcf");
+      expect(view.state.selection.from).toBe(start + 3);
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("supports word and line operator motions", () => {
+    const view = createView(["alpha beta gamma"]);
+
+    try {
+      const start = findTextPosition(view, "alpha");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["d", "w"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("beta gamma");
+
+      moveCursor(view, findTextPosition(view, "gamma"));
+      pressKey(view, "Escape");
+      expect(pressKeys(view, ["d", "$"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("beta ");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("multiplies operator counts with motion counts", () => {
+    const view = createView(["one two three four"]);
+
+    try {
+      const start = findTextPosition(view, "one");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["2", "d", "w"])).toEqual([true, true, true]);
+      expect(textContent(view)).toBe("three four");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("yanks and pastes whole text blocks with yy and p", () => {
+    const view = createView(["alpha", "beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["y", "y"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("alpha\nbeta");
+
+      expect(pressKey(view, "j")).toBe(true);
+      expect(pressKey(view, "p")).toBe(true);
+      expect(textContent(view)).toBe("alpha\nbeta\nalpha");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("undoes and redoes Vim edits", () => {
+    const view = createView(["alpha"]);
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 24,
+      left: 8,
+      right: 9,
+      top: 4
+    });
+    const scrollBySpy = vi.spyOn(window, "scrollBy").mockImplementation(() => {});
+
+    try {
+      const start = findTextPosition(view, "alpha");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "x")).toBe(true);
+      expect(textContent(view)).toBe("lpha");
+
+      expect(pressKey(view, "u")).toBe(true);
+      expect(textContent(view)).toBe("alpha");
+
+      expect(pressKey(view, "r", { ctrlKey: true })).toBe(true);
+      expect(textContent(view)).toBe("lpha");
+    } finally {
+      coordsSpy.mockRestore();
+      scrollBySpy.mockRestore();
+      destroyView(view);
+    }
+  });
+
+  it("consumes destructive editing keys in normal mode", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "Backspace")).toBe(true);
+      expect(pressKey(view, "Delete")).toBe(true);
+      expect(pressKey(view, "Enter")).toBe(true);
+      expect(textContent(view)).toBe("alpha");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("deletes the current text block with dd", () => {
+    const view = createView(["alpha", "beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "d")).toBe(true);
+      expect(textContent(view)).toBe("alpha\nbeta");
+
+      expect(pressKey(view, "d")).toBe(true);
+      expect(textContent(view)).toBe("beta");
+    } finally {
+      destroyView(view);
+    }
+  });
+});

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -1213,6 +1213,49 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim line motions as linewise operators", () => {
+    const deleteToEnd = createView(["alpha", "beta", "gamma"]);
+    const deleteToStart = createView(["alpha", "beta", "gamma"]);
+    const changeToEnd = createView(["alpha", "beta", "gamma"]);
+    const yankToEnd = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(deleteToEnd, findTextPosition(deleteToEnd, "beta"));
+      pressKey(deleteToEnd, "Escape");
+
+      expect(pressKeys(deleteToEnd, ["d", "G"])).toEqual([true, true]);
+      expect(textContent(deleteToEnd)).toBe("alpha");
+
+      moveCursor(deleteToStart, findTextPosition(deleteToStart, "beta"));
+      pressKey(deleteToStart, "Escape");
+
+      expect(pressKeys(deleteToStart, ["d", "g", "g"])).toEqual([true, true, true]);
+      expect(textContent(deleteToStart)).toBe("gamma");
+
+      moveCursor(changeToEnd, findTextPosition(changeToEnd, "beta"));
+      pressKey(changeToEnd, "Escape");
+
+      expect(pressKeys(changeToEnd, ["c", "G"])).toEqual([true, true]);
+      expect(getVimMode(changeToEnd.state)).toBe("insert");
+      expect(textContent(changeToEnd)).toBe("alpha\n");
+
+      expect(typeText(changeToEnd, "delta")).toBe(true);
+      expect(textContent(changeToEnd)).toBe("alpha\ndelta");
+
+      moveCursor(yankToEnd, findTextPosition(yankToEnd, "beta"));
+      pressKey(yankToEnd, "Escape");
+
+      expect(pressKeys(yankToEnd, ["y", "G"])).toEqual([true, true]);
+      expect(pressKey(yankToEnd, "p")).toBe(true);
+      expect(textContent(yankToEnd)).toBe("alpha\nbeta\nbeta\ngamma\ngamma");
+    } finally {
+      destroyView(deleteToEnd);
+      destroyView(deleteToStart);
+      destroyView(changeToEnd);
+      destroyView(yankToEnd);
+    }
+  });
+
   it("uses % as a Vim operator motion", () => {
     const view = createView(["alpha (beta) gamma"]);
     const backward = createView(["alpha (beta) gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -303,7 +303,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(view.state)).toBe("insert");
       expect(textContent(view)).toBe("lpha");
 
-      expect(typeText(view, "X")).toBe(false);
+      expect(typeText(view, "X")).toBe(true);
       expect(textContent(view)).toBe("Xlpha");
     } finally {
       destroyView(view);
@@ -514,7 +514,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(view.state)).toBe("insert");
       expect(textContent(view)).toBe("alpha ");
 
-      expect(typeText(view, "X")).toBe(false);
+      expect(typeText(view, "X")).toBe(true);
       expect(textContent(view)).toBe("alpha X");
     } finally {
       destroyView(view);
@@ -546,7 +546,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(view.state)).toBe("insert");
       expect(textContent(view)).toBe(" beta");
 
-      expect(typeText(view, "X")).toBe(false);
+      expect(typeText(view, "X")).toBe(true);
       expect(textContent(view)).toBe("X beta");
     } finally {
       destroyView(view);
@@ -571,7 +571,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(changeInner.state)).toBe("insert");
       expect(textContent(changeInner)).toBe("alpha  gamma");
 
-      expect(typeText(changeInner, "delta")).toBe(false);
+      expect(typeText(changeInner, "delta")).toBe(true);
       expect(textContent(changeInner)).toBe("alpha delta gamma");
     } finally {
       destroyView(deleteInner);
@@ -637,7 +637,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(changeInner.state)).toBe("insert");
       expect(textContent(changeInner)).toBe('alpha "" gamma');
 
-      expect(typeText(changeInner, "delta")).toBe(false);
+      expect(typeText(changeInner, "delta")).toBe(true);
       expect(textContent(changeInner)).toBe('alpha "delta" gamma');
     } finally {
       destroyView(deleteInner);
@@ -689,7 +689,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(changeBraces.state)).toBe("insert");
       expect(textContent(changeBraces)).toBe("alpha {} gamma");
 
-      expect(typeText(changeBraces, "delta")).toBe(false);
+      expect(typeText(changeBraces, "delta")).toBe(true);
       expect(textContent(changeBraces)).toBe("alpha {delta} gamma");
     } finally {
       destroyView(deleteNested);
@@ -734,7 +734,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(view.state)).toBe("insert");
       expect(textContent(view)).toBe("\nbeta");
 
-      expect(typeText(view, "X")).toBe(false);
+      expect(typeText(view, "X")).toBe(true);
       expect(textContent(view)).toBe("X\nbeta");
     } finally {
       destroyView(view);
@@ -752,7 +752,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(view.state)).toBe("insert");
       expect(textContent(view)).toBe("\nbeta");
 
-      expect(typeText(view, "X")).toBe(false);
+      expect(typeText(view, "X")).toBe(true);
       expect(textContent(view)).toBe("X\nbeta");
     } finally {
       destroyView(view);
@@ -847,7 +847,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(changeWord.state)).toBe("insert");
       expect(textContent(changeWord)).toBe(" three");
 
-      expect(typeText(changeWord, "token")).toBe(false);
+      expect(typeText(changeWord, "token")).toBe(true);
       expect(textContent(changeWord)).toBe("token three");
     } finally {
       destroyView(deleteToNextWord);
@@ -957,7 +957,7 @@ describe("vim mode plugin", () => {
       expect(getVimMode(changeBackward.state)).toBe("insert");
       expect(textContent(changeBackward)).toBe("alpha gamma");
 
-      expect(typeText(changeBackward, "delta ")).toBe(false);
+      expect(typeText(changeBackward, "delta ")).toBe(true);
       expect(textContent(changeBackward)).toBe("alpha delta gamma");
     } finally {
       destroyView(deleteForward);
@@ -1147,6 +1147,29 @@ describe("vim mode plugin", () => {
       destroyView(paste);
       destroyView(join);
       destroyView(insertEdit);
+    }
+  });
+
+  it("repeats insert-text changes with .", () => {
+    const view = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["c", "w"])).toEqual([true, true]);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(typeText(view, "X")).toBe(true);
+      expect(textContent(view)).toBe("X beta gamma");
+      expect(pressKey(view, "Escape")).toBe(true);
+
+      expect(pressKey(view, "w")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta"));
+      expect(pressKey(view, ".")).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(textContent(view)).toBe("X X gamma");
+    } finally {
+      destroyView(view);
     }
   });
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -622,6 +622,28 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("applies counts to Vim $ motions", () => {
+    const movement = createView(["alpha", "beta", "gamma"]);
+    const deletion = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(movement, findTextPosition(movement, "alpha"));
+      pressKey(movement, "Escape");
+
+      expect(pressKeys(movement, ["2", "$"])).toEqual([true, true]);
+      expect(movement.state.selection.from).toBe(findTextPosition(movement, "beta", "beta".length - 1));
+
+      moveCursor(deletion, findTextPosition(deletion, "alpha"));
+      pressKey(deletion, "Escape");
+
+      expect(pressKeys(deletion, ["d", "2", "$"])).toEqual([true, true, true]);
+      expect(textContent(deletion)).toBe("\ngamma");
+    } finally {
+      destroyView(movement);
+      destroyView(deletion);
+    }
+  });
+
   it("uses character find motions for Vim operators", () => {
     const deleteThrough = createView(["alpha,beta"]);
     const deleteTill = createView(["alpha,beta"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -223,6 +223,25 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("substitutes the character under the cursor with s and enters insert mode", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      const start = findTextPosition(view, "alpha");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "s")).toBe(true);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(textContent(view)).toBe("lpha");
+
+      expect(typeText(view, "X")).toBe(false);
+      expect(textContent(view)).toBe("Xlpha");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("appends after the current character at the end of a text block", () => {
     const view = createView(["abc"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -280,6 +280,38 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("deletes to the end of the text block with D", () => {
+    const view = createView(["alpha beta"]);
+
+    try {
+      pressKey(view, "Escape");
+      moveCursor(view, findTextPosition(view, "beta"));
+
+      expect(pressKey(view, "D")).toBe(true);
+      expect(textContent(view)).toBe("alpha ");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("changes to the end of the text block with C", () => {
+    const view = createView(["alpha beta"]);
+
+    try {
+      pressKey(view, "Escape");
+      moveCursor(view, findTextPosition(view, "beta"));
+
+      expect(pressKey(view, "C")).toBe(true);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(textContent(view)).toBe("alpha ");
+
+      expect(typeText(view, "X")).toBe(false);
+      expect(textContent(view)).toBe("alpha X");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("includes the final character for Vim end-word operators", () => {
     const view = createView(["alpha beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -527,6 +527,29 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("extends Vim visual selections with character find motions", () => {
+    const find = createView(["alpha,beta"]);
+    const repeat = createView(["a-b-c"]);
+
+    try {
+      moveCursor(find, findTextPosition(find, "alpha"));
+      pressKey(find, "Escape");
+
+      expect(pressKeys(find, ["v", "f", ",", "d"])).toEqual([true, true, true, true]);
+      expect(getVimMode(find.state)).toBe("normal");
+      expect(textContent(find)).toBe("beta");
+
+      moveCursor(repeat, findTextPosition(repeat, "a-b-c"));
+      pressKey(repeat, "Escape");
+
+      expect(pressKeys(repeat, ["v", "f", "-", ";", "d"])).toEqual([true, true, true, true, true]);
+      expect(textContent(repeat)).toBe("c");
+    } finally {
+      destroyView(find);
+      destroyView(repeat);
+    }
+  });
+
   it("uses Vim visual line selections for yank, delete, and change", () => {
     const yank = createView(["alpha", "beta", "gamma"]);
     const deletion = createView(["alpha", "beta", "gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -322,6 +322,36 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("toggles character case with ~", () => {
+    const view = createView(["aBcDe"]);
+    const repeat = createView(["abcdef"]);
+
+    try {
+      const start = findTextPosition(view, "aBcDe");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "~")).toBe(true);
+      expect(textContent(view)).toBe("ABcDe");
+      expect(view.state.selection.from).toBe(start + 1);
+
+      expect(pressKeys(view, ["3", "~"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("AbCde");
+      expect(view.state.selection.from).toBe(start + 4);
+
+      moveCursor(repeat, findTextPosition(repeat, "abcdef"));
+      pressKey(repeat, "Escape");
+
+      expect(pressKeys(repeat, ["2", "~"])).toEqual([true, true]);
+      expect(textContent(repeat)).toBe("ABcdef");
+      expect(pressKey(repeat, ".")).toBe(true);
+      expect(textContent(repeat)).toBe("ABCDef");
+    } finally {
+      destroyView(view);
+      destroyView(repeat);
+    }
+  });
+
   it("substitutes the character under the cursor with s and enters insert mode", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -1068,6 +1068,33 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("yanks whole text blocks with Y", () => {
+    const single = createView(["alpha", "beta"]);
+    const counted = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(single, findTextPosition(single, "alpha"));
+      pressKey(single, "Escape");
+
+      expect(pressKey(single, "Y")).toBe(true);
+      expect(textContent(single)).toBe("alpha\nbeta");
+      expect(pressKey(single, "j")).toBe(true);
+      expect(pressKey(single, "p")).toBe(true);
+      expect(textContent(single)).toBe("alpha\nbeta\nalpha");
+
+      moveCursor(counted, findTextPosition(counted, "alpha"));
+      pressKey(counted, "Escape");
+
+      expect(pressKeys(counted, ["2", "Y"])).toEqual([true, true]);
+      expect(pressKey(counted, "G")).toBe(true);
+      expect(pressKey(counted, "p")).toBe(true);
+      expect(textContent(counted)).toBe("alpha\nbeta\ngamma\nalpha\nbeta");
+    } finally {
+      destroyView(single);
+      destroyView(counted);
+    }
+  });
+
   it("undoes and redoes Vim edits", () => {
     const view = createView(["alpha"]);
     const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -258,6 +258,24 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("changes the current word with cw and enters insert mode", () => {
+    const view = createView(["alpha beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["c", "w"])).toEqual([true, true]);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(textContent(view)).toBe(" beta");
+
+      expect(typeText(view, "X")).toBe(false);
+      expect(textContent(view)).toBe("X beta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("moves w and b across text blocks", () => {
     const view = createView(["alpha", "beta gamma"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -250,6 +250,30 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("moves by character with Space, Backspace, and Ctrl-h", () => {
+    const view = createView(["abcdef"]);
+
+    try {
+      const start = findTextPosition(view, "abcdef");
+      moveCursor(view, start + 3);
+      pressKey(view, "Escape");
+
+      expect(view.state.selection.from).toBe(start + 2);
+
+      expect(pressKey(view, " ")).toBe(true);
+      expect(view.state.selection.from).toBe(start + 3);
+
+      expect(pressKey(view, "Backspace")).toBe(true);
+      expect(view.state.selection.from).toBe(start + 2);
+
+      expect(pressKey(view, "h", { ctrlKey: true })).toBe(true);
+      expect(view.state.selection.from).toBe(start + 1);
+      expect(textContent(view)).toBe("abcdef");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("joins the current text block with the next one using J", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -187,6 +187,35 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("joins the current text block with the next one using J", () => {
+    const view = createView(["alpha", "beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "J")).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(textContent(view)).toBe("alpha beta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("treats a J count as the total number of joined text blocks", () => {
+    const view = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["2", "J"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("alpha beta\ngamma");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("applies counts to motions and character deletes", () => {
     const view = createView(["abcdef"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -157,6 +157,22 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("deletes the previous word with Ctrl-w in insert mode", () => {
+    const view = createView(["alpha beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "beta", "beta".length));
+
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(pressKey(view, "w", { ctrlKey: true })).toBe(true);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(textContent(view)).toBe("alpha ");
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha ", "alpha ".length));
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("treats Ctrl-[ as Escape", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -350,6 +350,61 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim visual line selections for yank, delete, and change", () => {
+    const yank = createView(["alpha", "beta", "gamma"]);
+    const deletion = createView(["alpha", "beta", "gamma"]);
+    const change = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(yank, findTextPosition(yank, "alpha"));
+      pressKey(yank, "Escape");
+
+      expect(pressKeys(yank, ["V", "j", "y"])).toEqual([true, true, true]);
+      expect(getVimMode(yank.state)).toBe("normal");
+      expect(textContent(yank)).toBe("alpha\nbeta\ngamma");
+
+      moveCursor(yank, findTextPosition(yank, "gamma"));
+      expect(pressKey(yank, "p")).toBe(true);
+      expect(textContent(yank)).toBe("alpha\nbeta\ngamma\nalpha\nbeta");
+
+      moveCursor(deletion, findTextPosition(deletion, "alpha"));
+      pressKey(deletion, "Escape");
+
+      expect(pressKeys(deletion, ["V", "j", "d"])).toEqual([true, true, true]);
+      expect(getVimMode(deletion.state)).toBe("normal");
+      expect(textContent(deletion)).toBe("gamma");
+
+      moveCursor(change, findTextPosition(change, "alpha"));
+      pressKey(change, "Escape");
+
+      expect(pressKeys(change, ["V", "j", "c"])).toEqual([true, true, true]);
+      expect(getVimMode(change.state)).toBe("insert");
+      expect(textContent(change)).toBe("\ngamma");
+
+      expect(typeText(change, "X")).toBe(false);
+      expect(textContent(change)).toBe("X\ngamma");
+    } finally {
+      destroyView(yank);
+      destroyView(deletion);
+      destroyView(change);
+    }
+  });
+
+  it("shrinks Vim visual line selections with reverse line motions", () => {
+    const view = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "beta"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["V", "j", "k", "d"])).toEqual([true, true, true, true]);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(textContent(view)).toBe("alpha\ngamma");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("exits Vim visual mode with Escape", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -490,6 +490,58 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim inner quote text objects for delete and change operators", () => {
+    const deleteInner = createView(['alpha "beta" gamma']);
+    const changeInner = createView(['alpha "beta" gamma']);
+
+    try {
+      moveCursor(deleteInner, findTextPosition(deleteInner, "beta", 1));
+      pressKey(deleteInner, "Escape");
+
+      expect(pressKeys(deleteInner, ["d", "i", '"'])).toEqual([true, true, true]);
+      expect(textContent(deleteInner)).toBe('alpha "" gamma');
+
+      moveCursor(changeInner, findTextPosition(changeInner, "beta", 1));
+      pressKey(changeInner, "Escape");
+
+      expect(pressKeys(changeInner, ["c", "i", '"'])).toEqual([true, true, true]);
+      expect(getVimMode(changeInner.state)).toBe("insert");
+      expect(textContent(changeInner)).toBe('alpha "" gamma');
+
+      expect(typeText(changeInner, "delta")).toBe(false);
+      expect(textContent(changeInner)).toBe('alpha "delta" gamma');
+    } finally {
+      destroyView(deleteInner);
+      destroyView(changeInner);
+    }
+  });
+
+  it("uses Vim around quote text objects and yanks inline code", () => {
+    const deleteAround = createView(['alpha "beta" gamma']);
+    const yankInlineCode = createView(["alpha `code` gamma"]);
+
+    try {
+      moveCursor(deleteAround, findTextPosition(deleteAround, "beta", 1));
+      pressKey(deleteAround, "Escape");
+
+      expect(pressKeys(deleteAround, ["d", "a", '"'])).toEqual([true, true, true]);
+      expect(textContent(deleteAround)).toBe("alpha  gamma");
+
+      moveCursor(yankInlineCode, findTextPosition(yankInlineCode, "code", 1));
+      pressKey(yankInlineCode, "Escape");
+
+      expect(pressKeys(yankInlineCode, ["y", "i", "`"])).toEqual([true, true, true]);
+      expect(textContent(yankInlineCode)).toBe("alpha `code` gamma");
+
+      expect(pressKey(yankInlineCode, "$")).toBe(true);
+      expect(pressKey(yankInlineCode, "p")).toBe(true);
+      expect(textContent(yankInlineCode)).toBe("alpha `code` gammacode");
+    } finally {
+      destroyView(deleteAround);
+      destroyView(yankInlineCode);
+    }
+  });
+
   it("changes the current text block with cc and enters insert mode", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -235,6 +235,35 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("finds characters with Vim f, t, F, T, and repeat keys", () => {
+    const view = createView(["ab-cd-ef"]);
+
+    try {
+      const start = findTextPosition(view, "ab-cd-ef");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["2", "f", "-"])).toEqual([true, true, true]);
+      expect(view.state.selection.from).toBe(start + 5);
+
+      expect(pressKey(view, ",")).toBe(true);
+      expect(view.state.selection.from).toBe(start + 2);
+
+      expect(pressKeys(view, ["t", "-"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(start + 4);
+
+      moveCursor(view, start + 7);
+      expect(pressKeys(view, ["F", "-"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(start + 5);
+
+      moveCursor(view, start + 7);
+      expect(pressKeys(view, ["T", "-"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(start + 6);
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("replaces the character under the cursor with r and stays in normal mode", () => {
     const view = createView(["alpha"]);
 
@@ -306,6 +335,28 @@ describe("vim mode plugin", () => {
       expect(textContent(view)).toBe("beta ");
     } finally {
       destroyView(view);
+    }
+  });
+
+  it("uses character find motions for Vim operators", () => {
+    const deleteThrough = createView(["alpha,beta"]);
+    const deleteTill = createView(["alpha,beta"]);
+
+    try {
+      moveCursor(deleteThrough, findTextPosition(deleteThrough, "alpha"));
+      pressKey(deleteThrough, "Escape");
+
+      expect(pressKeys(deleteThrough, ["d", "f", ","])).toEqual([true, true, true]);
+      expect(textContent(deleteThrough)).toBe("beta");
+
+      moveCursor(deleteTill, findTextPosition(deleteTill, "alpha"));
+      pressKey(deleteTill, "Escape");
+
+      expect(pressKeys(deleteTill, ["d", "t", ","])).toEqual([true, true, true]);
+      expect(textContent(deleteTill)).toBe(",beta");
+    } finally {
+      destroyView(deleteThrough);
+      destroyView(deleteTill);
     }
   });
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -1067,6 +1067,89 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("repeats normal-mode changes with .", () => {
+    const characterDelete = createView(["abcdef"]);
+    const wordDelete = createView(["alpha beta gamma"]);
+    const lineDelete = createView(["alpha", "beta", "gamma"]);
+    const replace = createView(["alpha"]);
+    const paste = createView(["alpha", "beta"]);
+    const join = createView(["alpha", "beta", "gamma"]);
+    const insertEdit = createView(["abcd"]);
+
+    try {
+      moveCursor(characterDelete, findTextPosition(characterDelete, "abcdef"));
+      pressKey(characterDelete, "Escape");
+
+      expect(pressKeys(characterDelete, ["2", "x"])).toEqual([true, true]);
+      expect(textContent(characterDelete)).toBe("cdef");
+      expect(pressKey(characterDelete, ".")).toBe(true);
+      expect(textContent(characterDelete)).toBe("ef");
+
+      moveCursor(wordDelete, findTextPosition(wordDelete, "alpha"));
+      pressKey(wordDelete, "Escape");
+
+      expect(pressKeys(wordDelete, ["d", "w"])).toEqual([true, true]);
+      expect(textContent(wordDelete)).toBe("beta gamma");
+      expect(pressKey(wordDelete, ".")).toBe(true);
+      expect(textContent(wordDelete)).toBe("gamma");
+
+      moveCursor(lineDelete, findTextPosition(lineDelete, "alpha"));
+      pressKey(lineDelete, "Escape");
+
+      expect(pressKeys(lineDelete, ["d", "d"])).toEqual([true, true]);
+      expect(textContent(lineDelete)).toBe("beta\ngamma");
+      expect(pressKey(lineDelete, ".")).toBe(true);
+      expect(textContent(lineDelete)).toBe("gamma");
+
+      moveCursor(replace, findTextPosition(replace, "alpha"));
+      pressKey(replace, "Escape");
+
+      expect(pressKeys(replace, ["r", "X"])).toEqual([true, true]);
+      expect(textContent(replace)).toBe("Xlpha");
+      expect(pressKey(replace, "l")).toBe(true);
+      expect(pressKey(replace, ".")).toBe(true);
+      expect(textContent(replace)).toBe("XXpha");
+
+      moveCursor(paste, findTextPosition(paste, "alpha"));
+      pressKey(paste, "Escape");
+
+      expect(pressKeys(paste, ["y", "y"])).toEqual([true, true]);
+      expect(pressKey(paste, "j")).toBe(true);
+      expect(pressKey(paste, "p")).toBe(true);
+      expect(textContent(paste)).toBe("alpha\nbeta\nalpha");
+      expect(pressKey(paste, ".")).toBe(true);
+      expect(textContent(paste)).toBe("alpha\nbeta\nalpha\nalpha");
+
+      moveCursor(join, findTextPosition(join, "alpha"));
+      pressKey(join, "Escape");
+
+      expect(pressKey(join, "J")).toBe(true);
+      expect(textContent(join)).toBe("alpha beta\ngamma");
+      expect(pressKey(join, ".")).toBe(true);
+      expect(textContent(join)).toBe("alpha beta gamma");
+
+      moveCursor(insertEdit, findTextPosition(insertEdit, "abcd"));
+      pressKey(insertEdit, "Escape");
+
+      expect(pressKey(insertEdit, "x")).toBe(true);
+      expect(textContent(insertEdit)).toBe("bcd");
+      expect(pressKey(insertEdit, "i")).toBe(true);
+      expect(typeText(insertEdit, "Z")).toBe(false);
+      expect(textContent(insertEdit)).toBe("Zbcd");
+      expect(pressKey(insertEdit, "Escape")).toBe(true);
+      expect(pressKey(insertEdit, ".")).toBe(true);
+      expect(textContent(insertEdit)).toBe("Zbcd");
+    } finally {
+      destroyView(characterDelete);
+      destroyView(wordDelete);
+      destroyView(lineDelete);
+      destroyView(replace);
+      destroyView(paste);
+      destroyView(join);
+      destroyView(insertEdit);
+    }
+  });
+
   it("consumes destructive editing keys in normal mode", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -116,6 +116,16 @@ describe("vim mode plugin", () => {
       expect(paper?.classList.contains("markra-vim-normal")).toBe(true);
       expect(paper?.classList.contains("markra-vim-insert")).toBe(false);
 
+      pressKey(view, "v");
+      expect(getVimMode(view.state)).toBe("visual");
+      expect(view.dom.classList.contains("markra-vim-visual")).toBe(true);
+      expect(paper?.classList.contains("markra-vim-visual")).toBe(true);
+
+      pressKey(view, "Escape");
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.dom.classList.contains("markra-vim-visual")).toBe(false);
+      expect(paper?.classList.contains("markra-vim-visual")).toBe(false);
+
       pressKey(view, "i");
       expect(view.dom.classList.contains("markra-vim-insert")).toBe(true);
       expect(view.dom.classList.contains("markra-vim-normal")).toBe(false);
@@ -295,6 +305,70 @@ describe("vim mode plugin", () => {
 
       expect(typeText(view, "X")).toBe(false);
       expect(textContent(view)).toBe("Xlpha");
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("uses Vim visual character selections for yank, delete, and change", () => {
+    const yank = createView(["alpha beta"]);
+    const deletion = createView(["alpha beta"]);
+    const change = createView(["alpha beta"]);
+
+    try {
+      moveCursor(yank, findTextPosition(yank, "alpha"));
+      pressKey(yank, "Escape");
+
+      expect(pressKeys(yank, ["v", "l", "y"])).toEqual([true, true, true]);
+      expect(getVimMode(yank.state)).toBe("normal");
+      expect(textContent(yank)).toBe("alpha beta");
+
+      moveCursor(yank, findTextPosition(yank, "beta"));
+      expect(pressKey(yank, "p")).toBe(true);
+      expect(textContent(yank)).toBe("alpha baleta");
+
+      moveCursor(deletion, findTextPosition(deletion, "alpha"));
+      pressKey(deletion, "Escape");
+
+      expect(pressKeys(deletion, ["v", "l", "d"])).toEqual([true, true, true]);
+      expect(getVimMode(deletion.state)).toBe("normal");
+      expect(textContent(deletion)).toBe("pha beta");
+
+      moveCursor(change, findTextPosition(change, "alpha"));
+      pressKey(change, "Escape");
+
+      expect(pressKeys(change, ["v", "l", "c"])).toEqual([true, true, true]);
+      expect(getVimMode(change.state)).toBe("insert");
+      expect(textContent(change)).toBe("pha beta");
+
+      expect(typeText(change, "X")).toBe(false);
+      expect(textContent(change)).toBe("Xpha beta");
+    } finally {
+      destroyView(yank);
+      destroyView(deletion);
+      destroyView(change);
+    }
+  });
+
+  it("exits Vim visual mode with Escape", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["v", "l"])).toEqual([true, true]);
+      expect(getVimMode(view.state)).toBe("visual");
+      expect(view.state.selection.empty).toBe(false);
+      expect(pressKey(view, "Backspace")).toBe(true);
+      expect(pressKey(view, "Delete")).toBe(true);
+      expect(pressKey(view, "Enter")).toBe(true);
+      expect(textContent(view)).toBe("alpha");
+      expect(getVimMode(view.state)).toBe("visual");
+
+      expect(pressKey(view, "Escape")).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.empty).toBe(true);
     } finally {
       destroyView(view);
     }

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -274,6 +274,28 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("moves to first nonblank text blocks with Enter, +, and -", () => {
+    const view = createView(["  alpha", "    beta", "  gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 1));
+      pressKey(view, "Escape");
+
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha"));
+
+      expect(pressKey(view, "Enter")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta"));
+
+      expect(pressKey(view, "-")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha"));
+
+      expect(pressKeys(view, ["2", "+"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "gamma"));
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("joins the current text block with the next one using J", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -296,6 +296,32 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("moves to first and last nonblank characters with _ and g_", () => {
+    const view = createView(["  alpha  ", "    beta   ", "  gamma  "]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "_")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha"));
+
+      expect(pressKeys(view, ["2", "_"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta"));
+
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["g", "_"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha", "alpha".length - 1));
+
+      expect(pressKeys(view, ["2", "g", "_"])).toEqual([true, true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta", "beta".length - 1));
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("joins the current text block with the next one using J", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -179,6 +179,37 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("deletes characters before the cursor with X", () => {
+    const view = createView(["abcdef"]);
+    const repeat = createView(["abcdef"]);
+
+    try {
+      const start = findTextPosition(view, "abcdef");
+      moveCursor(view, start + 3);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "X")).toBe(true);
+      expect(textContent(view)).toBe("acdef");
+      expect(view.state.selection.from).toBe(findTextPosition(view, "cdef"));
+
+      moveCursor(view, findTextPosition(view, "e"));
+      expect(pressKeys(view, ["2", "X"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("aef");
+      expect(view.state.selection.from).toBe(findTextPosition(view, "e"));
+
+      moveCursor(repeat, findTextPosition(repeat, "abcdef", 4));
+      pressKey(repeat, "Escape");
+
+      expect(pressKey(repeat, "X")).toBe(true);
+      expect(textContent(repeat)).toBe("abdef");
+      expect(pressKey(repeat, ".")).toBe(true);
+      expect(textContent(repeat)).toBe("adef");
+    } finally {
+      destroyView(view);
+      destroyView(repeat);
+    }
+  });
+
   it("moves between text blocks with j and k", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -424,6 +424,72 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim inner word text objects for delete and change operators", () => {
+    const deleteInner = createView(["alpha beta gamma"]);
+    const changeInner = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(deleteInner, findTextPosition(deleteInner, "beta", 1));
+      pressKey(deleteInner, "Escape");
+
+      expect(pressKeys(deleteInner, ["d", "i", "w"])).toEqual([true, true, true]);
+      expect(textContent(deleteInner)).toBe("alpha  gamma");
+
+      moveCursor(changeInner, findTextPosition(changeInner, "beta", 1));
+      pressKey(changeInner, "Escape");
+
+      expect(pressKeys(changeInner, ["c", "i", "w"])).toEqual([true, true, true]);
+      expect(getVimMode(changeInner.state)).toBe("insert");
+      expect(textContent(changeInner)).toBe("alpha  gamma");
+
+      expect(typeText(changeInner, "delta")).toBe(false);
+      expect(textContent(changeInner)).toBe("alpha delta gamma");
+    } finally {
+      destroyView(deleteInner);
+      destroyView(changeInner);
+    }
+  });
+
+  it("includes adjacent spacing for Vim a word text objects", () => {
+    const view = createView(["alpha beta gamma"]);
+    const lastWord = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "beta", 1));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["d", "a", "w"])).toEqual([true, true, true]);
+      expect(textContent(view)).toBe("alpha gamma");
+
+      moveCursor(lastWord, findTextPosition(lastWord, "gamma", 1));
+      pressKey(lastWord, "Escape");
+
+      expect(pressKeys(lastWord, ["d", "a", "w"])).toEqual([true, true, true]);
+      expect(textContent(lastWord)).toBe("alpha beta");
+    } finally {
+      destroyView(view);
+      destroyView(lastWord);
+    }
+  });
+
+  it("yanks Vim word text objects", () => {
+    const view = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "beta", 1));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["y", "i", "w"])).toEqual([true, true, true]);
+      expect(textContent(view)).toBe("alpha beta gamma");
+
+      expect(pressKey(view, "$")).toBe(true);
+      expect(pressKey(view, "p")).toBe(true);
+      expect(textContent(view)).toBe("alpha beta gammabeta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("changes the current text block with cc and enters insert mode", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -550,6 +550,30 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim visual word text objects", () => {
+    const inner = createView(["alpha beta gamma"]);
+    const around = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(inner, findTextPosition(inner, "beta", 1));
+      pressKey(inner, "Escape");
+
+      expect(pressKeys(inner, ["v", "i", "w", "d"])).toEqual([true, true, true, true]);
+      expect(getVimMode(inner.state)).toBe("normal");
+      expect(textContent(inner)).toBe("alpha  gamma");
+
+      moveCursor(around, findTextPosition(around, "beta", 1));
+      pressKey(around, "Escape");
+
+      expect(pressKeys(around, ["v", "a", "w", "d"])).toEqual([true, true, true, true]);
+      expect(getVimMode(around.state)).toBe("normal");
+      expect(textContent(around)).toBe("alpha gamma");
+    } finally {
+      destroyView(inner);
+      destroyView(around);
+    }
+  });
+
   it("uses Vim visual line selections for yank, delete, and change", () => {
     const yank = createView(["alpha", "beta", "gamma"]);
     const deletion = createView(["alpha", "beta", "gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -244,6 +244,20 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("includes the final character for Vim end-word operators", () => {
+    const view = createView(["alpha beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["d", "e"])).toEqual([true, true]);
+      expect(textContent(view)).toBe(" beta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("moves w and b across text blocks", () => {
     const view = createView(["alpha", "beta gamma"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -720,6 +720,32 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("applies Vim counts to D and C line-tail commands", () => {
+    const deletion = createView(["alpha", "beta", "gamma"]);
+    const change = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(deletion, findTextPosition(deletion, "alpha"));
+      pressKey(deletion, "Escape");
+
+      expect(pressKeys(deletion, ["2", "D"])).toEqual([true, true]);
+      expect(textContent(deletion)).toBe("\ngamma");
+
+      moveCursor(change, findTextPosition(change, "alpha"));
+      pressKey(change, "Escape");
+
+      expect(pressKeys(change, ["2", "C"])).toEqual([true, true]);
+      expect(getVimMode(change.state)).toBe("insert");
+      expect(textContent(change)).toBe("\ngamma");
+
+      expect(typeText(change, "delta")).toBe(true);
+      expect(textContent(change)).toBe("delta\ngamma");
+    } finally {
+      destroyView(deletion);
+      destroyView(change);
+    }
+  });
+
   it("includes the final character for Vim end-word operators", () => {
     const view = createView(["alpha beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -984,6 +984,38 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("searches the current word with * and #", () => {
+    const forward = createView(["alpha alphabet alpha", "beta alpha"]);
+    const backward = createView(["alpha beta alpha"]);
+
+    try {
+      moveCursor(forward, findTextPosition(forward, "alpha alphabet alpha"));
+      pressKey(forward, "Escape");
+
+      expect(pressKey(forward, "*")).toBe(true);
+      expect(forward.state.selection.from).toBe(
+        findTextPosition(forward, "alpha alphabet alpha", "alpha alphabet ".length)
+      );
+
+      expect(pressKey(forward, "n")).toBe(true);
+      expect(forward.state.selection.from).toBe(findTextPosition(forward, "beta alpha", "beta ".length));
+
+      expect(pressKey(forward, "N")).toBe(true);
+      expect(forward.state.selection.from).toBe(
+        findTextPosition(forward, "alpha alphabet alpha", "alpha alphabet ".length)
+      );
+
+      moveCursor(backward, findTextPosition(backward, "alpha beta alpha", "alpha beta ".length + 1));
+      pressKey(backward, "Escape");
+
+      expect(pressKey(backward, "#")).toBe(true);
+      expect(backward.state.selection.from).toBe(findTextPosition(backward, "alpha beta alpha"));
+    } finally {
+      destroyView(forward);
+      destroyView(backward);
+    }
+  });
+
   it("uses Vim searches as operator motions", () => {
     const deleteForward = createView(["alpha beta gamma"]);
     const changeBackward = createView(["alpha beta gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -1480,6 +1480,43 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("applies Vim counts to open-line insert changes", () => {
+    const openBelow = createView(["alpha"]);
+    const openAbove = createView(["alpha"]);
+    const repeat = createView(["alpha"]);
+
+    try {
+      moveCursor(openBelow, findTextPosition(openBelow, "alpha"));
+      pressKey(openBelow, "Escape");
+
+      expect(pressKeys(openBelow, ["3", "o"])).toEqual([true, true]);
+      expect(typeText(openBelow, "beta")).toBe(true);
+      expect(pressKey(openBelow, "Escape")).toBe(true);
+      expect(textContent(openBelow)).toBe("alpha\nbeta\nbeta\nbeta");
+
+      moveCursor(openAbove, findTextPosition(openAbove, "alpha"));
+      pressKey(openAbove, "Escape");
+
+      expect(pressKeys(openAbove, ["2", "O"])).toEqual([true, true]);
+      expect(typeText(openAbove, "beta")).toBe(true);
+      expect(pressKey(openAbove, "Escape")).toBe(true);
+      expect(textContent(openAbove)).toBe("beta\nbeta\nalpha");
+
+      moveCursor(repeat, findTextPosition(repeat, "alpha"));
+      pressKey(repeat, "Escape");
+
+      expect(pressKeys(repeat, ["2", "o"])).toEqual([true, true]);
+      expect(typeText(repeat, "beta")).toBe(true);
+      expect(pressKey(repeat, "Escape")).toBe(true);
+      expect(pressKey(repeat, ".")).toBe(true);
+      expect(textContent(repeat)).toBe("alpha\nbeta\nbeta\nbeta\nbeta");
+    } finally {
+      destroyView(openBelow);
+      destroyView(openAbove);
+      destroyView(repeat);
+    }
+  });
+
   it("consumes destructive editing keys in normal mode", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -150,7 +150,7 @@ describe("vim mode plugin", () => {
 
       expect(pressKey(view, "i")).toBe(true);
       expect(getVimMode(view.state)).toBe("insert");
-      expect(typeText(view, "z")).toBe(false);
+      expect(typeText(view, "z")).toBe(true);
       expect(textContent(view)).toBe("azlpha");
     } finally {
       destroyView(view);
@@ -440,7 +440,7 @@ describe("vim mode plugin", () => {
       expect(pressKey(view, "$")).toBe(true);
       expect(pressKey(view, "a")).toBe(true);
       expect(getVimMode(view.state)).toBe("insert");
-      expect(typeText(view, "X")).toBe(false);
+      expect(typeText(view, "X")).toBe(true);
       expect(textContent(view)).toBe("abcX");
     } finally {
       destroyView(view);
@@ -1134,11 +1134,11 @@ describe("vim mode plugin", () => {
       expect(pressKey(insertEdit, "x")).toBe(true);
       expect(textContent(insertEdit)).toBe("bcd");
       expect(pressKey(insertEdit, "i")).toBe(true);
-      expect(typeText(insertEdit, "Z")).toBe(false);
+      expect(typeText(insertEdit, "Z")).toBe(true);
       expect(textContent(insertEdit)).toBe("Zbcd");
       expect(pressKey(insertEdit, "Escape")).toBe(true);
       expect(pressKey(insertEdit, ".")).toBe(true);
-      expect(textContent(insertEdit)).toBe("Zbcd");
+      expect(textContent(insertEdit)).toBe("ZZbcd");
     } finally {
       destroyView(characterDelete);
       destroyView(wordDelete);
@@ -1170,6 +1170,39 @@ describe("vim mode plugin", () => {
       expect(textContent(view)).toBe("X X gamma");
     } finally {
       destroyView(view);
+    }
+  });
+
+  it("repeats plain insert commands with .", () => {
+    const append = createView(["alpha", "beta"]);
+    const openLine = createView(["alpha"]);
+
+    try {
+      moveCursor(append, findTextPosition(append, "alpha"));
+      pressKey(append, "Escape");
+
+      expect(pressKey(append, "A")).toBe(true);
+      expect(typeText(append, "!")).toBe(true);
+      expect(textContent(append)).toBe("alpha!\nbeta");
+      expect(pressKey(append, "Escape")).toBe(true);
+
+      expect(pressKey(append, "j")).toBe(true);
+      expect(pressKey(append, ".")).toBe(true);
+      expect(textContent(append)).toBe("alpha!\nbeta!");
+
+      moveCursor(openLine, findTextPosition(openLine, "alpha"));
+      pressKey(openLine, "Escape");
+
+      expect(pressKey(openLine, "o")).toBe(true);
+      expect(typeText(openLine, "beta")).toBe(true);
+      expect(textContent(openLine)).toBe("alpha\nbeta");
+      expect(pressKey(openLine, "Escape")).toBe(true);
+
+      expect(pressKey(openLine, ".")).toBe(true);
+      expect(textContent(openLine)).toBe("alpha\nbeta\nbeta");
+    } finally {
+      destroyView(append);
+      destroyView(openLine);
     }
   });
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -1442,6 +1442,44 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("applies Vim counts to direct insert text changes", () => {
+    const insert = createView(["alpha"]);
+    const append = createView(["alpha"]);
+    const repeat = createView(["alpha"]);
+
+    try {
+      moveCursor(insert, findTextPosition(insert, "alpha"));
+      pressKey(insert, "Escape");
+
+      expect(pressKeys(insert, ["3", "i"])).toEqual([true, true]);
+      expect(typeText(insert, "X")).toBe(true);
+      expect(pressKey(insert, "Escape")).toBe(true);
+      expect(textContent(insert)).toBe("XXXalpha");
+      expect(insert.state.selection.from).toBe(findTextPosition(insert, "XXXalpha", 2));
+
+      moveCursor(append, findTextPosition(append, "alpha"));
+      pressKey(append, "Escape");
+
+      expect(pressKeys(append, ["2", "A"])).toEqual([true, true]);
+      expect(typeText(append, "!")).toBe(true);
+      expect(pressKey(append, "Escape")).toBe(true);
+      expect(textContent(append)).toBe("alpha!!");
+
+      moveCursor(repeat, findTextPosition(repeat, "alpha"));
+      pressKey(repeat, "Escape");
+
+      expect(pressKeys(repeat, ["3", "i"])).toEqual([true, true]);
+      expect(typeText(repeat, "X")).toBe(true);
+      expect(pressKey(repeat, "Escape")).toBe(true);
+      expect(pressKey(repeat, ".")).toBe(true);
+      expect(textContent(repeat)).toBe("XXXXXXalpha");
+    } finally {
+      destroyView(insert);
+      destroyView(append);
+      destroyView(repeat);
+    }
+  });
+
   it("consumes destructive editing keys in normal mode", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -727,6 +727,54 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("jumps between matching pairs with %", () => {
+    const view = createView(["alpha (beta [gamma]) delta"]);
+
+    try {
+      const openParen = findTextPosition(view, "(");
+      const closeParen = findTextPosition(view, ")");
+      const openBracket = findTextPosition(view, "[");
+      const closeBracket = findTextPosition(view, "]");
+
+      moveCursor(view, openParen + 1);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "%")).toBe(true);
+      expect(view.state.selection.from).toBe(closeParen);
+
+      expect(pressKey(view, "%")).toBe(true);
+      expect(view.state.selection.from).toBe(openParen);
+
+      moveCursor(view, closeBracket);
+      expect(pressKey(view, "%")).toBe(true);
+      expect(view.state.selection.from).toBe(openBracket);
+    } finally {
+      destroyView(view);
+    }
+  });
+
+  it("uses % as a Vim operator motion", () => {
+    const view = createView(["alpha (beta) gamma"]);
+    const backward = createView(["alpha (beta) gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "(") + 1);
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["d", "%"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("alpha  gamma");
+
+      moveCursor(backward, findTextPosition(backward, ")") + 1);
+      pressKey(backward, "Escape");
+
+      expect(pressKeys(backward, ["d", "%"])).toEqual([true, true]);
+      expect(textContent(backward)).toBe("alpha  gamma");
+    } finally {
+      destroyView(view);
+      destroyView(backward);
+    }
+  });
+
   it("multiplies operator counts with motion counts", () => {
     const view = createView(["one two three four"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -550,6 +550,21 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("switches Vim visual selection ends with o", () => {
+    const view = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "beta"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["v", "e", "o", "b", "d"])).toEqual([true, true, true, true, true]);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(textContent(view)).toBe(" gamma");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("uses Vim visual word text objects", () => {
     const inner = createView(["alpha beta gamma"]);
     const around = createView(["alpha beta gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -264,6 +264,20 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("deletes with word operators across text blocks", () => {
+    const view = createView(["alpha", "beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["d", "w"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("beta gamma");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("multiplies operator counts with motion counts", () => {
     const view = createView(["one two three four"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -157,6 +157,28 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("treats Ctrl-[ as Escape", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+
+      expect(pressKey(view, "[", { ctrlKey: true })).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha", 1));
+
+      expect(pressKey(view, "v")).toBe(true);
+      expect(pressKey(view, "l")).toBe(true);
+      expect(getVimMode(view.state)).toBe("visual");
+
+      expect(pressKey(view, "[", { ctrlKey: true })).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.empty).toBe(true);
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("moves the cursor and deletes the character under the cursor in normal mode", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -244,6 +244,26 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("moves w and b across text blocks", () => {
+    const view = createView(["alpha", "beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "w")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta"));
+
+      expect(pressKey(view, "w")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "gamma"));
+
+      expect(pressKey(view, "b")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "beta"));
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("multiplies operator counts with motion counts", () => {
     const view = createView(["one two three four"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -206,6 +206,23 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("replaces the character under the cursor with r and stays in normal mode", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      const start = findTextPosition(view, "alpha");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["r", "X"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("Xlpha");
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.from).toBe(start);
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("appends after the current character at the end of a text block", () => {
     const view = createView(["abc"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -614,6 +614,28 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("extends Vim visual line selections with G and gg", () => {
+    const toEnd = createView(["alpha", "beta", "gamma"]);
+    const toStart = createView(["alpha", "beta", "gamma"]);
+
+    try {
+      moveCursor(toEnd, findTextPosition(toEnd, "beta"));
+      pressKey(toEnd, "Escape");
+
+      expect(pressKeys(toEnd, ["V", "G", "d"])).toEqual([true, true, true]);
+      expect(textContent(toEnd)).toBe("alpha");
+
+      moveCursor(toStart, findTextPosition(toStart, "beta"));
+      pressKey(toStart, "Escape");
+
+      expect(pressKeys(toStart, ["V", "g", "g", "d"])).toEqual([true, true, true, true]);
+      expect(textContent(toStart)).toBe("gamma");
+    } finally {
+      destroyView(toEnd);
+      destroyView(toStart);
+    }
+  });
+
   it("shrinks Vim visual line selections with reverse line motions", () => {
     const view = createView(["alpha", "beta", "gamma"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -542,6 +542,58 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim inner pair text objects for nested parentheses and braces", () => {
+    const deleteNested = createView(["alpha (beta (gamma) delta)"]);
+    const changeBraces = createView(["alpha {beta} gamma"]);
+
+    try {
+      moveCursor(deleteNested, findTextPosition(deleteNested, "gamma", 1));
+      pressKey(deleteNested, "Escape");
+
+      expect(pressKeys(deleteNested, ["d", "i", "("])).toEqual([true, true, true]);
+      expect(textContent(deleteNested)).toBe("alpha (beta () delta)");
+
+      moveCursor(changeBraces, findTextPosition(changeBraces, "beta", 1));
+      pressKey(changeBraces, "Escape");
+
+      expect(pressKeys(changeBraces, ["c", "i", "{"])).toEqual([true, true, true]);
+      expect(getVimMode(changeBraces.state)).toBe("insert");
+      expect(textContent(changeBraces)).toBe("alpha {} gamma");
+
+      expect(typeText(changeBraces, "delta")).toBe(false);
+      expect(textContent(changeBraces)).toBe("alpha {delta} gamma");
+    } finally {
+      destroyView(deleteNested);
+      destroyView(changeBraces);
+    }
+  });
+
+  it("uses Vim around pair text objects and yanks bracket contents", () => {
+    const deleteAround = createView(["alpha (beta) gamma"]);
+    const yankBrackets = createView(["alpha [beta] gamma"]);
+
+    try {
+      moveCursor(deleteAround, findTextPosition(deleteAround, "beta", 1));
+      pressKey(deleteAround, "Escape");
+
+      expect(pressKeys(deleteAround, ["d", "a", ")"])).toEqual([true, true, true]);
+      expect(textContent(deleteAround)).toBe("alpha  gamma");
+
+      moveCursor(yankBrackets, findTextPosition(yankBrackets, "beta", 1));
+      pressKey(yankBrackets, "Escape");
+
+      expect(pressKeys(yankBrackets, ["y", "i", "]"])).toEqual([true, true, true]);
+      expect(textContent(yankBrackets)).toBe("alpha [beta] gamma");
+
+      expect(pressKey(yankBrackets, "$")).toBe(true);
+      expect(pressKey(yankBrackets, "p")).toBe(true);
+      expect(textContent(yankBrackets)).toBe("alpha [beta] gammabeta");
+    } finally {
+      destroyView(deleteAround);
+      destroyView(yankBrackets);
+    }
+  });
+
   it("changes the current text block with cc and enters insert mode", () => {
     const view = createView(["alpha", "beta"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -362,6 +362,24 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("substitutes the current text block with S and enters insert mode", () => {
+    const view = createView(["alpha", "beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "S")).toBe(true);
+      expect(getVimMode(view.state)).toBe("insert");
+      expect(textContent(view)).toBe("\nbeta");
+
+      expect(typeText(view, "X")).toBe(false);
+      expect(textContent(view)).toBe("X\nbeta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("moves w and b across text blocks", () => {
     const view = createView(["alpha", "beta gamma"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -179,6 +179,28 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("treats Ctrl-c as Escape", () => {
+    const view = createView(["alpha"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha", 2));
+
+      expect(pressKey(view, "c", { ctrlKey: true })).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha", 1));
+
+      expect(pressKey(view, "v")).toBe(true);
+      expect(pressKey(view, "l")).toBe(true);
+      expect(getVimMode(view.state)).toBe("visual");
+
+      expect(pressKey(view, "c", { ctrlKey: true })).toBe(true);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(view.state.selection.empty).toBe(true);
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("moves the cursor and deletes the character under the cursor in normal mode", () => {
     const view = createView(["alpha"]);
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -565,6 +565,26 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("reselects the previous Vim visual selection with gv", () => {
+    const view = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "beta", 1));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["v", "l", "y"])).toEqual([true, true, true]);
+      expect(getVimMode(view.state)).toBe("normal");
+
+      moveCursor(view, findTextPosition(view, "gamma"));
+
+      expect(pressKeys(view, ["g", "v", "d"])).toEqual([true, true, true]);
+      expect(getVimMode(view.state)).toBe("normal");
+      expect(textContent(view)).toBe("alpha ta gamma");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("uses Vim visual word text objects", () => {
     const inner = createView(["alpha beta gamma"]);
     const around = createView(["alpha beta gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -794,6 +794,65 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("uses Vim searches as operator motions", () => {
+    const deleteForward = createView(["alpha beta gamma"]);
+    const changeBackward = createView(["alpha beta gamma"]);
+
+    try {
+      moveCursor(deleteForward, findTextPosition(deleteForward, "alpha"));
+      pressKey(deleteForward, "Escape");
+
+      expect(pressKeys(deleteForward, ["d", "/", "b", "e", "t", "a", "Enter"])).toEqual([
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ]);
+      expect(textContent(deleteForward)).toBe("beta gamma");
+
+      moveCursor(changeBackward, findTextPosition(changeBackward, "gamma"));
+      pressKey(changeBackward, "Escape");
+
+      expect(pressKeys(changeBackward, ["c", "?", "b", "e", "t", "a", "Enter"])).toEqual([
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ]);
+      expect(getVimMode(changeBackward.state)).toBe("insert");
+      expect(textContent(changeBackward)).toBe("alpha gamma");
+
+      expect(typeText(changeBackward, "delta ")).toBe(false);
+      expect(textContent(changeBackward)).toBe("alpha delta gamma");
+    } finally {
+      destroyView(deleteForward);
+      destroyView(changeBackward);
+    }
+  });
+
+  it("uses repeated searches as operator motions", () => {
+    const view = createView(["alpha beta gamma beta"]);
+
+    try {
+      moveCursor(view, findTextPosition(view, "alpha"));
+      pressKey(view, "Escape");
+
+      expect(pressKeys(view, ["/", "b", "e", "t", "a", "Enter"])).toEqual([true, true, true, true, true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "alpha beta", "alpha ".length));
+
+      expect(pressKeys(view, ["d", "n"])).toEqual([true, true]);
+      expect(textContent(view)).toBe("alpha beta");
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("uses % as a Vim operator motion", () => {
     const view = createView(["alpha (beta) gamma"]);
     const backward = createView(["alpha (beta) gamma"]);

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -546,6 +546,35 @@ describe("vim mode plugin", () => {
     }
   });
 
+  it("moves by Vim WORD motions across punctuation", () => {
+    const view = createView(["one.two three four"]);
+
+    try {
+      const start = findTextPosition(view, "one.two");
+      moveCursor(view, start);
+      pressKey(view, "Escape");
+
+      expect(pressKey(view, "W")).toBe(true);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "three"));
+
+      expect(pressKey(view, "B")).toBe(true);
+      expect(view.state.selection.from).toBe(start);
+
+      expect(pressKey(view, "E")).toBe(true);
+      expect(view.state.selection.from).toBe(start + "one.two".length - 1);
+
+      moveCursor(view, start);
+      expect(pressKeys(view, ["2", "W"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "four"));
+
+      moveCursor(view, findTextPosition(view, "four"));
+      expect(pressKeys(view, ["g", "E"])).toEqual([true, true]);
+      expect(view.state.selection.from).toBe(findTextPosition(view, "three", "three".length - 1));
+    } finally {
+      destroyView(view);
+    }
+  });
+
   it("deletes with word operators across text blocks", () => {
     const view = createView(["alpha", "beta gamma"]);
 
@@ -557,6 +586,40 @@ describe("vim mode plugin", () => {
       expect(textContent(view)).toBe("beta gamma");
     } finally {
       destroyView(view);
+    }
+  });
+
+  it("uses Vim WORD motions for operators", () => {
+    const deleteToNextWord = createView(["one.two three"]);
+    const deleteToWordEnd = createView(["one.two three"]);
+    const changeWord = createView(["one.two three"]);
+
+    try {
+      moveCursor(deleteToNextWord, findTextPosition(deleteToNextWord, "one.two"));
+      pressKey(deleteToNextWord, "Escape");
+
+      expect(pressKeys(deleteToNextWord, ["d", "W"])).toEqual([true, true]);
+      expect(textContent(deleteToNextWord)).toBe("three");
+
+      moveCursor(deleteToWordEnd, findTextPosition(deleteToWordEnd, "one.two"));
+      pressKey(deleteToWordEnd, "Escape");
+
+      expect(pressKeys(deleteToWordEnd, ["d", "E"])).toEqual([true, true]);
+      expect(textContent(deleteToWordEnd)).toBe(" three");
+
+      moveCursor(changeWord, findTextPosition(changeWord, "one.two"));
+      pressKey(changeWord, "Escape");
+
+      expect(pressKeys(changeWord, ["c", "W"])).toEqual([true, true]);
+      expect(getVimMode(changeWord.state)).toBe("insert");
+      expect(textContent(changeWord)).toBe(" three");
+
+      expect(typeText(changeWord, "token")).toBe(false);
+      expect(textContent(changeWord)).toBe("token three");
+    } finally {
+      destroyView(deleteToNextWord);
+      destroyView(deleteToWordEnd);
+      destroyView(changeWord);
     }
   });
 

--- a/packages/editor/src/vim-mode.test.ts
+++ b/packages/editor/src/vim-mode.test.ts
@@ -7,6 +7,28 @@ import {
   getVimMode
 } from "./vim-mode";
 
+const emptyRect = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  toJSON: () => ({}),
+  top: 0,
+  width: 0,
+  x: 0,
+  y: 0
+} as DOMRect;
+const originalElementGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+const originalElementGetClientRects = Element.prototype.getClientRects;
+const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
+const originalRangeGetClientRects = Range.prototype.getClientRects;
+const textPrototype = Text.prototype as Text & {
+  getBoundingClientRect?: () => DOMRect;
+  getClientRects?: () => DOMRectList;
+};
+const originalTextGetBoundingClientRect = textPrototype.getBoundingClientRect;
+const originalTextGetClientRects = textPrototype.getClientRects;
+
 const schema = new Schema({
   nodes: {
     doc: { content: "block+" },
@@ -98,6 +120,36 @@ function typeText(view: EditorView, text: string) {
 }
 
 describe("vim mode plugin", () => {
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = () => emptyRect;
+    Element.prototype.getClientRects = () => [emptyRect] as unknown as DOMRectList;
+    Range.prototype.getBoundingClientRect = () => emptyRect;
+    Range.prototype.getClientRects = () => [emptyRect] as unknown as DOMRectList;
+    Object.assign(Text.prototype, {
+      getBoundingClientRect: () => emptyRect,
+      getClientRects: () => [emptyRect] as unknown as DOMRectList
+    });
+  });
+
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = originalElementGetBoundingClientRect;
+    Element.prototype.getClientRects = originalElementGetClientRects;
+    Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
+    Range.prototype.getClientRects = originalRangeGetClientRects;
+
+    if (originalTextGetBoundingClientRect) {
+      textPrototype.getBoundingClientRect = originalTextGetBoundingClientRect;
+    } else {
+      delete textPrototype.getBoundingClientRect;
+    }
+
+    if (originalTextGetClientRects) {
+      textPrototype.getClientRects = originalTextGetClientRects;
+    } else {
+      delete textPrototype.getClientRects;
+    }
+  });
+
   it("marks the editor DOM with the active Vim mode", () => {
     const view = createView(["alpha"]);
 
@@ -272,18 +324,24 @@ describe("vim mode plugin", () => {
 
   it("moves between text blocks with j and k", () => {
     const view = createView(["alpha", "beta"]);
+    const dispatchSpy = vi.spyOn(view, "dispatch");
 
     try {
       const alphaOffset = 2;
       moveCursor(view, findTextPosition(view, "alpha", alphaOffset));
 
       pressKey(view, "Escape");
+      dispatchSpy.mockClear();
+
       expect(pressKey(view, "j")).toBe(true);
+      expect(dispatchSpy.mock.calls.at(-1)?.[0].scrolledIntoView).toBe(true);
       expect(view.state.selection.from).toBe(findTextPosition(view, "beta", alphaOffset - 1));
 
       expect(pressKey(view, "k")).toBe(true);
+      expect(dispatchSpy.mock.calls.at(-1)?.[0].scrolledIntoView).toBe(true);
       expect(view.state.selection.from).toBe(findTextPosition(view, "alpha", alphaOffset - 1));
     } finally {
+      dispatchSpy.mockRestore();
       destroyView(view);
     }
   });

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1299,6 +1299,51 @@ function deletePreviousCharacter(view: EditorView, count = 1) {
   return true;
 }
 
+function previousInsertWordDeleteStartOffset(text: string, offset: number) {
+  let start = Math.max(0, Math.min(text.length, offset));
+
+  while (start > 0 && isWhitespaceCharacter(text[start - 1] ?? "")) start -= 1;
+  if (start === 0) return 0;
+
+  const characterBeforeWord = text[start - 1] ?? "";
+  const isDeleteCharacter = isWordCharacter(characterBeforeWord)
+    ? isWordCharacter
+    : (character: string) => !isWordCharacter(character) && !isWhitespaceCharacter(character);
+
+  while (start > 0 && isDeleteCharacter(text[start - 1] ?? "")) start -= 1;
+  return start;
+}
+
+function deleteInsertWordBeforeCursor(view: EditorView) {
+  if (!(view.state.selection instanceof TextSelection)) return false;
+
+  if (!view.state.selection.empty) {
+    const transaction = view.state.tr.delete(view.state.selection.from, view.state.selection.to);
+    const position = Math.min(view.state.selection.from, transaction.doc.content.size);
+    dispatchTransaction(
+      view,
+      transaction.setSelection(TextSelection.near(transaction.doc.resolve(position), 1)),
+      clearedInputMeta()
+    );
+    return true;
+  }
+
+  const range = currentTextblockRange(view.state);
+  const end = view.state.selection.from;
+  if (!range || end <= range.start) return true;
+
+  const start = range.start + previousInsertWordDeleteStartOffset(range.text, end - range.start);
+  if (start === end) return true;
+
+  const transaction = view.state.tr.delete(start, end);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(start), 1)),
+    clearedInputMeta()
+  );
+  return true;
+}
+
 function toggledCharacterCase(character: string) {
   const lower = character.toLocaleLowerCase();
   const upper = character.toLocaleUpperCase();
@@ -2794,6 +2839,14 @@ function handleNormalModeModifiedKey(view: EditorView, event: KeyboardEvent, sta
   return false;
 }
 
+function handleInsertModeModifiedKey(view: EditorView, event: KeyboardEvent) {
+  if (event.ctrlKey && !event.metaKey && !event.altKey && event.key.toLocaleLowerCase() === "w") {
+    return deleteInsertWordBeforeCursor(view);
+  }
+
+  return false;
+}
+
 export function getVimMode(state: EditorState): VimMode {
   return vimModeKey.getState(state)?.mode ?? "insert";
 }
@@ -2818,7 +2871,13 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
         if (event.isComposing) return false;
 
         const state = vimModeKey.getState(view.state) ?? initialVimModeState(options.initialMode ?? "insert");
-        if (state.mode === "insert") return false;
+        if (state.mode === "insert") {
+          const handled = handleInsertModeModifiedKey(view, event);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        }
 
         if (hasCommandModifier(event)) {
           if (state.mode !== "normal") return false;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -5,7 +5,7 @@ import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
 export type VimMode = "insert" | "normal";
-type VimOperator = "delete" | "yank";
+type VimOperator = "change" | "delete" | "yank";
 
 export type VimModePluginOptions = {
   enabled?: boolean | (() => boolean);
@@ -553,6 +553,22 @@ function deleteRange(view: EditorView, from: number, to: number) {
   return true;
 }
 
+function changeRange(view: EditorView, from: number, to: number) {
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  if (start === end) return false;
+
+  const text = textRange(view, start, end);
+  const transaction = view.state.tr.delete(start, end);
+  const selectionPosition = Math.min(start, transaction.doc.content.size);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta({ mode: "insert", register: { kind: "text", text } })
+  );
+  return true;
+}
+
 function yankRange(view: EditorView, from: number, to: number) {
   const start = Math.min(from, to);
   const end = Math.max(from, to);
@@ -729,15 +745,27 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
   }
 }
 
+function shouldChangeCurrentWord(view: EditorView, operator: PendingOperator, key: string, count: number, prefix: string | null) {
+  if (operator.type !== "change" || key !== "w" || prefix !== null || count !== 1) return false;
+
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const offset = view.state.selection.from - range.start;
+  return isWordCharacter(range.text[offset] ?? "");
+}
+
 function operateRange(view: EditorView, operator: PendingOperator, key: string, state: VimModeState, prefix: string | null = null) {
   const count = operator.count * readCount(state);
-  const target = resolveMotionTarget(view, key, count, prefix);
+  const changeCurrentWord = shouldChangeCurrentWord(view, operator, key, count, prefix);
+  const target = resolveMotionTarget(view, changeCurrentWord ? "e" : key, count, prefix);
   if (target === null) return false;
 
   const from = view.state.selection.from;
-  const to = key === "e" && target >= from
+  const to = (key === "e" || changeCurrentWord) && target >= from
     ? Math.min(view.state.doc.content.size, target + 1)
     : target;
+  if (operator.type === "change") return changeRange(view, from, to);
   return operator.type === "delete" ? deleteRange(view, from, to) : yankRange(view, from, to);
 }
 
@@ -836,6 +864,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return beginOperator(view, "delete", state);
     case "y":
       return beginOperator(view, "yank", state);
+    case "c":
+      return beginOperator(view, "change", state);
     case "p":
       return pasteRegister(view, "after", count, state.register);
     case "P":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1,0 +1,819 @@
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import { redo, undo } from "@milkdown/kit/prose/history";
+import { Plugin, PluginKey, TextSelection, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+export type VimMode = "insert" | "normal";
+type VimOperator = "delete" | "yank";
+
+export type VimModePluginOptions = {
+  enabled?: boolean | (() => boolean);
+  initialMode?: VimMode;
+};
+
+type VimModeState = {
+  count: string;
+  mode: VimMode;
+  operator: PendingOperator | null;
+  pending: string | null;
+  preferredColumn: number | null;
+  register: VimRegister | null;
+};
+
+type VimModeMeta = Partial<VimModeState>;
+
+type TextblockRange = {
+  after: number;
+  before: number;
+  start: number;
+  end: number;
+  text: string;
+};
+
+type PendingOperator = {
+  count: number;
+  type: VimOperator;
+};
+
+type VimRegister =
+  | {
+      kind: "text";
+      text: string;
+    }
+  | {
+      kind: "line";
+      texts: string[];
+    };
+
+const vimModeKey = new PluginKey<VimModeState>("markra-vim-mode");
+export const vimModeClassName = "markra-vim-mode";
+export const vimInsertClassName = "markra-vim-insert";
+export const vimNormalClassName = "markra-vim-normal";
+
+function vimEnabled(options: VimModePluginOptions) {
+  return typeof options.enabled === "function" ? options.enabled() : options.enabled === true;
+}
+
+function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimModeState {
+  const meta = transaction.getMeta(vimModeKey) as VimModeMeta | undefined;
+  if (!meta) {
+    return transaction.docChanged || transaction.selectionSet
+      ? { ...state, count: "", operator: null, pending: null, preferredColumn: null }
+      : state;
+  }
+
+  return {
+    count: Object.hasOwn(meta, "count") ? meta.count ?? "" : state.count,
+    mode: meta.mode ?? state.mode,
+    operator: Object.hasOwn(meta, "operator") ? meta.operator ?? null : state.operator,
+    pending: Object.hasOwn(meta, "pending") ? meta.pending ?? null : state.pending,
+    preferredColumn: Object.hasOwn(meta, "preferredColumn")
+      ? meta.preferredColumn ?? null
+      : state.preferredColumn,
+    register: Object.hasOwn(meta, "register") ? meta.register ?? null : state.register
+  };
+}
+
+function clearedInputMeta(meta: VimModeMeta = {}): VimModeMeta {
+  return {
+    count: "",
+    operator: null,
+    pending: null,
+    preferredColumn: null,
+    ...meta
+  };
+}
+
+function dispatchMeta(view: EditorView, meta: VimModeMeta) {
+  view.dispatch(view.state.tr.setMeta(vimModeKey, meta));
+  view.focus();
+}
+
+function dispatchMode(view: EditorView, mode: VimMode, meta: VimModeMeta = {}) {
+  dispatchMeta(view, clearedInputMeta({ ...meta, mode }));
+}
+
+function dispatchTransaction(view: EditorView, transaction: Transaction, meta: VimModeMeta = clearedInputMeta()) {
+  view.dispatch(transaction.setMeta(vimModeKey, meta));
+  view.focus();
+}
+
+function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
+  return {
+    count: "",
+    mode: initialMode,
+    operator: null,
+    pending: null,
+    preferredColumn: null,
+    register: null
+  };
+}
+
+function enterNormalMode(view: EditorView, options: VimModePluginOptions) {
+  const state = vimModeKey.getState(view.state) ?? initialVimModeState(options.initialMode);
+  let transaction = view.state.tr;
+
+  if (state.mode === "insert" && view.state.selection instanceof TextSelection && view.state.selection.empty) {
+    const range = currentTextblockRange(view.state);
+    if (range) {
+      const target = view.state.selection.from > range.start
+        ? Math.max(range.start, view.state.selection.from - 1)
+        : range.start;
+      transaction = transaction.setSelection(TextSelection.near(transaction.doc.resolve(target), -1));
+    }
+  }
+
+  dispatchTransaction(view, transaction, clearedInputMeta({ mode: "normal", register: state.register }));
+}
+
+function vimModeClassTargets(view: EditorView) {
+  const root = view.dom.closest<HTMLElement>(".markdown-paper");
+  const targets = new Set<HTMLElement>();
+  targets.add(view.dom);
+  if (root) targets.add(root);
+  return targets;
+}
+
+function updateVimModeClasses(view: EditorView, options: VimModePluginOptions) {
+  const enabled = vimEnabled(options);
+  const state = vimModeKey.getState(view.state);
+  const mode = enabled ? state?.mode ?? options.initialMode ?? "insert" : null;
+
+  for (const target of vimModeClassTargets(view)) {
+    target.classList.toggle(vimModeClassName, enabled);
+    target.classList.toggle(vimInsertClassName, mode === "insert");
+    target.classList.toggle(vimNormalClassName, mode === "normal");
+  }
+}
+
+function clearVimModeClasses(view: EditorView) {
+  for (const target of vimModeClassTargets(view)) {
+    target.classList.remove(vimModeClassName, vimInsertClassName, vimNormalClassName);
+  }
+}
+
+function selectionIsTextSelection(state: EditorState) {
+  return state.selection instanceof TextSelection;
+}
+
+function textblockDepth(state: EditorState) {
+  const { $from } = state.selection;
+
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    if ($from.node(depth).isTextblock) return depth;
+  }
+
+  return null;
+}
+
+function moveSelection(view: EditorView, position: number, bias: -1 | 1 = 1, meta: VimModeMeta = clearedInputMeta()) {
+  const clamped = Math.max(0, Math.min(view.state.doc.content.size, position));
+  const selection = TextSelection.near(view.state.doc.resolve(clamped), bias);
+  dispatchTransaction(view, view.state.tr.setSelection(selection), meta);
+  return true;
+}
+
+function moveByCharacter(view: EditorView, delta: -1 | 1, count = 1) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const limitEnd = normalTextblockEnd(range);
+  const target = Math.max(range.start, Math.min(limitEnd, view.state.selection.from + delta * count));
+  return moveSelection(view, target, delta);
+}
+
+function textblockRanges(state: EditorState) {
+  const ranges: TextblockRange[] = [];
+
+  state.doc.descendants((node, position) => {
+    if (!node.isTextblock) return true;
+
+    const start = position + 1;
+    ranges.push({
+      after: position + node.nodeSize,
+      before: position,
+      end: start + node.content.size,
+      start,
+      text: node.textContent
+    });
+    return false;
+  });
+
+  return ranges;
+}
+
+function normalTextblockEnd(range: Pick<TextblockRange, "start" | "end">) {
+  return range.end > range.start ? range.end - 1 : range.start;
+}
+
+function currentTextblockRange(state: EditorState) {
+  const depth = textblockDepth(state);
+  if (depth === null) return null;
+
+  const { $from } = state.selection;
+  const start = $from.start(depth);
+  const end = $from.end(depth);
+  return {
+    after: $from.after(depth),
+    before: $from.before(depth),
+    end,
+    start,
+    text: $from.node(depth).textContent
+  } satisfies TextblockRange;
+}
+
+function nearestTextblockIndex(ranges: readonly TextblockRange[], position: number) {
+  let nearestIndex = 0;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const [index, range] of ranges.entries()) {
+    if (position >= range.start && position <= range.end) return index;
+
+    const distance = position < range.start ? range.start - position : position - range.end;
+    if (distance < nearestDistance) {
+      nearestIndex = index;
+      nearestDistance = distance;
+    }
+  }
+
+  return nearestIndex;
+}
+
+function moveByTextblock(view: EditorView, delta: -1 | 1, count = 1, preferredColumn?: number | null) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  const ranges = textblockRanges(view.state);
+  if (ranges.length === 0) return false;
+
+  const currentIndex = nearestTextblockIndex(ranges, view.state.selection.from);
+  const targetIndex = Math.max(0, Math.min(ranges.length - 1, currentIndex + delta * count));
+  const currentRange = ranges[currentIndex];
+  const targetRange = ranges[targetIndex];
+  if (!currentRange || !targetRange) return false;
+
+  const offset = preferredColumn ?? Math.max(0, view.state.selection.from - currentRange.start);
+  const targetOffset = Math.min(offset, normalTextblockEnd(targetRange) - targetRange.start);
+  return moveSelection(view, targetRange.start + targetOffset, delta, clearedInputMeta({ preferredColumn: offset }));
+}
+
+function moveToTextblockBoundary(view: EditorView, side: "start" | "end") {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const position = side === "start" ? range.start : normalTextblockEnd(range);
+  return moveSelection(view, position, side === "start" ? 1 : -1);
+}
+
+function isWordCharacter(character: string) {
+  return /[\p{L}\p{N}_]/u.test(character);
+}
+
+function nextWordStartOffset(text: string, offset: number) {
+  let next = Math.max(0, Math.min(text.length, offset));
+
+  while (next < text.length && isWordCharacter(text[next] ?? "")) next += 1;
+  while (next < text.length && !isWordCharacter(text[next] ?? "")) next += 1;
+
+  return next;
+}
+
+function nextWordEndOffset(text: string, offset: number) {
+  let next = Math.max(0, Math.min(text.length - 1, offset));
+
+  if (isWordCharacter(text[next] ?? "")) {
+    while (next < text.length - 1 && isWordCharacter(text[next + 1] ?? "")) next += 1;
+    return next;
+  }
+
+  while (next < text.length && !isWordCharacter(text[next] ?? "")) next += 1;
+  while (next < text.length - 1 && isWordCharacter(text[next + 1] ?? "")) next += 1;
+
+  return Math.max(0, Math.min(text.length - 1, next));
+}
+
+function previousWordStartOffset(text: string, offset: number) {
+  let previous = Math.max(0, Math.min(text.length, offset) - 1);
+
+  while (previous > 0 && !isWordCharacter(text[previous] ?? "")) previous -= 1;
+  while (previous > 0 && isWordCharacter(text[previous - 1] ?? "")) previous -= 1;
+
+  return previous;
+}
+
+function previousWordEndOffset(text: string, offset: number) {
+  let previous = Math.max(0, Math.min(text.length, offset) - 1);
+
+  while (previous > 0 && !isWordCharacter(text[previous] ?? "")) previous -= 1;
+  if (previous > 0 && isWordCharacter(text[previous] ?? "")) return previous;
+
+  return 0;
+}
+
+function wordMotionOffset(text: string, offset: number, direction: "forward" | "end" | "backward" | "backward-end", count: number) {
+  let next = offset;
+
+  for (let index = 0; index < count; index += 1) {
+    if (direction === "forward") next = nextWordStartOffset(text, next);
+    else if (direction === "end") next = nextWordEndOffset(text, next);
+    else if (direction === "backward") next = previousWordStartOffset(text, next);
+    else next = previousWordEndOffset(text, next);
+  }
+
+  return next;
+}
+
+function moveByWord(view: EditorView, direction: "forward" | "end" | "backward" | "backward-end", count = 1) {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const offset = Math.max(0, Math.min(range.text.length, view.state.selection.from - range.start));
+  const targetOffset = wordMotionOffset(range.text, offset, direction, count);
+  const target = Math.min(normalTextblockEnd(range), range.start + targetOffset);
+
+  return moveSelection(view, target, direction === "backward" || direction === "backward-end" ? -1 : 1);
+}
+
+function deleteCharacter(view: EditorView, count = 1) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  const { $from } = view.state.selection;
+  const depth = textblockDepth(view.state);
+  if (depth === null) return false;
+
+  const blockEnd = $from.end(depth);
+  if (view.state.selection.from >= blockEnd) return false;
+  const to = Math.min(blockEnd, view.state.selection.from + count);
+  const text = view.state.doc.textBetween(view.state.selection.from, to, "\n");
+
+  dispatchTransaction(
+    view,
+    view.state.tr.delete(view.state.selection.from, to),
+    clearedInputMeta({ register: { kind: "text", text } })
+  );
+  return true;
+}
+
+function emptyParagraph(state: EditorState) {
+  const paragraph = state.schema.nodes.paragraph;
+  return paragraph?.createAndFill() ?? paragraph?.create();
+}
+
+function paragraphWithText(state: EditorState, text: string) {
+  const paragraph = state.schema.nodes.paragraph;
+  if (!paragraph) return null;
+
+  return text ? paragraph.create(null, state.schema.text(text)) : paragraph.createAndFill() ?? paragraph.create();
+}
+
+function currentTextblockIndex(state: EditorState, ranges = textblockRanges(state)) {
+  return nearestTextblockIndex(ranges, state.selection.from);
+}
+
+function selectedTextblocks(state: EditorState, count: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const startIndex = currentTextblockIndex(state, ranges);
+  const endIndex = Math.min(ranges.length - 1, startIndex + Math.max(1, count) - 1);
+  return {
+    endIndex,
+    ranges,
+    selected: ranges.slice(startIndex, endIndex + 1),
+    startIndex
+  };
+}
+
+function deleteCurrentTextblock(view: EditorView, count = 1) {
+  const selection = selectedTextblocks(view.state, count);
+  if (!selection || selection.selected.length === 0) return false;
+
+  const from = selection.selected[0]?.before;
+  const to = selection.selected[selection.selected.length - 1]?.after;
+  if (from === undefined || to === undefined) return false;
+
+  const texts = selection.selected.map((range) => range.text);
+  const replacement = from === 0 && to >= view.state.doc.content.size ? emptyParagraph(view.state) : null;
+  const transaction = replacement
+    ? view.state.tr.replaceWith(from, to, replacement)
+    : view.state.tr.delete(from, to);
+  const selectionPosition = Math.min(from, transaction.doc.content.size);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta({ register: { kind: "line", texts } })
+  );
+  return true;
+}
+
+function yankCurrentTextblock(view: EditorView, count = 1) {
+  const selection = selectedTextblocks(view.state, count);
+  if (!selection || selection.selected.length === 0) return false;
+
+  dispatchMeta(
+    view,
+    clearedInputMeta({
+      register: {
+        kind: "line",
+        texts: selection.selected.map((range) => range.text)
+      }
+    })
+  );
+  return true;
+}
+
+function insertParagraphNearTextblock(view: EditorView, side: "before" | "after") {
+  const depth = textblockDepth(view.state);
+  const paragraph = emptyParagraph(view.state);
+  if (depth === null || !paragraph) return false;
+
+  const { $from } = view.state.selection;
+  const position = side === "before" ? $from.before(depth) : $from.after(depth);
+  const transaction = view.state.tr.insert(position, paragraph);
+  const selectionPosition = side === "before" ? position + 1 : position + paragraph.nodeSize - 1;
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta({ mode: "insert" })
+  );
+  return true;
+}
+
+function textRange(view: EditorView, from: number, to: number) {
+  return view.state.doc.textBetween(Math.min(from, to), Math.max(from, to), "\n");
+}
+
+function deleteRange(view: EditorView, from: number, to: number) {
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  if (start === end) return false;
+
+  dispatchTransaction(
+    view,
+    view.state.tr.delete(start, end),
+    clearedInputMeta({ register: { kind: "text", text: textRange(view, start, end) } })
+  );
+  return true;
+}
+
+function yankRange(view: EditorView, from: number, to: number) {
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  if (start === end) return false;
+
+  dispatchMeta(view, clearedInputMeta({ register: { kind: "text", text: textRange(view, start, end) } }));
+  return true;
+}
+
+function pasteRegister(view: EditorView, side: "before" | "after", count = 1, register?: VimRegister | null) {
+  if (!register) return false;
+
+  if (register.kind === "text") {
+    const range = currentTextblockRange(view.state);
+    if (!range) return false;
+
+    const position = side === "after"
+      ? Math.min(range.end, view.state.selection.from + 1)
+      : view.state.selection.from;
+    const text = register.text.repeat(Math.max(1, count));
+    const transaction = view.state.tr.insertText(text, position, position);
+    dispatchTransaction(
+      view,
+      transaction.setSelection(TextSelection.near(transaction.doc.resolve(position), 1)),
+      clearedInputMeta()
+    );
+    return true;
+  }
+
+  const ranges = textblockRanges(view.state);
+  if (ranges.length === 0) return false;
+
+  const currentRange = ranges[currentTextblockIndex(view.state, ranges)];
+  if (!currentRange) return false;
+
+  const nodes: ProseNode[] = [];
+  for (let repeat = 0; repeat < Math.max(1, count); repeat += 1) {
+    for (const text of register.texts) {
+      const node = paragraphWithText(view.state, text);
+      if (node) nodes.push(node);
+    }
+  }
+  if (nodes.length === 0) return false;
+
+  const position = side === "after" ? currentRange.after : currentRange.before;
+  let transaction = view.state.tr;
+  for (const node of nodes) {
+    transaction = transaction.insert(position + (transaction.doc.content.size - view.state.doc.content.size), node);
+  }
+
+  const selectionPosition = Math.min(position + 1, transaction.doc.content.size);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta()
+  );
+  return true;
+}
+
+function targetIsNestedControl(view: EditorView, event: KeyboardEvent) {
+  if (!(event.target instanceof Element)) return false;
+  if (event.target === view.dom) return false;
+
+  const control = event.target.closest("input, textarea, select, button");
+  return Boolean(control && view.dom.contains(control));
+}
+
+function hasCommandModifier(event: KeyboardEvent) {
+  return event.metaKey || event.ctrlKey || event.altKey;
+}
+
+function readCount(state: VimModeState) {
+  const parsed = Number.parseInt(state.count, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function keyStartsOrContinuesCount(key: string, state: VimModeState) {
+  return /^[0-9]$/u.test(key) && (key !== "0" || state.count.length > 0);
+}
+
+function appendCount(view: EditorView, key: string, state: VimModeState) {
+  dispatchMeta(view, { count: `${state.count}${key}` });
+  return true;
+}
+
+function beginOperator(view: EditorView, type: VimOperator, state: VimModeState) {
+  dispatchMeta(view, {
+    count: "",
+    operator: {
+      count: readCount(state),
+      type
+    },
+    pending: null
+  });
+  return true;
+}
+
+function firstNonblankPosition(range: TextblockRange) {
+  const match = /\S/u.exec(range.text);
+  return range.start + (match?.index ?? 0);
+}
+
+function insertAtTextblockBoundary(view: EditorView, side: "first-nonblank" | "end") {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const position = side === "first-nonblank" ? firstNonblankPosition(range) : range.end;
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(position), side === "end" ? -1 : 1)),
+    clearedInputMeta({ mode: "insert" })
+  );
+  return true;
+}
+
+function lineMotion(view: EditorView, key: "first" | "last", count: number) {
+  const ranges = textblockRanges(view.state);
+  if (ranges.length === 0) return false;
+
+  const targetIndex = key === "first"
+    ? Math.max(0, Math.min(ranges.length - 1, count > 1 ? count - 1 : 0))
+    : Math.max(0, Math.min(ranges.length - 1, count > 1 ? count - 1 : ranges.length - 1));
+  const targetRange = ranges[targetIndex];
+  if (!targetRange) return false;
+
+  return moveSelection(view, targetRange.start, 1);
+}
+
+function resolveMotionTarget(view: EditorView, key: string, count: number, prefix: string | null = null) {
+  const range = currentTextblockRange(view.state);
+  if (!range) return null;
+
+  const current = view.state.selection.from;
+  const offset = Math.max(0, Math.min(range.text.length, current - range.start));
+
+  if (prefix === "g" && key === "e") {
+    return range.start + wordMotionOffset(range.text, offset, "backward-end", count);
+  }
+
+  switch (key) {
+    case "h":
+    case "ArrowLeft":
+      return Math.max(range.start, current - count);
+    case "l":
+    case "ArrowRight":
+      return Math.min(normalTextblockEnd(range), current + count);
+    case "w":
+      return Math.min(range.end, range.start + wordMotionOffset(range.text, offset, "forward", count));
+    case "e":
+      return Math.min(normalTextblockEnd(range), range.start + wordMotionOffset(range.text, offset, "end", count));
+    case "b":
+      return Math.max(range.start, range.start + wordMotionOffset(range.text, offset, "backward", count));
+    case "0":
+      return range.start;
+    case "^":
+      return firstNonblankPosition(range);
+    case "$":
+      return range.end;
+    default:
+      return null;
+  }
+}
+
+function operateRange(view: EditorView, operator: PendingOperator, key: string, state: VimModeState, prefix: string | null = null) {
+  const count = operator.count * readCount(state);
+  const target = resolveMotionTarget(view, key, count, prefix);
+  if (target === null) return false;
+
+  const from = view.state.selection.from;
+  const to = key === "$" ? target : target;
+  return operator.type === "delete" ? deleteRange(view, from, to) : yankRange(view, from, to);
+}
+
+function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
+  const operator = state.operator;
+  if (!operator) return false;
+
+  if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
+
+  if (operator.type === "delete" && key === "d") return deleteCurrentTextblock(view, operator.count * readCount(state));
+  if (operator.type === "yank" && key === "y") return yankCurrentTextblock(view, operator.count * readCount(state));
+
+  if (state.pending === "g") {
+    if (key === "e") return operateRange(view, operator, key, state, "g");
+
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  if (key === "g") {
+    dispatchMeta(view, { pending: "g" });
+    return true;
+  }
+
+  if (operateRange(view, operator, key, state)) return true;
+
+  dispatchMeta(view, clearedInputMeta());
+  return true;
+}
+
+function handleNormalModeKey(view: EditorView, key: string, state: VimModeState) {
+  if (state.operator) return handleOperatorKey(view, key, state);
+
+  if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
+
+  const count = readCount(state);
+
+  if (state.pending === "g") {
+    if (key === "g") return lineMotion(view, "first", count);
+    if (key === "e") return moveByWord(view, "backward-end", count);
+
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  switch (key) {
+    case "i":
+      dispatchMode(view, "insert");
+      return true;
+    case "a":
+      moveByCharacter(view, 1);
+      dispatchMode(view, "insert");
+      return true;
+    case "I":
+      return insertAtTextblockBoundary(view, "first-nonblank");
+    case "A":
+      return insertAtTextblockBoundary(view, "end");
+    case "h":
+    case "ArrowLeft":
+      return moveByCharacter(view, -1, count);
+    case "l":
+    case "ArrowRight":
+      return moveByCharacter(view, 1, count);
+    case "j":
+    case "ArrowDown":
+      return moveByTextblock(view, 1, count, state.preferredColumn);
+    case "k":
+    case "ArrowUp":
+      return moveByTextblock(view, -1, count, state.preferredColumn);
+    case "Backspace":
+    case "Delete":
+    case "Enter":
+      return true;
+    case "w":
+      return moveByWord(view, "forward", count);
+    case "e":
+      return moveByWord(view, "end", count);
+    case "b":
+      return moveByWord(view, "backward", count);
+    case "0":
+      return moveToTextblockBoundary(view, "start");
+    case "^":
+      return moveSelection(view, firstNonblankPosition(currentTextblockRange(view.state) ?? {
+        after: view.state.selection.from,
+        before: view.state.selection.from,
+        end: view.state.selection.from,
+        start: view.state.selection.from,
+        text: ""
+      }), 1);
+    case "$":
+      return moveToTextblockBoundary(view, "end");
+    case "G":
+      return lineMotion(view, "last", count);
+    case "g":
+      dispatchMeta(view, { pending: "g" });
+      return true;
+    case "d":
+      return beginOperator(view, "delete", state);
+    case "y":
+      return beginOperator(view, "yank", state);
+    case "p":
+      return pasteRegister(view, "after", count, state.register);
+    case "P":
+      return pasteRegister(view, "before", count, state.register);
+    case "u": {
+      const handled = undo(view.state, view.dispatch);
+      if (handled) view.focus();
+      return handled;
+    }
+    case "x":
+      return deleteCharacter(view, count);
+    case "o":
+      return insertParagraphNearTextblock(view, "after");
+    case "O":
+      return insertParagraphNearTextblock(view, "before");
+    default:
+      return key.length === 1;
+  }
+}
+
+function handleNormalModeModifiedKey(view: EditorView, event: KeyboardEvent) {
+  if (event.ctrlKey && !event.metaKey && !event.altKey && event.key === "r") {
+    const handled = redo(view.state, view.dispatch);
+    if (handled) view.focus();
+    return handled;
+  }
+
+  return false;
+}
+
+export function getVimMode(state: EditorState): VimMode {
+  return vimModeKey.getState(state)?.mode ?? "insert";
+}
+
+export function createVimModePlugin(options: VimModePluginOptions = {}) {
+  return new Plugin<VimModeState>({
+    key: vimModeKey,
+    state: {
+      init: () => initialVimModeState(options.initialMode ?? "insert"),
+      apply: (transaction, state) => applyVimModeMeta(state, transaction)
+    },
+    props: {
+      handleKeyDown: (view, event) => {
+        if (!vimEnabled(options) || targetIsNestedControl(view, event)) return false;
+
+        if (event.key === "Escape") {
+          enterNormalMode(view, options);
+          event.preventDefault();
+          return true;
+        }
+
+        if (event.isComposing) return false;
+
+        const state = vimModeKey.getState(view.state) ?? initialVimModeState(options.initialMode ?? "insert");
+        if (state.mode !== "normal") return false;
+
+        if (hasCommandModifier(event)) {
+          const handled = handleNormalModeModifiedKey(view, event);
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        }
+
+        const handled = handleNormalModeKey(view, event.key, state);
+        if (!handled) return false;
+
+        event.preventDefault();
+        return true;
+      },
+      handleTextInput: (view) => {
+        if (!vimEnabled(options)) return false;
+
+        const state = vimModeKey.getState(view.state);
+        return state?.mode === "normal";
+      }
+    },
+    view: (view) => {
+      updateVimModeClasses(view, options);
+
+      return {
+        update: (updatedView) => updateVimModeClasses(updatedView, options),
+        destroy: () => clearVimModeClasses(view)
+      };
+    }
+  });
+}
+
+export const markraVimModePlugin = (options: VimModePluginOptions = {}) => $prose(() => createVimModePlugin(options));

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -2304,6 +2304,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return moveByCharacter(view, -1, count);
     case "l":
     case "ArrowRight":
+    case " ":
       return moveByCharacter(view, 1, count);
     case "j":
     case "ArrowDown":
@@ -2313,10 +2314,11 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return moveByTextblock(view, -1, count, state.preferredColumn);
     case "J":
       return joinTextblocks(view, count);
-    case "Backspace":
     case "Delete":
     case "Enter":
       return true;
+    case "Backspace":
+      return moveByCharacter(view, -1, count);
     case "w":
       return moveByWord(view, "forward", count);
     case "W":
@@ -2418,7 +2420,11 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
   }
 }
 
-function handleNormalModeModifiedKey(view: EditorView, event: KeyboardEvent) {
+function handleNormalModeModifiedKey(view: EditorView, event: KeyboardEvent, state: VimModeState) {
+  if (event.ctrlKey && !event.metaKey && !event.altKey && event.key === "h") {
+    return moveByCharacter(view, -1, readCount(state));
+  }
+
   if (event.ctrlKey && !event.metaKey && !event.altKey && event.key === "r") {
     const handled = redo(view.state, view.dispatch);
     if (handled) view.focus();
@@ -2457,7 +2463,7 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
         if (hasCommandModifier(event)) {
           if (state.mode !== "normal") return false;
 
-          const handled = handleNormalModeModifiedKey(view, event);
+          const handled = handleNormalModeModifiedKey(view, event, state);
           if (!handled) return false;
 
           event.preventDefault();

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -573,6 +573,19 @@ function insertAtTextblockBoundary(view: EditorView, side: "first-nonblank" | "e
   return true;
 }
 
+function insertAfterCharacter(view: EditorView) {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const position = Math.min(range.end, view.state.selection.from + 1);
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(position), -1)),
+    clearedInputMeta({ mode: "insert" })
+  );
+  return true;
+}
+
 function lineMotion(view: EditorView, key: "first" | "last", count: number) {
   const ranges = textblockRanges(view.state);
   if (ranges.length === 0) return false;
@@ -678,9 +691,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       dispatchMode(view, "insert");
       return true;
     case "a":
-      moveByCharacter(view, 1);
-      dispatchMode(view, "insert");
-      return true;
+      return insertAfterCharacter(view);
     case "I":
       return insertAtTextblockBoundary(view, "first-nonblank");
     case "A":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -478,6 +478,18 @@ function substituteCharacters(view: EditorView, count = 1) {
   return changeRange(view, from, to);
 }
 
+function operateToTextblockEnd(view: EditorView, operator: VimOperator) {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const from = view.state.selection.from;
+  if (from >= range.end) return false;
+
+  return operator === "change"
+    ? changeRange(view, from, range.end)
+    : deleteRange(view, from, range.end);
+}
+
 function emptyParagraph(state: EditorState) {
   const paragraph = state.schema.nodes.paragraph;
   return paragraph?.createAndFill() ?? paragraph?.create();
@@ -916,6 +928,10 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return beginOperator(view, "yank", state);
     case "c":
       return beginOperator(view, "change", state);
+    case "D":
+      return operateToTextblockEnd(view, "delete");
+    case "C":
+      return operateToTextblockEnd(view, "change");
     case "p":
       return pasteRegister(view, "after", count, state.register);
     case "P":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -31,10 +31,13 @@ type VimModeState = {
   count: string;
   lastFind: VimCharacterFind | null;
   lastChangeKeys: readonly string[] | null;
+  lastChangeText: string | null;
   lastSearch: VimSearch | null;
   mode: VimMode;
   operator: PendingOperator | null;
   pendingChangeKeys: readonly string[] | null;
+  pendingInsertChangeKeys: readonly string[] | null;
+  pendingInsertText: string;
   pending: string | null;
   preferredColumn: number | null;
   register: VimRegister | null;
@@ -101,6 +104,8 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
           operator: null,
           pending: null,
           pendingChangeKeys: null,
+          pendingInsertChangeKeys: null,
+          pendingInsertText: "",
           preferredColumn: null,
           searchQuery: "",
           visualAnchor: null,
@@ -116,12 +121,21 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
     lastChangeKeys: Object.hasOwn(meta, "lastChangeKeys")
       ? meta.lastChangeKeys ?? null
       : state.lastChangeKeys,
+    lastChangeText: Object.hasOwn(meta, "lastChangeText")
+      ? meta.lastChangeText ?? null
+      : state.lastChangeText,
     lastSearch: Object.hasOwn(meta, "lastSearch") ? meta.lastSearch ?? null : state.lastSearch,
     mode: meta.mode ?? state.mode,
     operator: Object.hasOwn(meta, "operator") ? meta.operator ?? null : state.operator,
     pendingChangeKeys: Object.hasOwn(meta, "pendingChangeKeys")
       ? meta.pendingChangeKeys ?? null
       : state.pendingChangeKeys,
+    pendingInsertChangeKeys: Object.hasOwn(meta, "pendingInsertChangeKeys")
+      ? meta.pendingInsertChangeKeys ?? null
+      : state.pendingInsertChangeKeys,
+    pendingInsertText: Object.hasOwn(meta, "pendingInsertText")
+      ? meta.pendingInsertText ?? ""
+      : state.pendingInsertText,
     pending: Object.hasOwn(meta, "pending") ? meta.pending ?? null : state.pending,
     preferredColumn: Object.hasOwn(meta, "preferredColumn")
       ? meta.preferredColumn ?? null
@@ -139,6 +153,8 @@ function clearedInputMeta(meta: VimModeMeta = {}): VimModeMeta {
     count: "",
     operator: null,
     pendingChangeKeys: null,
+    pendingInsertChangeKeys: null,
+    pendingInsertText: "",
     pending: null,
     preferredColumn: null,
     searchQuery: "",
@@ -168,10 +184,13 @@ function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
     count: "",
     lastFind: null,
     lastChangeKeys: null,
+    lastChangeText: null,
     lastSearch: null,
     mode: initialMode,
     operator: null,
     pendingChangeKeys: null,
+    pendingInsertChangeKeys: null,
+    pendingInsertText: "",
     pending: null,
     preferredColumn: null,
     register: null,
@@ -200,7 +219,16 @@ function enterNormalMode(view: EditorView, options: VimModePluginOptions) {
     }
   }
 
-  dispatchTransaction(view, transaction, clearedInputMeta({ mode: "normal", register: state.register }));
+  dispatchTransaction(
+    view,
+    transaction,
+    clearedInputMeta({
+      lastChangeKeys: state.pendingInsertChangeKeys ?? state.lastChangeKeys,
+      lastChangeText: state.pendingInsertChangeKeys ? state.pendingInsertText : state.lastChangeText,
+      mode: "normal",
+      register: state.register
+    })
+  );
 }
 
 function vimModeClassTargets(view: EditorView) {
@@ -1437,7 +1465,19 @@ function appendCount(view: EditorView, key: string, state: VimModeState) {
 function repeatableChangeStartKeys(state: VimModeState, key: string) {
   if (state.pendingChangeKeys) return [...state.pendingChangeKeys, key];
   // Insert-text changes need typed text capture before they can be faithfully replayed.
-  if (key !== "D" && key !== "J" && key !== "P" && key !== "d" && key !== "p" && key !== "r" && key !== "x") {
+  if (
+    key !== "C" &&
+    key !== "D" &&
+    key !== "J" &&
+    key !== "P" &&
+    key !== "S" &&
+    key !== "c" &&
+    key !== "d" &&
+    key !== "p" &&
+    key !== "r" &&
+    key !== "s" &&
+    key !== "x"
+  ) {
     return null;
   }
 
@@ -1454,7 +1494,18 @@ function recordRepeatableChange(view: EditorView, previousState: VimModeState, k
 
   const nextState = vimModeKey.getState(view.state);
   if (view.state.doc !== previousDoc) {
-    dispatchMeta(view, { lastChangeKeys: changeKeys, pendingChangeKeys: null });
+    if (nextState?.mode === "insert") {
+      dispatchMeta(view, {
+        lastChangeKeys: null,
+        lastChangeText: null,
+        pendingChangeKeys: null,
+        pendingInsertChangeKeys: changeKeys,
+        pendingInsertText: ""
+      });
+      return;
+    }
+
+    dispatchMeta(view, { lastChangeKeys: changeKeys, lastChangeText: null, pendingChangeKeys: null });
     return;
   }
 
@@ -1463,7 +1514,7 @@ function recordRepeatableChange(view: EditorView, previousState: VimModeState, k
   });
 }
 
-function repeatLastChange(view: EditorView, keys: readonly string[]) {
+function repeatLastChange(view: EditorView, keys: readonly string[], text: string | null) {
   if (keys.length === 0) return false;
 
   for (const key of keys) {
@@ -1472,7 +1523,22 @@ function repeatLastChange(view: EditorView, keys: readonly string[]) {
     if (!handleNormalModeKey(view, key, state)) return false;
   }
 
-  dispatchMeta(view, { lastChangeKeys: keys, pendingChangeKeys: null });
+  if (text !== null) {
+    const state = vimModeKey.getState(view.state);
+    if (state?.mode !== "insert") return false;
+
+    const { from, to } = view.state.selection;
+    const transaction = view.state.tr.insertText(text, from, to);
+    const position = Math.max(from, from + text.length - 1);
+    dispatchTransaction(
+      view,
+      transaction.setSelection(TextSelection.near(transaction.doc.resolve(position), 1)),
+      clearedInputMeta({ lastChangeKeys: keys, lastChangeText: text, mode: "normal", register: state.register })
+    );
+    return true;
+  }
+
+  dispatchMeta(view, { lastChangeKeys: keys, lastChangeText: null, pendingChangeKeys: null });
   return true;
 }
 
@@ -2288,7 +2354,7 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
         }
 
         if (state.mode === "normal" && event.key === ".") {
-          const handled = state.lastChangeKeys ? repeatLastChange(view, state.lastChangeKeys) : true;
+          const handled = state.lastChangeKeys ? repeatLastChange(view, state.lastChangeKeys, state.lastChangeText) : true;
           if (!handled) return false;
 
           event.preventDefault();
@@ -2306,10 +2372,19 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
         event.preventDefault();
         return true;
       },
-      handleTextInput: (view) => {
+      handleTextInput: (view, _from, _to, text, insertText) => {
         if (!vimEnabled(options)) return false;
 
         const state = vimModeKey.getState(view.state);
+        if (state?.mode === "insert" && state.pendingInsertChangeKeys) {
+          dispatchTransaction(
+            view,
+            insertText(),
+            { pendingInsertText: `${state.pendingInsertText}${text}` }
+          );
+          return true;
+        }
+
         return state?.mode === "normal" || state?.mode === "visual";
       }
     },

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -2311,6 +2311,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return beginOperator(view, "delete", state);
     case "y":
       return beginOperator(view, "yank", state);
+    case "Y":
+      return yankCurrentTextblock(view, count);
     case "c":
       return beginOperator(view, "change", state);
     case "D":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -185,10 +185,10 @@ function moveByCharacter(view: EditorView, delta: -1 | 1, count = 1) {
   return moveSelection(view, target, delta);
 }
 
-function textblockRanges(state: EditorState) {
+function textblockRangesFromDoc(doc: ProseNode) {
   const ranges: TextblockRange[] = [];
 
-  state.doc.descendants((node, position) => {
+  doc.descendants((node, position) => {
     if (!node.isTextblock) return true;
 
     const start = position + 1;
@@ -203,6 +203,10 @@ function textblockRanges(state: EditorState) {
   });
 
   return ranges;
+}
+
+function textblockRanges(state: EditorState) {
+  return textblockRangesFromDoc(state.doc);
 }
 
 function normalTextblockEnd(range: Pick<TextblockRange, "start" | "end">) {
@@ -257,6 +261,36 @@ function moveByTextblock(view: EditorView, delta: -1 | 1, count = 1, preferredCo
   const offset = preferredColumn ?? Math.max(0, view.state.selection.from - currentRange.start);
   const targetOffset = Math.min(offset, normalTextblockEnd(targetRange) - targetRange.start);
   return moveSelection(view, targetRange.start + targetOffset, delta, clearedInputMeta({ preferredColumn: offset }));
+}
+
+function joinTextblocks(view: EditorView, blockCount = 2) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  let transaction = view.state.tr;
+  let selectionPosition = view.state.selection.from;
+  let joined = false;
+  const joinCount = Math.max(1, blockCount - 1);
+
+  for (let step = 0; step < joinCount; step += 1) {
+    const ranges = textblockRangesFromDoc(transaction.doc);
+    const currentIndex = nearestTextblockIndex(ranges, selectionPosition);
+    const currentRange = ranges[currentIndex];
+    const nextRange = ranges[currentIndex + 1];
+    if (!currentRange || !nextRange) break;
+
+    selectionPosition = currentRange.end;
+    transaction = transaction.delete(currentRange.end, nextRange.start).insertText(" ", selectionPosition);
+    joined = true;
+  }
+
+  if (!joined) return false;
+
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), -1)),
+    clearedInputMeta()
+  );
+  return true;
 }
 
 function moveToTextblockBoundary(view: EditorView, side: "start" | "end") {
@@ -895,6 +929,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "k":
     case "ArrowUp":
       return moveByTextblock(view, -1, count, state.preferredColumn);
+    case "J":
+      return joinTextblocks(view, count);
     case "Backspace":
     case "Delete":
     case "Enter":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1397,6 +1397,29 @@ function selectedTextblocksBetween(state: EditorState, anchor: number, cursor: n
   };
 }
 
+function targetLineMotionIndex(ranges: readonly TextblockRange[], key: "first" | "last", count: number) {
+  return key === "first"
+    ? Math.max(0, Math.min(ranges.length - 1, count > 1 ? count - 1 : 0))
+    : Math.max(0, Math.min(ranges.length - 1, count > 1 ? count - 1 : ranges.length - 1));
+}
+
+function lineMotionTextblocks(state: EditorState, key: "first" | "last", count: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const currentIndex = currentTextblockIndex(state, ranges);
+  const targetIndex = targetLineMotionIndex(ranges, key, count);
+  const startIndex = Math.min(currentIndex, targetIndex);
+  const endIndex = Math.max(currentIndex, targetIndex);
+
+  return {
+    endIndex,
+    ranges,
+    selected: ranges.slice(startIndex, endIndex + 1),
+    startIndex
+  };
+}
+
 function textblockSelectionBounds(selection: ReturnType<typeof selectedTextblocks>) {
   if (!selection || selection.selected.length === 0) return false;
 
@@ -1449,8 +1472,7 @@ function changeCurrentTextblock(view: EditorView, count = 1) {
   return changeTextblockSelection(view, selectedTextblocks(view.state, count));
 }
 
-function yankCurrentTextblock(view: EditorView, count = 1) {
-  const selection = selectedTextblocks(view.state, count);
+function yankTextblockSelection(view: EditorView, selection: ReturnType<typeof selectedTextblocks>) {
   if (!selection || selection.selected.length === 0) return false;
 
   dispatchMeta(
@@ -1463,6 +1485,10 @@ function yankCurrentTextblock(view: EditorView, count = 1) {
     })
   );
   return true;
+}
+
+function yankCurrentTextblock(view: EditorView, count = 1) {
+  return yankTextblockSelection(view, selectedTextblocks(view.state, count));
 }
 
 function insertParagraphNearTextblock(view: EditorView, side: "before" | "after") {
@@ -1825,9 +1851,7 @@ function lineMotion(view: EditorView, key: "first" | "last", count: number) {
   const ranges = textblockRanges(view.state);
   if (ranges.length === 0) return false;
 
-  const targetIndex = key === "first"
-    ? Math.max(0, Math.min(ranges.length - 1, count > 1 ? count - 1 : 0))
-    : Math.max(0, Math.min(ranges.length - 1, count > 1 ? count - 1 : ranges.length - 1));
+  const targetIndex = targetLineMotionIndex(ranges, key, count);
   const targetRange = ranges[targetIndex];
   if (!targetRange) return false;
 
@@ -2002,6 +2026,14 @@ function operateTextObject(
   return operator.type === "delete"
     ? deleteRange(view, range.start, range.end)
     : yankRange(view, range.start, range.end);
+}
+
+function operateLineMotion(view: EditorView, operator: PendingOperator, key: "first" | "last", count: number) {
+  const selection = lineMotionTextblocks(view.state, key, count);
+
+  if (operator.type === "change") return changeTextblockSelection(view, selection);
+  if (operator.type === "delete") return deleteTextblockSelection(view, selection);
+  return yankTextblockSelection(view, selection);
 }
 
 function handlePendingOperatorTextObject(view: EditorView, key: string, state: VimModeState) {
@@ -2369,6 +2401,7 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   if (operator.type === "change" && key === "c") return changeCurrentTextblock(view, operator.count * readCount(state));
 
   if (state.pending === "g") {
+    if (key === "g") return operateLineMotion(view, operator, "first", operator.count * readCount(state));
     if (key === "e") return operateRange(view, operator, key, state, "g");
     if (key === "E") return operateRange(view, operator, key, state, "g");
     if (key === "_") return operateRange(view, operator, key, state, "g");
@@ -2381,6 +2414,8 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
     dispatchMeta(view, { pending: "g" });
     return true;
   }
+
+  if (key === "G") return operateLineMotion(view, operator, "last", operator.count * readCount(state));
 
   if (isFindKey(key)) {
     dispatchMeta(view, { pending: key });

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -723,8 +723,8 @@ function joinTextblocks(view: EditorView, blockCount = 2) {
   return true;
 }
 
-function moveToTextblockBoundary(view: EditorView, side: "start" | "end") {
-  const range = currentTextblockRange(view.state);
+function moveToTextblockBoundary(view: EditorView, side: "start" | "end", count = 1) {
+  const range = side === "end" ? countedTextblockRange(view.state, count) : currentTextblockRange(view.state);
   if (!range) return false;
 
   const position = side === "start" ? range.start : normalTextblockEnd(range);
@@ -1794,7 +1794,7 @@ function resolveMotionTarget(state: EditorState, key: string, count: number, pre
     case "_":
       return textblockNonblankPosition(state, "first", count);
     case "$":
-      return range.end;
+      return countedTextblockRange(state, count)?.end ?? null;
     default:
       return null;
   }
@@ -2404,7 +2404,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "_":
       return moveToTextblockNonblank(view, "first", count);
     case "$":
-      return moveToTextblockBoundary(view, "end");
+      return moveToTextblockBoundary(view, "end", count);
     case "G":
       return lineMotion(view, "last", count);
     case "g":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -503,6 +503,26 @@ function deleteCurrentTextblock(view: EditorView, count = 1) {
   return true;
 }
 
+function changeCurrentTextblock(view: EditorView, count = 1) {
+  const selection = selectedTextblocks(view.state, count);
+  const replacement = emptyParagraph(view.state);
+  if (!selection || selection.selected.length === 0 || !replacement) return false;
+
+  const from = selection.selected[0]?.before;
+  const to = selection.selected[selection.selected.length - 1]?.after;
+  if (from === undefined || to === undefined) return false;
+
+  const texts = selection.selected.map((range) => range.text);
+  const transaction = view.state.tr.replaceWith(from, to, replacement);
+  const selectionPosition = Math.min(from + 1, transaction.doc.content.size);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta({ mode: "insert", register: { kind: "line", texts } })
+  );
+  return true;
+}
+
 function yankCurrentTextblock(view: EditorView, count = 1) {
   const selection = selectedTextblocks(view.state, count);
   if (!selection || selection.selected.length === 0) return false;
@@ -777,6 +797,7 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
 
   if (operator.type === "delete" && key === "d") return deleteCurrentTextblock(view, operator.count * readCount(state));
   if (operator.type === "yank" && key === "y") return yankCurrentTextblock(view, operator.count * readCount(state));
+  if (operator.type === "change" && key === "c") return changeCurrentTextblock(view, operator.count * readCount(state));
 
   if (state.pending === "g") {
     if (key === "e") return operateRange(view, operator, key, state, "g");

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -469,6 +469,15 @@ function replaceCharacters(view: EditorView, character: string, count = 1) {
   return true;
 }
 
+function substituteCharacters(view: EditorView, count = 1) {
+  const range = currentTextblockRange(view.state);
+  if (!range || view.state.selection.from >= range.end) return false;
+
+  const from = view.state.selection.from;
+  const to = Math.min(range.end, from + count);
+  return changeRange(view, from, to);
+}
+
 function emptyParagraph(state: EditorState) {
   const paragraph = state.schema.nodes.paragraph;
   return paragraph?.createAndFill() ?? paragraph?.create();
@@ -921,6 +930,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "r":
       dispatchMeta(view, { pending: "r" });
       return true;
+    case "s":
+      return substituteCharacters(view, count);
     case "o":
       return insertParagraphNearTextblock(view, "after");
     case "O":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1193,6 +1193,34 @@ function deletePreviousCharacter(view: EditorView, count = 1) {
   return true;
 }
 
+function toggledCharacterCase(character: string) {
+  const lower = character.toLocaleLowerCase();
+  const upper = character.toLocaleUpperCase();
+
+  if (lower === upper) return character;
+  return character === lower ? upper : lower;
+}
+
+function toggleCharacterCase(view: EditorView, count = 1) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  const range = currentTextblockRange(view.state);
+  if (!range || view.state.selection.from >= range.end) return false;
+
+  const from = view.state.selection.from;
+  const to = Math.min(range.end, from + count);
+  const text = view.state.doc.textBetween(from, to, "\n");
+  const replacement = Array.from(text, toggledCharacterCase).join("");
+  const transaction = view.state.tr.insertText(replacement, from, to);
+  const selectionPosition = Math.min(normalTextblockEnd(range), to);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta()
+  );
+  return true;
+}
+
 function replaceCharacters(view: EditorView, character: string, count = 1) {
   if (!selectionIsTextSelection(view.state) || character.length !== 1) return false;
 
@@ -1502,7 +1530,8 @@ function repeatableChangeStartKeys(state: VimModeState, key: string) {
     key !== "p" &&
     key !== "r" &&
     key !== "s" &&
-    key !== "x"
+    key !== "x" &&
+    key !== "~"
   ) {
     return null;
   }
@@ -2332,6 +2361,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return deletePreviousCharacter(view, count);
     case "x":
       return deleteCharacter(view, count);
+    case "~":
+      return toggleCharacterCase(view, count);
     case "r":
       dispatchMeta(view, { pending: "r" });
       return true;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -2073,6 +2073,45 @@ function handleRepeatedNormalFind(view: EditorView, key: string, state: VimModeS
   return moveByCharacterFind(view, find, readCount(state));
 }
 
+function moveVisualSelectionByFind(view: EditorView, find: VimCharacterFind, count: number, state: VimModeState) {
+  const selection = view.state.selection;
+  if (!(selection instanceof TextSelection)) return false;
+
+  const anchor = state.visualAnchor ?? selection.from;
+  const cursor = state.visualCursor ?? visualCursorPosition(selection, anchor);
+  const kind = state.visualKind ?? "character";
+  const target = characterFindTarget(stateWithCursorAt(view.state, cursor), find, count);
+  if (target === null) {
+    dispatchMeta(view, { count: "", pending: null });
+    return true;
+  }
+
+  return moveVisualSelectionWithMeta(view, anchor, target, kind, { lastFind: find });
+}
+
+function handlePendingVisualFind(view: EditorView, key: string, state: VimModeState) {
+  const pending = state.pending;
+  if (!pending || !isFindKey(pending)) return false;
+
+  if (key.length !== 1) {
+    dispatchMeta(view, { count: "", pending: null });
+    return true;
+  }
+
+  const find = characterFindFromKey(pending, key);
+  return moveVisualSelectionByFind(view, find, readCount(state), state);
+}
+
+function handleRepeatedVisualFind(view: EditorView, key: string, state: VimModeState) {
+  if (!state.lastFind) {
+    dispatchMeta(view, { count: "", pending: null });
+    return true;
+  }
+
+  const find = key === "," ? reversedCharacterFind(state.lastFind) : state.lastFind;
+  return moveVisualSelectionByFind(view, find, readCount(state), state);
+}
+
 function handlePendingSearch(view: EditorView, key: string, state: VimModeState) {
   const pending = state.pending;
   if (!isSearchPending(pending)) return false;
@@ -2316,6 +2355,7 @@ function extendVisualSelection(view: EditorView, key: string, state: VimModeStat
 }
 
 function handleVisualModeKey(view: EditorView, key: string, state: VimModeState) {
+  if (isFindKey(state.pending ?? "")) return handlePendingVisualFind(view, key, state);
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
   if (state.pending === "g") {
@@ -2361,6 +2401,15 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
     case "g":
       dispatchMeta(view, { pending: "g" });
       return true;
+    case "f":
+    case "F":
+    case "t":
+    case "T":
+      dispatchMeta(view, { pending: key });
+      return true;
+    case ";":
+    case ",":
+      return handleRepeatedVisualFind(view, key, state);
     case "h":
     case "ArrowLeft":
     case "l":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -8,6 +8,8 @@ export type VimMode = "insert" | "normal";
 type VimOperator = "change" | "delete" | "yank";
 type VimFindDirection = "backward" | "forward";
 type VimFindKey = "F" | "T" | "f" | "t";
+type VimSearchDirection = "backward" | "forward";
+type VimSearchPending = "search-backward" | "search-forward";
 type VimTextObjectPending = "text-object-around" | "text-object-inner";
 type VimPairTextObjectKey = "(" | ")" | "[" | "]" | "{" | "}";
 type VimQuoteTextObjectKey = "'" | '"' | "`";
@@ -27,11 +29,13 @@ export type VimModePluginOptions = {
 type VimModeState = {
   count: string;
   lastFind: VimCharacterFind | null;
+  lastSearch: VimSearch | null;
   mode: VimMode;
   operator: PendingOperator | null;
   pending: string | null;
   preferredColumn: number | null;
   register: VimRegister | null;
+  searchQuery: string;
 };
 
 type VimModeMeta = Partial<VimModeState>;
@@ -53,6 +57,11 @@ type VimCharacterFind = {
   character: string;
   direction: VimFindDirection;
   till: boolean;
+};
+
+type VimSearch = {
+  direction: VimSearchDirection;
+  query: string;
 };
 
 type VimRegister =
@@ -78,20 +87,22 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
   const meta = transaction.getMeta(vimModeKey) as VimModeMeta | undefined;
   if (!meta) {
     return transaction.docChanged || transaction.selectionSet
-      ? { ...state, count: "", operator: null, pending: null, preferredColumn: null }
+      ? { ...state, count: "", operator: null, pending: null, preferredColumn: null, searchQuery: "" }
       : state;
   }
 
   return {
     count: Object.hasOwn(meta, "count") ? meta.count ?? "" : state.count,
     lastFind: Object.hasOwn(meta, "lastFind") ? meta.lastFind ?? null : state.lastFind,
+    lastSearch: Object.hasOwn(meta, "lastSearch") ? meta.lastSearch ?? null : state.lastSearch,
     mode: meta.mode ?? state.mode,
     operator: Object.hasOwn(meta, "operator") ? meta.operator ?? null : state.operator,
     pending: Object.hasOwn(meta, "pending") ? meta.pending ?? null : state.pending,
     preferredColumn: Object.hasOwn(meta, "preferredColumn")
       ? meta.preferredColumn ?? null
       : state.preferredColumn,
-    register: Object.hasOwn(meta, "register") ? meta.register ?? null : state.register
+    register: Object.hasOwn(meta, "register") ? meta.register ?? null : state.register,
+    searchQuery: Object.hasOwn(meta, "searchQuery") ? meta.searchQuery ?? "" : state.searchQuery
   };
 }
 
@@ -101,6 +112,7 @@ function clearedInputMeta(meta: VimModeMeta = {}): VimModeMeta {
     operator: null,
     pending: null,
     preferredColumn: null,
+    searchQuery: "",
     ...meta
   };
 }
@@ -123,11 +135,13 @@ function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
   return {
     count: "",
     lastFind: null,
+    lastSearch: null,
     mode: initialMode,
     operator: null,
     pending: null,
     preferredColumn: null,
-    register: null
+    register: null,
+    searchQuery: ""
   };
 }
 
@@ -208,6 +222,21 @@ function moveByCharacter(view: EditorView, delta: -1 | 1, count = 1) {
 
 function isFindKey(key: string): key is VimFindKey {
   return key === "f" || key === "F" || key === "t" || key === "T";
+}
+
+function isSearchPending(pending: string | null): pending is VimSearchPending {
+  return pending === "search-forward" || pending === "search-backward";
+}
+
+function searchDirectionFromPending(pending: VimSearchPending): VimSearchDirection {
+  return pending === "search-forward" ? "forward" : "backward";
+}
+
+function reversedSearch(search: VimSearch): VimSearch {
+  return {
+    query: search.query,
+    direction: search.direction === "forward" ? "backward" : "forward"
+  };
 }
 
 function isTextObjectPending(pending: string | null): pending is VimTextObjectPending {
@@ -350,6 +379,59 @@ function currentTextblockRange(state: EditorState) {
     start,
     text: $from.node(depth).textContent
   } satisfies TextblockRange;
+}
+
+function searchMatchPositions(state: EditorState, query: string) {
+  if (query.length === 0) return [];
+
+  const positions: number[] = [];
+  for (const range of textblockRanges(state)) {
+    let offset = range.text.indexOf(query);
+
+    while (offset >= 0) {
+      positions.push(range.start + offset);
+      offset = range.text.indexOf(query, offset + Math.max(1, query.length));
+    }
+  }
+
+  return positions;
+}
+
+function nextSearchPosition(positions: readonly number[], direction: VimSearchDirection, from: number) {
+  if (positions.length === 0) return null;
+
+  if (direction === "forward") {
+    return positions.find((position) => position > from) ?? positions[0] ?? null;
+  }
+
+  for (let index = positions.length - 1; index >= 0; index -= 1) {
+    const position = positions[index];
+    if (position !== undefined && position < from) return position;
+  }
+
+  return positions[positions.length - 1] ?? null;
+}
+
+function moveBySearch(view: EditorView, search: VimSearch, count = 1, rememberedSearch = search) {
+  const positions = searchMatchPositions(view.state, search.query);
+  if (positions.length === 0) {
+    dispatchMeta(view, clearedInputMeta({ lastSearch: rememberedSearch }));
+    return true;
+  }
+
+  let position = view.state.selection.from;
+  for (let index = 0; index < Math.max(1, count); index += 1) {
+    const next = nextSearchPosition(positions, search.direction, position);
+    if (next === null) return false;
+    position = next;
+  }
+
+  return moveSelection(
+    view,
+    position,
+    search.direction === "backward" ? -1 : 1,
+    clearedInputMeta({ lastSearch: rememberedSearch })
+  );
 }
 
 function nearestTextblockIndex(ranges: readonly TextblockRange[], position: number) {
@@ -1458,6 +1540,51 @@ function handleRepeatedNormalFind(view: EditorView, key: string, state: VimModeS
   return moveByCharacterFind(view, find, readCount(state));
 }
 
+function handlePendingSearch(view: EditorView, key: string, state: VimModeState) {
+  const pending = state.pending;
+  if (!isSearchPending(pending)) return false;
+
+  if (key === "Escape") {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  if (key === "Backspace") {
+    dispatchMeta(view, { searchQuery: state.searchQuery.slice(0, -1) });
+    return true;
+  }
+
+  if (key === "Enter") {
+    const query = state.searchQuery;
+    if (query.length === 0) {
+      dispatchMeta(view, clearedInputMeta());
+      return true;
+    }
+
+    return moveBySearch(view, {
+      direction: searchDirectionFromPending(pending),
+      query
+    });
+  }
+
+  if (key.length === 1) {
+    dispatchMeta(view, { searchQuery: `${state.searchQuery}${key}` });
+    return true;
+  }
+
+  return true;
+}
+
+function repeatSearch(view: EditorView, state: VimModeState, count: number, reversed: boolean) {
+  if (!state.lastSearch) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const search = reversed ? reversedSearch(state.lastSearch) : state.lastSearch;
+  return moveBySearch(view, search, count, state.lastSearch);
+}
+
 function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   const operator = state.operator;
   if (!operator) return false;
@@ -1507,6 +1634,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
 
   if (state.pending === "r") return replaceCharacters(view, key, readCount(state));
   if (isFindKey(state.pending ?? "")) return handlePendingNormalFind(view, key, state);
+  if (isSearchPending(state.pending)) return handlePendingSearch(view, key, state);
 
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
@@ -1580,6 +1708,12 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "g":
       dispatchMeta(view, { pending: "g" });
       return true;
+    case "/":
+      dispatchMeta(view, { pending: "search-forward", searchQuery: "" });
+      return true;
+    case "?":
+      dispatchMeta(view, { pending: "search-backward", searchQuery: "" });
+      return true;
     case "f":
     case "F":
     case "t":
@@ -1589,6 +1723,10 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case ";":
     case ",":
       return handleRepeatedNormalFind(view, key, state);
+    case "n":
+      return repeatSearch(view, state, count, false);
+    case "N":
+      return repeatSearch(view, state, count, true);
     case "d":
       return beginOperator(view, "delete", state);
     case "y":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -364,7 +364,12 @@ function previousTextblockWordStart(ranges: readonly TextblockRange[], currentIn
   return null;
 }
 
-function wordStartMotionPosition(state: EditorState, direction: "forward" | "backward", count: number) {
+function wordStartMotionPosition(
+  state: EditorState,
+  direction: "forward" | "backward",
+  count: number,
+  finalForwardTarget: "caret" | "boundary" = "caret"
+) {
   const ranges = textblockRanges(state);
   if (ranges.length === 0) return null;
 
@@ -385,7 +390,7 @@ function wordStartMotionPosition(state: EditorState, direction: "forward" | "bac
       }
 
       const next = nextTextblockWordStart(ranges, currentIndex);
-      if (!next) return normalTextblockEnd(range);
+      if (!next) return finalForwardTarget === "boundary" ? range.end : normalTextblockEnd(range);
 
       currentIndex = next.index;
       position = next.position;
@@ -708,11 +713,11 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
     case "ArrowRight":
       return Math.min(normalTextblockEnd(range), current + count);
     case "w":
-      return Math.min(range.end, range.start + wordMotionOffset(range.text, offset, "forward", count));
+      return wordStartMotionPosition(view.state, "forward", count, "boundary");
     case "e":
       return Math.min(normalTextblockEnd(range), range.start + wordMotionOffset(range.text, offset, "end", count));
     case "b":
-      return Math.max(range.start, range.start + wordMotionOffset(range.text, offset, "backward", count));
+      return wordStartMotionPosition(view.state, "backward", count);
     case "0":
       return range.start;
     case "^":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1174,6 +1174,25 @@ function deleteCharacter(view: EditorView, count = 1) {
   return true;
 }
 
+function deletePreviousCharacter(view: EditorView, count = 1) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  const range = currentTextblockRange(view.state);
+  if (!range || view.state.selection.from <= range.start) return false;
+
+  const end = view.state.selection.from;
+  const start = Math.max(range.start, end - count);
+  const text = view.state.doc.textBetween(start, end, "\n");
+  const transaction = view.state.tr.delete(start, end);
+  const selectionPosition = Math.min(start, transaction.doc.content.size);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
+    clearedInputMeta({ register: { kind: "text", text } })
+  );
+  return true;
+}
+
 function replaceCharacters(view: EditorView, character: string, count = 1) {
   if (!selectionIsTextSelection(view.state) || character.length !== 1) return false;
 
@@ -1474,6 +1493,7 @@ function repeatableChangeStartKeys(state: VimModeState, key: string) {
     key !== "O" &&
     key !== "P" &&
     key !== "S" &&
+    key !== "X" &&
     key !== "a" &&
     key !== "c" &&
     key !== "d" &&
@@ -2306,6 +2326,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       if (handled) view.focus();
       return handled;
     }
+    case "X":
+      return deletePreviousCharacter(view, count);
     case "x":
       return deleteCharacter(view, count);
     case "r":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -14,6 +14,7 @@ type VimTextObjectPending = "text-object-around" | "text-object-inner";
 type VimPairTextObjectKey = "(" | ")" | "[" | "]" | "{" | "}";
 type VimQuoteTextObjectKey = "'" | '"' | "`";
 type VimTextObjectScope = "around" | "inner";
+type VimVisualKind = "character" | "line";
 type WordClassifier = (character: string) => boolean;
 
 type VimPairDelimiters = {
@@ -37,6 +38,8 @@ type VimModeState = {
   register: VimRegister | null;
   searchQuery: string;
   visualAnchor: number | null;
+  visualCursor: number | null;
+  visualKind: VimVisualKind | null;
 };
 
 type VimModeMeta = Partial<VimModeState>;
@@ -97,7 +100,9 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
           pending: null,
           preferredColumn: null,
           searchQuery: "",
-          visualAnchor: null
+          visualAnchor: null,
+          visualCursor: null,
+          visualKind: null
         }
       : state;
   }
@@ -114,7 +119,9 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
       : state.preferredColumn,
     register: Object.hasOwn(meta, "register") ? meta.register ?? null : state.register,
     searchQuery: Object.hasOwn(meta, "searchQuery") ? meta.searchQuery ?? "" : state.searchQuery,
-    visualAnchor: Object.hasOwn(meta, "visualAnchor") ? meta.visualAnchor ?? null : state.visualAnchor
+    visualAnchor: Object.hasOwn(meta, "visualAnchor") ? meta.visualAnchor ?? null : state.visualAnchor,
+    visualCursor: Object.hasOwn(meta, "visualCursor") ? meta.visualCursor ?? null : state.visualCursor,
+    visualKind: Object.hasOwn(meta, "visualKind") ? meta.visualKind ?? null : state.visualKind
   };
 }
 
@@ -126,6 +133,8 @@ function clearedInputMeta(meta: VimModeMeta = {}): VimModeMeta {
     preferredColumn: null,
     searchQuery: "",
     visualAnchor: null,
+    visualCursor: null,
+    visualKind: null,
     ...meta
   };
 }
@@ -155,7 +164,9 @@ function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
     preferredColumn: null,
     register: null,
     searchQuery: "",
-    visualAnchor: null
+    visualAnchor: null,
+    visualCursor: null,
+    visualKind: null
   };
 }
 
@@ -164,7 +175,8 @@ function enterNormalMode(view: EditorView, options: VimModePluginOptions) {
   let transaction = view.state.tr;
 
   if (state.mode === "visual" && view.state.selection instanceof TextSelection && !view.state.selection.empty) {
-    const target = visualCursorPosition(view.state.selection, state.visualAnchor ?? view.state.selection.from);
+    const target = state.visualCursor
+      ?? visualCursorPosition(view.state.selection, state.visualAnchor ?? view.state.selection.from);
     transaction = transaction.setSelection(TextSelection.near(transaction.doc.resolve(target), 1));
   } else if (state.mode === "insert" && view.state.selection instanceof TextSelection && view.state.selection.empty) {
     const range = currentTextblockRange(view.state);
@@ -244,13 +256,33 @@ function visualTextSelection(state: EditorState, anchor: number, cursor: number)
   return TextSelection.create(state.doc, Math.min(state.doc.content.size, clampedAnchor + 1), clampedCursor);
 }
 
-function moveVisualSelection(view: EditorView, anchor: number, cursor: number) {
-  dispatchTransaction(
-    view,
-    view.state.tr.setSelection(visualTextSelection(view.state, anchor, cursor)),
-    clearedInputMeta({ mode: "visual", visualAnchor: anchor })
-  );
-  return true;
+function visualTextblockSelection(state: EditorState, anchor: number, cursor: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const anchorIndex = nearestTextblockIndex(ranges, anchor);
+  const cursorIndex = nearestTextblockIndex(ranges, cursor);
+  const startIndex = Math.min(anchorIndex, cursorIndex);
+  const endIndex = Math.max(anchorIndex, cursorIndex);
+  const startRange = ranges[startIndex];
+  const endRange = ranges[endIndex];
+  const anchorRange = ranges[anchorIndex];
+  const cursorRange = ranges[cursorIndex];
+  if (!startRange || !endRange || !anchorRange || !cursorRange) return null;
+
+  return cursorIndex >= anchorIndex
+    ? TextSelection.create(state.doc, startRange.start, endRange.end)
+    : TextSelection.create(state.doc, anchorRange.end, cursorRange.start);
+}
+
+function visualSelectionForKind(state: EditorState, kind: VimVisualKind, anchor: number, cursor: number) {
+  return kind === "line"
+    ? visualTextblockSelection(state, anchor, cursor)
+    : visualTextSelection(state, anchor, cursor);
+}
+
+function moveVisualSelection(view: EditorView, anchor: number, cursor: number, kind: VimVisualKind) {
+  return moveVisualSelectionWithMeta(view, anchor, cursor, kind);
 }
 
 function moveByCharacter(view: EditorView, delta: -1 | 1, count = 1) {
@@ -1171,46 +1203,72 @@ function selectedTextblocks(state: EditorState, count: number) {
   };
 }
 
-function deleteCurrentTextblock(view: EditorView, count = 1) {
-  const selection = selectedTextblocks(view.state, count);
+function selectedTextblocksBetween(state: EditorState, anchor: number, cursor: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const anchorIndex = nearestTextblockIndex(ranges, anchor);
+  const cursorIndex = nearestTextblockIndex(ranges, cursor);
+  const startIndex = Math.min(anchorIndex, cursorIndex);
+  const endIndex = Math.max(anchorIndex, cursorIndex);
+  return {
+    endIndex,
+    ranges,
+    selected: ranges.slice(startIndex, endIndex + 1),
+    startIndex
+  };
+}
+
+function textblockSelectionBounds(selection: ReturnType<typeof selectedTextblocks>) {
   if (!selection || selection.selected.length === 0) return false;
 
   const from = selection.selected[0]?.before;
   const to = selection.selected[selection.selected.length - 1]?.after;
   if (from === undefined || to === undefined) return false;
 
+  return { from, to };
+}
+
+function deleteTextblockSelection(view: EditorView, selection: ReturnType<typeof selectedTextblocks>) {
+  const bounds = textblockSelectionBounds(selection);
+  if (!bounds || !selection) return false;
+
   const texts = selection.selected.map((range) => range.text);
-  const replacement = from === 0 && to >= view.state.doc.content.size ? emptyParagraph(view.state) : null;
+  const replacement = bounds.from === 0 && bounds.to >= view.state.doc.content.size ? emptyParagraph(view.state) : null;
   const transaction = replacement
-    ? view.state.tr.replaceWith(from, to, replacement)
-    : view.state.tr.delete(from, to);
-  const selectionPosition = Math.min(from, transaction.doc.content.size);
+    ? view.state.tr.replaceWith(bounds.from, bounds.to, replacement)
+    : view.state.tr.delete(bounds.from, bounds.to);
+  const selectionPosition = Math.min(bounds.from, transaction.doc.content.size);
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ register: { kind: "line", texts } })
+    clearedInputMeta({ mode: "normal", register: { kind: "line", texts } })
   );
   return true;
 }
 
-function changeCurrentTextblock(view: EditorView, count = 1) {
-  const selection = selectedTextblocks(view.state, count);
+function changeTextblockSelection(view: EditorView, selection: ReturnType<typeof selectedTextblocks>) {
   const replacement = emptyParagraph(view.state);
-  if (!selection || selection.selected.length === 0 || !replacement) return false;
-
-  const from = selection.selected[0]?.before;
-  const to = selection.selected[selection.selected.length - 1]?.after;
-  if (from === undefined || to === undefined) return false;
+  const bounds = textblockSelectionBounds(selection);
+  if (!selection || !bounds || !replacement) return false;
 
   const texts = selection.selected.map((range) => range.text);
-  const transaction = view.state.tr.replaceWith(from, to, replacement);
-  const selectionPosition = Math.min(from + 1, transaction.doc.content.size);
+  const transaction = view.state.tr.replaceWith(bounds.from, bounds.to, replacement);
+  const selectionPosition = Math.min(bounds.from + 1, transaction.doc.content.size);
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
     clearedInputMeta({ mode: "insert", register: { kind: "line", texts } })
   );
   return true;
+}
+
+function deleteCurrentTextblock(view: EditorView, count = 1) {
+  return deleteTextblockSelection(view, selectedTextblocks(view.state, count));
+}
+
+function changeCurrentTextblock(view: EditorView, count = 1) {
+  return changeTextblockSelection(view, selectedTextblocks(view.state, count));
 }
 
 function yankCurrentTextblock(view: EditorView, count = 1) {
@@ -1720,10 +1778,30 @@ function enterVisualMode(view: EditorView, state: VimModeState) {
   if (!range) return false;
 
   const cursor = Math.min(normalTextblockEnd(range), view.state.selection.from);
+  return moveVisualSelectionWithMeta(view, cursor, cursor, "character", { register: state.register });
+}
+
+function enterVisualLineMode(view: EditorView, state: VimModeState) {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  return moveVisualSelectionWithMeta(view, range.start, range.start, "line", { register: state.register });
+}
+
+function moveVisualSelectionWithMeta(
+  view: EditorView,
+  anchor: number,
+  cursor: number,
+  kind: VimVisualKind,
+  meta: VimModeMeta = {}
+) {
+  const selection = visualSelectionForKind(view.state, kind, anchor, cursor);
+  if (!selection) return false;
+
   dispatchTransaction(
     view,
-    view.state.tr.setSelection(visualTextSelection(view.state, cursor, cursor)),
-    clearedInputMeta({ mode: "visual", register: state.register, visualAnchor: cursor })
+    view.state.tr.setSelection(selection),
+    clearedInputMeta({ ...meta, mode: "visual", visualAnchor: anchor, visualCursor: cursor, visualKind: kind })
   );
   return true;
 }
@@ -1732,7 +1810,7 @@ function collapseVisualSelection(view: EditorView, state: VimModeState) {
   const selection = view.state.selection;
   if (!(selection instanceof TextSelection)) return false;
 
-  const target = visualCursorPosition(selection, state.visualAnchor ?? selection.from);
+  const target = state.visualCursor ?? visualCursorPosition(selection, state.visualAnchor ?? selection.from);
   dispatchTransaction(
     view,
     view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(target), 1)),
@@ -1741,16 +1819,46 @@ function collapseVisualSelection(view: EditorView, state: VimModeState) {
   return true;
 }
 
-function visualSelectionRange(view: EditorView) {
+function visualSelectionRange(view: EditorView, state: VimModeState) {
+  if (state.visualKind === "line") {
+    const selection = visualLineTextblocks(view.state, state);
+    const bounds = textblockSelectionBounds(selection);
+    return bounds ? { ...bounds, kind: "line" as const, selection } : null;
+  }
+
   const selection = view.state.selection;
   if (!(selection instanceof TextSelection) || selection.empty) return null;
 
-  return { from: selection.from, to: selection.to };
+  return { from: selection.from, kind: "character" as const, to: selection.to };
+}
+
+function visualLineTextblocks(state: EditorState, vimState: VimModeState) {
+  const selection = state.selection;
+  if (!(selection instanceof TextSelection)) return null;
+
+  const anchor = vimState.visualAnchor ?? selection.from;
+  const cursor = vimState.visualCursor ?? visualCursorPosition(selection, anchor);
+  return selectedTextblocksBetween(state, anchor, cursor);
 }
 
 function yankVisualSelection(view: EditorView, state: VimModeState) {
-  const range = visualSelectionRange(view);
+  const range = visualSelectionRange(view, state);
   if (!range) return collapseVisualSelection(view, state);
+
+  if (range.kind === "line") {
+    const selection = range.selection;
+    if (!selection || selection.selected.length === 0) return false;
+
+    dispatchTransaction(
+      view,
+      view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(range.from), 1)),
+      clearedInputMeta({
+        mode: "normal",
+        register: { kind: "line", texts: selection.selected.map((textblock) => textblock.text) }
+      })
+    );
+    return true;
+  }
 
   const text = textRange(view, range.from, range.to);
   dispatchTransaction(
@@ -1761,16 +1869,20 @@ function yankVisualSelection(view: EditorView, state: VimModeState) {
   return true;
 }
 
-function deleteVisualSelection(view: EditorView) {
-  const range = visualSelectionRange(view);
+function deleteVisualSelection(view: EditorView, state: VimModeState) {
+  const range = visualSelectionRange(view, state);
   if (!range) return false;
+
+  if (range.kind === "line") return deleteTextblockSelection(view, range.selection);
 
   return deleteRange(view, range.from, range.to, { mode: "normal" });
 }
 
-function changeVisualSelection(view: EditorView) {
-  const range = visualSelectionRange(view);
+function changeVisualSelection(view: EditorView, state: VimModeState) {
+  const range = visualSelectionRange(view, state);
   if (!range) return false;
+
+  if (range.kind === "line") return changeTextblockSelection(view, range.selection);
 
   return changeRange(view, range.from, range.to);
 }
@@ -1784,17 +1896,30 @@ function visualMotionTarget(state: EditorState, key: string, count: number, pref
   return resolveMotionTarget(state, key, count, prefix);
 }
 
+function visualLineMotionTarget(state: EditorState, cursor: number, delta: -1 | 1, count: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const currentIndex = nearestTextblockIndex(ranges, cursor);
+  const targetIndex = Math.max(0, Math.min(ranges.length - 1, currentIndex + delta * count));
+  return ranges[targetIndex]?.start ?? null;
+}
+
 function extendVisualSelection(view: EditorView, key: string, state: VimModeState, prefix: string | null = null) {
   const selection = view.state.selection;
   if (!(selection instanceof TextSelection)) return false;
 
   const anchor = state.visualAnchor ?? selection.from;
-  const cursor = visualCursorPosition(selection, anchor);
-  const cursorState = stateWithCursorAt(view.state, cursor);
-  const target = visualMotionTarget(cursorState, key, readCount(state), prefix);
+  const cursor = state.visualCursor ?? visualCursorPosition(selection, anchor);
+  const kind = state.visualKind ?? "character";
+  const count = readCount(state);
+  const lineDelta = key === "j" || key === "ArrowDown" ? 1 : key === "k" || key === "ArrowUp" ? -1 : null;
+  const target = kind === "line" && lineDelta !== null
+    ? visualLineMotionTarget(view.state, cursor, lineDelta, count)
+    : visualMotionTarget(stateWithCursorAt(view.state, cursor), key, count, prefix);
   if (target === null) return true;
 
-  return moveVisualSelection(view, anchor, target);
+  return moveVisualSelection(view, anchor, target, kind);
 }
 
 function handleVisualModeKey(view: EditorView, key: string, state: VimModeState) {
@@ -1804,24 +1929,41 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
     if (key === "e") return extendVisualSelection(view, key, state, "g");
     if (key === "E") return extendVisualSelection(view, key, state, "g");
 
-    dispatchMeta(view, clearedInputMeta({ mode: "visual", visualAnchor: state.visualAnchor }));
+    dispatchMeta(
+      view,
+      clearedInputMeta({
+        mode: "visual",
+        visualAnchor: state.visualAnchor,
+        visualCursor: state.visualCursor,
+        visualKind: state.visualKind
+      })
+    );
     return true;
   }
 
   switch (key) {
     case "v":
       return collapseVisualSelection(view, state);
+    case "V": {
+      const selection = view.state.selection;
+      if (!(selection instanceof TextSelection)) return false;
+      const anchor = state.visualAnchor ?? selection.from;
+      const cursor = state.visualCursor ?? visualCursorPosition(selection, anchor);
+      return state.visualKind === "line"
+        ? collapseVisualSelection(view, state)
+        : moveVisualSelectionWithMeta(view, anchor, cursor, "line", { register: state.register });
+    }
     case "y":
       return yankVisualSelection(view, state);
     case "d":
     case "x":
-      return deleteVisualSelection(view);
+      return deleteVisualSelection(view, state);
     case "Backspace":
     case "Delete":
     case "Enter":
       return true;
     case "c":
-      return changeVisualSelection(view);
+      return changeVisualSelection(view, state);
     case "g":
       dispatchMeta(view, { pending: "g" });
       return true;
@@ -1829,6 +1971,10 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
     case "ArrowLeft":
     case "l":
     case "ArrowRight":
+    case "j":
+    case "ArrowDown":
+    case "k":
+    case "ArrowUp":
     case "w":
     case "W":
     case "e":
@@ -2002,6 +2148,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return repeatSearch(view, state, count, true);
     case "v":
       return enterVisualMode(view, state);
+    case "V":
+      return enterVisualLineMode(view, state);
     case "d":
       return beginOperator(view, "delete", state);
     case "y":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -214,10 +214,19 @@ function enterNormalMode(view: EditorView, options: VimModePluginOptions) {
     const range = currentTextblockRange(view.state);
     if (range) {
       const insertRepeatText = repeatedDirectInsertText(state.pendingInsertChangeKeys, state.pendingInsertText);
-      const selectionPosition = view.state.selection.from + insertRepeatText.length;
+      let selectionPosition = view.state.selection.from + insertRepeatText.length;
       if (insertRepeatText.length > 0) {
         transaction = transaction.insertText(insertRepeatText, view.state.selection.from, view.state.selection.from);
       }
+
+      const openLineRepeat = repeatedOpenLineInsertTransaction(
+        view,
+        transaction,
+        state.pendingInsertChangeKeys,
+        state.pendingInsertText
+      );
+      transaction = openLineRepeat.transaction;
+      selectionPosition = openLineRepeat.selectionPosition ?? selectionPosition;
 
       const target = selectionPosition > range.start
         ? Math.max(range.start, selectionPosition - 1)
@@ -1637,21 +1646,55 @@ function leadingCountEndIndex(keys: readonly string[]) {
   return index;
 }
 
-function directInsertRepeatCount(keys: readonly string[] | null) {
+function insertCommandRepeatCount(keys: readonly string[] | null, commands: readonly string[]) {
   if (!keys) return 1;
 
   const countEndIndex = leadingCountEndIndex(keys);
   const command = keys[countEndIndex];
-  if (command !== "A" && command !== "I" && command !== "a" && command !== "i") return 1;
+  if (!command || !commands.includes(command)) return 1;
 
   const count = Number.parseInt(keys.slice(0, countEndIndex).join(""), 10);
   return Number.isFinite(count) && count > 1 ? count : 1;
+}
+
+function directInsertRepeatCount(keys: readonly string[] | null) {
+  return insertCommandRepeatCount(keys, ["A", "I", "a", "i"]);
 }
 
 function repeatedDirectInsertText(keys: readonly string[] | null, text: string, offset = 1) {
   const repeatCount = directInsertRepeatCount(keys);
   const repeats = Math.max(0, repeatCount - offset);
   return repeats > 0 ? text.repeat(repeats) : "";
+}
+
+function openLineInsertRepeatCount(keys: readonly string[] | null) {
+  return insertCommandRepeatCount(keys, ["O", "o"]);
+}
+
+// Counted o/O repeats need new textblocks for each repetition, unlike i/a/I/A.
+function repeatedOpenLineInsertTransaction(
+  view: EditorView,
+  transaction: Transaction,
+  keys: readonly string[] | null,
+  text: string,
+  offset = 1
+) {
+  let nextTransaction = transaction;
+  let selectionPosition: number | null = null;
+  const range = currentTextblockRange(view.state);
+  const repeats = Math.max(0, openLineInsertRepeatCount(keys) - offset);
+  if (!range || repeats === 0) return { selectionPosition, transaction: nextTransaction };
+
+  for (let repeat = 0; repeat < repeats; repeat += 1) {
+    const node = paragraphWithText(view.state, text);
+    if (!node) break;
+
+    const position = range.after + (nextTransaction.doc.content.size - view.state.doc.content.size);
+    nextTransaction = nextTransaction.insert(position, node);
+    selectionPosition = text.length > 0 ? position + text.length : position + 1;
+  }
+
+  return { selectionPosition, transaction: nextTransaction };
 }
 
 function changeIsWaitingForMoreKeys(state: VimModeState | undefined) {
@@ -1710,11 +1753,16 @@ function repeatLastChange(view: EditorView, keys: readonly string[], text: strin
 
     const { from, to } = view.state.selection;
     const insertion = text + repeatedDirectInsertText(keys, text);
-    const transaction = view.state.tr.insertText(insertion, from, to);
-    const position = Math.max(from, from + insertion.length - 1);
+    const repeated = repeatedOpenLineInsertTransaction(
+      view,
+      view.state.tr.insertText(insertion, from, to),
+      keys,
+      text
+    );
+    const position = repeated.selectionPosition ?? Math.max(from, from + insertion.length - 1);
     dispatchTransaction(
       view,
-      transaction.setSelection(TextSelection.near(transaction.doc.resolve(position), 1)),
+      repeated.transaction.setSelection(TextSelection.near(repeated.transaction.doc.resolve(position), 1)),
       clearedInputMeta({ lastChangeKeys: keys, lastChangeText: text, mode: "normal", register: state.register })
     );
     return true;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -2112,6 +2112,44 @@ function handleRepeatedVisualFind(view: EditorView, key: string, state: VimModeS
   return moveVisualSelectionByFind(view, find, readCount(state), state);
 }
 
+function selectVisualTextObject(
+  view: EditorView,
+  scope: VimTextObjectScope,
+  key: string,
+  count: number
+) {
+  const range = textObjectRange(view.state, scope, key, count);
+
+  if (!range) {
+    dispatchMeta(view, { count: "", pending: null });
+    return true;
+  }
+
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(TextSelection.create(view.state.doc, range.start, range.end)),
+    clearedInputMeta({
+      mode: "visual",
+      visualAnchor: range.start,
+      visualCursor: Math.max(range.start, range.end - 1),
+      visualKind: "character"
+    })
+  );
+  return true;
+}
+
+function handlePendingVisualTextObject(view: EditorView, key: string, state: VimModeState) {
+  const pending = state.pending;
+  if (!isTextObjectPending(pending)) return false;
+
+  return selectVisualTextObject(
+    view,
+    textObjectScopeFromPending(pending),
+    key,
+    readCount(state)
+  );
+}
+
 function handlePendingSearch(view: EditorView, key: string, state: VimModeState) {
   const pending = state.pending;
   if (!isSearchPending(pending)) return false;
@@ -2356,6 +2394,7 @@ function extendVisualSelection(view: EditorView, key: string, state: VimModeStat
 
 function handleVisualModeKey(view: EditorView, key: string, state: VimModeState) {
   if (isFindKey(state.pending ?? "")) return handlePendingVisualFind(view, key, state);
+  if (isTextObjectPending(state.pending)) return handlePendingVisualTextObject(view, key, state);
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
   if (state.pending === "g") {
@@ -2410,6 +2449,10 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
     case ";":
     case ",":
       return handleRepeatedVisualFind(view, key, state);
+    case "i":
+    case "a":
+      dispatchMeta(view, { pending: key === "i" ? "text-object-inner" : "text-object-around" });
+      return true;
     case "h":
     case "ArrowLeft":
     case "l":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1526,6 +1526,10 @@ function hasCommandModifier(event: KeyboardEvent) {
   return event.metaKey || event.ctrlKey || event.altKey;
 }
 
+function isNormalModeExitKey(event: KeyboardEvent) {
+  return event.key === "Escape" || (event.ctrlKey && !event.metaKey && !event.altKey && event.key === "[");
+}
+
 function readCount(state: VimModeState) {
   const parsed = Number.parseInt(state.count, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
@@ -2439,7 +2443,7 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
       handleKeyDown: (view, event) => {
         if (!vimEnabled(options) || targetIsNestedControl(view, event)) return false;
 
-        if (event.key === "Escape") {
+        if (isNormalModeExitKey(event)) {
           enterNormalMode(view, options);
           event.preventDefault();
           return true;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1587,7 +1587,13 @@ function hasCommandModifier(event: KeyboardEvent) {
 }
 
 function isNormalModeExitKey(event: KeyboardEvent) {
-  return event.key === "Escape" || (event.ctrlKey && !event.metaKey && !event.altKey && event.key === "[");
+  return event.key === "Escape"
+    || (
+      event.ctrlKey
+      && !event.metaKey
+      && !event.altKey
+      && (event.key === "[" || event.key.toLocaleLowerCase() === "c")
+    );
 }
 
 function readCount(state: VimModeState) {

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -662,6 +662,37 @@ function moveByTextblockFirstNonblank(view: EditorView, delta: -1 | 1, count = 1
   return moveSelection(view, firstNonblankPosition(targetRange), delta);
 }
 
+function countedTextblockRange(state: EditorState, count = 1) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const currentIndex = nearestTextblockIndex(ranges, state.selection.from);
+  const targetIndex = Math.max(0, Math.min(ranges.length - 1, currentIndex + Math.max(0, count - 1)));
+  return ranges[targetIndex] ?? null;
+}
+
+function lastNonblankPosition(range: TextblockRange) {
+  for (let offset = range.text.length - 1; offset >= 0; offset -= 1) {
+    if (/\S/u.test(range.text[offset] ?? "")) return range.start + offset;
+  }
+
+  return range.start;
+}
+
+function textblockNonblankPosition(state: EditorState, side: "first" | "last", count = 1) {
+  const range = countedTextblockRange(state, count);
+  if (!range) return null;
+
+  return side === "first" ? firstNonblankPosition(range) : lastNonblankPosition(range);
+}
+
+function moveToTextblockNonblank(view: EditorView, side: "first" | "last", count = 1) {
+  const target = textblockNonblankPosition(view.state, side, count);
+  if (target === null) return false;
+
+  return moveSelection(view, target, side === "last" ? -1 : 1);
+}
+
 function joinTextblocks(view: EditorView, blockCount = 2) {
   if (!selectionIsTextSelection(view.state)) return false;
 
@@ -1731,6 +1762,9 @@ function resolveMotionTarget(state: EditorState, key: string, count: number, pre
   if (prefix === "g" && key === "E") {
     return range.start + bigWordMotionOffset(range.text, offset, "backward-end", count);
   }
+  if (prefix === "g" && key === "_") {
+    return textblockNonblankPosition(state, "last", count);
+  }
 
   switch (key) {
     case "h":
@@ -1757,6 +1791,8 @@ function resolveMotionTarget(state: EditorState, key: string, count: number, pre
       return range.start;
     case "^":
       return firstNonblankPosition(range);
+    case "_":
+      return textblockNonblankPosition(state, "first", count);
     case "$":
       return range.end;
     default:
@@ -2163,6 +2199,7 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
   if (state.pending === "g") {
     if (key === "e") return extendVisualSelection(view, key, state, "g");
     if (key === "E") return extendVisualSelection(view, key, state, "g");
+    if (key === "_") return extendVisualSelection(view, key, state, "g");
 
     dispatchMeta(
       view,
@@ -2219,6 +2256,7 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
     case "%":
     case "0":
     case "^":
+    case "_":
     case "$":
       return extendVisualSelection(view, key, state);
     default:
@@ -2243,6 +2281,7 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   if (state.pending === "g") {
     if (key === "e") return operateRange(view, operator, key, state, "g");
     if (key === "E") return operateRange(view, operator, key, state, "g");
+    if (key === "_") return operateRange(view, operator, key, state, "g");
 
     dispatchMeta(view, clearedInputMeta());
     return true;
@@ -2298,6 +2337,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     if (key === "g") return lineMotion(view, "first", count);
     if (key === "e") return moveByWord(view, "backward-end", count);
     if (key === "E") return moveByBigWord(view, "backward-end", count);
+    if (key === "_") return moveToTextblockNonblank(view, "last", count);
 
     dispatchMeta(view, clearedInputMeta());
     return true;
@@ -2361,6 +2401,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
         start: view.state.selection.from,
         text: ""
       }), 1);
+    case "_":
+      return moveToTextblockNonblank(view, "first", count);
     case "$":
       return moveToTextblockBoundary(view, "end");
     case "G":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -4,7 +4,7 @@ import { Plugin, PluginKey, TextSelection, type EditorState, type Transaction } 
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 
-export type VimMode = "insert" | "normal";
+export type VimMode = "insert" | "normal" | "visual";
 type VimOperator = "change" | "delete" | "yank";
 type VimFindDirection = "backward" | "forward";
 type VimFindKey = "F" | "T" | "f" | "t";
@@ -36,6 +36,7 @@ type VimModeState = {
   preferredColumn: number | null;
   register: VimRegister | null;
   searchQuery: string;
+  visualAnchor: number | null;
 };
 
 type VimModeMeta = Partial<VimModeState>;
@@ -78,6 +79,7 @@ const vimModeKey = new PluginKey<VimModeState>("markra-vim-mode");
 export const vimModeClassName = "markra-vim-mode";
 export const vimInsertClassName = "markra-vim-insert";
 export const vimNormalClassName = "markra-vim-normal";
+export const vimVisualClassName = "markra-vim-visual";
 
 function vimEnabled(options: VimModePluginOptions) {
   return typeof options.enabled === "function" ? options.enabled() : options.enabled === true;
@@ -87,7 +89,16 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
   const meta = transaction.getMeta(vimModeKey) as VimModeMeta | undefined;
   if (!meta) {
     return transaction.docChanged || transaction.selectionSet
-      ? { ...state, count: "", operator: null, pending: null, preferredColumn: null, searchQuery: "" }
+      ? {
+          ...state,
+          count: "",
+          mode: state.mode === "visual" ? "normal" : state.mode,
+          operator: null,
+          pending: null,
+          preferredColumn: null,
+          searchQuery: "",
+          visualAnchor: null
+        }
       : state;
   }
 
@@ -102,7 +113,8 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
       ? meta.preferredColumn ?? null
       : state.preferredColumn,
     register: Object.hasOwn(meta, "register") ? meta.register ?? null : state.register,
-    searchQuery: Object.hasOwn(meta, "searchQuery") ? meta.searchQuery ?? "" : state.searchQuery
+    searchQuery: Object.hasOwn(meta, "searchQuery") ? meta.searchQuery ?? "" : state.searchQuery,
+    visualAnchor: Object.hasOwn(meta, "visualAnchor") ? meta.visualAnchor ?? null : state.visualAnchor
   };
 }
 
@@ -113,6 +125,7 @@ function clearedInputMeta(meta: VimModeMeta = {}): VimModeMeta {
     pending: null,
     preferredColumn: null,
     searchQuery: "",
+    visualAnchor: null,
     ...meta
   };
 }
@@ -141,7 +154,8 @@ function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
     pending: null,
     preferredColumn: null,
     register: null,
-    searchQuery: ""
+    searchQuery: "",
+    visualAnchor: null
   };
 }
 
@@ -149,7 +163,10 @@ function enterNormalMode(view: EditorView, options: VimModePluginOptions) {
   const state = vimModeKey.getState(view.state) ?? initialVimModeState(options.initialMode);
   let transaction = view.state.tr;
 
-  if (state.mode === "insert" && view.state.selection instanceof TextSelection && view.state.selection.empty) {
+  if (state.mode === "visual" && view.state.selection instanceof TextSelection && !view.state.selection.empty) {
+    const target = visualCursorPosition(view.state.selection, state.visualAnchor ?? view.state.selection.from);
+    transaction = transaction.setSelection(TextSelection.near(transaction.doc.resolve(target), 1));
+  } else if (state.mode === "insert" && view.state.selection instanceof TextSelection && view.state.selection.empty) {
     const range = currentTextblockRange(view.state);
     if (range) {
       const target = view.state.selection.from > range.start
@@ -179,12 +196,13 @@ function updateVimModeClasses(view: EditorView, options: VimModePluginOptions) {
     target.classList.toggle(vimModeClassName, enabled);
     target.classList.toggle(vimInsertClassName, mode === "insert");
     target.classList.toggle(vimNormalClassName, mode === "normal");
+    target.classList.toggle(vimVisualClassName, mode === "visual");
   }
 }
 
 function clearVimModeClasses(view: EditorView) {
   for (const target of vimModeClassTargets(view)) {
-    target.classList.remove(vimModeClassName, vimInsertClassName, vimNormalClassName);
+    target.classList.remove(vimModeClassName, vimInsertClassName, vimNormalClassName, vimVisualClassName);
   }
 }
 
@@ -206,6 +224,32 @@ function moveSelection(view: EditorView, position: number, bias: -1 | 1 = 1, met
   const clamped = Math.max(0, Math.min(view.state.doc.content.size, position));
   const selection = TextSelection.near(view.state.doc.resolve(clamped), bias);
   dispatchTransaction(view, view.state.tr.setSelection(selection), meta);
+  return true;
+}
+
+function visualCursorPosition(selection: TextSelection, anchor: number) {
+  const head = selection.$head.pos;
+  return head > anchor ? Math.max(anchor, head - 1) : head;
+}
+
+// ProseMirror selections use text boundaries; Vim visual mode selects the characters between anchor and cursor.
+function visualTextSelection(state: EditorState, anchor: number, cursor: number) {
+  const clampedAnchor = Math.max(0, Math.min(state.doc.content.size, anchor));
+  const clampedCursor = Math.max(0, Math.min(state.doc.content.size, cursor));
+
+  if (clampedCursor >= clampedAnchor) {
+    return TextSelection.create(state.doc, clampedAnchor, Math.min(state.doc.content.size, clampedCursor + 1));
+  }
+
+  return TextSelection.create(state.doc, Math.min(state.doc.content.size, clampedAnchor + 1), clampedCursor);
+}
+
+function moveVisualSelection(view: EditorView, anchor: number, cursor: number) {
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(visualTextSelection(view.state, anchor, cursor)),
+    clearedInputMeta({ mode: "visual", visualAnchor: anchor })
+  );
   return true;
 }
 
@@ -1376,11 +1420,16 @@ function lineMotion(view: EditorView, key: "first" | "last", count: number) {
   return moveSelection(view, targetRange.start, 1);
 }
 
-function resolveMotionTarget(view: EditorView, key: string, count: number, prefix: string | null = null) {
-  const range = currentTextblockRange(view.state);
+function stateWithCursorAt(state: EditorState, position: number) {
+  const clamped = Math.max(0, Math.min(state.doc.content.size, position));
+  return state.apply(state.tr.setSelection(TextSelection.near(state.doc.resolve(clamped), 1)));
+}
+
+function resolveMotionTarget(state: EditorState, key: string, count: number, prefix: string | null = null) {
+  const range = currentTextblockRange(state);
   if (!range) return null;
 
-  const current = view.state.selection.from;
+  const current = state.selection.from;
   const offset = Math.max(0, Math.min(range.text.length, current - range.start));
 
   if (prefix === "g" && key === "e") {
@@ -1398,19 +1447,19 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
     case "ArrowRight":
       return Math.min(normalTextblockEnd(range), current + count);
     case "w":
-      return wordStartMotionPosition(view.state, "forward", count, "boundary");
+      return wordStartMotionPosition(state, "forward", count, "boundary");
     case "W":
-      return bigWordStartMotionPosition(view.state, "forward", count, "boundary");
+      return bigWordStartMotionPosition(state, "forward", count, "boundary");
     case "e":
       return Math.min(normalTextblockEnd(range), range.start + wordMotionOffset(range.text, offset, "end", count));
     case "E":
       return Math.min(normalTextblockEnd(range), range.start + bigWordMotionOffset(range.text, offset, "end", count));
     case "b":
-      return wordStartMotionPosition(view.state, "backward", count);
+      return wordStartMotionPosition(state, "backward", count);
     case "B":
-      return bigWordStartMotionPosition(view.state, "backward", count);
+      return bigWordStartMotionPosition(state, "backward", count);
     case "%":
-      return matchingPairPosition(view.state);
+      return matchingPairPosition(state);
     case "0":
       return range.start;
     case "^":
@@ -1440,7 +1489,7 @@ function operateRange(view: EditorView, operator: PendingOperator, key: string, 
   let motionKey = key;
   if (changeCurrentWord) motionKey = key === "W" ? "E" : "e";
 
-  const target = resolveMotionTarget(view, motionKey, count, prefix);
+  const target = resolveMotionTarget(view.state, motionKey, count, prefix);
   if (target === null) return false;
 
   let from = view.state.selection.from;
@@ -1666,6 +1715,136 @@ function repeatOperatorSearch(view: EditorView, state: VimModeState, reversed: b
   return operateSearch(view, operator, search, operator.count * readCount(state), state.lastSearch);
 }
 
+function enterVisualMode(view: EditorView, state: VimModeState) {
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const cursor = Math.min(normalTextblockEnd(range), view.state.selection.from);
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(visualTextSelection(view.state, cursor, cursor)),
+    clearedInputMeta({ mode: "visual", register: state.register, visualAnchor: cursor })
+  );
+  return true;
+}
+
+function collapseVisualSelection(view: EditorView, state: VimModeState) {
+  const selection = view.state.selection;
+  if (!(selection instanceof TextSelection)) return false;
+
+  const target = visualCursorPosition(selection, state.visualAnchor ?? selection.from);
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(target), 1)),
+    clearedInputMeta({ mode: "normal", register: state.register })
+  );
+  return true;
+}
+
+function visualSelectionRange(view: EditorView) {
+  const selection = view.state.selection;
+  if (!(selection instanceof TextSelection) || selection.empty) return null;
+
+  return { from: selection.from, to: selection.to };
+}
+
+function yankVisualSelection(view: EditorView, state: VimModeState) {
+  const range = visualSelectionRange(view);
+  if (!range) return collapseVisualSelection(view, state);
+
+  const text = textRange(view, range.from, range.to);
+  dispatchTransaction(
+    view,
+    view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(range.from), 1)),
+    clearedInputMeta({ mode: "normal", register: { kind: "text", text } })
+  );
+  return true;
+}
+
+function deleteVisualSelection(view: EditorView) {
+  const range = visualSelectionRange(view);
+  if (!range) return false;
+
+  return deleteRange(view, range.from, range.to, { mode: "normal" });
+}
+
+function changeVisualSelection(view: EditorView) {
+  const range = visualSelectionRange(view);
+  if (!range) return false;
+
+  return changeRange(view, range.from, range.to);
+}
+
+function visualMotionTarget(state: EditorState, key: string, count: number, prefix: string | null = null) {
+  if (key === "$") {
+    const range = currentTextblockRange(state);
+    return range ? normalTextblockEnd(range) : null;
+  }
+
+  return resolveMotionTarget(state, key, count, prefix);
+}
+
+function extendVisualSelection(view: EditorView, key: string, state: VimModeState, prefix: string | null = null) {
+  const selection = view.state.selection;
+  if (!(selection instanceof TextSelection)) return false;
+
+  const anchor = state.visualAnchor ?? selection.from;
+  const cursor = visualCursorPosition(selection, anchor);
+  const cursorState = stateWithCursorAt(view.state, cursor);
+  const target = visualMotionTarget(cursorState, key, readCount(state), prefix);
+  if (target === null) return true;
+
+  return moveVisualSelection(view, anchor, target);
+}
+
+function handleVisualModeKey(view: EditorView, key: string, state: VimModeState) {
+  if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
+
+  if (state.pending === "g") {
+    if (key === "e") return extendVisualSelection(view, key, state, "g");
+    if (key === "E") return extendVisualSelection(view, key, state, "g");
+
+    dispatchMeta(view, clearedInputMeta({ mode: "visual", visualAnchor: state.visualAnchor }));
+    return true;
+  }
+
+  switch (key) {
+    case "v":
+      return collapseVisualSelection(view, state);
+    case "y":
+      return yankVisualSelection(view, state);
+    case "d":
+    case "x":
+      return deleteVisualSelection(view);
+    case "Backspace":
+    case "Delete":
+    case "Enter":
+      return true;
+    case "c":
+      return changeVisualSelection(view);
+    case "g":
+      dispatchMeta(view, { pending: "g" });
+      return true;
+    case "h":
+    case "ArrowLeft":
+    case "l":
+    case "ArrowRight":
+    case "w":
+    case "W":
+    case "e":
+    case "E":
+    case "b":
+    case "B":
+    case "%":
+    case "0":
+    case "^":
+    case "$":
+      return extendVisualSelection(view, key, state);
+    default:
+      return key.length === 1;
+  }
+}
+
 function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   const operator = state.operator;
   if (!operator) return false;
@@ -1821,6 +2000,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return repeatSearch(view, state, count, false);
     case "N":
       return repeatSearch(view, state, count, true);
+    case "v":
+      return enterVisualMode(view, state);
     case "d":
       return beginOperator(view, "delete", state);
     case "y":
@@ -1892,9 +2073,11 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
         if (event.isComposing) return false;
 
         const state = vimModeKey.getState(view.state) ?? initialVimModeState(options.initialMode ?? "insert");
-        if (state.mode !== "normal") return false;
+        if (state.mode === "insert") return false;
 
         if (hasCommandModifier(event)) {
+          if (state.mode !== "normal") return false;
+
           const handled = handleNormalModeModifiedKey(view, event);
           if (!handled) return false;
 
@@ -1902,7 +2085,9 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
           return true;
         }
 
-        const handled = handleNormalModeKey(view, event.key, state);
+        const handled = state.mode === "visual"
+          ? handleVisualModeKey(view, event.key, state)
+          : handleNormalModeKey(view, event.key, state);
         if (!handled) return false;
 
         event.preventDefault();
@@ -1912,7 +2097,7 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
         if (!vimEnabled(options)) return false;
 
         const state = vimModeKey.getState(view.state);
-        return state?.mode === "normal";
+        return state?.mode === "normal" || state?.mode === "visual";
       }
     },
     view: (view) => {

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -2375,6 +2375,14 @@ function visualLineMotionTarget(state: EditorState, cursor: number, delta: -1 | 
   return ranges[targetIndex]?.start ?? null;
 }
 
+function visualAbsoluteLineMotionTarget(state: EditorState, key: "first" | "last", count: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  const targetIndex = targetLineMotionIndex(ranges, key, count);
+  return ranges[targetIndex]?.start ?? null;
+}
+
 function extendVisualSelection(view: EditorView, key: string, state: VimModeState, prefix: string | null = null) {
   const selection = view.state.selection;
   if (!(selection instanceof TextSelection)) return false;
@@ -2384,9 +2392,13 @@ function extendVisualSelection(view: EditorView, key: string, state: VimModeStat
   const kind = state.visualKind ?? "character";
   const count = readCount(state);
   const lineDelta = key === "j" || key === "ArrowDown" ? 1 : key === "k" || key === "ArrowUp" ? -1 : null;
-  const target = kind === "line" && lineDelta !== null
-    ? visualLineMotionTarget(view.state, cursor, lineDelta, count)
-    : visualMotionTarget(stateWithCursorAt(view.state, cursor), key, count, prefix);
+  const absoluteLineKey: "first" | "last" | null =
+    key === "G" ? "last" : prefix === "g" && key === "g" ? "first" : null;
+  const target = absoluteLineKey
+    ? visualAbsoluteLineMotionTarget(view.state, absoluteLineKey, count)
+    : kind === "line" && lineDelta !== null
+      ? visualLineMotionTarget(view.state, cursor, lineDelta, count)
+      : visualMotionTarget(stateWithCursorAt(view.state, cursor), key, count, prefix);
   if (target === null) return true;
 
   return moveVisualSelection(view, anchor, target, kind);
@@ -2398,6 +2410,7 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
   if (state.pending === "g") {
+    if (key === "g") return extendVisualSelection(view, key, state, "g");
     if (key === "e") return extendVisualSelection(view, key, state, "g");
     if (key === "E") return extendVisualSelection(view, key, state, "g");
     if (key === "_") return extendVisualSelection(view, key, state, "g");
@@ -2472,6 +2485,7 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
     case "^":
     case "_":
     case "$":
+    case "G":
       return extendVisualSelection(view, key, state);
     default:
       return key.length === 1;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -9,9 +9,15 @@ type VimOperator = "change" | "delete" | "yank";
 type VimFindDirection = "backward" | "forward";
 type VimFindKey = "F" | "T" | "f" | "t";
 type VimTextObjectPending = "text-object-around" | "text-object-inner";
+type VimPairTextObjectKey = "(" | ")" | "[" | "]" | "{" | "}";
 type VimQuoteTextObjectKey = "'" | '"' | "`";
 type VimTextObjectScope = "around" | "inner";
 type WordClassifier = (character: string) => boolean;
+
+type VimPairDelimiters = {
+  close: ")" | "]" | "}";
+  open: "(" | "[" | "{";
+};
 
 export type VimModePluginOptions = {
   enabled?: boolean | (() => boolean);
@@ -214,6 +220,16 @@ function textObjectScopeFromPending(pending: VimTextObjectPending): VimTextObjec
 
 function isQuoteTextObjectKey(key: string): key is VimQuoteTextObjectKey {
   return key === '"' || key === "'" || key === "`";
+}
+
+function isPairTextObjectKey(key: string): key is VimPairTextObjectKey {
+  return key === "(" || key === ")" || key === "[" || key === "]" || key === "{" || key === "}";
+}
+
+function pairDelimitersFromKey(key: VimPairTextObjectKey): VimPairDelimiters {
+  if (key === "(" || key === ")") return { close: ")", open: "(" };
+  if (key === "[" || key === "]") return { close: "]", open: "[" };
+  return { close: "}", open: "{" };
 }
 
 function characterFindFromKey(key: VimFindKey, character: string): VimCharacterFind {
@@ -555,6 +571,50 @@ function quoteTextObjectRange(state: EditorState, scope: VimTextObjectScope, del
 
   const start = scope === "inner" ? startDelimiter + 1 : startDelimiter;
   const end = scope === "inner" ? endDelimiter : endDelimiter + 1;
+  if (start > end) return null;
+
+  return {
+    end: range.start + end,
+    start: range.start + start
+  };
+}
+
+function enclosingPairOffsets(text: string, delimiters: VimPairDelimiters, offset: number) {
+  const stack: number[] = [];
+  let enclosing: { end: number; start: number } | null = null;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+
+    if (character === delimiters.open) {
+      stack.push(index);
+      continue;
+    }
+
+    if (character !== delimiters.close) continue;
+
+    const start = stack.pop();
+    if (start === undefined) continue;
+    if (start > offset || index < offset) continue;
+
+    if (!enclosing || index - start < enclosing.end - enclosing.start) {
+      enclosing = { end: index, start };
+    }
+  }
+
+  return enclosing;
+}
+
+function pairTextObjectRange(state: EditorState, scope: VimTextObjectScope, key: VimPairTextObjectKey) {
+  const range = currentTextblockRange(state);
+  if (!range) return null;
+
+  const offset = Math.max(0, Math.min(range.text.length - 1, state.selection.from - range.start));
+  const pair = enclosingPairOffsets(range.text, pairDelimitersFromKey(key), offset);
+  if (!pair) return null;
+
+  const start = scope === "inner" ? pair.start + 1 : pair.start;
+  const end = scope === "inner" ? pair.end : pair.end + 1;
   if (start > end) return null;
 
   return {
@@ -1285,6 +1345,7 @@ function handleRepeatedOperatorFind(view: EditorView, key: string, state: VimMod
 function textObjectRange(state: EditorState, scope: VimTextObjectScope, key: string, count: number) {
   if (key === "w") return wordTextObjectRange(state, scope, count);
   if (isQuoteTextObjectKey(key)) return quoteTextObjectRange(state, scope, key);
+  if (isPairTextObjectKey(key)) return pairTextObjectRange(state, scope, key);
 
   return null;
 }

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -232,6 +232,14 @@ function pairDelimitersFromKey(key: VimPairTextObjectKey): VimPairDelimiters {
   return { close: "}", open: "{" };
 }
 
+function pairDelimitersAtCharacter(character: string): VimPairDelimiters | null {
+  if (character === "(" || character === ")") return { close: ")", open: "(" };
+  if (character === "[" || character === "]") return { close: "]", open: "[" };
+  if (character === "{" || character === "}") return { close: "}", open: "{" };
+
+  return null;
+}
+
 function characterFindFromKey(key: VimFindKey, character: string): VimCharacterFind {
   return {
     character,
@@ -603,6 +611,43 @@ function enclosingPairOffsets(text: string, delimiters: VimPairDelimiters, offse
   }
 
   return enclosing;
+}
+
+function matchingPairOffset(text: string, offset: number) {
+  const character = text[offset] ?? "";
+  const delimiters = pairDelimitersAtCharacter(character);
+  if (!delimiters) return null;
+
+  if (character === delimiters.open) {
+    let depth = 0;
+    for (let index = offset; index < text.length; index += 1) {
+      if (text[index] === delimiters.open) depth += 1;
+      else if (text[index] === delimiters.close) depth -= 1;
+
+      if (depth === 0) return index;
+    }
+
+    return null;
+  }
+
+  let depth = 0;
+  for (let index = offset; index >= 0; index -= 1) {
+    if (text[index] === delimiters.close) depth += 1;
+    else if (text[index] === delimiters.open) depth -= 1;
+
+    if (depth === 0) return index;
+  }
+
+  return null;
+}
+
+function matchingPairPosition(state: EditorState) {
+  const range = currentTextblockRange(state);
+  if (!range) return null;
+
+  const offset = Math.max(0, Math.min(range.text.length - 1, state.selection.from - range.start));
+  const targetOffset = matchingPairOffset(range.text, offset);
+  return targetOffset === null ? null : range.start + targetOffset;
 }
 
 function pairTextObjectRange(state: EditorState, scope: VimTextObjectScope, key: VimPairTextObjectKey) {
@@ -1249,6 +1294,8 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
       return wordStartMotionPosition(view.state, "backward", count);
     case "B":
       return bigWordStartMotionPosition(view.state, "backward", count);
+    case "%":
+      return matchingPairPosition(view.state);
     case "0":
       return range.start;
     case "^":
@@ -1281,10 +1328,14 @@ function operateRange(view: EditorView, operator: PendingOperator, key: string, 
   const target = resolveMotionTarget(view, motionKey, count, prefix);
   if (target === null) return false;
 
-  const from = view.state.selection.from;
-  const to = (key === "e" || key === "E" || changeCurrentWord) && target >= from
+  let from = view.state.selection.from;
+  let to = (key === "e" || key === "E" || changeCurrentWord) && target >= from
     ? Math.min(view.state.doc.content.size, target + 1)
     : target;
+  if (key === "%") {
+    from = Math.min(view.state.selection.from, target);
+    to = Math.min(view.state.doc.content.size, Math.max(view.state.selection.from, target) + 1);
+  }
   if (operator.type === "change") return changeRange(view, from, to);
   return operator.type === "delete" ? deleteRange(view, from, to) : yankRange(view, from, to);
 }
@@ -1510,6 +1561,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return moveByWord(view, "backward", count);
     case "B":
       return moveByBigWord(view, "backward", count);
+    case "%":
+      return moveSelection(view, matchingPairPosition(view.state) ?? view.state.selection.from, 1);
     case "0":
       return moveToTextblockBoundary(view, "start");
     case "^":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -213,8 +213,14 @@ function enterNormalMode(view: EditorView, options: VimModePluginOptions) {
   } else if (state.mode === "insert" && view.state.selection instanceof TextSelection && view.state.selection.empty) {
     const range = currentTextblockRange(view.state);
     if (range) {
-      const target = view.state.selection.from > range.start
-        ? Math.max(range.start, view.state.selection.from - 1)
+      const insertRepeatText = repeatedDirectInsertText(state.pendingInsertChangeKeys, state.pendingInsertText);
+      const selectionPosition = view.state.selection.from + insertRepeatText.length;
+      if (insertRepeatText.length > 0) {
+        transaction = transaction.insertText(insertRepeatText, view.state.selection.from, view.state.selection.from);
+      }
+
+      const target = selectionPosition > range.start
+        ? Math.max(range.start, selectionPosition - 1)
         : range.start;
       transaction = transaction.setSelection(TextSelection.near(transaction.doc.resolve(target), -1));
     }
@@ -1619,6 +1625,35 @@ function repeatableChangeStartKeys(state: VimModeState, key: string) {
   return [...state.count, key];
 }
 
+function leadingCountEndIndex(keys: readonly string[]) {
+  let index = 0;
+
+  while (index < keys.length) {
+    const key = keys[index] ?? "";
+    if (!/^[0-9]$/u.test(key) || (key === "0" && index === 0)) break;
+    index += 1;
+  }
+
+  return index;
+}
+
+function directInsertRepeatCount(keys: readonly string[] | null) {
+  if (!keys) return 1;
+
+  const countEndIndex = leadingCountEndIndex(keys);
+  const command = keys[countEndIndex];
+  if (command !== "A" && command !== "I" && command !== "a" && command !== "i") return 1;
+
+  const count = Number.parseInt(keys.slice(0, countEndIndex).join(""), 10);
+  return Number.isFinite(count) && count > 1 ? count : 1;
+}
+
+function repeatedDirectInsertText(keys: readonly string[] | null, text: string, offset = 1) {
+  const repeatCount = directInsertRepeatCount(keys);
+  const repeats = Math.max(0, repeatCount - offset);
+  return repeats > 0 ? text.repeat(repeats) : "";
+}
+
 function changeIsWaitingForMoreKeys(state: VimModeState | undefined) {
   return Boolean(state?.operator || state?.pending);
 }
@@ -1674,8 +1709,9 @@ function repeatLastChange(view: EditorView, keys: readonly string[], text: strin
     if (state?.mode !== "insert") return false;
 
     const { from, to } = view.state.selection;
-    const transaction = view.state.tr.insertText(text, from, to);
-    const position = Math.max(from, from + text.length - 1);
+    const insertion = text + repeatedDirectInsertText(keys, text);
+    const transaction = view.state.tr.insertText(insertion, from, to);
+    const position = Math.max(from, from + insertion.length - 1);
     dispatchTransaction(
       view,
       transaction.setSelection(TextSelection.near(transaction.doc.resolve(position), 1)),

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -648,6 +648,20 @@ function moveByTextblock(view: EditorView, delta: -1 | 1, count = 1, preferredCo
   return moveSelection(view, targetRange.start + targetOffset, delta, clearedInputMeta({ preferredColumn: offset }));
 }
 
+function moveByTextblockFirstNonblank(view: EditorView, delta: -1 | 1, count = 1) {
+  if (!selectionIsTextSelection(view.state)) return false;
+
+  const ranges = textblockRanges(view.state);
+  if (ranges.length === 0) return false;
+
+  const currentIndex = nearestTextblockIndex(ranges, view.state.selection.from);
+  const targetIndex = Math.max(0, Math.min(ranges.length - 1, currentIndex + delta * count));
+  const targetRange = ranges[targetIndex];
+  if (!targetRange) return false;
+
+  return moveSelection(view, firstNonblankPosition(targetRange), delta);
+}
+
 function joinTextblocks(view: EditorView, blockCount = 2) {
   if (!selectionIsTextSelection(view.state)) return false;
 
@@ -2315,10 +2329,14 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "J":
       return joinTextblocks(view, count);
     case "Delete":
-    case "Enter":
       return true;
     case "Backspace":
       return moveByCharacter(view, -1, count);
+    case "Enter":
+    case "+":
+      return moveByTextblockFirstNonblank(view, 1, count);
+    case "-":
+      return moveByTextblockFirstNonblank(view, -1, count);
     case "w":
       return moveByWord(view, "forward", count);
     case "W":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1339,8 +1339,8 @@ function substituteCharacters(view: EditorView, count = 1) {
   return changeRange(view, from, to);
 }
 
-function operateToTextblockEnd(view: EditorView, operator: VimOperator) {
-  const range = currentTextblockRange(view.state);
+function operateToTextblockEnd(view: EditorView, operator: VimOperator, count = 1) {
+  const range = countedTextblockRange(view.state, count);
   if (!range) return false;
 
   const from = view.state.selection.from;
@@ -2571,9 +2571,9 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "c":
       return beginOperator(view, "change", state);
     case "D":
-      return operateToTextblockEnd(view, "delete");
+      return operateToTextblockEnd(view, "delete", count);
     case "C":
-      return operateToTextblockEnd(view, "change");
+      return operateToTextblockEnd(view, "change", count);
     case "p":
       return pasteRegister(view, "after", count, state.register);
     case "P":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -312,6 +312,21 @@ function previousWordEndOffset(text: string, offset: number) {
   return 0;
 }
 
+function firstWordStartOffset(text: string) {
+  const match = /[\p{L}\p{N}_]/u.exec(text);
+  return match?.index ?? null;
+}
+
+function lastWordStartOffset(text: string) {
+  let offset = text.length - 1;
+
+  while (offset > 0 && !isWordCharacter(text[offset] ?? "")) offset -= 1;
+  if (!isWordCharacter(text[offset] ?? "")) return null;
+
+  while (offset > 0 && isWordCharacter(text[offset - 1] ?? "")) offset -= 1;
+  return offset;
+}
+
 function wordMotionOffset(text: string, offset: number, direction: "forward" | "end" | "backward" | "backward-end", count: number) {
   let next = offset;
 
@@ -325,7 +340,82 @@ function wordMotionOffset(text: string, offset: number, direction: "forward" | "
   return next;
 }
 
+function nextTextblockWordStart(ranges: readonly TextblockRange[], currentIndex: number) {
+  for (let index = currentIndex + 1; index < ranges.length; index += 1) {
+    const range = ranges[index];
+    if (!range) continue;
+
+    const offset = firstWordStartOffset(range.text);
+    if (offset !== null) return { index, position: range.start + offset };
+  }
+
+  return null;
+}
+
+function previousTextblockWordStart(ranges: readonly TextblockRange[], currentIndex: number) {
+  for (let index = currentIndex - 1; index >= 0; index -= 1) {
+    const range = ranges[index];
+    if (!range) continue;
+
+    const offset = lastWordStartOffset(range.text);
+    if (offset !== null) return { index, position: range.start + offset };
+  }
+
+  return null;
+}
+
+function wordStartMotionPosition(state: EditorState, direction: "forward" | "backward", count: number) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  let currentIndex = currentTextblockIndex(state, ranges);
+  let position = state.selection.from;
+
+  for (let step = 0; step < count; step += 1) {
+    const range = ranges[currentIndex];
+    if (!range) return null;
+
+    const offset = Math.max(0, Math.min(range.text.length, position - range.start));
+
+    if (direction === "forward") {
+      const targetOffset = nextWordStartOffset(range.text, offset);
+      if (targetOffset < range.text.length) {
+        position = range.start + targetOffset;
+        continue;
+      }
+
+      const next = nextTextblockWordStart(ranges, currentIndex);
+      if (!next) return normalTextblockEnd(range);
+
+      currentIndex = next.index;
+      position = next.position;
+      continue;
+    }
+
+    const targetOffset = previousWordStartOffset(range.text, offset);
+    if (targetOffset < offset) {
+      position = range.start + targetOffset;
+      continue;
+    }
+
+    const previous = previousTextblockWordStart(ranges, currentIndex);
+    if (!previous) return range.start;
+
+    currentIndex = previous.index;
+    position = previous.position;
+  }
+
+  return position;
+}
+
 function moveByWord(view: EditorView, direction: "forward" | "end" | "backward" | "backward-end", count = 1) {
+  if (direction === "forward" || direction === "backward") {
+    const target = wordStartMotionPosition(view.state, direction, count);
+    if (target === null) return false;
+
+    return moveSelection(view, target, direction === "backward" ? -1 : 1);
+  }
+
   const range = currentTextblockRange(view.state);
   if (!range) return false;
 
@@ -333,7 +423,7 @@ function moveByWord(view: EditorView, direction: "forward" | "end" | "backward" 
   const targetOffset = wordMotionOffset(range.text, offset, direction, count);
   const target = Math.min(normalTextblockEnd(range), range.start + targetOffset);
 
-  return moveSelection(view, target, direction === "backward" || direction === "backward-end" ? -1 : 1);
+  return moveSelection(view, target, direction === "backward-end" ? -1 : 1);
 }
 
 function deleteCharacter(view: EditorView, count = 1) {

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -1466,13 +1466,19 @@ function repeatableChangeStartKeys(state: VimModeState, key: string) {
   if (state.pendingChangeKeys) return [...state.pendingChangeKeys, key];
   // Insert-text changes need typed text capture before they can be faithfully replayed.
   if (
+    key !== "A" &&
     key !== "C" &&
     key !== "D" &&
+    key !== "I" &&
     key !== "J" &&
+    key !== "O" &&
     key !== "P" &&
     key !== "S" &&
+    key !== "a" &&
     key !== "c" &&
     key !== "d" &&
+    key !== "i" &&
+    key !== "o" &&
     key !== "p" &&
     key !== "r" &&
     key !== "s" &&
@@ -1506,6 +1512,17 @@ function recordRepeatableChange(view: EditorView, previousState: VimModeState, k
     }
 
     dispatchMeta(view, { lastChangeKeys: changeKeys, lastChangeText: null, pendingChangeKeys: null });
+    return;
+  }
+
+  if (nextState?.mode === "insert") {
+    dispatchMeta(view, {
+      lastChangeKeys: null,
+      lastChangeText: null,
+      pendingChangeKeys: null,
+      pendingInsertChangeKeys: changeKeys,
+      pendingInsertText: ""
+    });
     return;
   }
 

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -6,6 +6,8 @@ import { $prose } from "@milkdown/kit/utils";
 
 export type VimMode = "insert" | "normal";
 type VimOperator = "change" | "delete" | "yank";
+type VimFindDirection = "backward" | "forward";
+type VimFindKey = "F" | "T" | "f" | "t";
 
 export type VimModePluginOptions = {
   enabled?: boolean | (() => boolean);
@@ -14,6 +16,7 @@ export type VimModePluginOptions = {
 
 type VimModeState = {
   count: string;
+  lastFind: VimCharacterFind | null;
   mode: VimMode;
   operator: PendingOperator | null;
   pending: string | null;
@@ -34,6 +37,12 @@ type TextblockRange = {
 type PendingOperator = {
   count: number;
   type: VimOperator;
+};
+
+type VimCharacterFind = {
+  character: string;
+  direction: VimFindDirection;
+  till: boolean;
 };
 
 type VimRegister =
@@ -65,6 +74,7 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
 
   return {
     count: Object.hasOwn(meta, "count") ? meta.count ?? "" : state.count,
+    lastFind: Object.hasOwn(meta, "lastFind") ? meta.lastFind ?? null : state.lastFind,
     mode: meta.mode ?? state.mode,
     operator: Object.hasOwn(meta, "operator") ? meta.operator ?? null : state.operator,
     pending: Object.hasOwn(meta, "pending") ? meta.pending ?? null : state.pending,
@@ -102,6 +112,7 @@ function dispatchTransaction(view: EditorView, transaction: Transaction, meta: V
 function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
   return {
     count: "",
+    lastFind: null,
     mode: initialMode,
     operator: null,
     pending: null,
@@ -183,6 +194,78 @@ function moveByCharacter(view: EditorView, delta: -1 | 1, count = 1) {
   const limitEnd = normalTextblockEnd(range);
   const target = Math.max(range.start, Math.min(limitEnd, view.state.selection.from + delta * count));
   return moveSelection(view, target, delta);
+}
+
+function isFindKey(key: string): key is VimFindKey {
+  return key === "f" || key === "F" || key === "t" || key === "T";
+}
+
+function characterFindFromKey(key: VimFindKey, character: string): VimCharacterFind {
+  return {
+    character,
+    direction: key === "f" || key === "t" ? "forward" : "backward",
+    till: key === "t" || key === "T"
+  };
+}
+
+function reversedCharacterFind(find: VimCharacterFind): VimCharacterFind {
+  return {
+    ...find,
+    direction: find.direction === "forward" ? "backward" : "forward"
+  };
+}
+
+function findCharacterOffset(text: string, find: VimCharacterFind, offset: number, count: number) {
+  let remaining = Math.max(1, count);
+
+  if (find.direction === "forward") {
+    for (let index = offset + 1; index < text.length; index += 1) {
+      if (text[index] !== find.character) continue;
+      remaining -= 1;
+      if (remaining === 0) return index;
+    }
+
+    return null;
+  }
+
+  for (let index = offset - 1; index >= 0; index -= 1) {
+    if (text[index] !== find.character) continue;
+    remaining -= 1;
+    if (remaining === 0) return index;
+  }
+
+  return null;
+}
+
+function characterFindTarget(state: EditorState, find: VimCharacterFind, count: number) {
+  const range = currentTextblockRange(state);
+  if (!range) return null;
+
+  const offset = Math.max(0, Math.min(range.text.length - 1, state.selection.from - range.start));
+  const foundOffset = findCharacterOffset(range.text, find, offset, count);
+  if (foundOffset === null) return null;
+
+  const targetOffset = find.till
+    ? foundOffset + (find.direction === "forward" ? -1 : 1)
+    : foundOffset;
+  if (targetOffset < 0 || targetOffset >= range.text.length) return null;
+
+  return range.start + targetOffset;
+}
+
+function moveByCharacterFind(view: EditorView, find: VimCharacterFind, count: number, meta: VimModeMeta = {}) {
+  const target = characterFindTarget(view.state, find, count);
+  if (target === null) {
+    dispatchMeta(view, clearedInputMeta(meta));
+    return true;
+  }
+
+  return moveSelection(
+    view,
+    target,
+    find.direction === "backward" ? -1 : 1,
+    clearedInputMeta(meta)
+  );
 }
 
 function textblockRangesFromDoc(doc: ProseNode) {
@@ -633,7 +716,7 @@ function textRange(view: EditorView, from: number, to: number) {
   return view.state.doc.textBetween(Math.min(from, to), Math.max(from, to), "\n");
 }
 
-function deleteRange(view: EditorView, from: number, to: number) {
+function deleteRange(view: EditorView, from: number, to: number, meta: VimModeMeta = {}) {
   const start = Math.min(from, to);
   const end = Math.max(from, to);
   if (start === end) return false;
@@ -641,12 +724,12 @@ function deleteRange(view: EditorView, from: number, to: number) {
   dispatchTransaction(
     view,
     view.state.tr.delete(start, end),
-    clearedInputMeta({ register: { kind: "text", text: textRange(view, start, end) } })
+    clearedInputMeta({ ...meta, register: { kind: "text", text: textRange(view, start, end) } })
   );
   return true;
 }
 
-function changeRange(view: EditorView, from: number, to: number) {
+function changeRange(view: EditorView, from: number, to: number, meta: VimModeMeta = {}) {
   const start = Math.min(from, to);
   const end = Math.max(from, to);
   if (start === end) return false;
@@ -657,17 +740,17 @@ function changeRange(view: EditorView, from: number, to: number) {
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ mode: "insert", register: { kind: "text", text } })
+    clearedInputMeta({ ...meta, mode: "insert", register: { kind: "text", text } })
   );
   return true;
 }
 
-function yankRange(view: EditorView, from: number, to: number) {
+function yankRange(view: EditorView, from: number, to: number, meta: VimModeMeta = {}) {
   const start = Math.min(from, to);
   const end = Math.max(from, to);
   if (start === end) return false;
 
-  dispatchMeta(view, clearedInputMeta({ register: { kind: "text", text: textRange(view, start, end) } }));
+  dispatchMeta(view, clearedInputMeta({ ...meta, register: { kind: "text", text: textRange(view, start, end) } }));
   return true;
 }
 
@@ -862,9 +945,87 @@ function operateRange(view: EditorView, operator: PendingOperator, key: string, 
   return operator.type === "delete" ? deleteRange(view, from, to) : yankRange(view, from, to);
 }
 
+function operateCharacterFind(
+  view: EditorView,
+  operator: PendingOperator,
+  find: VimCharacterFind,
+  count: number,
+  meta: VimModeMeta = {}
+) {
+  const target = characterFindTarget(view.state, find, count);
+  if (target === null) {
+    dispatchMeta(view, clearedInputMeta(meta));
+    return true;
+  }
+
+  const from = view.state.selection.from;
+  const to = find.direction === "forward" && target >= from
+    ? Math.min(view.state.doc.content.size, target + 1)
+    : target;
+
+  if (operator.type === "change") return changeRange(view, from, to, meta);
+  return operator.type === "delete" ? deleteRange(view, from, to, meta) : yankRange(view, from, to, meta);
+}
+
+function handlePendingOperatorFind(view: EditorView, key: string, state: VimModeState) {
+  const operator = state.operator;
+  const pending = state.pending;
+  if (!operator || !pending || !isFindKey(pending)) return false;
+
+  if (key.length !== 1) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const find = characterFindFromKey(pending, key);
+  return operateCharacterFind(
+    view,
+    operator,
+    find,
+    operator.count * readCount(state),
+    { lastFind: find }
+  );
+}
+
+function handleRepeatedOperatorFind(view: EditorView, key: string, state: VimModeState) {
+  const operator = state.operator;
+  if (!operator || !state.lastFind) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const find = key === "," ? reversedCharacterFind(state.lastFind) : state.lastFind;
+  return operateCharacterFind(view, operator, find, operator.count * readCount(state));
+}
+
+function handlePendingNormalFind(view: EditorView, key: string, state: VimModeState) {
+  const pending = state.pending;
+  if (!pending || !isFindKey(pending)) return false;
+
+  if (key.length !== 1) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const find = characterFindFromKey(pending, key);
+  return moveByCharacterFind(view, find, readCount(state), { lastFind: find });
+}
+
+function handleRepeatedNormalFind(view: EditorView, key: string, state: VimModeState) {
+  if (!state.lastFind) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const find = key === "," ? reversedCharacterFind(state.lastFind) : state.lastFind;
+  return moveByCharacterFind(view, find, readCount(state));
+}
+
 function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   const operator = state.operator;
   if (!operator) return false;
+
+  if (isFindKey(state.pending ?? "")) return handlePendingOperatorFind(view, key, state);
 
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
@@ -884,6 +1045,13 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
     return true;
   }
 
+  if (isFindKey(key)) {
+    dispatchMeta(view, { pending: key });
+    return true;
+  }
+
+  if (key === ";" || key === ",") return handleRepeatedOperatorFind(view, key, state);
+
   if (operateRange(view, operator, key, state)) return true;
 
   dispatchMeta(view, clearedInputMeta());
@@ -894,6 +1062,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
   if (state.operator) return handleOperatorKey(view, key, state);
 
   if (state.pending === "r") return replaceCharacters(view, key, readCount(state));
+  if (isFindKey(state.pending ?? "")) return handlePendingNormalFind(view, key, state);
 
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
@@ -958,6 +1127,15 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     case "g":
       dispatchMeta(view, { pending: "g" });
       return true;
+    case "f":
+    case "F":
+    case "t":
+    case "T":
+      dispatchMeta(view, { pending: key });
+      return true;
+    case ";":
+    case ",":
+      return handleRepeatedNormalFind(view, key, state);
     case "d":
       return beginOperator(view, "delete", state);
     case "y":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -948,6 +948,8 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return true;
     case "s":
       return substituteCharacters(view, count);
+    case "S":
+      return changeCurrentTextblock(view, count);
     case "o":
       return insertParagraphNearTextblock(view, "after");
     case "O":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -10,6 +10,7 @@ type VimFindDirection = "backward" | "forward";
 type VimFindKey = "F" | "T" | "f" | "t";
 type VimTextObjectPending = "text-object-around" | "text-object-inner";
 type VimTextObjectScope = "around" | "inner";
+type WordClassifier = (character: string) => boolean;
 
 export type VimModePluginOptions = {
   enabled?: boolean | (() => boolean);
@@ -402,6 +403,69 @@ function isWhitespaceCharacter(character: string) {
   return /\s/u.test(character);
 }
 
+function isBigWordCharacter(character: string) {
+  return character.length > 0 && !isWhitespaceCharacter(character);
+}
+
+function nextClassifiedWordStartOffset(text: string, offset: number, isCharacter: WordClassifier) {
+  let next = Math.max(0, Math.min(text.length, offset));
+
+  while (next < text.length && isCharacter(text[next] ?? "")) next += 1;
+  while (next < text.length && !isCharacter(text[next] ?? "")) next += 1;
+
+  return next;
+}
+
+function nextClassifiedWordEndOffset(text: string, offset: number, isCharacter: WordClassifier) {
+  let next = Math.max(0, Math.min(text.length - 1, offset));
+
+  if (isCharacter(text[next] ?? "")) {
+    while (next < text.length - 1 && isCharacter(text[next + 1] ?? "")) next += 1;
+    return next;
+  }
+
+  while (next < text.length && !isCharacter(text[next] ?? "")) next += 1;
+  while (next < text.length - 1 && isCharacter(text[next + 1] ?? "")) next += 1;
+
+  return Math.max(0, Math.min(text.length - 1, next));
+}
+
+function previousClassifiedWordStartOffset(text: string, offset: number, isCharacter: WordClassifier) {
+  let previous = Math.max(0, Math.min(text.length, offset) - 1);
+
+  while (previous > 0 && !isCharacter(text[previous] ?? "")) previous -= 1;
+  while (previous > 0 && isCharacter(text[previous - 1] ?? "")) previous -= 1;
+
+  return previous;
+}
+
+function previousClassifiedWordEndOffset(text: string, offset: number, isCharacter: WordClassifier) {
+  let previous = Math.max(0, Math.min(text.length, offset) - 1);
+
+  while (previous > 0 && !isCharacter(text[previous] ?? "")) previous -= 1;
+  if (previous > 0 && isCharacter(text[previous] ?? "")) return previous;
+
+  return 0;
+}
+
+function firstClassifiedWordStartOffset(text: string, isCharacter: WordClassifier) {
+  for (let offset = 0; offset < text.length; offset += 1) {
+    if (isCharacter(text[offset] ?? "")) return offset;
+  }
+
+  return null;
+}
+
+function lastClassifiedWordStartOffset(text: string, isCharacter: WordClassifier) {
+  let offset = text.length - 1;
+
+  while (offset > 0 && !isCharacter(text[offset] ?? "")) offset -= 1;
+  if (!isCharacter(text[offset] ?? "")) return null;
+
+  while (offset > 0 && isCharacter(text[offset - 1] ?? "")) offset -= 1;
+  return offset;
+}
+
 function wordRangeAtOffset(text: string, offset: number) {
   if (text.length === 0) return null;
 
@@ -458,59 +522,51 @@ function wordTextObjectRange(state: EditorState, scope: VimTextObjectScope, coun
 }
 
 function nextWordStartOffset(text: string, offset: number) {
-  let next = Math.max(0, Math.min(text.length, offset));
+  return nextClassifiedWordStartOffset(text, offset, isWordCharacter);
+}
 
-  while (next < text.length && isWordCharacter(text[next] ?? "")) next += 1;
-  while (next < text.length && !isWordCharacter(text[next] ?? "")) next += 1;
-
-  return next;
+function nextBigWordStartOffset(text: string, offset: number) {
+  return nextClassifiedWordStartOffset(text, offset, isBigWordCharacter);
 }
 
 function nextWordEndOffset(text: string, offset: number) {
-  let next = Math.max(0, Math.min(text.length - 1, offset));
+  return nextClassifiedWordEndOffset(text, offset, isWordCharacter);
+}
 
-  if (isWordCharacter(text[next] ?? "")) {
-    while (next < text.length - 1 && isWordCharacter(text[next + 1] ?? "")) next += 1;
-    return next;
-  }
-
-  while (next < text.length && !isWordCharacter(text[next] ?? "")) next += 1;
-  while (next < text.length - 1 && isWordCharacter(text[next + 1] ?? "")) next += 1;
-
-  return Math.max(0, Math.min(text.length - 1, next));
+function nextBigWordEndOffset(text: string, offset: number) {
+  return nextClassifiedWordEndOffset(text, offset, isBigWordCharacter);
 }
 
 function previousWordStartOffset(text: string, offset: number) {
-  let previous = Math.max(0, Math.min(text.length, offset) - 1);
+  return previousClassifiedWordStartOffset(text, offset, isWordCharacter);
+}
 
-  while (previous > 0 && !isWordCharacter(text[previous] ?? "")) previous -= 1;
-  while (previous > 0 && isWordCharacter(text[previous - 1] ?? "")) previous -= 1;
-
-  return previous;
+function previousBigWordStartOffset(text: string, offset: number) {
+  return previousClassifiedWordStartOffset(text, offset, isBigWordCharacter);
 }
 
 function previousWordEndOffset(text: string, offset: number) {
-  let previous = Math.max(0, Math.min(text.length, offset) - 1);
+  return previousClassifiedWordEndOffset(text, offset, isWordCharacter);
+}
 
-  while (previous > 0 && !isWordCharacter(text[previous] ?? "")) previous -= 1;
-  if (previous > 0 && isWordCharacter(text[previous] ?? "")) return previous;
-
-  return 0;
+function previousBigWordEndOffset(text: string, offset: number) {
+  return previousClassifiedWordEndOffset(text, offset, isBigWordCharacter);
 }
 
 function firstWordStartOffset(text: string) {
-  const match = /[\p{L}\p{N}_]/u.exec(text);
-  return match?.index ?? null;
+  return firstClassifiedWordStartOffset(text, isWordCharacter);
+}
+
+function firstBigWordStartOffset(text: string) {
+  return firstClassifiedWordStartOffset(text, isBigWordCharacter);
 }
 
 function lastWordStartOffset(text: string) {
-  let offset = text.length - 1;
+  return lastClassifiedWordStartOffset(text, isWordCharacter);
+}
 
-  while (offset > 0 && !isWordCharacter(text[offset] ?? "")) offset -= 1;
-  if (!isWordCharacter(text[offset] ?? "")) return null;
-
-  while (offset > 0 && isWordCharacter(text[offset - 1] ?? "")) offset -= 1;
-  return offset;
+function lastBigWordStartOffset(text: string) {
+  return lastClassifiedWordStartOffset(text, isBigWordCharacter);
 }
 
 function wordMotionOffset(text: string, offset: number, direction: "forward" | "end" | "backward" | "backward-end", count: number) {
@@ -521,6 +577,18 @@ function wordMotionOffset(text: string, offset: number, direction: "forward" | "
     else if (direction === "end") next = nextWordEndOffset(text, next);
     else if (direction === "backward") next = previousWordStartOffset(text, next);
     else next = previousWordEndOffset(text, next);
+  }
+
+  return next;
+}
+
+function bigWordMotionOffset(text: string, offset: number, direction: "end" | "backward-end", count: number) {
+  let next = offset;
+
+  for (let index = 0; index < count; index += 1) {
+    next = direction === "end"
+      ? nextBigWordEndOffset(text, next)
+      : previousBigWordEndOffset(text, next);
   }
 
   return next;
@@ -538,12 +606,36 @@ function nextTextblockWordStart(ranges: readonly TextblockRange[], currentIndex:
   return null;
 }
 
+function nextTextblockBigWordStart(ranges: readonly TextblockRange[], currentIndex: number) {
+  for (let index = currentIndex + 1; index < ranges.length; index += 1) {
+    const range = ranges[index];
+    if (!range) continue;
+
+    const offset = firstBigWordStartOffset(range.text);
+    if (offset !== null) return { index, position: range.start + offset };
+  }
+
+  return null;
+}
+
 function previousTextblockWordStart(ranges: readonly TextblockRange[], currentIndex: number) {
   for (let index = currentIndex - 1; index >= 0; index -= 1) {
     const range = ranges[index];
     if (!range) continue;
 
     const offset = lastWordStartOffset(range.text);
+    if (offset !== null) return { index, position: range.start + offset };
+  }
+
+  return null;
+}
+
+function previousTextblockBigWordStart(ranges: readonly TextblockRange[], currentIndex: number) {
+  for (let index = currentIndex - 1; index >= 0; index -= 1) {
+    const range = ranges[index];
+    if (!range) continue;
+
+    const offset = lastBigWordStartOffset(range.text);
     if (offset !== null) return { index, position: range.start + offset };
   }
 
@@ -599,6 +691,55 @@ function wordStartMotionPosition(
   return position;
 }
 
+function bigWordStartMotionPosition(
+  state: EditorState,
+  direction: "forward" | "backward",
+  count: number,
+  finalForwardTarget: "caret" | "boundary" = "caret"
+) {
+  const ranges = textblockRanges(state);
+  if (ranges.length === 0) return null;
+
+  let currentIndex = currentTextblockIndex(state, ranges);
+  let position = state.selection.from;
+
+  for (let step = 0; step < count; step += 1) {
+    const range = ranges[currentIndex];
+    if (!range) return null;
+
+    const offset = Math.max(0, Math.min(range.text.length, position - range.start));
+
+    if (direction === "forward") {
+      const targetOffset = nextBigWordStartOffset(range.text, offset);
+      if (targetOffset < range.text.length) {
+        position = range.start + targetOffset;
+        continue;
+      }
+
+      const next = nextTextblockBigWordStart(ranges, currentIndex);
+      if (!next) return finalForwardTarget === "boundary" ? range.end : normalTextblockEnd(range);
+
+      currentIndex = next.index;
+      position = next.position;
+      continue;
+    }
+
+    const targetOffset = previousBigWordStartOffset(range.text, offset);
+    if (targetOffset < offset) {
+      position = range.start + targetOffset;
+      continue;
+    }
+
+    const previous = previousTextblockBigWordStart(ranges, currentIndex);
+    if (!previous) return range.start;
+
+    currentIndex = previous.index;
+    position = previous.position;
+  }
+
+  return position;
+}
+
 function moveByWord(view: EditorView, direction: "forward" | "end" | "backward" | "backward-end", count = 1) {
   if (direction === "forward" || direction === "backward") {
     const target = wordStartMotionPosition(view.state, direction, count);
@@ -612,6 +753,24 @@ function moveByWord(view: EditorView, direction: "forward" | "end" | "backward" 
 
   const offset = Math.max(0, Math.min(range.text.length, view.state.selection.from - range.start));
   const targetOffset = wordMotionOffset(range.text, offset, direction, count);
+  const target = Math.min(normalTextblockEnd(range), range.start + targetOffset);
+
+  return moveSelection(view, target, direction === "backward-end" ? -1 : 1);
+}
+
+function moveByBigWord(view: EditorView, direction: "forward" | "end" | "backward" | "backward-end", count = 1) {
+  if (direction === "forward" || direction === "backward") {
+    const target = bigWordStartMotionPosition(view.state, direction, count);
+    if (target === null) return false;
+
+    return moveSelection(view, target, direction === "backward" ? -1 : 1);
+  }
+
+  const range = currentTextblockRange(view.state);
+  if (!range) return false;
+
+  const offset = Math.max(0, Math.min(range.text.length, view.state.selection.from - range.start));
+  const targetOffset = bigWordMotionOffset(range.text, offset, direction, count);
   const target = Math.min(normalTextblockEnd(range), range.start + targetOffset);
 
   return moveSelection(view, target, direction === "backward-end" ? -1 : 1);
@@ -965,6 +1124,9 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
   if (prefix === "g" && key === "e") {
     return range.start + wordMotionOffset(range.text, offset, "backward-end", count);
   }
+  if (prefix === "g" && key === "E") {
+    return range.start + bigWordMotionOffset(range.text, offset, "backward-end", count);
+  }
 
   switch (key) {
     case "h":
@@ -975,10 +1137,16 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
       return Math.min(normalTextblockEnd(range), current + count);
     case "w":
       return wordStartMotionPosition(view.state, "forward", count, "boundary");
+    case "W":
+      return bigWordStartMotionPosition(view.state, "forward", count, "boundary");
     case "e":
       return Math.min(normalTextblockEnd(range), range.start + wordMotionOffset(range.text, offset, "end", count));
+    case "E":
+      return Math.min(normalTextblockEnd(range), range.start + bigWordMotionOffset(range.text, offset, "end", count));
     case "b":
       return wordStartMotionPosition(view.state, "backward", count);
+    case "B":
+      return bigWordStartMotionPosition(view.state, "backward", count);
     case "0":
       return range.start;
     case "^":
@@ -991,23 +1159,28 @@ function resolveMotionTarget(view: EditorView, key: string, count: number, prefi
 }
 
 function shouldChangeCurrentWord(view: EditorView, operator: PendingOperator, key: string, count: number, prefix: string | null) {
-  if (operator.type !== "change" || key !== "w" || prefix !== null || count !== 1) return false;
+  if (operator.type !== "change" || prefix !== null || count !== 1) return false;
+  if (key !== "w" && key !== "W") return false;
 
   const range = currentTextblockRange(view.state);
   if (!range) return false;
 
   const offset = view.state.selection.from - range.start;
-  return isWordCharacter(range.text[offset] ?? "");
+  const character = range.text[offset] ?? "";
+  return key === "w" ? isWordCharacter(character) : isBigWordCharacter(character);
 }
 
 function operateRange(view: EditorView, operator: PendingOperator, key: string, state: VimModeState, prefix: string | null = null) {
   const count = operator.count * readCount(state);
   const changeCurrentWord = shouldChangeCurrentWord(view, operator, key, count, prefix);
-  const target = resolveMotionTarget(view, changeCurrentWord ? "e" : key, count, prefix);
+  let motionKey = key;
+  if (changeCurrentWord) motionKey = key === "W" ? "E" : "e";
+
+  const target = resolveMotionTarget(view, motionKey, count, prefix);
   if (target === null) return false;
 
   const from = view.state.selection.from;
-  const to = (key === "e" || changeCurrentWord) && target >= from
+  const to = (key === "e" || key === "E" || changeCurrentWord) && target >= from
     ? Math.min(view.state.doc.content.size, target + 1)
     : target;
   if (operator.type === "change") return changeRange(view, from, to);
@@ -1143,6 +1316,7 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
 
   if (state.pending === "g") {
     if (key === "e") return operateRange(view, operator, key, state, "g");
+    if (key === "E") return operateRange(view, operator, key, state, "g");
 
     dispatchMeta(view, clearedInputMeta());
     return true;
@@ -1184,6 +1358,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
   if (state.pending === "g") {
     if (key === "g") return lineMotion(view, "first", count);
     if (key === "e") return moveByWord(view, "backward-end", count);
+    if (key === "E") return moveByBigWord(view, "backward-end", count);
 
     dispatchMeta(view, clearedInputMeta());
     return true;
@@ -1219,10 +1394,16 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return true;
     case "w":
       return moveByWord(view, "forward", count);
+    case "W":
+      return moveByBigWord(view, "forward", count);
     case "e":
       return moveByWord(view, "end", count);
+    case "E":
+      return moveByBigWord(view, "end", count);
     case "b":
       return moveByWord(view, "backward", count);
+    case "B":
+      return moveByBigWord(view, "backward", count);
     case "0":
       return moveToTextblockBoundary(view, "start");
     case "^":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -451,6 +451,24 @@ function deleteCharacter(view: EditorView, count = 1) {
   return true;
 }
 
+function replaceCharacters(view: EditorView, character: string, count = 1) {
+  if (!selectionIsTextSelection(view.state) || character.length !== 1) return false;
+
+  const range = currentTextblockRange(view.state);
+  if (!range || view.state.selection.from >= range.end) return false;
+
+  const from = view.state.selection.from;
+  const to = Math.min(range.end, from + count);
+  const replacement = character.repeat(to - from);
+  const transaction = view.state.tr.insertText(replacement, from, to);
+  dispatchTransaction(
+    view,
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(from), 1)),
+    clearedInputMeta()
+  );
+  return true;
+}
+
 function emptyParagraph(state: EditorState) {
   const paragraph = state.schema.nodes.paragraph;
   return paragraph?.createAndFill() ?? paragraph?.create();
@@ -820,6 +838,8 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
 function handleNormalModeKey(view: EditorView, key: string, state: VimModeState) {
   if (state.operator) return handleOperatorKey(view, key, state);
 
+  if (state.pending === "r") return replaceCharacters(view, key, readCount(state));
+
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
   const count = readCount(state);
@@ -898,6 +918,9 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
     }
     case "x":
       return deleteCharacter(view, count);
+    case "r":
+      dispatchMeta(view, { pending: "r" });
+      return true;
     case "o":
       return insertParagraphNearTextblock(view, "after");
     case "O":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -30,9 +30,11 @@ export type VimModePluginOptions = {
 type VimModeState = {
   count: string;
   lastFind: VimCharacterFind | null;
+  lastChangeKeys: readonly string[] | null;
   lastSearch: VimSearch | null;
   mode: VimMode;
   operator: PendingOperator | null;
+  pendingChangeKeys: readonly string[] | null;
   pending: string | null;
   preferredColumn: number | null;
   register: VimRegister | null;
@@ -98,6 +100,7 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
           mode: state.mode === "visual" ? "normal" : state.mode,
           operator: null,
           pending: null,
+          pendingChangeKeys: null,
           preferredColumn: null,
           searchQuery: "",
           visualAnchor: null,
@@ -110,9 +113,15 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
   return {
     count: Object.hasOwn(meta, "count") ? meta.count ?? "" : state.count,
     lastFind: Object.hasOwn(meta, "lastFind") ? meta.lastFind ?? null : state.lastFind,
+    lastChangeKeys: Object.hasOwn(meta, "lastChangeKeys")
+      ? meta.lastChangeKeys ?? null
+      : state.lastChangeKeys,
     lastSearch: Object.hasOwn(meta, "lastSearch") ? meta.lastSearch ?? null : state.lastSearch,
     mode: meta.mode ?? state.mode,
     operator: Object.hasOwn(meta, "operator") ? meta.operator ?? null : state.operator,
+    pendingChangeKeys: Object.hasOwn(meta, "pendingChangeKeys")
+      ? meta.pendingChangeKeys ?? null
+      : state.pendingChangeKeys,
     pending: Object.hasOwn(meta, "pending") ? meta.pending ?? null : state.pending,
     preferredColumn: Object.hasOwn(meta, "preferredColumn")
       ? meta.preferredColumn ?? null
@@ -129,6 +138,7 @@ function clearedInputMeta(meta: VimModeMeta = {}): VimModeMeta {
   return {
     count: "",
     operator: null,
+    pendingChangeKeys: null,
     pending: null,
     preferredColumn: null,
     searchQuery: "",
@@ -145,7 +155,7 @@ function dispatchMeta(view: EditorView, meta: VimModeMeta) {
 }
 
 function dispatchMode(view: EditorView, mode: VimMode, meta: VimModeMeta = {}) {
-  dispatchMeta(view, clearedInputMeta({ ...meta, mode }));
+  dispatchMeta(view, clearedInputMeta({ ...(mode === "insert" ? { lastChangeKeys: null } : {}), ...meta, mode }));
 }
 
 function dispatchTransaction(view: EditorView, transaction: Transaction, meta: VimModeMeta = clearedInputMeta()) {
@@ -157,9 +167,11 @@ function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
   return {
     count: "",
     lastFind: null,
+    lastChangeKeys: null,
     lastSearch: null,
     mode: initialMode,
     operator: null,
+    pendingChangeKeys: null,
     pending: null,
     preferredColumn: null,
     register: null,
@@ -1258,7 +1270,7 @@ function changeTextblockSelection(view: EditorView, selection: ReturnType<typeof
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ mode: "insert", register: { kind: "line", texts } })
+    clearedInputMeta({ lastChangeKeys: null, mode: "insert", register: { kind: "line", texts } })
   );
   return true;
 }
@@ -1299,7 +1311,7 @@ function insertParagraphNearTextblock(view: EditorView, side: "before" | "after"
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ mode: "insert" })
+    clearedInputMeta({ lastChangeKeys: null, mode: "insert" })
   );
   return true;
 }
@@ -1332,7 +1344,7 @@ function changeRange(view: EditorView, from: number, to: number, meta: VimModeMe
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ ...meta, mode: "insert", register: { kind: "text", text } })
+    clearedInputMeta({ ...meta, lastChangeKeys: null, mode: "insert", register: { kind: "text", text } })
   );
   return true;
 }
@@ -1422,6 +1434,48 @@ function appendCount(view: EditorView, key: string, state: VimModeState) {
   return true;
 }
 
+function repeatableChangeStartKeys(state: VimModeState, key: string) {
+  if (state.pendingChangeKeys) return [...state.pendingChangeKeys, key];
+  // Insert-text changes need typed text capture before they can be faithfully replayed.
+  if (key !== "D" && key !== "J" && key !== "P" && key !== "d" && key !== "p" && key !== "r" && key !== "x") {
+    return null;
+  }
+
+  return [...state.count, key];
+}
+
+function changeIsWaitingForMoreKeys(state: VimModeState | undefined) {
+  return Boolean(state?.operator || state?.pending);
+}
+
+function recordRepeatableChange(view: EditorView, previousState: VimModeState, key: string, previousDoc: ProseNode) {
+  const changeKeys = repeatableChangeStartKeys(previousState, key);
+  if (!changeKeys) return;
+
+  const nextState = vimModeKey.getState(view.state);
+  if (view.state.doc !== previousDoc) {
+    dispatchMeta(view, { lastChangeKeys: changeKeys, pendingChangeKeys: null });
+    return;
+  }
+
+  dispatchMeta(view, {
+    pendingChangeKeys: changeIsWaitingForMoreKeys(nextState) ? changeKeys : null
+  });
+}
+
+function repeatLastChange(view: EditorView, keys: readonly string[]) {
+  if (keys.length === 0) return false;
+
+  for (const key of keys) {
+    const state = vimModeKey.getState(view.state) ?? initialVimModeState();
+    if (state.mode !== "normal") return false;
+    if (!handleNormalModeKey(view, key, state)) return false;
+  }
+
+  dispatchMeta(view, { lastChangeKeys: keys, pendingChangeKeys: null });
+  return true;
+}
+
 function beginOperator(view: EditorView, type: VimOperator, state: VimModeState) {
   dispatchMeta(view, {
     count: "",
@@ -1447,7 +1501,7 @@ function insertAtTextblockBoundary(view: EditorView, side: "first-nonblank" | "e
   dispatchTransaction(
     view,
     view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(position), side === "end" ? -1 : 1)),
-    clearedInputMeta({ mode: "insert" })
+    clearedInputMeta({ lastChangeKeys: null, mode: "insert" })
   );
   return true;
 }
@@ -1460,7 +1514,7 @@ function insertAfterCharacter(view: EditorView) {
   dispatchTransaction(
     view,
     view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(position), -1)),
-    clearedInputMeta({ mode: "insert" })
+    clearedInputMeta({ lastChangeKeys: null, mode: "insert" })
   );
   return true;
 }
@@ -2233,10 +2287,21 @@ export function createVimModePlugin(options: VimModePluginOptions = {}) {
           return true;
         }
 
+        if (state.mode === "normal" && event.key === ".") {
+          const handled = state.lastChangeKeys ? repeatLastChange(view, state.lastChangeKeys) : true;
+          if (!handled) return false;
+
+          event.preventDefault();
+          return true;
+        }
+
+        const previousDoc = view.state.doc;
         const handled = state.mode === "visual"
           ? handleVisualModeKey(view, event.key, state)
           : handleNormalModeKey(view, event.key, state);
         if (!handled) return false;
+
+        if (state.mode === "normal") recordRepeatableChange(view, state, event.key, previousDoc);
 
         event.preventDefault();
         return true;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -9,6 +9,7 @@ type VimOperator = "change" | "delete" | "yank";
 type VimFindDirection = "backward" | "forward";
 type VimFindKey = "F" | "T" | "f" | "t";
 type VimTextObjectPending = "text-object-around" | "text-object-inner";
+type VimQuoteTextObjectKey = "'" | '"' | "`";
 type VimTextObjectScope = "around" | "inner";
 type WordClassifier = (character: string) => boolean;
 
@@ -209,6 +210,10 @@ function isTextObjectPending(pending: string | null): pending is VimTextObjectPe
 
 function textObjectScopeFromPending(pending: VimTextObjectPending): VimTextObjectScope {
   return pending === "text-object-inner" ? "inner" : "around";
+}
+
+function isQuoteTextObjectKey(key: string): key is VimQuoteTextObjectKey {
+  return key === '"' || key === "'" || key === "`";
 }
 
 function characterFindFromKey(key: VimFindKey, character: string): VimCharacterFind {
@@ -514,6 +519,43 @@ function wordTextObjectRange(state: EditorState, scope: VimTextObjectScope, coun
       while (start > 0 && isWhitespaceCharacter(range.text[start - 1] ?? "")) start -= 1;
     }
   }
+
+  return {
+    end: range.start + end,
+    start: range.start + start
+  };
+}
+
+function nextDelimiterOffset(text: string, delimiter: VimQuoteTextObjectKey, from: number) {
+  for (let offset = Math.max(0, from); offset < text.length; offset += 1) {
+    if (text[offset] === delimiter) return offset;
+  }
+
+  return null;
+}
+
+function previousDelimiterOffset(text: string, delimiter: VimQuoteTextObjectKey, from: number) {
+  for (let offset = Math.min(text.length - 1, from); offset >= 0; offset -= 1) {
+    if (text[offset] === delimiter) return offset;
+  }
+
+  return null;
+}
+
+function quoteTextObjectRange(state: EditorState, scope: VimTextObjectScope, delimiter: VimQuoteTextObjectKey) {
+  const range = currentTextblockRange(state);
+  if (!range) return null;
+
+  const offset = Math.max(0, Math.min(range.text.length - 1, state.selection.from - range.start));
+  const startDelimiter = previousDelimiterOffset(range.text, delimiter, offset);
+  if (startDelimiter === null) return null;
+
+  const endDelimiter = nextDelimiterOffset(range.text, delimiter, startDelimiter + 1);
+  if (endDelimiter === null) return null;
+
+  const start = scope === "inner" ? startDelimiter + 1 : startDelimiter;
+  const end = scope === "inner" ? endDelimiter : endDelimiter + 1;
+  if (start > end) return null;
 
   return {
     end: range.start + end,
@@ -1240,6 +1282,13 @@ function handleRepeatedOperatorFind(view: EditorView, key: string, state: VimMod
   return operateCharacterFind(view, operator, find, operator.count * readCount(state));
 }
 
+function textObjectRange(state: EditorState, scope: VimTextObjectScope, key: string, count: number) {
+  if (key === "w") return wordTextObjectRange(state, scope, count);
+  if (isQuoteTextObjectKey(key)) return quoteTextObjectRange(state, scope, key);
+
+  return null;
+}
+
 function operateTextObject(
   view: EditorView,
   operator: PendingOperator,
@@ -1247,12 +1296,8 @@ function operateTextObject(
   key: string,
   count: number
 ) {
-  if (key !== "w") {
-    dispatchMeta(view, clearedInputMeta());
-    return true;
-  }
+  const range = textObjectRange(view.state, scope, key, count);
 
-  const range = wordTextObjectRange(view.state, scope, count);
   if (!range) {
     dispatchMeta(view, clearedInputMeta());
     return true;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -412,18 +412,25 @@ function nextSearchPosition(positions: readonly number[], direction: VimSearchDi
   return positions[positions.length - 1] ?? null;
 }
 
-function moveBySearch(view: EditorView, search: VimSearch, count = 1, rememberedSearch = search) {
-  const positions = searchMatchPositions(view.state, search.query);
-  if (positions.length === 0) {
-    dispatchMeta(view, clearedInputMeta({ lastSearch: rememberedSearch }));
-    return true;
-  }
+function searchMotionTarget(state: EditorState, search: VimSearch, count: number) {
+  const positions = searchMatchPositions(state, search.query);
+  if (positions.length === 0) return null;
 
-  let position = view.state.selection.from;
+  let position = state.selection.from;
   for (let index = 0; index < Math.max(1, count); index += 1) {
     const next = nextSearchPosition(positions, search.direction, position);
-    if (next === null) return false;
+    if (next === null) return null;
     position = next;
+  }
+
+  return position;
+}
+
+function moveBySearch(view: EditorView, search: VimSearch, count = 1, rememberedSearch = search) {
+  const position = searchMotionTarget(view.state, search, count);
+  if (position === null) {
+    dispatchMeta(view, clearedInputMeta({ lastSearch: rememberedSearch }));
+    return true;
   }
 
   return moveSelection(
@@ -432,6 +439,32 @@ function moveBySearch(view: EditorView, search: VimSearch, count = 1, remembered
     search.direction === "backward" ? -1 : 1,
     clearedInputMeta({ lastSearch: rememberedSearch })
   );
+}
+
+function operateSearch(
+  view: EditorView,
+  operator: PendingOperator,
+  search: VimSearch,
+  count: number,
+  rememberedSearch = search
+) {
+  const target = searchMotionTarget(view.state, search, count);
+  if (target === null) {
+    dispatchMeta(view, clearedInputMeta({ lastSearch: rememberedSearch }));
+    return true;
+  }
+
+  const current = view.state.selection.from;
+  // Match Vim's backward search operator boundary: c?x/d?x remove the match and text up to the cursor.
+  const from = search.direction === "backward" && target <= current ? target : current;
+  const to = search.direction === "backward" && target <= current
+    ? Math.min(view.state.doc.content.size, current + 1)
+    : target;
+
+  if (operator.type === "change") return changeRange(view, from, to, { lastSearch: rememberedSearch });
+  return operator.type === "delete"
+    ? deleteRange(view, from, to, { lastSearch: rememberedSearch })
+    : yankRange(view, from, to, { lastSearch: rememberedSearch });
 }
 
 function nearestTextblockIndex(ranges: readonly TextblockRange[], position: number) {
@@ -1575,6 +1608,43 @@ function handlePendingSearch(view: EditorView, key: string, state: VimModeState)
   return true;
 }
 
+function handlePendingOperatorSearch(view: EditorView, key: string, state: VimModeState) {
+  const operator = state.operator;
+  const pending = state.pending;
+  if (!operator || !isSearchPending(pending)) return false;
+
+  if (key === "Escape") {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  if (key === "Backspace") {
+    dispatchMeta(view, { searchQuery: state.searchQuery.slice(0, -1) });
+    return true;
+  }
+
+  if (key === "Enter") {
+    const query = state.searchQuery;
+    if (query.length === 0) {
+      dispatchMeta(view, clearedInputMeta());
+      return true;
+    }
+
+    const search = {
+      direction: searchDirectionFromPending(pending),
+      query
+    } satisfies VimSearch;
+    return operateSearch(view, operator, search, operator.count * readCount(state));
+  }
+
+  if (key.length === 1) {
+    dispatchMeta(view, { searchQuery: `${state.searchQuery}${key}` });
+    return true;
+  }
+
+  return true;
+}
+
 function repeatSearch(view: EditorView, state: VimModeState, count: number, reversed: boolean) {
   if (!state.lastSearch) {
     dispatchMeta(view, clearedInputMeta());
@@ -1585,11 +1655,23 @@ function repeatSearch(view: EditorView, state: VimModeState, count: number, reve
   return moveBySearch(view, search, count, state.lastSearch);
 }
 
+function repeatOperatorSearch(view: EditorView, state: VimModeState, reversed: boolean) {
+  const operator = state.operator;
+  if (!operator || !state.lastSearch) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const search = reversed ? reversedSearch(state.lastSearch) : state.lastSearch;
+  return operateSearch(view, operator, search, operator.count * readCount(state), state.lastSearch);
+}
+
 function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   const operator = state.operator;
   if (!operator) return false;
 
   if (isFindKey(state.pending ?? "")) return handlePendingOperatorFind(view, key, state);
+  if (isSearchPending(state.pending)) return handlePendingOperatorSearch(view, key, state);
   if (isTextObjectPending(state.pending)) return handlePendingOperatorTextObject(view, key, state);
 
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
@@ -1616,7 +1698,19 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
     return true;
   }
 
+  if (key === "/") {
+    dispatchMeta(view, { pending: "search-forward", searchQuery: "" });
+    return true;
+  }
+
+  if (key === "?") {
+    dispatchMeta(view, { pending: "search-backward", searchQuery: "" });
+    return true;
+  }
+
   if (key === ";" || key === ",") return handleRepeatedOperatorFind(view, key, state);
+  if (key === "n") return repeatOperatorSearch(view, state, false);
+  if (key === "N") return repeatOperatorSearch(view, state, true);
 
   if (key === "i" || key === "a") {
     dispatchMeta(view, { pending: key === "i" ? "text-object-inner" : "text-object-around" });

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -71,6 +71,7 @@ type VimCharacterFind = {
 type VimSearch = {
   direction: VimSearchDirection;
   query: string;
+  word?: boolean;
 };
 
 type VimRegister =
@@ -350,6 +351,7 @@ function searchDirectionFromPending(pending: VimSearchPending): VimSearchDirecti
 
 function reversedSearch(search: VimSearch): VimSearch {
   return {
+    ...search,
     query: search.query,
     direction: search.direction === "forward" ? "backward" : "forward"
   };
@@ -497,7 +499,14 @@ function currentTextblockRange(state: EditorState) {
   } satisfies TextblockRange;
 }
 
-function searchMatchPositions(state: EditorState, query: string) {
+function searchMatchesAtWordBoundary(text: string, offset: number, query: string) {
+  const before = text[offset - 1] ?? "";
+  const after = text[offset + query.length] ?? "";
+  return !isWordCharacter(before) && !isWordCharacter(after);
+}
+
+function searchMatchPositions(state: EditorState, search: Pick<VimSearch, "query" | "word">) {
+  const { query } = search;
   if (query.length === 0) return [];
 
   const positions: number[] = [];
@@ -505,7 +514,9 @@ function searchMatchPositions(state: EditorState, query: string) {
     let offset = range.text.indexOf(query);
 
     while (offset >= 0) {
-      positions.push(range.start + offset);
+      if (!search.word || searchMatchesAtWordBoundary(range.text, offset, query)) {
+        positions.push(range.start + offset);
+      }
       offset = range.text.indexOf(query, offset + Math.max(1, query.length));
     }
   }
@@ -529,7 +540,7 @@ function nextSearchPosition(positions: readonly number[], direction: VimSearchDi
 }
 
 function searchMotionTarget(state: EditorState, search: VimSearch, count: number) {
-  const positions = searchMatchPositions(state, search.query);
+  const positions = searchMatchPositions(state, search);
   if (positions.length === 0) return null;
 
   let position = state.selection.from;
@@ -555,6 +566,26 @@ function moveBySearch(view: EditorView, search: VimSearch, count = 1, remembered
     search.direction === "backward" ? -1 : 1,
     clearedInputMeta({ lastSearch: rememberedSearch })
   );
+}
+
+function currentWordSearchQuery(state: EditorState) {
+  const range = currentTextblockRange(state);
+  if (!range) return null;
+
+  const offset = Math.max(0, Math.min(range.text.length - 1, state.selection.from - range.start));
+  const wordRange = wordRangeAtOffset(range.text, offset);
+  return wordRange ? range.text.slice(wordRange.start, wordRange.end) : null;
+}
+
+function searchCurrentWord(view: EditorView, direction: VimSearchDirection, count = 1) {
+  const query = currentWordSearchQuery(view.state);
+  if (!query) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const search: VimSearch = { direction, query, word: true };
+  return moveBySearch(view, search, count, search);
 }
 
 function operateSearch(
@@ -2332,6 +2363,10 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
       return repeatSearch(view, state, count, false);
     case "N":
       return repeatSearch(view, state, count, true);
+    case "*":
+      return searchCurrentWord(view, "forward", count);
+    case "#":
+      return searchCurrentWord(view, "backward", count);
     case "v":
       return enterVisualMode(view, state);
     case "V":

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -8,6 +8,8 @@ export type VimMode = "insert" | "normal";
 type VimOperator = "change" | "delete" | "yank";
 type VimFindDirection = "backward" | "forward";
 type VimFindKey = "F" | "T" | "f" | "t";
+type VimTextObjectPending = "text-object-around" | "text-object-inner";
+type VimTextObjectScope = "around" | "inner";
 
 export type VimModePluginOptions = {
   enabled?: boolean | (() => boolean);
@@ -200,6 +202,14 @@ function isFindKey(key: string): key is VimFindKey {
   return key === "f" || key === "F" || key === "t" || key === "T";
 }
 
+function isTextObjectPending(pending: string | null): pending is VimTextObjectPending {
+  return pending === "text-object-inner" || pending === "text-object-around";
+}
+
+function textObjectScopeFromPending(pending: VimTextObjectPending): VimTextObjectScope {
+  return pending === "text-object-inner" ? "inner" : "around";
+}
+
 function characterFindFromKey(key: VimFindKey, character: string): VimCharacterFind {
   return {
     character,
@@ -386,6 +396,65 @@ function moveToTextblockBoundary(view: EditorView, side: "start" | "end") {
 
 function isWordCharacter(character: string) {
   return /[\p{L}\p{N}_]/u.test(character);
+}
+
+function isWhitespaceCharacter(character: string) {
+  return /\s/u.test(character);
+}
+
+function wordRangeAtOffset(text: string, offset: number) {
+  if (text.length === 0) return null;
+
+  let cursor = Math.max(0, Math.min(text.length - 1, offset));
+  if (!isWordCharacter(text[cursor] ?? "") && cursor > 0 && isWordCharacter(text[cursor - 1] ?? "")) {
+    cursor -= 1;
+  }
+  if (!isWordCharacter(text[cursor] ?? "")) return null;
+
+  let start = cursor;
+  let end = cursor + 1;
+
+  while (start > 0 && isWordCharacter(text[start - 1] ?? "")) start -= 1;
+  while (end < text.length && isWordCharacter(text[end] ?? "")) end += 1;
+
+  return { end, start };
+}
+
+function nextWordRange(text: string, offset: number) {
+  let cursor = Math.max(0, Math.min(text.length, offset));
+
+  while (cursor < text.length && !isWordCharacter(text[cursor] ?? "")) cursor += 1;
+  return cursor < text.length ? wordRangeAtOffset(text, cursor) : null;
+}
+
+function wordTextObjectRange(state: EditorState, scope: VimTextObjectScope, count: number) {
+  const range = currentTextblockRange(state);
+  if (!range) return null;
+
+  const offset = Math.max(0, Math.min(range.text.length, state.selection.from - range.start));
+  const wordRange = wordRangeAtOffset(range.text, offset);
+  if (!wordRange) return null;
+
+  let end = wordRange.end;
+  for (let index = 1; index < Math.max(1, count); index += 1) {
+    const next = nextWordRange(range.text, end);
+    if (!next) break;
+    end = next.end;
+  }
+
+  let start = wordRange.start;
+  if (scope === "around") {
+    const contentEnd = end;
+    while (end < range.text.length && isWhitespaceCharacter(range.text[end] ?? "")) end += 1;
+    if (end === contentEnd) {
+      while (start > 0 && isWhitespaceCharacter(range.text[start - 1] ?? "")) start -= 1;
+    }
+  }
+
+  return {
+    end: range.start + end,
+    start: range.start + start
+  };
 }
 
 function nextWordStartOffset(text: string, offset: number) {
@@ -998,6 +1067,44 @@ function handleRepeatedOperatorFind(view: EditorView, key: string, state: VimMod
   return operateCharacterFind(view, operator, find, operator.count * readCount(state));
 }
 
+function operateTextObject(
+  view: EditorView,
+  operator: PendingOperator,
+  scope: VimTextObjectScope,
+  key: string,
+  count: number
+) {
+  if (key !== "w") {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  const range = wordTextObjectRange(view.state, scope, count);
+  if (!range) {
+    dispatchMeta(view, clearedInputMeta());
+    return true;
+  }
+
+  if (operator.type === "change") return changeRange(view, range.start, range.end);
+  return operator.type === "delete"
+    ? deleteRange(view, range.start, range.end)
+    : yankRange(view, range.start, range.end);
+}
+
+function handlePendingOperatorTextObject(view: EditorView, key: string, state: VimModeState) {
+  const operator = state.operator;
+  const pending = state.pending;
+  if (!operator || !isTextObjectPending(pending)) return false;
+
+  return operateTextObject(
+    view,
+    operator,
+    textObjectScopeFromPending(pending),
+    key,
+    operator.count * readCount(state)
+  );
+}
+
 function handlePendingNormalFind(view: EditorView, key: string, state: VimModeState) {
   const pending = state.pending;
   if (!pending || !isFindKey(pending)) return false;
@@ -1026,6 +1133,7 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   if (!operator) return false;
 
   if (isFindKey(state.pending ?? "")) return handlePendingOperatorFind(view, key, state);
+  if (isTextObjectPending(state.pending)) return handlePendingOperatorTextObject(view, key, state);
 
   if (keyStartsOrContinuesCount(key, state)) return appendCount(view, key, state);
 
@@ -1051,6 +1159,11 @@ function handleOperatorKey(view: EditorView, key: string, state: VimModeState) {
   }
 
   if (key === ";" || key === ",") return handleRepeatedOperatorFind(view, key, state);
+
+  if (key === "i" || key === "a") {
+    dispatchMeta(view, { pending: key === "i" ? "text-object-inner" : "text-object-around" });
+    return true;
+  }
 
   if (operateRange(view, operator, key, state)) return true;
 

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -735,7 +735,9 @@ function operateRange(view: EditorView, operator: PendingOperator, key: string, 
   if (target === null) return false;
 
   const from = view.state.selection.from;
-  const to = key === "$" ? target : target;
+  const to = key === "e" && target >= from
+    ? Math.min(view.state.doc.content.size, target + 1)
+    : target;
   return operator.type === "delete" ? deleteRange(view, from, to) : yankRange(view, from, to);
 }
 

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -33,6 +33,9 @@ type VimModeState = {
   lastChangeKeys: readonly string[] | null;
   lastChangeText: string | null;
   lastSearch: VimSearch | null;
+  lastVisualAnchor: number | null;
+  lastVisualCursor: number | null;
+  lastVisualKind: VimVisualKind | null;
   mode: VimMode;
   operator: PendingOperator | null;
   pendingChangeKeys: readonly string[] | null;
@@ -126,6 +129,15 @@ function applyVimModeMeta(state: VimModeState, transaction: Transaction): VimMod
       ? meta.lastChangeText ?? null
       : state.lastChangeText,
     lastSearch: Object.hasOwn(meta, "lastSearch") ? meta.lastSearch ?? null : state.lastSearch,
+    lastVisualAnchor: Object.hasOwn(meta, "lastVisualAnchor")
+      ? meta.lastVisualAnchor ?? null
+      : state.lastVisualAnchor,
+    lastVisualCursor: Object.hasOwn(meta, "lastVisualCursor")
+      ? meta.lastVisualCursor ?? null
+      : state.lastVisualCursor,
+    lastVisualKind: Object.hasOwn(meta, "lastVisualKind")
+      ? meta.lastVisualKind ?? null
+      : state.lastVisualKind,
     mode: meta.mode ?? state.mode,
     operator: Object.hasOwn(meta, "operator") ? meta.operator ?? null : state.operator,
     pendingChangeKeys: Object.hasOwn(meta, "pendingChangeKeys")
@@ -187,6 +199,9 @@ function initialVimModeState(initialMode: VimMode = "insert"): VimModeState {
     lastChangeKeys: null,
     lastChangeText: null,
     lastSearch: null,
+    lastVisualAnchor: null,
+    lastVisualCursor: null,
+    lastVisualKind: null,
     mode: initialMode,
     operator: null,
     pendingChangeKeys: null,
@@ -1430,7 +1445,11 @@ function textblockSelectionBounds(selection: ReturnType<typeof selectedTextblock
   return { from, to };
 }
 
-function deleteTextblockSelection(view: EditorView, selection: ReturnType<typeof selectedTextblocks>) {
+function deleteTextblockSelection(
+  view: EditorView,
+  selection: ReturnType<typeof selectedTextblocks>,
+  meta: VimModeMeta = {}
+) {
   const bounds = textblockSelectionBounds(selection);
   if (!bounds || !selection) return false;
 
@@ -1443,12 +1462,16 @@ function deleteTextblockSelection(view: EditorView, selection: ReturnType<typeof
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ mode: "normal", register: { kind: "line", texts } })
+    clearedInputMeta({ ...meta, mode: "normal", register: { kind: "line", texts } })
   );
   return true;
 }
 
-function changeTextblockSelection(view: EditorView, selection: ReturnType<typeof selectedTextblocks>) {
+function changeTextblockSelection(
+  view: EditorView,
+  selection: ReturnType<typeof selectedTextblocks>,
+  meta: VimModeMeta = {}
+) {
   const replacement = emptyParagraph(view.state);
   const bounds = textblockSelectionBounds(selection);
   if (!selection || !bounds || !replacement) return false;
@@ -1459,7 +1482,7 @@ function changeTextblockSelection(view: EditorView, selection: ReturnType<typeof
   dispatchTransaction(
     view,
     transaction.setSelection(TextSelection.near(transaction.doc.resolve(selectionPosition), 1)),
-    clearedInputMeta({ lastChangeKeys: null, mode: "insert", register: { kind: "line", texts } })
+    clearedInputMeta({ ...meta, lastChangeKeys: null, mode: "insert", register: { kind: "line", texts } })
   );
   return true;
 }
@@ -2276,15 +2299,44 @@ function moveVisualSelectionWithMeta(
   return true;
 }
 
+function lastVisualSelectionMeta(view: EditorView, state: VimModeState): VimModeMeta {
+  const selection = view.state.selection;
+  if (!(selection instanceof TextSelection)) return {};
+
+  const anchor = state.visualAnchor ?? selection.from;
+  return {
+    lastVisualAnchor: anchor,
+    lastVisualCursor: state.visualCursor ?? visualCursorPosition(selection, anchor),
+    lastVisualKind: state.visualKind ?? "character"
+  };
+}
+
+function restoreLastVisualSelection(view: EditorView, state: VimModeState) {
+  if (
+    state.lastVisualAnchor === null ||
+    state.lastVisualCursor === null ||
+    state.lastVisualKind === null
+  ) {
+    dispatchMeta(view, clearedInputMeta({ register: state.register }));
+    return true;
+  }
+
+  const docSize = view.state.doc.content.size;
+  const anchor = Math.max(0, Math.min(docSize, state.lastVisualAnchor));
+  const cursor = Math.max(0, Math.min(docSize, state.lastVisualCursor));
+  return moveVisualSelectionWithMeta(view, anchor, cursor, state.lastVisualKind, { register: state.register });
+}
+
 function collapseVisualSelection(view: EditorView, state: VimModeState) {
   const selection = view.state.selection;
   if (!(selection instanceof TextSelection)) return false;
 
-  const target = state.visualCursor ?? visualCursorPosition(selection, state.visualAnchor ?? selection.from);
+  const anchor = state.visualAnchor ?? selection.from;
+  const target = state.visualCursor ?? visualCursorPosition(selection, anchor);
   dispatchTransaction(
     view,
     view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(target), 1)),
-    clearedInputMeta({ mode: "normal", register: state.register })
+    clearedInputMeta({ ...lastVisualSelectionMeta(view, state), mode: "normal", register: state.register })
   );
   return true;
 }
@@ -2324,6 +2376,7 @@ function visualLineTextblocks(state: EditorState, vimState: VimModeState) {
 function yankVisualSelection(view: EditorView, state: VimModeState) {
   const range = visualSelectionRange(view, state);
   if (!range) return collapseVisualSelection(view, state);
+  const visualMeta = lastVisualSelectionMeta(view, state);
 
   if (range.kind === "line") {
     const selection = range.selection;
@@ -2333,6 +2386,7 @@ function yankVisualSelection(view: EditorView, state: VimModeState) {
       view,
       view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(range.from), 1)),
       clearedInputMeta({
+        ...visualMeta,
         mode: "normal",
         register: { kind: "line", texts: selection.selected.map((textblock) => textblock.text) }
       })
@@ -2344,7 +2398,7 @@ function yankVisualSelection(view: EditorView, state: VimModeState) {
   dispatchTransaction(
     view,
     view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(range.from), 1)),
-    clearedInputMeta({ mode: "normal", register: { kind: "text", text } })
+    clearedInputMeta({ ...visualMeta, mode: "normal", register: { kind: "text", text } })
   );
   return true;
 }
@@ -2352,19 +2406,21 @@ function yankVisualSelection(view: EditorView, state: VimModeState) {
 function deleteVisualSelection(view: EditorView, state: VimModeState) {
   const range = visualSelectionRange(view, state);
   if (!range) return false;
+  const visualMeta = lastVisualSelectionMeta(view, state);
 
-  if (range.kind === "line") return deleteTextblockSelection(view, range.selection);
+  if (range.kind === "line") return deleteTextblockSelection(view, range.selection, visualMeta);
 
-  return deleteRange(view, range.from, range.to, { mode: "normal" });
+  return deleteRange(view, range.from, range.to, { ...visualMeta, mode: "normal" });
 }
 
 function changeVisualSelection(view: EditorView, state: VimModeState) {
   const range = visualSelectionRange(view, state);
   if (!range) return false;
+  const visualMeta = lastVisualSelectionMeta(view, state);
 
-  if (range.kind === "line") return changeTextblockSelection(view, range.selection);
+  if (range.kind === "line") return changeTextblockSelection(view, range.selection, visualMeta);
 
-  return changeRange(view, range.from, range.to);
+  return changeRange(view, range.from, range.to, visualMeta);
 }
 
 function visualMotionTarget(state: EditorState, key: string, count: number, prefix: string | null = null) {
@@ -2578,6 +2634,7 @@ function handleNormalModeKey(view: EditorView, key: string, state: VimModeState)
 
   if (state.pending === "g") {
     if (key === "g") return lineMotion(view, "first", count);
+    if (key === "v") return restoreLastVisualSelection(view, state);
     if (key === "e") return moveByWord(view, "backward-end", count);
     if (key === "E") return moveByBigWord(view, "backward-end", count);
     if (key === "_") return moveToTextblockNonblank(view, "last", count);

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -2289,6 +2289,16 @@ function collapseVisualSelection(view: EditorView, state: VimModeState) {
   return true;
 }
 
+function switchVisualSelectionEnds(view: EditorView, state: VimModeState) {
+  const selection = view.state.selection;
+  if (!(selection instanceof TextSelection)) return false;
+
+  const anchor = state.visualAnchor ?? selection.from;
+  const cursor = state.visualCursor ?? visualCursorPosition(selection, anchor);
+  const kind = state.visualKind ?? "character";
+  return moveVisualSelectionWithMeta(view, cursor, anchor, kind, { register: state.register });
+}
+
 function visualSelectionRange(view: EditorView, state: VimModeState) {
   if (state.visualKind === "line") {
     const selection = visualLineTextblocks(view.state, state);
@@ -2430,6 +2440,8 @@ function handleVisualModeKey(view: EditorView, key: string, state: VimModeState)
   switch (key) {
     case "v":
       return collapseVisualSelection(view, state);
+    case "o":
+      return switchVisualSelectionEnds(view, state);
     case "V": {
       const selection = view.state.selection;
       if (!(selection instanceof TextSelection)) return false;

--- a/packages/editor/src/vim-mode.ts
+++ b/packages/editor/src/vim-mode.ts
@@ -306,7 +306,7 @@ function textblockDepth(state: EditorState) {
 function moveSelection(view: EditorView, position: number, bias: -1 | 1 = 1, meta: VimModeMeta = clearedInputMeta()) {
   const clamped = Math.max(0, Math.min(view.state.doc.content.size, position));
   const selection = TextSelection.near(view.state.doc.resolve(clamped), bias);
-  dispatchTransaction(view, view.state.tr.setSelection(selection), meta);
+  dispatchTransaction(view, view.state.tr.setSelection(selection).scrollIntoView(), meta);
   return true;
 }
 

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "Zeigt Rückverweise und nicht verlinkte Erwähnungen des aktuellen Dokuments in der Seitenleiste.",
   "settings.editor.showWordCount": "Wortzahl anzeigen",
   "settings.editor.showWordCountDescription": "Zeigt die Wortzahl des Dokuments in der Statuszeile des Editors.",
+  "settings.editor.vimMode": "Vim-Modus",
+  "settings.editor.vimModeDescription": "Verwendet Vim-ähnliche Normal- und Einfügemodi im visuellen Editor und im Quelltexteditor.",
   "settings.editor.wrapCodeBlocks": "Codeblock-Zeilen umbrechen",
   "settings.editor.wrapCodeBlocksDescription": "Bricht lange Zeilen in Codeblöcken um, statt horizontales Scrollen zu erzwingen.",
   "settings.editor.spellcheck": "Rechtschreibung prüfen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -295,6 +295,8 @@ const messages: BaseLocaleMessages = {
   "settings.editor.documentLinksDescription": "Show backlinks and unlinked mentions for the current document in the sidebar.",
   "settings.editor.showWordCount": "Show word count",
   "settings.editor.showWordCountDescription": "Show document word count in the editor status line.",
+  "settings.editor.vimMode": "Vim mode",
+  "settings.editor.vimModeDescription": "Use Vim-style normal and insert modes in both visual and source editors.",
   "settings.editor.wrapCodeBlocks": "Wrap code block lines",
   "settings.editor.wrapCodeBlocksDescription": "Wrap long lines inside code blocks instead of requiring horizontal scrolling.",
   "settings.editor.spellcheck": "Check spelling",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "Muestra enlaces entrantes y menciones sin enlazar del documento actual en la barra lateral.",
   "settings.editor.showWordCount": "Mostrar recuento de palabras",
   "settings.editor.showWordCountDescription": "Muestra el recuento de palabras en la línea de estado del editor.",
+  "settings.editor.vimMode": "Modo Vim",
+  "settings.editor.vimModeDescription": "Usa modos normal e inserción de estilo Vim en los editores visual y de código fuente.",
   "settings.editor.wrapCodeBlocks": "Ajustar líneas de bloques de código",
   "settings.editor.wrapCodeBlocksDescription": "Ajusta las líneas largas dentro de bloques de código en vez de requerir desplazamiento horizontal.",
   "settings.editor.spellcheck": "Revisar ortografía",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "Affiche les liens entrants et les mentions non liées du document actuel dans la barre latérale.",
   "settings.editor.showWordCount": "Afficher le nombre de mots",
   "settings.editor.showWordCountDescription": "Affiche le nombre de mots dans la ligne d’état de l’éditeur.",
+  "settings.editor.vimMode": "Mode Vim",
+  "settings.editor.vimModeDescription": "Utilise les modes normal et insertion de style Vim dans les éditeurs visuel et source.",
   "settings.editor.wrapCodeBlocks": "Renvoyer les lignes des blocs de code",
   "settings.editor.wrapCodeBlocksDescription": "Renvoie les longues lignes dans les blocs de code au lieu d’imposer un défilement horizontal.",
   "settings.editor.spellcheck": "Vérifier l’orthographe",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "Mostra nella barra laterale i backlink e le menzioni non collegate del documento attuale.",
   "settings.editor.showWordCount": "Mostra conteggio parole",
   "settings.editor.showWordCountDescription": "Mostra il conteggio parole nella riga di stato dell’editor.",
+  "settings.editor.vimMode": "Modalità Vim",
+  "settings.editor.vimModeDescription": "Usa le modalità normale e inserimento in stile Vim sia nell’editor visuale sia in quello sorgente.",
   "settings.editor.wrapCodeBlocks": "Manda a capo le righe dei blocchi di codice",
   "settings.editor.wrapCodeBlocksDescription": "Manda a capo le righe lunghe nei blocchi di codice invece di richiedere lo scorrimento orizzontale.",
   "settings.editor.spellcheck": "Controlla ortografia",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "現在のドキュメントのバックリンクと未リンクの言及をサイドバーに表示します。",
   "settings.editor.showWordCount": "単語数を表示",
   "settings.editor.showWordCountDescription": "エディターのステータス行にドキュメントの単語数を表示します。",
+  "settings.editor.vimMode": "Vim mode",
+  "settings.editor.vimModeDescription": "Use Vim-style normal and insert modes in both visual and source editors.",
   "settings.editor.wrapCodeBlocks": "コードブロックの行を折り返す",
   "settings.editor.wrapCodeBlocksDescription": "横スクロールではなく、コードブロック内の長い行を折り返します。",
   "settings.editor.spellcheck": "スペルチェック",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "현재 문서의 백링크와 연결되지 않은 언급을 사이드바에 표시합니다.",
   "settings.editor.showWordCount": "단어 수 표시",
   "settings.editor.showWordCountDescription": "편집기 상태 줄에 문서 단어 수를 표시합니다.",
+  "settings.editor.vimMode": "Vim mode",
+  "settings.editor.vimModeDescription": "Use Vim-style normal and insert modes in both visual and source editors.",
   "settings.editor.wrapCodeBlocks": "코드 블록 줄 바꿈",
   "settings.editor.wrapCodeBlocksDescription": "가로 스크롤 대신 코드 블록의 긴 줄을 줄 바꿈합니다.",
   "settings.editor.spellcheck": "맞춤법 검사",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "Mostra backlinks e menções sem link do documento atual na barra lateral.",
   "settings.editor.showWordCount": "Mostrar contagem de palavras",
   "settings.editor.showWordCountDescription": "Mostra a contagem de palavras na linha de status do editor.",
+  "settings.editor.vimMode": "Modo Vim",
+  "settings.editor.vimModeDescription": "Usa modos normal e inserção no estilo Vim nos editores visual e de código-fonte.",
   "settings.editor.wrapCodeBlocks": "Quebrar linhas em blocos de código",
   "settings.editor.wrapCodeBlocksDescription": "Quebra linhas longas dentro de blocos de código em vez de exigir rolagem horizontal.",
   "settings.editor.spellcheck": "Verificar ortografia",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "Показывает обратные ссылки и несвязанные упоминания текущего документа на боковой панели.",
   "settings.editor.showWordCount": "Показывать число слов",
   "settings.editor.showWordCountDescription": "Показывает число слов документа в строке состояния редактора.",
+  "settings.editor.vimMode": "Режим Vim",
+  "settings.editor.vimModeDescription": "Использует обычный режим и режим вставки в стиле Vim в визуальном редакторе и редакторе исходного текста.",
   "settings.editor.wrapCodeBlocks": "Переносить строки в блоках кода",
   "settings.editor.wrapCodeBlocksDescription": "Переносит длинные строки в блоках кода вместо горизонтальной прокрутки.",
   "settings.editor.spellcheck": "Проверять орфографию",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -324,6 +324,8 @@ export type I18nKey =
   | "settings.editor.documentLinksDescription"
   | "settings.editor.showWordCount"
   | "settings.editor.showWordCountDescription"
+  | "settings.editor.vimMode"
+  | "settings.editor.vimModeDescription"
   | "settings.editor.wrapCodeBlocks"
   | "settings.editor.wrapCodeBlocksDescription"
   | "settings.editor.spellcheck"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -295,6 +295,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "在侧栏显示当前文档的反向链接和未链接提及。",
   "settings.editor.showWordCount": "显示字数统计",
   "settings.editor.showWordCountDescription": "在编辑器状态栏显示当前文档字数。",
+  "settings.editor.vimMode": "Vim 模式",
+  "settings.editor.vimModeDescription": "在所见即所得和源码编辑器中使用 Vim 风格的普通模式和插入模式。",
   "settings.editor.wrapCodeBlocks": "代码块自动换行",
   "settings.editor.wrapCodeBlocksDescription": "在代码块中折行显示长行，而不是依赖横向滚动。",
   "settings.editor.spellcheck": "检查拼写",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -681,6 +681,8 @@ const messages: LocaleMessages = {
   "settings.editor.documentLinksDescription": "在側欄顯示目前文件的反向連結與未連結提及。",
   "settings.editor.showWordCount": "顯示字數統計",
   "settings.editor.showWordCountDescription": "在編輯器狀態列顯示目前文件字數。",
+  "settings.editor.vimMode": "Vim 模式",
+  "settings.editor.vimModeDescription": "在所見即所得與原始碼編輯器中使用 Vim 風格的一般模式與插入模式。",
   "settings.editor.wrapCodeBlocks": "程式碼區塊自動換行",
   "settings.editor.wrapCodeBlocksDescription": "在程式碼區塊中折行顯示長行，而不是依賴水平捲動。",
   "settings.editor.spellcheck": "檢查拼字",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@noble/hashes':
         specifier: ^2.2.0
         version: 2.2.0
+      '@replit/codemirror-vim':
+        specifier: 6.3.0
+        version: 6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)
       '@tanstack/react-virtual':
         specifier: 3.14.2
         version: 3.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1210,6 +1213,15 @@ packages:
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@replit/codemirror-vim@6.3.0':
+    resolution: {integrity: sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==}
+    peerDependencies:
+      '@codemirror/commands': 6.x.x
+      '@codemirror/language': 6.x.x
+      '@codemirror/search': 6.x.x
+      '@codemirror/state': 6.x.x
+      '@codemirror/view': 6.x.x
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -4548,6 +4560,14 @@ snapshots:
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
+
+  '@replit/codemirror-vim@6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)':
+    dependencies:
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true


### PR DESCRIPTION
## Summary
- Add a setting-backed Vim mode that applies to source, visual, split, and side document editors.
- Use `@replit/codemirror-vim` for source mode.
- Add a ProseMirror Vim-lite layer for visual editing with normal/insert modes, counts, core motions, delete/yank operators, paste, undo/redo, and a measured block caret.

## Why
- Gives keyboard-heavy users a Vim-shaped editing path without replacing the Markdown editor surface.
- Keeps source mode backed by a mature CodeMirror Vim implementation while making visual mode feel closer to Vim than a few isolated shortcuts.

## Validation
- `pnpm --filter @markra/editor test -- vim-mode.test.ts` passed
- `pnpm --filter @markra/app test -- MarkdownPaper.test.tsx styles.test.ts MarkdownSourceEditor.test.tsx` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed

## Risk
- Draft PR: visual Vim mode is intentionally Vim-lite and should get hands-on review for editing feel before it is marked ready.
