### PR TITLE
perf(app): smooth file tree sidebar opening

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -155,6 +155,10 @@ describe("MarkdownFileTreeDrawer", () => {
       minWidth: "288px",
       width: "288px"
     });
+    expect(container.querySelector(".markdown-file-tree-content")).toHaveStyle({
+      minWidth: "288px",
+      width: "288px"
+    });
 
     rerender(
       <MarkdownFileTreeDrawer
@@ -175,6 +179,10 @@ describe("MarkdownFileTreeDrawer", () => {
     });
     expect(container.querySelector(".markdown-file-tree")).not.toHaveClass("opacity-0");
     expect(container.querySelector(".markdown-file-tree-content")).toHaveClass("opacity-0");
+    expect(container.querySelector(".markdown-file-tree-content")).toHaveStyle({
+      minWidth: "288px",
+      width: "288px"
+    });
   });
 
   it("marks file rows as AI workspace operation targets", () => {
@@ -1502,6 +1510,48 @@ describe("MarkdownFileTreeDrawer", () => {
         onSelectOutlineItem={() => {}}
       />
     );
+
+    expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("defers automatic active-file reveal until after the drawer starts opening", () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <MarkdownFileTreeDrawer
+        autoRevealActiveFile
+        currentPath="/vault/deploy/deploy.md"
+        files={markdownFiles}
+        open={false}
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    rerender(
+      <MarkdownFileTreeDrawer
+        autoRevealActiveFile
+        currentPath="/vault/deploy/deploy.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootPath="/vault"
+        rootName="Obsidian Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: "deploy/deploy.md" })).not.toBeInTheDocument();
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     expect(screen.getByRole("button", { name: "deploy" })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toHaveAttribute("aria-current", "page");

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -204,6 +204,7 @@ const minOutlineHeightPercent = 24;
 const maxOutlineHeightPercent = 72;
 const outlineResizeKeyboardStepPercent = 5;
 const outlineResizeFallbackHeight = 320;
+const sidebarAutoRevealDelayMs = 220;
 const defaultDocumentLinksHeightPercent = 28;
 const minDocumentLinksHeightPercent = 16;
 const maxDocumentLinksHeightPercent = 60;
@@ -529,6 +530,7 @@ export function MarkdownFileTreeDrawer({
   const [pendingRevealPath, setPendingRevealPath] = useState<string | null>(null);
   const [selectedFileTreePaths, setSelectedFileTreePaths] = useState<Set<string>>(() => new Set());
   const [fileTreeSelectionAnchorPath, setFileTreeSelectionAnchorPath] = useState<string | null>(null);
+  const fileTreeWasOpenRef = useRef(open);
   const lastRevealRequestIdRef = useRef<number | null>(null);
   const lastAutoRevealedPathRef = useRef<string | null>(null);
   const operationOpenedFolderPathsRef = useRef<Set<string>>(new Set());
@@ -691,6 +693,7 @@ export function MarkdownFileTreeDrawer({
   const resolvedMaxWidth = Math.max(resolvedMinWidth, maxWidth);
   const resolvedWidth = clampNumber(width, resolvedMinWidth, resolvedMaxWidth);
   const drawerWidth = resolvedWidth === null ? null : open ? resolvedWidth : 0;
+  const drawerContentStyle = resolvedWidth === null ? undefined : { minWidth: resolvedWidth, width: resolvedWidth };
   const showWindowsOpenFolderAction = platform === "windows" && onOpenFolder;
   const drawerTopPaddingClassName = platform === "windows" ? "pt-0" : "pt-10";
   const fileCreationAvailable = Boolean(onCreateFile);
@@ -991,12 +994,30 @@ export function MarkdownFileTreeDrawer({
   }, [open, revealFileTreePath, revealPathRequest]);
 
   useEffect(() => {
+    const openedFromClosed = open && !fileTreeWasOpenRef.current;
+    fileTreeWasOpenRef.current = open;
     if (!autoRevealActiveFile || !open || !currentPath) return;
     if (lastAutoRevealedPathRef.current === currentPath) return;
 
-    if (revealFileTreePath(currentPath)) {
-      lastAutoRevealedPathRef.current = currentPath;
+    const revealActiveFile = () => {
+      if (lastAutoRevealedPathRef.current === currentPath) return;
+
+      if (revealFileTreePath(currentPath)) {
+        lastAutoRevealedPathRef.current = currentPath;
+      }
+    };
+
+    if (!openedFromClosed) {
+      revealActiveFile();
+      return;
     }
+
+    // Keep automatic reveal from competing with the sidebar opening animation.
+    const timeoutId = window.setTimeout(revealActiveFile, sidebarAutoRevealDelayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
   }, [autoRevealActiveFile, currentPath, open, revealFileTreePath]);
 
   useEffect(() => {
@@ -2592,7 +2613,10 @@ export function MarkdownFileTreeDrawer({
         inert={!open}
         style={drawerWidth === null ? undefined : { maxWidth: drawerWidth, minWidth: drawerWidth, width: drawerWidth }}
       >
-        <div className={`markdown-file-tree-content flex min-h-0 flex-1 flex-col transition-opacity duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${drawerContentStateClass}`}>
+        <div
+          className={`markdown-file-tree-content flex min-h-0 flex-1 flex-col transition-opacity duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] ${drawerContentStateClass}`}
+          style={drawerContentStyle}
+        >
         {renderSidebarPanelTabs()}
         {open && onResize && resolvedWidth !== null ? (
           <div

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -971,6 +971,32 @@ describe("useMarkdownFileTree", () => {
     expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({ fileTreeOpen: true });
   });
 
+  it("reopens an already loaded file tree without immediately rescanning the folder", async () => {
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      path: "/vault",
+      name: "vault"
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+    ]);
+
+    render(<FileTreeProbe currentPath="/vault/index.md" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+
+    mockedListNativeMarkdownFilesForPath.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+    expect(mockedListNativeMarkdownFilesForPath).not.toHaveBeenCalled();
+  });
+
   it("tracks a resizable markdown tree width for the workspace layout", async () => {
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([]);
 

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -448,12 +448,18 @@ export function useMarkdownFileTree({
       openChangedBeforeWorkspaceRestoreRef.current = true;
       setOpen((currentOpen) => {
         const nextOpen = !currentOpen;
-        if (nextOpen) refresh(fallbackPath);
+        const refreshPath = sourcePath ?? fallbackPath;
+        const treeAlreadyLoaded =
+          Boolean(refreshPath) &&
+          loadedFileTreeRequestRef.current?.path === refreshPath &&
+          loadedFileTreeRequestRef.current.managedAttachmentFolder === normalizedManagedAttachmentFolder;
+
+        if (nextOpen && !treeAlreadyLoaded) refresh(fallbackPath);
         persistWorkspaceState({ fileTreeOpen: nextOpen });
         return nextOpen;
       });
     },
-    [refresh]
+    [normalizedManagedAttachmentFolder, refresh, sourcePath]
   );
 
   const rootNameForDocument = useCallback(


### PR DESCRIPTION
## Summary
- Avoid refreshing an already loaded workspace file tree when reopening the left sidebar.
- Keep sidebar contents at the target layout width while the outer drawer clips the width animation.
- Defer automatic active-file reveal until after the sidebar has started opening.

## Why
Opening the sidebar could rescan large file trees and expand/scroll the active file during the opening animation, causing visible jank when many files are present.

## Validation
- `pnpm --filter @markra/app test -- useMarkdownFileTree.test.tsx --runInBand` passed
- `pnpm --filter @markra/app test -- MarkdownFileTreeDrawer.test.tsx --runInBand` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed
- `git diff --cached --check` passed

## Risk
- Low. The file tree still refreshes when first opened, when the watched folder changes, and when folder contents change; reopening an already loaded sidebar skips only the immediate redundant refresh.