### PR TITLE
perf(app): coalesce native watcher refreshes

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -77,6 +77,19 @@ const mockedGetStoredWorkspaceState = vi.mocked(getStoredWorkspaceState);
 const mockedRemoveStoredRecentMarkdownFile = vi.mocked(removeStoredRecentMarkdownFile);
 const mockedSaveStoredRecentMarkdownFile = vi.mocked(saveStoredRecentMarkdownFile);
 const mockedSaveStoredWorkspaceState = vi.mocked(saveStoredWorkspaceState);
+type NativeMarkdownFileResult = Awaited<ReturnType<typeof readNativeMarkdownFile>>;
+
+function createDeferredNativeMarkdownFile() {
+  let resolve!: (file: NativeMarkdownFileResult) => undefined;
+  const promise = new Promise<NativeMarkdownFileResult>((resolvePromise) => {
+    resolve = (file) => {
+      resolvePromise(file);
+      return undefined;
+    };
+  });
+
+  return { promise, resolve };
+}
 
 describe("useMarkdownDocument", () => {
   beforeEach(() => {
@@ -576,6 +589,78 @@ describe("useMarkdownDocument", () => {
       name: "guide.md",
       path: "/mock-files/guide.md"
     });
+  });
+
+  it("coalesces repeated native watcher file events while a disk read is in flight", async () => {
+    const path = "/mock-files/guide.md";
+    const firstWatcherRead = createDeferredNativeMarkdownFile();
+    const secondWatcherRead = createDeferredNativeMarkdownFile();
+    const thirdWatcherRead = createDeferredNativeMarkdownFile();
+    let emitExternalChange: (path: string) => unknown | Promise<unknown> = () => {};
+    mockedWatchNativeMarkdownFile.mockImplementation(async (_path, onChange) => {
+      emitExternalChange = onChange;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile
+      .mockResolvedValueOnce({
+        content: "# Guide\n\nCurrent",
+        name: "guide.md",
+        path
+      })
+      .mockReturnValueOnce(firstWatcherRead.promise)
+      .mockReturnValueOnce(secondWatcherRead.promise)
+      .mockReturnValueOnce(thirdWatcherRead.promise);
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path,
+        relativePath: "guide.md"
+      });
+    });
+    await waitFor(() => expect(mockedWatchNativeMarkdownFile).toHaveBeenCalled());
+
+    await act(async () => {
+      emitExternalChange(path);
+      emitExternalChange(path);
+      emitExternalChange(path);
+      await Promise.resolve();
+    });
+
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      firstWatcherRead.resolve({
+        content: "# Guide\n\nIntermediate",
+        name: "guide.md",
+        path
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedReadNativeMarkdownFile).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      secondWatcherRead.resolve({
+        content: "# Guide\n\nLatest",
+        name: "guide.md",
+        path
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.document.content).toBe("# Guide\n\nLatest"));
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledTimes(3);
   });
 
   it("does not overwrite the active tab when restored history save resolves after switching tabs", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -162,6 +162,12 @@ type ClearOpenDocumentOptions = {
   persistWorkspace?: boolean;
 };
 
+type WatchedMarkdownFileReadState = {
+  changedPath: string;
+  pending: boolean;
+  promise: Promise<unknown> | null;
+};
+
 type OpenMarkdownFileOptions = {
   pickerTitle?: string;
 };
@@ -1966,6 +1972,76 @@ export function useMarkdownDocument({
 
     let active = true;
     const stopWatchers: Array<() => unknown> = [];
+    const watchedFileReadStates = new Map<string, WatchedMarkdownFileReadState>();
+
+    const readAndApplyWatchedFile = async (changedPath: string, watchedPath: string) => {
+      debug(() => ["[markra-history] watcher file event", {
+        changedPath,
+        watchedPath
+      }]);
+      let file: NativeMarkdownFile;
+      try {
+        file = await readMarkdownFileWithPerformance(changedPath, "watcher");
+      } catch (error: unknown) {
+        if (active && isMissingMarkdownFileReadError(error)) {
+          const markedDeleted = markExternallyDeletedDocumentFile(changedPath);
+          debug(() => ["[markra-history] watcher marked missing file", {
+            changedPath,
+            markedDeleted,
+            watchedPath
+          }]);
+          onMarkdownTreeChange?.(changedPath);
+          return;
+        }
+
+        debug(() => ["[markra-history] watcher read failed", {
+          changedPath,
+          error: error instanceof Error ? error.message : String(error),
+          watchedPath
+        }]);
+        return;
+      }
+      if (!active) return;
+
+      applyDiskFileToCleanOpenTab(file, "watcher");
+    };
+
+    const drainWatchedFileRead = async (watchedPath: string, state: WatchedMarkdownFileReadState) => {
+      try {
+        while (active) {
+          state.pending = false;
+          await readAndApplyWatchedFile(state.changedPath, watchedPath);
+          if (!state.pending) break;
+        }
+      } finally {
+        if (watchedFileReadStates.get(watchedPath) === state) {
+          watchedFileReadStates.delete(watchedPath);
+        }
+      }
+    };
+
+    const requestWatchedFileRead = (changedPath: string, watchedPath: string) => {
+      const existingState = watchedFileReadStates.get(watchedPath);
+      if (existingState) {
+        existingState.changedPath = changedPath;
+        existingState.pending = true;
+        debug(() => ["[markra-history] watcher file event coalesced", {
+          changedPath,
+          watchedPath
+        }]);
+        return existingState.promise ?? Promise.resolve();
+      }
+
+      const state: WatchedMarkdownFileReadState = {
+        changedPath,
+        pending: false,
+        promise: null
+      };
+      watchedFileReadStates.set(watchedPath, state);
+      const promise = drainWatchedFileRead(watchedPath, state);
+      state.promise = promise;
+      return promise;
+    };
 
     watchedPaths.forEach((watchedPath) => {
       debug(() => ["[markra-history] watcher start", {
@@ -1986,35 +2062,7 @@ export function useMarkdownDocument({
       watchNativeMarkdownFile(watchedPath, async (changedPath) => {
         if (!active) return;
 
-        debug(() => ["[markra-history] watcher file event", {
-          changedPath,
-          watchedPath
-        }]);
-        let file: NativeMarkdownFile;
-        try {
-          file = await readMarkdownFileWithPerformance(changedPath, "watcher");
-        } catch (error: unknown) {
-          if (active && isMissingMarkdownFileReadError(error)) {
-            const markedDeleted = markExternallyDeletedDocumentFile(changedPath);
-            debug(() => ["[markra-history] watcher marked missing file", {
-              changedPath,
-              markedDeleted,
-              watchedPath
-            }]);
-            onMarkdownTreeChange?.(changedPath);
-            return;
-          }
-
-          debug(() => ["[markra-history] watcher read failed", {
-            changedPath,
-            error: error instanceof Error ? error.message : String(error),
-            watchedPath
-          }]);
-          return;
-        }
-        if (!active) return;
-
-        applyDiskFileToCleanOpenTab(file, "watcher");
+        await requestWatchedFileRead(changedPath, watchedPath);
       }, treeChangeHandler).then((stopWatching) => {
         if (!active) {
           stopWatching();

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -460,6 +460,65 @@ describe("useMarkdownFileTree", () => {
     expect(screen.getByText("docs/added.md")).toBeInTheDocument();
   });
 
+  it("coalesces native tree watcher refreshes while a refresh is in flight", async () => {
+    let emitTreeChange: (path: string) => unknown | Promise<unknown> = () => {};
+    const firstRefresh = createDeferredMarkdownFileList();
+    const secondRefresh = createDeferredMarkdownFileList();
+    const thirdRefresh = createDeferredMarkdownFileList();
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      path: "/vault",
+      name: "vault"
+    });
+    mockedListNativeMarkdownFilesForPath
+      .mockResolvedValueOnce([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+      ])
+      .mockReturnValueOnce(firstRefresh.promise)
+      .mockReturnValueOnce(secondRefresh.promise)
+      .mockReturnValueOnce(thirdRefresh.promise);
+    mockedWatchNativeMarkdownTree.mockImplementation(async (_rootPath, onTreeChange) => {
+      emitTreeChange = onTreeChange;
+      return () => {};
+    });
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+    await waitFor(() => expect(mockedWatchNativeMarkdownTree).toHaveBeenCalledWith("/vault", expect.any(Function)));
+
+    await act(async () => {
+      emitTreeChange("/vault/docs/first.md");
+      emitTreeChange("/vault/docs/second.md");
+      emitTreeChange("/vault/docs/third.md");
+      await Promise.resolve();
+    });
+
+    expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      firstRefresh.resolve([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" },
+        { path: "/vault/docs/intermediate.md", name: "intermediate.md", relativePath: "docs/intermediate.md" }
+      ]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      secondRefresh.resolve([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" },
+        { path: "/vault/docs/latest.md", name: "latest.md", relativePath: "docs/latest.md" }
+      ]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByText("docs/latest.md")).toBeInTheDocument());
+    expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledTimes(3);
+  });
+
   it("ignores stale native tree refreshes after switching folders", async () => {
     let emitTreeChange: (path: string) => unknown | Promise<unknown> = () => {};
     const staleVaultRefresh = createDeferredMarkdownFileList();

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -93,6 +93,13 @@ type PendingOpenFolderLoad = {
   cancel: () => undefined;
   timeoutId: number;
 };
+type FileTreeRefreshState = {
+  managedAttachmentFolder: string;
+  path: string;
+  pending: boolean;
+  promise: Promise<unknown> | null;
+  requestId: number;
+};
 
 function filterManagedAttachmentFiles(
   files: readonly NativeMarkdownFolderFile[],
@@ -133,6 +140,7 @@ export function useMarkdownFileTree({
   const openFolderRequestIdRef = useRef(0);
   const openingFolderPathRef = useRef<string | null>(null);
   const pendingOpenFolderLoadRef = useRef<PendingOpenFolderLoad | null>(null);
+  const fileTreeRefreshStateRef = useRef<FileTreeRefreshState | null>(null);
   const openChangedBeforeWorkspaceRestoreRef = useRef(false);
   const normalizedManagedAttachmentFolder = useMemo(
     () => normalizeManagedAttachmentFolder(managedAttachmentFolder),
@@ -182,23 +190,63 @@ export function useMarkdownFileTree({
         return;
       }
 
-      try {
-        const nextFiles = await listNativeMarkdownFilesForPath(path, {
-          managedAttachmentFolder: normalizedManagedAttachmentFolder
-        });
-        if (openFolderRequestIdRef.current !== requestId) return;
-        if (openingFolderPathRef.current && openingFolderPathRef.current !== path) return;
-
-        loadedFileTreeRequestRef.current = { managedAttachmentFolder: normalizedManagedAttachmentFolder, path };
-        startTransition(() => {
-          setFiles(nextFiles);
-        });
-      } catch {
-        if (openFolderRequestIdRef.current !== requestId) return;
-        if (openingFolderPathRef.current && openingFolderPathRef.current !== path) return;
-
-        setFiles([]);
+      const existingRefresh = fileTreeRefreshStateRef.current;
+      if (
+        existingRefresh?.path === path &&
+        existingRefresh.managedAttachmentFolder === normalizedManagedAttachmentFolder &&
+        existingRefresh.requestId === requestId
+      ) {
+        existingRefresh.pending = true;
+        return existingRefresh.promise ?? undefined;
       }
+
+      const refreshState: FileTreeRefreshState = {
+        managedAttachmentFolder: normalizedManagedAttachmentFolder,
+        path,
+        pending: false,
+        promise: null,
+        requestId
+      };
+      fileTreeRefreshStateRef.current = refreshState;
+
+      const refreshPromise = (async () => {
+        try {
+          while (true) {
+            refreshState.pending = false;
+            try {
+              const nextFiles = await listNativeMarkdownFilesForPath(refreshState.path, {
+                managedAttachmentFolder: refreshState.managedAttachmentFolder
+              });
+              if (fileTreeRefreshStateRef.current !== refreshState) return;
+              if (openFolderRequestIdRef.current !== refreshState.requestId) return;
+              if (openingFolderPathRef.current && openingFolderPathRef.current !== refreshState.path) return;
+
+              loadedFileTreeRequestRef.current = {
+                managedAttachmentFolder: refreshState.managedAttachmentFolder,
+                path: refreshState.path
+              };
+              startTransition(() => {
+                setFiles(nextFiles);
+              });
+            } catch {
+              if (fileTreeRefreshStateRef.current !== refreshState) return;
+              if (openFolderRequestIdRef.current !== refreshState.requestId) return;
+              if (openingFolderPathRef.current && openingFolderPathRef.current !== refreshState.path) return;
+
+              setFiles([]);
+            }
+
+            if (!refreshState.pending) return;
+          }
+        } finally {
+          if (fileTreeRefreshStateRef.current === refreshState) {
+            fileTreeRefreshStateRef.current = null;
+          }
+        }
+      })();
+
+      refreshState.promise = refreshPromise;
+      return refreshPromise;
     },
     [normalizedManagedAttachmentFolder, sourcePath]
   );


### PR DESCRIPTION
## Summary
- Coalesce repeated native file watcher events per open markdown file while a disk read is already in flight.
- Coalesce markdown file tree watcher refreshes while a folder scan is already in flight.
- Add regression tests for both event-storm paths.

## Why
- Repeated Windows watcher events could previously start unbounded concurrent file reads and folder scans when the app or system was under memory pressure.
- This keeps the latest pending change and runs at most one follow-up read/refresh after the in-flight work finishes.

## Validation
- `corepack pnpm --filter @markra/app test -- useMarkdownDocument.test.tsx useMarkdownFileTree.test.tsx` passed: 103 test files, 1566 tests.
- `corepack pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Intermediate filesystem states during a burst may be skipped; Markra still refreshes to the latest pending disk state after the current operation completes.

Refs #450