### PR TITLE
fix(app): preserve agent and disk edits in editor flows

### DIFF
--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -1,4 +1,7 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { Editor as MilkdownEditor, editorViewCtx } from "@milkdown/kit/core";
+import { TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorView as ProseMirrorEditorView } from "@milkdown/kit/prose/view";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import { defaultAiQuickActionPrompts } from "./lib/ai-actions";
 import {
@@ -24,6 +27,47 @@ import {
 import { agentSessionSummary, storedAgentSession } from "./test/ai-fixtures";
 
 installAppTestHarness();
+
+async function settleEditorUpdates() {
+  await new Promise((resolve) => {
+    window.setTimeout(resolve, 300);
+  });
+}
+
+function visibleEditorView(
+  container: HTMLElement,
+  editors: Array<ReturnType<typeof MilkdownEditor.make>>
+): ProseMirrorEditorView {
+  for (const editor of editors) {
+    try {
+      const view = editor.action((ctx) => ctx.get(editorViewCtx));
+      if (container.contains(view.dom) && !view.dom.closest("[hidden]")) return view;
+    } catch {
+      // Some editor instances may be disposed while the app swaps surfaces.
+    }
+  }
+
+  throw new Error("Expected a visible Milkdown editor view.");
+}
+
+function findTextPosition(view: ProseMirrorEditorView, text: string, offset = 0) {
+  let result: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (result !== null || !node.isText) return true;
+
+    const textOffset = node.text?.indexOf(text) ?? -1;
+    if (textOffset < 0) return true;
+
+    result = nodePosition + textOffset + offset;
+    return false;
+  });
+
+  if (result === null) throw new Error(`Text not found in editor: ${text}`);
+
+  return result;
+}
+
 describe("Markra AI workspace", () => {
   it("opens a right-side Markra AI workspace from the titlebar", async () => {
     mockedGetStoredAiSettings.mockResolvedValue({
@@ -70,6 +114,42 @@ describe("Markra AI workspace", () => {
     expect((container.querySelector(".editor-agent-layout") as HTMLElement).style.gridTemplateColumns).toBe(
       "minmax(0,1fr) 0px"
     );
+  });
+
+  it("keeps the selected editor text visibly held when the right-side AI input is focused", async () => {
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+
+    try {
+      const { container } = renderApp();
+
+      await screen.findByText("Welcome to Markra");
+      await settleEditorUpdates();
+
+      const view = visibleEditorView(container, createdEditors);
+      const from = findTextPosition(view, "Welcome");
+      act(() => {
+        view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, from + "Welcome".length)));
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Toggle Markra AI" }));
+
+      const agentPanel = await screen.findByRole("complementary", { name: "Markra AI" });
+      const input = within(agentPanel).getByRole("textbox", { name: "Markra AI message" });
+
+      fireEvent.focus(input);
+
+      await waitFor(() => {
+        expect(container.querySelector(".ProseMirror .markra-ai-selection-hold")).toHaveTextContent("Welcome");
+      });
+    } finally {
+      makeSpy.mockRestore();
+    }
   });
 
   it("toggles the Markra AI panel from the keyboard shortcut", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -7677,7 +7677,7 @@ describe("Markra workspace", () => {
     expect(options?.getAiCommandsAvailable?.()).toBe(false);
   });
 
-  it("reloads the current file when a native watcher reports an external change", async () => {
+  it("reloads the current file as an undoable edit when a native watcher reports an external change", async () => {
     let emitExternalChange: (path: string) => unknown | Promise<unknown> = () => {};
 
     mockOpenMarkdownFile({
@@ -7695,11 +7695,13 @@ describe("Markra workspace", () => {
       return () => {};
     });
 
-    renderApp();
+    const { container } = renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true });
 
-    expect(await screen.findByText("Native file")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Native file");
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalled());
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls.at(-1)?.[0] as NativeMenuHandlers;
 
     await waitFor(() =>
       expect(mockedWatchNativeMarkdownFile).toHaveBeenCalledWith(
@@ -7708,11 +7710,20 @@ describe("Markra workspace", () => {
         expect.any(Function)
       )
     );
-    await emitExternalChange(mockNativePath);
+    await act(async () => {
+      await emitExternalChange(mockNativePath);
+    });
 
-    expect(await screen.findByText("Changed elsewhere")).toBeInTheDocument();
-    expect(screen.getByText("Reloaded from disk.")).toBeInTheDocument();
+    await expectVisibleMilkdownText(container, "Changed elsewhere");
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(mockNativePath);
+
+    act(() => {
+      menuHandlers.editUndo?.();
+    });
+
+    await expectVisibleMilkdownText(container, "Native file");
+    await waitFor(() => expect(screen.getByLabelText("Unsaved changes")).toBeInTheDocument());
+    expect(within(getVisibleMilkdownEditor(container)).queryByText("Changed elsewhere")).not.toBeInTheDocument();
   });
 
   it("refreshes the markdown file tree when the native folder watcher reports a new asset", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -61,7 +61,7 @@ import { useEditorPreferences } from "./hooks/useEditorPreferences";
 import { useDeferredAiSelectionReveal } from "./hooks/ai-selection-reveal";
 import { useExportSettings } from "./hooks/useExportSettings";
 import { shouldFocusEditorOnReady, useEditorController } from "./hooks/useEditorController";
-import { useMarkdownDocument } from "./hooks/useMarkdownDocument";
+import { useMarkdownDocument, type ActiveDiskFileContentChange } from "./hooks/useMarkdownDocument";
 import { useMarkdownFileTree } from "./hooks/useMarkdownFileTree";
 import { useSelectionToolbarAnchorRefresh } from "./hooks/useSelectionToolbarAnchorRefresh";
 import { useSharedEditorHistory } from "./hooks/useSharedEditorHistory";
@@ -359,6 +359,7 @@ function WorkspaceApp() {
   const aiResultsRef = useRef<AiDiffResult[]>([]);
   const appliedAiPreviewKeysRef = useRef(new Set<string>());
   const activeAiSelectionRef = useRef<AiSelectionContext | null>(null);
+  const selectedAcpModelIdRef = useRef<string | null>(null);
   const aiContextMenuActionIdRef = useRef(0);
   const aiSelectionCopySuccessTimerRef = useRef<number | null>(null);
   const exportRequestIdRef = useRef(0);
@@ -389,6 +390,7 @@ function WorkspaceApp() {
   // Late visual-editor updates may arrive after focus moves to source; source edits after that focus win.
   const sourceEditSequenceRef = useRef(0);
   const sourceFocusSourceEditSequenceRef = useRef(0);
+  const syncingExternalDocumentHistoryRef = useRef(false);
   const exportContextRef = useRef({
     activeImageFile: false,
     content: "",
@@ -511,6 +513,19 @@ function WorkspaceApp() {
       visualEditorReadyRevisionRef.current = null;
     }
   }, [handleMilkdownEditorReady]);
+  const handleActiveDiskFileContentChange = useCallback((change: ActiveDiskFileContentChange) => {
+    if (largeMarkdownVisualBlockedRef.current) return false;
+
+    syncingExternalDocumentHistoryRef.current = true;
+    try {
+      return replaceEditorMarkdown(change.content, {
+        addToHistory: true,
+        historyBaselineMarkdown: change.previousContent
+      });
+    } finally {
+      syncingExternalDocumentHistoryRef.current = false;
+    }
+  }, [replaceEditorMarkdown]);
   const handleActiveOutlineIndexChange = useCallback((index: number | null) => {
     setActiveOutlineIndex((current) => current === index ? current : index);
   }, []);
@@ -598,6 +613,7 @@ function WorkspaceApp() {
     editorReady: isDocumentEditorReady,
     getCurrentMarkdown: readCurrentMarkdownForDocument,
     isCurrentMarkdownEquivalent: isCurrentMarkdownEquivalentForDocument,
+    onActiveDiskFileContentChange: handleActiveDiskFileContentChange,
     onMarkdownTreeChange: refreshMarkdownFileTree,
     onTreeRootFromFolderPath: openFolderPath,
     onTreeRootFromFilePath: setRootFromMarkdownFilePath,
@@ -1159,9 +1175,11 @@ function WorkspaceApp() {
     aiSettings.selectAgentModel(selection.agentProviderId, selection.agentModelId).catch(() => {});
   }, [aiSettings.agentModelId, aiSettings.agentProviderId, aiSettings.selectAgentModel]);
   const aiCommand = useAiCommandUi({
+    acpAgentSettings: acpAgentSettings.settings,
     documentPath: document.path,
     getDocumentContent: getAiDocumentContent,
     getPendingResult: getPendingAiResult,
+    getSelectedAcpModelId: () => selectedAcpModelIdRef.current,
     getSelection: getActiveAiSelection,
     model: aiSettings.inlineModelId,
     onAiResult: handleAiResult,
@@ -1169,6 +1187,7 @@ function WorkspaceApp() {
     settingsLoading: aiSettings.loading,
     translate,
     translationTargetLanguage: aiTranslationLanguageName(appLanguage.ready ? appLanguage.language : "en"),
+    workspaceKey,
     workspaceFiles: fileTreeFiles
   });
   const aiCommandVisible = aiCommand.open && (hasAiCommandContext || Boolean(aiResult) || aiContextMenuActionPending);
@@ -1241,6 +1260,7 @@ function WorkspaceApp() {
     workspaceKey,
     workspaceFiles: fileTreeFiles
   });
+  selectedAcpModelIdRef.current = aiAgent.selectedAcpModelId;
   aiAgentInitialSessionOptionsRef.current = {
     agentModelId: aiSettings.agentModelId,
     agentProviderId: aiSettings.agentProviderId,
@@ -1577,6 +1597,13 @@ function WorkspaceApp() {
   ]);
   const handleAiCommandSelectionContextFocus = useCallback(() => {
     const selection = aiCommandSelection(getActiveAiSelection()) ?? aiCommandSelection(getEditorSelection());
+    if (!selection) return;
+
+    holdAiSelection(selection);
+    updateActiveAiSelection(selection);
+  }, [getActiveAiSelection, getEditorSelection, holdAiSelection, updateActiveAiSelection]);
+  const handleAiAgentComposerFocus = useCallback(() => {
+    const selection = automaticAiSelection(getActiveAiSelection()) ?? automaticAiSelection(getEditorSelection());
     if (!selection) return;
 
     holdAiSelection(selection);
@@ -2605,6 +2632,7 @@ function WorkspaceApp() {
   }, []);
   const handleVisualMarkdownChange = useCallback((content: string, options?: { documentRevision?: number }) => {
     if (isApplyingSourceToVisualSync()) return;
+    if (syncingExternalDocumentHistoryRef.current) return;
     if (sourceMode) return;
     if (readOnlyMode) return;
     if (
@@ -3051,6 +3079,7 @@ function WorkspaceApp() {
       })
     );
   }, [
+    document.content,
     document.revision,
     documentSearchAvailable,
     documentSearchCaseSensitive,
@@ -3861,6 +3890,7 @@ function WorkspaceApp() {
           aiAgent.applyWorkspacePlan().catch(() => {});
         }}
         onClose={closeAiAgentPanel}
+        onComposerFocus={handleAiAgentComposerFocus}
         onCreateSession={handleCreateAiAgentSession}
         onDeleteSession={(sessionId) => {
           handleDeleteAiAgentSession(sessionId).catch(() => {});

--- a/packages/app/src/components/AiAgentPanel.tsx
+++ b/packages/app/src/components/AiAgentPanel.tsx
@@ -86,6 +86,7 @@ type AiAgentPanelProps = {
   onCreateSession?: () => unknown;
   onDeleteSession?: (sessionId: string) => unknown;
   onDisableThinking?: () => unknown;
+  onComposerFocus?: () => unknown;
   onDraftChange?: (value: string) => unknown;
   onInterrupt?: () => unknown;
   onRenameSession?: (sessionId: string, title: string) => unknown;
@@ -140,6 +141,7 @@ export function AiAgentPanel({
   onArchiveSession,
   onApplyWorkspacePlan,
   onClose,
+  onComposerFocus,
   onCreateSession,
   onDeleteSession,
   onDisableThinking,
@@ -824,6 +826,7 @@ export function AiAgentPanel({
               }}
               onCompositionEnd={handleCompositionEnd}
               onCompositionStart={handleCompositionStart}
+              onFocus={onComposerFocus}
               onKeyDown={handleKeyDown}
             />
             <div className="mt-2 flex items-center justify-between gap-3 border-t border-(--border-default) pt-2">

--- a/packages/app/src/components/settings/AiSettings.test.tsx
+++ b/packages/app/src/components/settings/AiSettings.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { translate } from "../../test/settings-components";
-import { defaultAcpAgentSettings, defaultEditorPreferences } from "../../lib/settings/app-settings";
+import { codexAcpAgentArgs, defaultAcpAgentSettings, defaultEditorPreferences } from "../../lib/settings/app-settings";
 import { defaultAiQuickActionPrompt, defaultAiQuickActionPrompts } from "../../lib/ai-actions";
 import { AiSettings } from "./AiSettings";
 
@@ -65,7 +65,7 @@ describe("AiSettings", () => {
     expect(screen.getByRole("textbox", { name: "ACP command" })).toHaveAttribute("placeholder", "/bin/zsh");
     expect(screen.getByRole("textbox", { name: "ACP arguments" })).toHaveAttribute(
       "placeholder",
-      "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'"
+      codexAcpAgentArgs
     );
     expect(screen.getByRole("textbox", { name: "ACP working directory" })).toHaveAttribute(
       "placeholder",
@@ -102,7 +102,7 @@ describe("AiSettings", () => {
     ]);
 
     const expectedPresets = [
-      ["codex-acp", "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'"],
+      ["codex-acp", codexAcpAgentArgs],
       ["claude-acp", "-lc 'exec npx -y @agentclientprotocol/claude-agent-acp'"],
       ["gemini", "-lc 'exec npx -y @google/gemini-cli --acp'"],
       ["github-copilot-cli", "-lc 'exec npx -y @github/copilot --acp'"],

--- a/packages/app/src/components/settings/AiSettings.tsx
+++ b/packages/app/src/components/settings/AiSettings.tsx
@@ -7,7 +7,7 @@ import {
   defaultAiQuickActionPrompts,
   type AiQuickActionId
 } from "../../lib/ai-actions";
-import type { EditorPreferences } from "../../lib/settings/app-settings";
+import { codexAcpAgentArgs, type EditorPreferences } from "../../lib/settings/app-settings";
 import {
   SettingsButton,
   SettingsRow,
@@ -28,7 +28,7 @@ function acpShellArgs(command: string) {
 
 const acpAgentPresets = [
   {
-    args: acpShellArgs("env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp"),
+    args: codexAcpAgentArgs,
     command: acpShellCommand,
     id: "codex-acp",
     label: "Codex"

--- a/packages/app/src/hooks/useAiAgentSession.test.tsx
+++ b/packages/app/src/hooks/useAiAgentSession.test.tsx
@@ -96,6 +96,7 @@ describe("useAiAgentSession", () => {
     let agentEventHandler: ((event: { connectionId: string; message: string; type: "exit" | "message" | "stderr" }) => unknown) | null = null;
     const startAgent = vi.fn(async () => ({ connectionId: "acp-1" }));
     const stopAgent = vi.fn(async () => undefined);
+    let promptBlocks: unknown = null;
     const listenAgentMessages = vi.fn(async (handler) => {
       agentEventHandler = handler;
 
@@ -123,6 +124,10 @@ describe("useAiAgentSession", () => {
       }
 
       if (message.method === "session/prompt") {
+        const params = "params" in message && message.params && typeof message.params === "object"
+          ? message.params as { prompt?: unknown }
+          : {};
+        promptBlocks = params.prompt ?? null;
         agentEventHandler?.({
           connectionId: "acp-1",
           message: JSON.stringify({
@@ -238,6 +243,13 @@ describe("useAiAgentSession", () => {
 
     const { result } = renderAiAgentSession({
       documentPath: "/mock-vault/note.md",
+      getSelection: () => ({
+        cursor: 18,
+        from: 8,
+        source: "selection",
+        text: "selected synthetic text",
+        to: 31
+      }),
       model: null,
       provider: null,
       sessionId: "session-a",
@@ -256,6 +268,11 @@ describe("useAiAgentSession", () => {
       env: []
     });
     expect(mockedRunDocumentAiAgent).not.toHaveBeenCalled();
+    const editorContextBlock = (promptBlocks as Array<{ text?: string; type?: string }>).find((block) =>
+      block.type === "text" && block.text?.includes("Markra editor context:")
+    );
+    expect(editorContextBlock?.text).toContain("Current selection snapshot:");
+    expect(editorContextBlock?.text).toContain("Selected text:\nselected synthetic text");
     expect(result.current.messages.at(-1)).toMatchObject({
       role: "assistant",
       text: "ACP summary"
@@ -469,6 +486,117 @@ describe("useAiAgentSession", () => {
       preview,
       role: "assistant",
       text: "The editor change is ready."
+    });
+  });
+
+  it("keeps ACP text responses in the transcript when no filesystem write occurs", async () => {
+    let agentEventHandler: ((event: { connectionId: string; message: string; type: "exit" | "message" | "stderr" }) => unknown) | null = null;
+    const onAiPreviewReady = vi.fn();
+    const onAiResult = vi.fn();
+    const suggestedResponse = [
+      "```markdown",
+      "Improved draft",
+      "```"
+    ].join("\n");
+    const writeAgentMessage = vi.fn(async (_connectionId, message) => {
+      if (!("id" in message) || !("method" in message)) return;
+
+      if (message.method === "initialize") {
+        agentEventHandler?.({
+          connectionId: "acp-1",
+          message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { protocolVersion: 1 } }),
+          type: "message"
+        });
+      }
+
+      if (message.method === "session/new") {
+        agentEventHandler?.({
+          connectionId: "acp-1",
+          message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { sessionId: "session-acp" } }),
+          type: "message"
+        });
+      }
+
+      if (message.method === "session/prompt") {
+        agentEventHandler?.({
+          connectionId: "acp-1",
+          message: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: "session-acp",
+              update: {
+                content: {
+                  text: suggestedResponse,
+                  type: "text"
+                },
+                sessionUpdate: "agent_message_chunk"
+              }
+            }
+          }),
+          type: "message"
+        });
+        agentEventHandler?.({
+          connectionId: "acp-1",
+          message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { stopReason: "end_turn" } }),
+          type: "message"
+        });
+      }
+    });
+
+    configureAppRuntime({
+      ...createDefaultAppRuntime(),
+      acp: {
+        listenAgentMessages: vi.fn(async (handler) => {
+          agentEventHandler = handler;
+
+          return () => {
+            agentEventHandler = null;
+          };
+        }),
+        startAgent: vi.fn(async () => ({ connectionId: "acp-1" })),
+        stopAgent: vi.fn(async () => undefined),
+        writeAgentMessage
+      }
+    });
+    mockedGetStoredAcpAgentSettings.mockResolvedValue({
+      args: "",
+      command: "synthetic-agent",
+      cwd: "",
+      enabled: true
+    });
+
+    const { result } = renderAiAgentSession({
+      documentPath: "/mock-vault/note.md",
+      getDocumentContent: () => "# Draft\n\nOriginal draft",
+      getSelection: () => ({
+        cursor: 23,
+        from: 9,
+        source: "selection",
+        text: "Original draft",
+        to: 23
+      }),
+      model: null,
+      onAiPreviewReady,
+      onAiResult,
+      provider: null,
+      sessionId: "session-a",
+      translate: testTranslate({
+        "app.aiAgentPreviewReady": "The editor change is ready."
+      }),
+      workspaceKey: "/mock-vault"
+    });
+
+    await act(async () => {
+      await result.current.submit("Polish the selected text");
+    });
+
+    expect(onAiResult).not.toHaveBeenCalled();
+    expect(onAiPreviewReady).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("idle");
+    expect(result.current.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      text: suggestedResponse
     });
   });
 

--- a/packages/app/src/hooks/useAiAgentSession.ts
+++ b/packages/app/src/hooks/useAiAgentSession.ts
@@ -673,6 +673,7 @@ export function useAiAgentSession(ctx: AiAgentSessionContext) {
             prompt,
             readWorkspaceFile: ctx.readWorkspaceFile,
             selectedModelId: selectedAcpModelId,
+            selection: ctx.getSelection?.() ?? null,
             settings: acpAgentSettings,
             signal: acpAbortController?.signal,
             workspaceKey: ctx.workspaceKey ?? null

--- a/packages/app/src/hooks/useAiCommandUi.test.tsx
+++ b/packages/app/src/hooks/useAiCommandUi.test.tsx
@@ -190,6 +190,58 @@ describe("useAiCommandUi", () => {
     });
   });
 
+  it("aborts an in-flight ACP inline request when interrupted", async () => {
+    const onAiResult = vi.fn();
+    let capturedSignal: AbortSignal | undefined;
+    mockedRunAcpInlineAiAgent.mockImplementation((input) => {
+      capturedSignal = input.signal;
+      return new Promise((_resolve, reject) => {
+        input.signal?.addEventListener("abort", () => {
+          reject(new Error("Aborted"));
+        }, { once: true });
+      });
+    });
+    const { result } = renderHook(() =>
+      useAiCommandUi({
+        acpAgentSettings: {
+          args: "--acp",
+          command: "synthetic-acp-agent",
+          cwd: "",
+          enabled: true
+        },
+        documentPath: "/vault/README.md",
+        getDocumentContent: () => "# Draft\n\nOriginal draft",
+        getSelection: () => ({ from: 9, source: "selection", text: "Original draft", to: 23 }),
+        model: "gpt-5.5",
+        onAiResult,
+        provider: provider(),
+        settingsLoading: false,
+        workspaceKey: "/vault"
+      })
+    );
+
+    let submitPromise: Promise<unknown> = Promise.resolve();
+    act(() => {
+      submitPromise = result.current.submitPrompt("make it clearer");
+    });
+
+    expect(mockedRunAcpInlineAiAgent).toHaveBeenCalled();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    act(() => {
+      result.current.interruptPrompt();
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(result.current.submitting).toBe(false);
+
+    await act(async () => {
+      await submitPromise;
+    });
+
+    expect(onAiResult).not.toHaveBeenCalled();
+  });
+
   it("passes command thinking options into the inline agent", async () => {
     mockedRunInlineAiAgent.mockResolvedValue({ content: "Better draft", finishReason: "stop" });
     const { result } = renderHook(() =>

--- a/packages/app/src/hooks/useAiCommandUi.test.tsx
+++ b/packages/app/src/hooks/useAiCommandUi.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { runInlineAiAgent } from "@markra/ai";
+import { runAcpInlineAiAgent } from "../lib/acp-agent";
 import { useAiCommandUi } from "./useAiCommandUi";
 import type { AiProviderConfig } from "@markra/providers";
 
@@ -12,7 +13,12 @@ vi.mock("@markra/ai", async (importOriginal) => {
   };
 });
 
+vi.mock("../lib/acp-agent", () => ({
+  runAcpInlineAiAgent: vi.fn()
+}));
+
 const mockedRunInlineAiAgent = vi.mocked(runInlineAiAgent);
+const mockedRunAcpInlineAiAgent = vi.mocked(runAcpInlineAiAgent);
 
 function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
   return {
@@ -31,6 +37,7 @@ function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
 describe("useAiCommandUi", () => {
   beforeEach(() => {
     mockedRunInlineAiAgent.mockReset();
+    mockedRunAcpInlineAiAgent.mockReset();
   });
 
   it("only opens the command surface when text is selected", () => {
@@ -120,6 +127,59 @@ describe("useAiCommandUi", () => {
         scope: "selection",
         type: "replace"
       })
+    }));
+    expect(onAiResult).toHaveBeenCalledWith({
+      from: 9,
+      original: "Original draft",
+      replacement: "Better draft",
+      to: 23,
+      type: "replace"
+    });
+  });
+
+  it("routes quick AI through ACP when an ACP agent is configured", async () => {
+    const onAiResult = vi.fn();
+    mockedRunAcpInlineAiAgent.mockResolvedValue({ content: "Better draft", finishReason: "stop" });
+    const acpAgentSettings = {
+      args: "--acp",
+      command: "synthetic-acp-agent",
+      cwd: "",
+      enabled: true
+    };
+    const { result } = renderHook(() =>
+      useAiCommandUi({
+        acpAgentSettings,
+        documentPath: "/vault/README.md",
+        getDocumentContent: () => "# Draft\n\nOriginal draft",
+        getSelection: () => ({ from: 9, source: "selection", text: "Original draft", to: 23 }),
+        model: "gpt-5.5",
+        onAiResult,
+        provider: provider(),
+        selectedAcpModelId: "synthetic-acp-model",
+        settingsLoading: false,
+        workspaceKey: "/vault"
+      })
+    );
+
+    await act(async () => {
+      await result.current.submitPrompt("make it clearer", "polish");
+    });
+
+    expect(mockedRunInlineAiAgent).not.toHaveBeenCalled();
+    expect(mockedRunAcpInlineAiAgent).toHaveBeenCalledWith(expect.objectContaining({
+      documentContent: "# Draft\n\nOriginal draft",
+      documentPath: "/vault/README.md",
+      intent: "polish",
+      prompt: "make it clearer",
+      selectedModelId: "synthetic-acp-model",
+      settings: acpAgentSettings,
+      target: expect.objectContaining({
+        original: "Original draft",
+        promptText: "Original draft",
+        scope: "selection",
+        type: "replace"
+      }),
+      workspaceKey: "/vault"
     }));
     expect(onAiResult).toHaveBeenCalledWith({
       from: 9,

--- a/packages/app/src/hooks/useAiCommandUi.ts
+++ b/packages/app/src/hooks/useAiCommandUi.ts
@@ -48,6 +48,7 @@ export function useAiCommandUi(ctx: AiCommandContext) {
   const [prompt, setPrompt] = useState("");
   const [status, setStatus] = useState<AiCommandStatus>("idle");
   const requestIdRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
   const submitting = isSubmittingStatus(status);
 
   const openAiCommand = useCallback((selectionOverride?: AiSelectionContext | null) => {
@@ -70,6 +71,8 @@ export function useAiCommandUi(ctx: AiCommandContext) {
 
   const interruptPrompt = useCallback(() => {
     requestIdRef.current += 1;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
     setStatus("idle");
   }, []);
 
@@ -124,6 +127,8 @@ export function useAiCommandUi(ctx: AiCommandContext) {
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    const abortController = runWithAcpAgent ? new AbortController() : null;
+    abortControllerRef.current = abortController;
     setStatus("thinking");
     try {
       const response = runWithAcpAgent
@@ -145,6 +150,7 @@ export function useAiCommandUi(ctx: AiCommandContext) {
             prompt: trimmedPrompt,
             selectedModelId: ctx.getSelectedAcpModelId?.() ?? ctx.selectedAcpModelId,
             settings: acpAgentSettings,
+            signal: abortController?.signal,
             target,
             translationTargetLanguage: ctx.translationTargetLanguage ?? "English",
             workspaceKey: ctx.workspaceKey ?? null
@@ -206,6 +212,10 @@ export function useAiCommandUi(ctx: AiCommandContext) {
         type: "error"
       });
       setStatus("error");
+    } finally {
+      if (abortControllerRef.current === abortController) {
+        abortControllerRef.current = null;
+      }
     }
   }, [ctx, prompt, submitting]);
 

--- a/packages/app/src/hooks/useAiCommandUi.ts
+++ b/packages/app/src/hooks/useAiCommandUi.ts
@@ -11,21 +11,27 @@ import {
 import { getProviderCapabilities, type AiProviderConfig } from "@markra/providers";
 import type { I18nKey } from "@markra/shared";
 import { requestNativeChat, requestNativeChatStream } from "../lib/tauri";
+import { runAcpInlineAiAgent } from "../lib/acp-agent";
+import type { AcpAgentSettings } from "../lib/settings/app-settings";
 
 type AiTextDiffResult = Extract<AiDiffResult, { type: "insert" | "replace" }>;
 export type AiCommandStatus = "idle" | "composing" | "thinking" | "streaming" | "suggestion" | "error";
 
 type AiCommandContext = {
+  acpAgentSettings?: AcpAgentSettings | null;
   documentPath?: string | null;
   getDocumentContent: () => string;
   getPendingResult?: () => AiDiffResult | null;
+  getSelectedAcpModelId?: () => string | null;
   getSelection: () => AiSelectionContext | null;
   model: string | null;
   onAiResult: (result: AiDiffResult, previewId?: string) => unknown;
   provider: AiProviderConfig | null;
+  selectedAcpModelId?: string | null;
   settingsLoading: boolean;
   translate?: (key: I18nKey) => string;
   translationTargetLanguage?: string;
+  workspaceKey?: string | null;
   workspaceFiles?: AgentWorkspaceFile[];
 };
 
@@ -92,14 +98,17 @@ export function useAiCommandUi(ctx: AiCommandContext) {
       return;
     }
 
-    if (!ctx.provider || !ctx.model) {
+    const acpAgentSettings = ctx.acpAgentSettings;
+    const runWithAcpAgent = acpAgentSettings?.enabled === true && Boolean(acpAgentSettings.command.trim());
+
+    if (!runWithAcpAgent && (!ctx.provider || !ctx.model)) {
       ctx.onAiResult({ message: message("app.aiMissingProvider"), type: "error" });
       setStatus("error");
       return;
     }
 
-    const capabilities = getProviderCapabilities(ctx.provider.id, ctx.provider.type);
-    if (!capabilities.chat) {
+    const capabilities = ctx.provider ? getProviderCapabilities(ctx.provider.id, ctx.provider.type) : null;
+    if (!runWithAcpAgent && !capabilities?.chat) {
       ctx.onAiResult({ message: message("app.aiProviderUnsupported"), type: "error" });
       setStatus("error");
       return;
@@ -117,39 +126,62 @@ export function useAiCommandUi(ctx: AiCommandContext) {
     requestIdRef.current = requestId;
     setStatus("thinking");
     try {
-      const response = await runInlineAiAgent({
-        complete: (provider, model, messages, completionOptions) =>
-          chatCompletionStream(provider, model, messages, {
-            ...completionOptions,
-            fallbackTransport: requestNativeChat,
-            streamTransport: requestNativeChatStream,
-            useVercelAiSdk: true
-          }),
-        documentContent,
-        documentPath: ctx.documentPath ?? null,
-        intent,
-        model: ctx.model,
-        prompt: trimmedPrompt,
-        provider: ctx.provider,
-        target,
-        thinkingEnabled: options.thinkingEnabled,
-        translationTargetLanguage: ctx.translationTargetLanguage ?? "English",
-        onEvent: (event) => {
-          if (requestIdRef.current !== requestId) return;
-          setStatus(agentStatusFromEvent(event));
-          const streamedReplacement = agentReplacementFromEvent(event);
-          if (!streamedReplacement) return;
+      const response = runWithAcpAgent
+        ? await runAcpInlineAiAgent({
+            documentContent,
+            documentPath: ctx.documentPath ?? null,
+            intent,
+            onTextDelta: (text) => {
+              if (requestIdRef.current !== requestId) return;
+              setStatus("streaming");
+              ctx.onAiResult({
+                from: target.from,
+                original: target.original,
+                replacement: text,
+                to: target.to,
+                type: target.type
+              });
+            },
+            prompt: trimmedPrompt,
+            selectedModelId: ctx.getSelectedAcpModelId?.() ?? ctx.selectedAcpModelId,
+            settings: acpAgentSettings,
+            target,
+            translationTargetLanguage: ctx.translationTargetLanguage ?? "English",
+            workspaceKey: ctx.workspaceKey ?? null
+          })
+        : await runInlineAiAgent({
+            complete: (provider, model, messages, completionOptions) =>
+              chatCompletionStream(provider, model, messages, {
+                ...completionOptions,
+                fallbackTransport: requestNativeChat,
+                streamTransport: requestNativeChatStream,
+                useVercelAiSdk: true
+              }),
+            documentContent,
+            documentPath: ctx.documentPath ?? null,
+            intent,
+            model: ctx.model!,
+            prompt: trimmedPrompt,
+            provider: ctx.provider!,
+            target,
+            thinkingEnabled: options.thinkingEnabled,
+            translationTargetLanguage: ctx.translationTargetLanguage ?? "English",
+            onEvent: (event) => {
+              if (requestIdRef.current !== requestId) return;
+              setStatus(agentStatusFromEvent(event));
+              const streamedReplacement = agentReplacementFromEvent(event);
+              if (!streamedReplacement) return;
 
-          ctx.onAiResult({
-            from: target.from,
-            original: target.original,
-            replacement: streamedReplacement,
-            to: target.to,
-            type: target.type
+              ctx.onAiResult({
+                from: target.from,
+                original: target.original,
+                replacement: streamedReplacement,
+                to: target.to,
+                type: target.type
+              });
+            },
+            workspaceFiles: ctx.workspaceFiles ?? []
           });
-        },
-        workspaceFiles: ctx.workspaceFiles ?? []
-      });
       if (requestIdRef.current !== requestId) return;
 
       if (!response.content.trim()) {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -99,6 +99,14 @@ type ApplySavedCurrentDocumentOptions = {
   targetTabId?: string | null;
 };
 
+export type ActiveDiskFileContentChange = {
+  content: string;
+  path: string;
+  previousContent: string;
+  revision: number;
+  source: string;
+};
+
 type MarkdownDocumentSummary = {
   key: string;
   outlineItems: MarkdownOutlineItem[];
@@ -143,6 +151,7 @@ type UseMarkdownDocumentOptions = {
   editorReady?: boolean | (() => boolean);
   getCurrentMarkdown: (fallbackContent: string) => string;
   isCurrentMarkdownEquivalent?: (markdown: string) => boolean | undefined;
+  onActiveDiskFileContentChange?: (change: ActiveDiskFileContentChange) => boolean | undefined;
   onMarkdownTreeChange?: (path: string) => unknown | Promise<unknown>;
   onTreeRootFromFolderPath: (
     path: string,
@@ -226,6 +235,7 @@ export function useMarkdownDocument({
   editorReady = true,
   getCurrentMarkdown,
   isCurrentMarkdownEquivalent,
+  onActiveDiskFileContentChange,
   onMarkdownTreeChange,
   onTreeRootFromFolderPath,
   onTreeRootFromFilePath,
@@ -768,6 +778,18 @@ export function useMarkdownDocument({
       return false;
     }
 
+    const activeTabChanged = targetTab.id === activeTabIdRef.current;
+    const activeEditorUpdated =
+      activeTabChanged &&
+      onActiveDiskFileContentChange?.({
+        content: file.content,
+        path: file.path,
+        previousContent: targetTab.content,
+        revision: targetTab.revision,
+        source: reason
+      }) === true;
+
+    // Keep the active editor mounted when it already accepted the disk update as an undoable transaction.
     const nextDocument = {
       path: file.path,
       name: file.name,
@@ -776,7 +798,7 @@ export function useMarkdownDocument({
       deleted: false,
       dirty: false,
       open: true,
-      revision: targetTab.revision + 1
+      revision: activeEditorUpdated ? targetTab.revision : targetTab.revision + 1
     };
     const nextTabs = currentTabs.map((tab) =>
       tab.id === targetTab.id ? createDocumentTab(nextDocument, tab.id) : tab
@@ -784,7 +806,7 @@ export function useMarkdownDocument({
 
     tabsRef.current = nextTabs;
     setTabs(nextTabs);
-    if (targetTab.id === activeTabIdRef.current) {
+    if (activeTabChanged) {
       documentRef.current = nextDocument;
       setDocument(nextDocument);
     }
@@ -797,7 +819,7 @@ export function useMarkdownDocument({
       tabId: targetTab.id
     }]);
     return true;
-  }, []);
+  }, [onActiveDiskFileContentChange]);
 
   const refreshCleanOpenTabFromDisk = useCallback((path: string, reason: string) => {
     const currentTab = tabsRef.current.find((tab) => tab.path !== null && sameNativePath(tab.path, path));

--- a/packages/app/src/lib/acp-agent.test.ts
+++ b/packages/app/src/lib/acp-agent.test.ts
@@ -1,5 +1,5 @@
 import { configureAppRuntime, createDefaultAppRuntime, resetAppRuntimeForTests, type AppAcpAgentMessageEvent } from "../runtime";
-import { parseAcpAgentArgs, resolveAcpAgentCwd, runAcpDocumentAgent } from "./acp-agent";
+import { parseAcpAgentArgs, resolveAcpAgentCwd, runAcpDocumentAgent, runAcpInlineAiAgent } from "./acp-agent";
 
 describe("ACP agent helpers", () => {
   afterEach(() => {
@@ -193,6 +193,410 @@ describe("ACP agent helpers", () => {
       finishReason: "stop",
       preparedPreview: true,
       stopReasonCode: undefined
+    });
+  });
+
+  it("keeps ACP text responses as chat content when no filesystem write occurs", async () => {
+    let handleAgentMessage: ((event: AppAcpAgentMessageEvent) => unknown) | null = null;
+    const runtime = createDefaultAppRuntime();
+    const onPreviewResult = vi.fn();
+    const onTextDelta = vi.fn();
+    const suggestedResponse = [
+      "```markdown",
+      "Markra 是一个本地优先、开源的 Markdown 编辑器。",
+      "```"
+    ].join("\n");
+
+    configureAppRuntime({
+      ...runtime,
+      acp: {
+        listenAgentMessages: vi.fn(async (handler) => {
+          handleAgentMessage = handler;
+
+          return () => {
+            handleAgentMessage = null;
+          };
+        }),
+        startAgent: vi.fn(async () => ({ connectionId: "acp-1" })),
+        stopAgent: vi.fn(async () => undefined),
+        writeAgentMessage: vi.fn(async (_connectionId, message) => {
+          if (message && typeof message === "object" && "method" in message && message.method === "initialize") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: {} }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/new") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { sessionId: "session-1" } }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/prompt") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: "session-1",
+                  update: {
+                    content: {
+                      text: suggestedResponse,
+                      type: "text"
+                    },
+                    sessionUpdate: "agent_message_chunk"
+                  }
+                }
+              }),
+              type: "message"
+            });
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { stopReason: "end_turn" } }),
+              type: "message"
+            });
+          }
+        })
+      }
+    });
+
+    const result = await runAcpDocumentAgent({
+      documentContent: "# Draft\n\nMarkra 是一个 Markdown 编辑器。",
+      documentPath: "/mock-workspace/current.md",
+      history: [],
+      onPreviewResult,
+      onTextDelta,
+      prompt: "优化一下这段话",
+      selection: {
+        cursor: 29,
+        from: 9,
+        source: "selection",
+        text: "Markra 是一个 Markdown 编辑器。",
+        to: 29
+      },
+      settings: {
+        args: "",
+        command: "synthetic-acp-agent",
+        cwd: "",
+        enabled: true
+      },
+      workspaceKey: "/mock-workspace"
+    });
+
+    expect(onTextDelta).toHaveBeenCalledWith(suggestedResponse);
+    expect(onPreviewResult).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: suggestedResponse,
+      finishReason: "stop",
+      preparedPreview: false,
+      stopReasonCode: undefined
+    });
+  });
+
+  it("does not use replacement cue text to infer ACP editor previews", async () => {
+    let handleAgentMessage: ((event: AppAcpAgentMessageEvent) => unknown) | null = null;
+    const runtime = createDefaultAppRuntime();
+    const onPreviewResult = vi.fn();
+    const suggestedResponse = [
+      "建议替换为：",
+      "",
+      "```markdown",
+      "Markra 是一个本地优先、开源的 Markdown 编辑器。",
+      "```",
+      "",
+      "这只是普通说明，不是 Markra 编辑预览输出。"
+    ].join("\n");
+
+    configureAppRuntime({
+      ...runtime,
+      acp: {
+        listenAgentMessages: vi.fn(async (handler) => {
+          handleAgentMessage = handler;
+
+          return () => {
+            handleAgentMessage = null;
+          };
+        }),
+        startAgent: vi.fn(async () => ({ connectionId: "acp-1" })),
+        stopAgent: vi.fn(async () => undefined),
+        writeAgentMessage: vi.fn(async (_connectionId, message) => {
+          if (message && typeof message === "object" && "method" in message && message.method === "initialize") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: {} }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/new") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { sessionId: "session-1" } }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/prompt") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: "session-1",
+                  update: {
+                    content: {
+                      text: suggestedResponse,
+                      type: "text"
+                    },
+                    sessionUpdate: "agent_message_chunk"
+                  }
+                }
+              }),
+              type: "message"
+            });
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { stopReason: "end_turn" } }),
+              type: "message"
+            });
+          }
+        })
+      }
+    });
+
+    const result = await runAcpDocumentAgent({
+      documentContent: "# Draft\n\nMarkra 是一个 Markdown 编辑器。",
+      documentPath: "/mock-workspace/current.md",
+      history: [],
+      onPreviewResult,
+      onTextDelta: vi.fn(),
+      prompt: "优化一下这段话",
+      selection: {
+        cursor: 29,
+        from: 9,
+        source: "selection",
+        text: "Markra 是一个 Markdown 编辑器。",
+        to: 29
+      },
+      settings: {
+        args: "",
+        command: "synthetic-acp-agent",
+        cwd: "",
+        enabled: true
+      },
+      workspaceKey: "/mock-workspace"
+    });
+
+    expect(onPreviewResult).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: suggestedResponse,
+      finishReason: "stop",
+      preparedPreview: false,
+      stopReasonCode: undefined
+    });
+  });
+
+  it("includes current editor selection context in ACP document prompts", async () => {
+    let handleAgentMessage: ((event: AppAcpAgentMessageEvent) => unknown) | null = null;
+    const runtime = createDefaultAppRuntime();
+    let promptBlocks: unknown = null;
+
+    configureAppRuntime({
+      ...runtime,
+      acp: {
+        listenAgentMessages: vi.fn(async (handler) => {
+          handleAgentMessage = handler;
+
+          return () => {
+            handleAgentMessage = null;
+          };
+        }),
+        startAgent: vi.fn(async () => ({ connectionId: "acp-1" })),
+        stopAgent: vi.fn(async () => undefined),
+        writeAgentMessage: vi.fn(async (_connectionId, message) => {
+          if (message && typeof message === "object" && "method" in message && message.method === "initialize") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: {} }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/new") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { sessionId: "session-1" } }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/prompt") {
+            const params = "params" in message && message.params && typeof message.params === "object"
+              ? message.params as { prompt?: unknown }
+              : {};
+            promptBlocks = params.prompt ?? null;
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { stopReason: "end_turn" } }),
+              type: "message"
+            });
+          }
+        })
+      }
+    });
+
+    await runAcpDocumentAgent({
+      documentContent: "# Draft\n\nOriginal draft",
+      documentPath: "/mock-workspace/current.md",
+      history: [],
+      onTextDelta: vi.fn(),
+      prompt: "Polish this selection",
+      selection: {
+        cursor: 23,
+        from: 9,
+        source: "selection",
+        text: "Original draft",
+        to: 23
+      },
+      settings: {
+        args: "",
+        command: "synthetic-acp-agent",
+        cwd: "",
+        enabled: true
+      },
+      workspaceKey: "/mock-workspace"
+    });
+
+    expect(promptBlocks).toEqual(expect.any(Array));
+    const textBlocks = promptBlocks as Array<{ text?: string; type?: string }>;
+    const previewPolicyBlock = textBlocks.find((block) =>
+      block.type === "text" && block.text?.includes("Markra edit preview policy:")
+    );
+    const contextBlock = textBlocks.find((block) =>
+      block.type === "text" && block.text?.includes("Markra editor context:")
+    );
+
+    expect(previewPolicyBlock).toBeUndefined();
+    expect(contextBlock?.text).toContain("Current selection snapshot:");
+    expect(contextBlock?.text).toContain("Range: 9-23");
+    expect(contextBlock?.text).toContain("Cursor: 23");
+    expect(contextBlock?.text).toContain("Source: selection");
+    expect(contextBlock?.text).toContain("Selected text:\nOriginal draft");
+  });
+
+  it("runs ACP inline edit prompts and returns normalized replacement content", async () => {
+    let handleAgentMessage: ((event: AppAcpAgentMessageEvent) => unknown) | null = null;
+    const runtime = createDefaultAppRuntime();
+    const onTextDelta = vi.fn();
+    let promptText = "";
+
+    configureAppRuntime({
+      ...runtime,
+      acp: {
+        listenAgentMessages: vi.fn(async (handler) => {
+          handleAgentMessage = handler;
+
+          return () => {
+            handleAgentMessage = null;
+          };
+        }),
+        startAgent: vi.fn(async () => ({ connectionId: "acp-1" })),
+        stopAgent: vi.fn(async () => undefined),
+        writeAgentMessage: vi.fn(async (_connectionId, message) => {
+          if (message && typeof message === "object" && "method" in message && message.method === "initialize") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: {} }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/new") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { sessionId: "session-1" } }),
+              type: "message"
+            });
+            return;
+          }
+
+          if (message && typeof message === "object" && "method" in message && message.method === "session/prompt") {
+            const params = "params" in message && message.params && typeof message.params === "object"
+              ? message.params as { prompt?: Array<{ text?: string }> }
+              : {};
+            promptText = params.prompt?.map((block) => block.text ?? "").join("\n\n") ?? "";
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: "session-1",
+                  update: {
+                    content: [{ text: "Better draft", type: "text" }],
+                    sessionUpdate: "agent_message_chunk"
+                  }
+                }
+              }),
+              type: "message"
+            });
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { stopReason: "end_turn" } }),
+              type: "message"
+            });
+          }
+        })
+      }
+    });
+
+    const result = await runAcpInlineAiAgent({
+      documentContent: "# Draft\n\nOriginal draft",
+      documentPath: "/mock-workspace/current.md",
+      intent: "polish",
+      onTextDelta,
+      prompt: "Make it clearer",
+      settings: {
+        args: "",
+        command: "synthetic-acp-agent",
+        cwd: "",
+        enabled: true
+      },
+      target: {
+        from: 9,
+        original: "Original draft",
+        promptText: "Original draft",
+        scope: "selection",
+        to: 23,
+        type: "replace"
+      },
+      workspaceKey: "/mock-workspace"
+    });
+
+    expect(promptText).toContain("Markra inline edit task:");
+    expect(promptText).toContain("Return only the Markdown fragment");
+    expect(promptText).toContain("Target scope:\nSelected text");
+    expect(promptText).toContain("Edit mode:\nReplace the target");
+    expect(promptText).toContain("Target range:\n9-23");
+    expect(promptText).toContain("Target text:\nOriginal draft");
+    expect(promptText).toContain("User instruction:\nMake it clearer");
+    expect(onTextDelta).toHaveBeenCalledWith("Better draft");
+    expect(result).toEqual({
+      content: "Better draft",
+      finishReason: "stop"
     });
   });
 

--- a/packages/app/src/lib/acp-agent.ts
+++ b/packages/app/src/lib/acp-agent.ts
@@ -2,16 +2,23 @@ import {
   AcpClient,
   type AcpAuthMethod,
   type AcpContentBlock,
+  type AcpFileSystem,
   type AcpInitializeResponse,
   type AcpJsonRpcMessage,
+  type AcpPermissions,
   type AcpPermissionRequest,
   type AcpPermissionRequestOutcome,
   type AcpSessionNewResponse,
   type AcpSessionUpdate,
+  buildInlineAiMessages,
   extractAcpModelConfig,
   type AiDiffResult,
+  type AiEditIntent,
+  type AiSelectionContext,
   type DocumentAiHistoryMessage,
+  type InlineAiAgentTarget,
   isAcpAuthRequiredError,
+  normalizeInlineAiReplacement,
   safeAcpPermissionOutcome
 } from "@markra/ai";
 import type { AgentEvent } from "@earendil-works/pi-agent-core";
@@ -33,8 +40,23 @@ export type AcpDocumentAgentRunOptions = {
   prompt: string;
   readWorkspaceFile?: (path: string) => Promise<string>;
   selectedModelId?: string | null;
+  selection?: AiSelectionContext | null;
   settings: AcpAgentSettings;
   signal?: AbortSignal;
+  workspaceKey: string | null;
+};
+
+export type AcpInlineAiAgentRunOptions = {
+  documentContent: string;
+  documentPath: string | null;
+  intent?: AiEditIntent;
+  onTextDelta?: (text: string) => unknown;
+  prompt: string;
+  selectedModelId?: string | null;
+  settings: AcpAgentSettings;
+  signal?: AbortSignal;
+  target: InlineAiAgentTarget;
+  translationTargetLanguage?: string;
   workspaceKey: string | null;
 };
 
@@ -68,52 +90,20 @@ export async function runAcpDocumentAgent({
   prompt,
   readWorkspaceFile,
   selectedModelId,
+  selection = null,
   settings,
   signal,
   workspaceKey
 }: AcpDocumentAgentRunOptions) {
-  const runtime = getAppRuntime();
   const cwd = resolveAcpAgentCwd(settings, documentPath, workspaceKey);
   const workspaceRoot = resolveAcpWorkspaceRoot(documentPath, workspaceKey);
   throwIfAcpRunAborted(signal);
-  const connection = await runtime.acp.startAgent({
-    args: parseAcpAgentArgs(settings.args),
-    command: settings.command,
-    cwd,
-    env: []
-  });
-  let stopListening: RuntimeCleanup | null = null;
-  const agentFailure = createAcpAgentFailureSignal();
-  const stderrMessages: string[] = [];
-  const transportHandlers = new Set<(message: AcpJsonRpcMessage) => unknown>();
   let preparedPreview = false;
   let permissionRequestCount = 0;
   let writePreviewCount = 0;
 
-  try {
-    stopListening = await runtime.acp.listenAgentMessages((event) => {
-      if (event.connectionId !== connection.connectionId) return;
-      if (event.type === "stderr") {
-        appendAcpStderrMessage(stderrMessages, event.message);
-        return;
-      }
-      if (event.type === "exit") {
-        agentFailure.fail(acpAgentExitedError(event.message, stderrMessages));
-        return;
-      }
-      if (event.type !== "message") return;
-
-      const message = parseAcpJsonRpcMessage(event.message);
-      if (!message) return;
-
-      transportHandlers.forEach((handler) => handler(message));
-    });
-  } catch (error) {
-    await runtime.acp.stopAgent(connection.connectionId).catch(() => {});
-    throw error;
-  }
-
-  const client = new AcpClient({
+  const { agentFailure, client } = await createAcpRuntimeClient({
+    cwd,
     fileSystem: {
       readTextFile: ({ path }) => {
         const resolvedPath = resolveAcpRequestedPath(path, cwd);
@@ -187,23 +177,7 @@ export async function runAcpDocumentAgent({
         return outcome;
       }
     },
-    transport: {
-      close: async () => {
-        if (stopListening) {
-          await Promise.resolve(stopListening());
-          stopListening = null;
-        }
-        await runtime.acp.stopAgent(connection.connectionId);
-      },
-      onMessage: (handler) => {
-        transportHandlers.add(handler);
-
-        return () => {
-          transportHandlers.delete(handler);
-        };
-      },
-      send: (message) => runtime.acp.writeAgentMessage(connection.connectionId, message)
-    }
+    settings
   });
   let sessionId: string | null = null;
   let stopAbortListening: (() => unknown) | null = null;
@@ -254,35 +228,117 @@ export async function runAcpDocumentAgent({
     });
     sessionId = session.sessionId;
     throwIfAcpRunAborted(signal);
-    let modelState = acpModelStateFromConfigOptions(session.configOptions);
-    if (modelState) {
-      onModelState?.(modelState);
-    }
-
-    if (selectedModelId && modelState && modelState.selectedModelId !== selectedModelId && hasAcpModel(modelState, selectedModelId)) {
-      const response = await agentFailure.race(client.setSessionConfigOption({
-        configId: modelState.configId,
-        sessionId: session.sessionId,
-        value: selectedModelId
-      }));
-      modelState = acpModelStateFromConfigOptions(response.configOptions) ?? {
-        ...modelState,
-        selectedModelId
-      };
-      onModelState?.(modelState);
-    }
+    await configureAcpSelectedModel({ agentFailure, client, onModelState, selectedModelId, session });
 
     throwIfAcpRunAborted(signal);
     await agentFailure.race(client.prompt({
-      prompt: createAcpPromptBlocks({ documentContent, documentPath, history, prompt }),
+      prompt: createAcpPromptBlocks({ documentContent, documentPath, history, prompt, selection }),
       sessionId: session.sessionId
     }));
 
     return {
-      content,
+      content: preparedPreview ? "" : content,
       finishReason: "stop" as const,
       preparedPreview,
       stopReasonCode: undefined
+    };
+  } finally {
+    stopAbortListening?.();
+    unsubscribe();
+    await client.dispose().catch(() => {});
+  }
+}
+
+export async function runAcpInlineAiAgent({
+  documentContent,
+  documentPath,
+  intent = "custom",
+  onTextDelta,
+  prompt,
+  selectedModelId,
+  settings,
+  signal,
+  target,
+  translationTargetLanguage,
+  workspaceKey
+}: AcpInlineAiAgentRunOptions) {
+  const cwd = resolveAcpAgentCwd(settings, documentPath, workspaceKey);
+  throwIfAcpRunAborted(signal);
+  // Inline ACP returns text for Markra's existing preview flow; it should not write files directly.
+  const fileSystem: AcpFileSystem | undefined = documentPath
+    ? {
+        readTextFile: ({ path }) => {
+          const resolvedPath = resolveAcpRequestedPath(path, cwd);
+          if (samePath(resolvedPath, documentPath)) return documentContent;
+
+          throw new Error("ACP inline filesystem reads are only available for the current document.");
+        }
+      }
+    : undefined;
+  const { agentFailure, client } = await createAcpRuntimeClient({
+    cwd,
+    fileSystem,
+    settings
+  });
+  let sessionId: string | null = null;
+  let stopAbortListening: (() => unknown) | null = null;
+  let content = "";
+  const unsubscribe = client.subscribe((update) => {
+    const text = textFromAcpSessionUpdate(update);
+    if (!text) return;
+
+    content += text;
+    onTextDelta?.(content);
+  });
+  const cancelRun = () => {
+    agentFailure.fail(acpRunCancelledError());
+    const cancelSession = sessionId
+      ? Promise.resolve(client.cancel(sessionId)).catch(() => {})
+      : Promise.resolve(undefined);
+    cancelSession
+      .then(() => client.dispose())
+      .catch(() => {
+        client.dispose().catch(() => {});
+      });
+  };
+  if (signal) {
+    if (signal.aborted) {
+      cancelRun();
+    } else {
+      signal.addEventListener("abort", cancelRun, { once: true });
+      stopAbortListening = () => signal.removeEventListener("abort", cancelRun);
+    }
+  }
+
+  try {
+    const initializeResponse = await agentFailure.race(client.initialize({ name: "markra", title: "Markra" }));
+    const session = await createAcpSession({
+      agentFailure,
+      client,
+      cwd,
+      initializeResponse
+    });
+    sessionId = session.sessionId;
+    throwIfAcpRunAborted(signal);
+    await configureAcpSelectedModel({ agentFailure, client, selectedModelId, session });
+
+    throwIfAcpRunAborted(signal);
+    await agentFailure.race(client.prompt({
+      prompt: createAcpInlinePromptBlocks({
+        documentContent,
+        intent,
+        prompt,
+        target,
+        translationTargetLanguage
+      }),
+      sessionId: session.sessionId
+    }));
+
+    return {
+      content: normalizeInlineAiReplacement(content, {
+        preserveLeadingWhitespace: target.type === "insert"
+      }),
+      finishReason: "stop" as const
     };
   } finally {
     stopAbortListening?.();
@@ -307,6 +363,111 @@ function hasAcpModel(state: AcpAgentModelState, modelId: string) {
 }
 
 type AcpAgentFailureSignal = ReturnType<typeof createAcpAgentFailureSignal>;
+
+async function createAcpRuntimeClient({
+  cwd,
+  fileSystem,
+  permissions,
+  settings
+}: {
+  cwd: string;
+  fileSystem?: AcpFileSystem;
+  permissions?: AcpPermissions;
+  settings: AcpAgentSettings;
+}) {
+  const runtime = getAppRuntime();
+  const connection = await runtime.acp.startAgent({
+    args: parseAcpAgentArgs(settings.args),
+    command: settings.command,
+    cwd,
+    env: []
+  });
+  let stopListening: RuntimeCleanup | null = null;
+  const agentFailure = createAcpAgentFailureSignal();
+  const stderrMessages: string[] = [];
+  const transportHandlers = new Set<(message: AcpJsonRpcMessage) => unknown>();
+
+  try {
+    stopListening = await runtime.acp.listenAgentMessages((event) => {
+      if (event.connectionId !== connection.connectionId) return;
+      if (event.type === "stderr") {
+        appendAcpStderrMessage(stderrMessages, event.message);
+        return;
+      }
+      if (event.type === "exit") {
+        agentFailure.fail(acpAgentExitedError(event.message, stderrMessages));
+        return;
+      }
+      if (event.type !== "message") return;
+
+      const message = parseAcpJsonRpcMessage(event.message);
+      if (!message) return;
+
+      transportHandlers.forEach((handler) => handler(message));
+    });
+  } catch (error) {
+    await runtime.acp.stopAgent(connection.connectionId).catch(() => {});
+    throw error;
+  }
+
+  const client = new AcpClient({
+    fileSystem,
+    permissions,
+    transport: {
+      close: async () => {
+        if (stopListening) {
+          await Promise.resolve(stopListening());
+          stopListening = null;
+        }
+        await runtime.acp.stopAgent(connection.connectionId);
+      },
+      onMessage: (handler) => {
+        transportHandlers.add(handler);
+
+        return () => {
+          transportHandlers.delete(handler);
+        };
+      },
+      send: (message) => runtime.acp.writeAgentMessage(connection.connectionId, message)
+    }
+  });
+
+  return { agentFailure, client };
+}
+
+async function configureAcpSelectedModel({
+  agentFailure,
+  client,
+  onModelState,
+  selectedModelId,
+  session
+}: {
+  agentFailure: AcpAgentFailureSignal;
+  client: AcpClient;
+  onModelState?: (state: AcpAgentModelState) => unknown;
+  selectedModelId?: string | null;
+  session: AcpSessionNewResponse;
+}) {
+  let modelState = acpModelStateFromConfigOptions(session.configOptions);
+  if (modelState) {
+    onModelState?.(modelState);
+  }
+
+  if (!selectedModelId || !modelState || modelState.selectedModelId === selectedModelId || !hasAcpModel(modelState, selectedModelId)) {
+    return;
+  }
+
+  const response = await agentFailure.race(client.setSessionConfigOption({
+    configId: modelState.configId,
+    sessionId: session.sessionId,
+    value: selectedModelId
+  }));
+  modelState = acpModelStateFromConfigOptions(response.configOptions) ?? {
+    ...modelState,
+    selectedModelId
+  };
+  onModelState?.(modelState);
+}
 
 async function createAcpSession({
   agentFailure,
@@ -921,8 +1082,9 @@ function createAcpPromptBlocks({
   documentContent,
   documentPath,
   history,
-  prompt
-}: Pick<AcpDocumentAgentRunOptions, "documentContent" | "documentPath" | "history" | "prompt">): AcpContentBlock[] {
+  prompt,
+  selection
+}: Pick<AcpDocumentAgentRunOptions, "documentContent" | "documentPath" | "history" | "prompt" | "selection">): AcpContentBlock[] {
   const blocks: AcpContentBlock[] = [];
   const historyText = history
     .map((message) => `${message.role}: ${message.text}`.trim())
@@ -944,12 +1106,132 @@ function createAcpPromptBlocks({
     },
     type: "resource"
   });
+  const editorContext = formatAcpEditorContextText(selection);
+  if (editorContext) {
+    blocks.push({
+      text: editorContext,
+      type: "text"
+    });
+  }
   blocks.push({
     text: `User request:\n${prompt}`,
     type: "text"
   });
 
   return blocks;
+}
+
+function createAcpInlinePromptBlocks({
+  documentContent,
+  intent,
+  prompt,
+  target,
+  translationTargetLanguage
+}: Pick<AcpInlineAiAgentRunOptions, "documentContent" | "intent" | "prompt" | "target" | "translationTargetLanguage">): AcpContentBlock[] {
+  const targetContext = nearbyTargetContext(documentContent, target.from, target.to, {
+    direction: target.type === "insert" || intent === "continue" ? "before" : "around"
+  });
+  const messages = buildInlineAiMessages({
+    documentContent: "",
+    intent,
+    prompt,
+    suggestionContext: target.suggestionContext,
+    targetContext,
+    targetScope: target.scope,
+    targetText: target.promptText,
+    targetType: target.type,
+    translationTargetLanguage
+  });
+  const systemPrompt = messages.find((message) => message.role === "system")?.content ?? "";
+  const userPrompt = messages
+    .filter((message) => message.role !== "system")
+    .map((message) => message.content)
+    .join("\n\n");
+  const targetRange = acpInlineTargetRange(target);
+
+  return [
+    {
+      text: [
+        "Markra inline edit task:",
+        systemPrompt,
+        targetRange ? `Target range:\n${targetRange}` : null,
+        userPrompt
+      ].filter(Boolean).join("\n\n"),
+      type: "text"
+    }
+  ];
+}
+
+function formatAcpEditorContextText(selection: AiSelectionContext | null | undefined) {
+  if (!selection || !selection.text.trim()) return null;
+
+  const source = selection.source ?? "selection";
+  const snapshotLabel = source === "block" ? "Current block snapshot:" : "Current selection snapshot:";
+  const textLabel = source === "block" ? "Block text:" : "Selected text:";
+
+  return [
+    "Markra editor context:",
+    snapshotLabel,
+    `Range: ${selection.from}-${selection.to}`,
+    `Cursor: ${selection.cursor ?? selection.to}`,
+    `Source: ${source}`,
+    "",
+    `${textLabel}\n${selection.text}`
+  ].join("\n");
+}
+
+function acpInlineTargetRange(target: InlineAiAgentTarget) {
+  if (typeof target.from !== "number" || typeof target.to !== "number") return null;
+
+  return `${target.from}-${target.to}`;
+}
+
+const maxTargetContextChars = 1_600;
+
+function nearbyTargetContext(
+  documentContent: string,
+  from: number | undefined,
+  to: number | undefined,
+  {
+    direction = "around"
+  }: {
+    direction?: "around" | "before";
+  } = {}
+) {
+  if (typeof from !== "number" || typeof to !== "number") return null;
+  if (!Number.isInteger(from) || !Number.isInteger(to) || from < 0 || to < 0 || to < from) return null;
+
+  const targetFrom = clampPosition(from, documentContent.length);
+  const targetTo = clampPosition(to, documentContent.length);
+  const beforeChars = direction === "before" ? maxTargetContextChars : Math.floor(maxTargetContextChars / 2);
+  const afterChars = direction === "before" ? 0 : Math.floor(maxTargetContextChars / 2);
+
+  const contextStart = Math.max(0, targetFrom - beforeChars);
+  const contextEnd = Math.min(documentContent.length, targetTo + afterChars);
+  const lineStart = documentContent.lastIndexOf("\n", Math.max(0, contextStart - 1)) + 1;
+  const nextLineBreak = documentContent.indexOf("\n", contextEnd);
+  const lineEnd = nextLineBreak === -1 ? documentContent.length : nextLineBreak;
+  const excerpt = documentContent.slice(lineStart, lineEnd).trim();
+
+  if (!excerpt) return null;
+  if (excerpt.length <= maxTargetContextChars) return excerpt;
+
+  return compactTargetContext(excerpt, targetFrom - lineStart, targetTo - lineStart);
+}
+
+function compactTargetContext(excerpt: string, targetFrom: number, targetTo: number) {
+  const targetText = excerpt.slice(targetFrom, targetTo);
+  const sideLength = Math.max(0, Math.floor((maxTargetContextChars - targetText.length) / 2) - 8);
+  const start = Math.max(0, targetFrom - sideLength);
+  const end = Math.min(excerpt.length, targetTo + sideLength);
+  const prefix = start > 0 ? "[...]\n" : "";
+  const suffix = end < excerpt.length ? "\n[...]" : "";
+
+  return `${prefix}${excerpt.slice(start, end).trim()}${suffix}`;
+}
+
+function clampPosition(position: number, documentLength: number) {
+  return Math.min(Math.max(position, 0), documentLength);
 }
 
 function parseAcpJsonRpcMessage(message: string): AcpJsonRpcMessage | null {

--- a/packages/app/src/lib/settings/app-settings.test.ts
+++ b/packages/app/src/lib/settings/app-settings.test.ts
@@ -2,6 +2,7 @@ import { createSettingsStoreHarness, resetSettingsStoreRuntime, setupSettingsSto
 import {
   darkEditorThemeOptions,
   defaultAcpAgentSettings,
+  codexAcpAgentArgs,
   defaultEditorPreferences,
   exportStoredAppSettings,
   getStoredAcpAgentSettings,
@@ -31,6 +32,18 @@ import {
 
 const settingsStore = createSettingsStoreHarness();
 const { loadStore: mockedLoadStore, store } = settingsStore;
+const legacyCodexAcpAgentArgsWithPathFallback = [
+  "-lc '",
+  "CODEX_BIN=\"$(command -v codex || true)\"; ",
+  "if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then ",
+  "CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; ",
+  "fi; ",
+  "if [ -n \"$CODEX_BIN\" ]; then ",
+  "exec env CODEX_PATH=\"$CODEX_BIN\" npx -y @agentclientprotocol/codex-acp; ",
+  "fi; ",
+  "exec npx -y @agentclientprotocol/codex-acp",
+  "'"
+].join("");
 
 describe("app settings", () => {
   beforeEach(() => {
@@ -245,6 +258,27 @@ describe("app settings", () => {
     });
 
     expect(normalizeAcpAgentSettings({ command: "", enabled: "yes" })).toEqual(defaultAcpAgentSettings);
+    expect(codexAcpAgentArgs).toContain("INITIAL_AGENT_MODE=read-only");
+    expect(normalizeAcpAgentSettings({
+      args: "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+      command: "/bin/zsh",
+      enabled: true
+    })).toEqual({
+      args: codexAcpAgentArgs,
+      command: "/bin/zsh",
+      cwd: "",
+      enabled: true
+    });
+    expect(normalizeAcpAgentSettings({
+      args: legacyCodexAcpAgentArgsWithPathFallback,
+      command: "/bin/zsh",
+      enabled: true
+    })).toEqual({
+      args: codexAcpAgentArgs,
+      command: "/bin/zsh",
+      cwd: "",
+      enabled: true
+    });
 
     await saveStoredAcpAgentSettings({
       args: " --acp ",

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -508,6 +508,31 @@ export const defaultAiAgentPreferences: AiAgentPreferences = {
   thinkingEnabled: false,
   webSearchEnabled: false
 };
+const legacyCodexAcpAgentArgs = "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'";
+const legacyCodexAcpAgentArgsWithPathFallback = [
+  "-lc '",
+  "CODEX_BIN=\"$(command -v codex || true)\"; ",
+  "if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then ",
+  "CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; ",
+  "fi; ",
+  "if [ -n \"$CODEX_BIN\" ]; then ",
+  "exec env CODEX_PATH=\"$CODEX_BIN\" npx -y @agentclientprotocol/codex-acp; ",
+  "fi; ",
+  "exec npx -y @agentclientprotocol/codex-acp",
+  "'"
+].join("");
+export const codexAcpAgentArgs = [
+  "-lc '",
+  "CODEX_BIN=\"$(command -v codex || true)\"; ",
+  "if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then ",
+  "CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; ",
+  "fi; ",
+  "if [ -n \"$CODEX_BIN\" ]; then ",
+  "exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; ",
+  "fi; ",
+  "exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp",
+  "'"
+].join("");
 export const defaultAcpAgentSettings: AcpAgentSettings = {
   args: "",
   command: "",
@@ -1450,13 +1475,22 @@ export function normalizeAcpAgentSettings(value: unknown): AcpAgentSettings {
   if (typeof value !== "object" || value === null) return defaultAcpAgentSettings;
 
   const settings = value as Partial<AcpAgentSettings>;
+  const args = typeof settings.args === "string" ? settings.args.trim() : defaultAcpAgentSettings.args;
 
   return {
-    args: typeof settings.args === "string" ? settings.args.trim() : defaultAcpAgentSettings.args,
+    args: normalizeAcpAgentArgs(args),
     command: typeof settings.command === "string" ? settings.command.trim() : defaultAcpAgentSettings.command,
     cwd: typeof settings.cwd === "string" ? settings.cwd.trim() : defaultAcpAgentSettings.cwd,
     enabled: typeof settings.enabled === "boolean" ? settings.enabled : defaultAcpAgentSettings.enabled
   };
+}
+
+function normalizeAcpAgentArgs(args: string) {
+  if (args === legacyCodexAcpAgentArgs || args === legacyCodexAcpAgentArgsWithPathFallback) {
+    return codexAcpAgentArgs;
+  }
+
+  return args;
 }
 
 function normalizeShowAiQuickInputOnSelection(preferences: Partial<EditorPreferences> & LegacyEditorPreferences) {

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -229,6 +229,7 @@ vi.mock("../lib/platform", async (importOriginal) => {
 });
 
 vi.mock("../lib/settings/app-settings", () => ({
+  codexAcpAgentArgs: "mock-codex-acp-args",
   createAiAgentSessionId: vi.fn(),
   consumeWelcomeDocumentState: vi.fn(),
   deleteStoredAiAgentSession: vi.fn(),

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -398,7 +398,7 @@ const messages: BaseLocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -156,7 +156,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -148,7 +148,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP arguments",
   "settings.ai.acpAgentArgsDescription": "Optional command arguments separated by spaces.",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP working directory",
   "settings.ai.acpAgentCwdDescription": "Optional working directory. Empty uses the current workspace.",
   "settings.ai.acpAgentCwdPlaceholder": "Leave empty for current workspace",

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -398,7 +398,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP 参数",
   "settings.ai.acpAgentArgsDescription": "可选命令参数，用空格分隔。",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP 工作目录",
   "settings.ai.acpAgentCwdDescription": "可选工作目录。留空时使用当前 workspace。",
   "settings.ai.acpAgentCwdPlaceholder": "留空自动使用当前 workspace",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -156,7 +156,7 @@ const messages: LocaleMessages = {
   "settings.ai.acpAgentCommandPlaceholder": "/bin/zsh",
   "settings.ai.acpAgentArgs": "ACP 參數",
   "settings.ai.acpAgentArgsDescription": "可選命令參數，用空格分隔。",
-  "settings.ai.acpAgentArgsPlaceholder": "-lc 'exec env CODEX_PATH=\"$(command -v codex)\" npx -y @agentclientprotocol/codex-acp'",
+  "settings.ai.acpAgentArgsPlaceholder": "-lc 'CODEX_BIN=\"$(command -v codex || true)\"; if [ -z \"$CODEX_BIN\" ] && [ -x \"/Applications/Codex.app/Contents/Resources/codex\" ]; then CODEX_BIN=\"/Applications/Codex.app/Contents/Resources/codex\"; fi; if [ -n \"$CODEX_BIN\" ]; then exec env CODEX_PATH=\"$CODEX_BIN\" INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp; fi; exec env INITIAL_AGENT_MODE=read-only npx -y @agentclientprotocol/codex-acp'",
   "settings.ai.acpAgentCwd": "ACP 工作目錄",
   "settings.ai.acpAgentCwdDescription": "可選工作目錄。留空時使用目前 workspace。",
   "settings.ai.acpAgentCwdPlaceholder": "留空自動使用目前 workspace",


### PR DESCRIPTION
## Summary
- Route ACP `fs/write_text_file` edits through the editor preview flow without fallback text matching.
- Keep selected editor context available for ACP-backed AI command and agent panel flows.
- Make active-document external disk reloads undoable in the visual editor, marking the rollback as unsaved.

## Validation
- `pnpm --filter @markra/app exec vitest run src/App.test.tsx src/hooks/useMarkdownDocument.test.tsx --reporter=dot --silent`
- `pnpm --filter @markra/app exec vitest run src/components/settings/AiSettings.test.tsx src/hooks/useAiAgentSession.test.tsx src/components/AiAgentPanel.test.tsx src/App.ai.test.tsx src/hooks/useAiCommandUi.test.tsx src/lib/acp-agent.test.ts src/lib/settings/app-settings.test.ts --reporter=dot --silent`
- `pnpm --filter @markra/app typecheck:test`
- `pnpm --filter @markra/app build`
- `git diff --check`

## Risk
- Touches ACP edit application and active editor reload synchronization; covered by focused regression tests and app build.