### PR TITLE
fix(editor): render formatted soft line breaks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2785,6 +2785,18 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).not.toContain("<br");
   });
 
+  it("renders soft line breaks between formatted paragraph lines", async () => {
+    const source = ["**加黑**：内容 1", "**加黑**：内容 2", "**加黑**：内容 3"].join("\n");
+    const { container, editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const paragraph = container.querySelector(".ProseMirror p");
+
+    expect(paragraph?.querySelectorAll("br")).toHaveLength(2);
+    expect(paragraph?.querySelectorAll("strong")).toHaveLength(3);
+    expect(serializeMarkdown(view.state.doc)).toContain(source);
+    expect(serializeMarkdown(view.state.doc)).not.toContain("<br");
+  });
+
   it("keeps the native caret anchor when leaving display math source at the closing delimiter", async () => {
     const source = String.raw`$$ E = mc^2 $$`;
     const { container, view } = await renderEditor(source);
@@ -8967,7 +8979,10 @@ describe("MarkdownPaper editing", () => {
     });
 
     expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toBeInTheDocument();
-    expect(container.querySelector(".ProseMirror blockquote")).toHaveTextContent("[!NOTE] Keep this in mind.");
+    const blockquote = container.querySelector(".ProseMirror blockquote");
+    expect(blockquote).toHaveTextContent("[!NOTE]");
+    expect(blockquote).toHaveTextContent("Keep this in mind.");
+    expect(blockquote?.querySelectorAll("br")).toHaveLength(1);
     expect(container.querySelector(".markra-callout-title")).not.toBeInTheDocument();
   });
 

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -132,7 +132,7 @@ const markraHardbreakSchema = hardbreakSchema.extendSchema((previous) => (ctx) =
       }
     },
     toDOM: (node) => {
-      if (!(node.attrs.isInline && node.attrs.renderLineBreak)) {
+      if (!node.attrs.isInline) {
         return baseSchema.toDOM?.(node) ?? ["br", ctx.get(hardbreakAttr.key)(node)];
       }
 


### PR DESCRIPTION
## Summary
- Render inline Markdown soft breaks as actual line breaks in the visual editor.
- Add regression coverage for formatted consecutive lines like `**加黑**：内容 1`.
- Keep plain alert blockquotes visually line-broken when GitHub alerts are disabled.

## Why
- Milkdown parsed single newlines into inline hardbreak nodes, but Markra rendered those inline nodes as a space, collapsing formatted lines visually.

## Validation
- `pnpm --filter @markra/app test` passed (103 files, 1563 tests).
- `pnpm --filter @markra/app build` passed.

## Risk
- Low; scoped to hardbreak DOM rendering and related editor tests.

## Related Issues
Closes #449
