### PR TITLE
fix(editor): preserve spreadsheet table paste data

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -460,6 +460,25 @@ function pasteImage(view: EditorView, image: File) {
   return view.someProp("handlePaste", (handler) => handler(view, event, view.state.selection.content()));
 }
 
+function dispatchMixedClipboardPaste(view: EditorView, data: { files: File[]; html?: string; plainText?: string }) {
+  const event = new Event("paste", {
+    bubbles: true,
+    cancelable: true
+  }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: data.files,
+      getData: (type: string) => {
+        if (type === "text/html") return data.html ?? "";
+        if (type === "text/plain") return data.plainText ?? "";
+        return "";
+      }
+    }
+  });
+
+  view.dom.dispatchEvent(event);
+}
+
 function pasteFile(view: EditorView, file: File) {
   const event = new Event("paste", {
     bubbles: true,
@@ -3188,6 +3207,29 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("![Screenshot](assets/pasted-image.png)");
     expect(serializeMarkdown(view.state.doc)).not.toContain("!\\[Screenshot\\]\\(assets/pasted-image.png\\)");
     await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining("![Screenshot](assets/pasted-image.png)")));
+  });
+
+  it("lets pasted spreadsheet tables use structured clipboard data instead of the bitmap preview", async () => {
+    const onSaveClipboardImage = vi.fn().mockResolvedValue({
+      alt: "Spreadsheet preview",
+      src: "assets/spreadsheet-preview.png"
+    });
+    const image = new File([new Uint8Array([1, 2, 3])], "Spreadsheet preview.png", { type: "image/png" });
+    const { container, view } = await renderEditor("", { onSaveClipboardImage });
+
+    dispatchMixedClipboardPaste(
+      view,
+      {
+        files: [image],
+        html: "<table><tbody><tr><td>Name</td><td>Role</td></tr><tr><td>Alpha</td><td>Beta</td></tr></tbody></table>",
+        plainText: "Name\tRole\nAlpha\tBeta"
+      }
+    );
+
+    expect(onSaveClipboardImage).not.toHaveBeenCalled();
+    await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+    expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Name");
+    expect(container.querySelector(".ProseMirror table")).toHaveTextContent("Beta");
   });
 
   it("saves pasted clipboard attachments and inserts markdown links", async () => {

--- a/packages/editor/src/clipboard-images.ts
+++ b/packages/editor/src/clipboard-images.ts
@@ -90,6 +90,24 @@ function clipboardHtml(event: ClipboardEvent) {
   return event.clipboardData?.getData("text/html") ?? "";
 }
 
+function clipboardPlainText(event: ClipboardEvent) {
+  return event.clipboardData?.getData("text/plain") ?? "";
+}
+
+function isPlainTextTable(value: string) {
+  const rows = value.trim().split(/\r\n?|\n/u).filter(Boolean);
+  if (!rows.length) return false;
+
+  return rows.some((row) => row.includes("\t"));
+}
+
+function clipboardHasStructuredTableData(event: ClipboardEvent) {
+  const html = clipboardHtml(event);
+  if (/<table[\s>]/iu.test(html)) return true;
+
+  return isPlainTextTable(clipboardPlainText(event));
+}
+
 function droppedImageFiles(event: DragEvent) {
   return dataTransferImageFiles(event.dataTransfer);
 }
@@ -397,7 +415,7 @@ export function markraClipboardImagePluginWithOptions(
       props: {
         handlePaste: (view, event, slice) => {
           const files = clipboardImageFiles(event);
-          if (files.length) {
+          if (files.length && !clipboardHasStructuredTableData(event)) {
             event.preventDefault();
             saveAndInsertClipboardImages(view, files, saveClipboardImage, image).catch((error: unknown) => {
               console.error("[markra-clipboard-images] failed to insert pasted image", error);


### PR DESCRIPTION
## Summary
- Keep spreadsheet paste payloads from being intercepted by clipboard image handling when structured table data is available.
- Add a regression test for mixed clipboard data containing a bitmap preview, HTML table, and TSV text.

## Why
- Spreadsheet apps can put a bitmap preview on the clipboard alongside table data. The image plugin consumed the image first, so Markra inserted a screenshot instead of a table.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx --testNamePattern "pasted clipboard|remote images from pasted web HTML|pasted spreadsheet"` passed: 4 tests.
- `pnpm --filter @markra/editor build` passed.
- `pnpm --filter @markra/app build` passed.
- `pnpm --filter @markra/app typecheck:test` passed.

## Risk
- Low. The image paste path still handles image-only clipboard payloads; it only yields when the clipboard also contains table HTML or tab-delimited table text.