### PR TITLE
perf(app): reduce file tree loading jank

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -32,15 +32,16 @@ use external_urls::open_external_url;
 use fonts::list_system_font_families;
 use image_upload::{upload_picgo_image, upload_s3_image, upload_webdav_image};
 use markdown_files::{
-    check_pandoc_available, create_markdown_tree_file, create_markdown_tree_folder,
-    delete_markdown_template_file, delete_markdown_tree_file, detect_pandoc_path,
-    export_pandoc_file, export_pdf_file, list_markdown_file_history, list_markdown_files_for_path,
-    move_markdown_tree_file, open_containing_folder, open_markdown_attachment,
-    open_markdown_file_in_new_window, open_markdown_folder_in_new_window, open_markdown_path,
-    read_local_image_file, read_markdown_file, read_markdown_file_history,
-    read_markdown_image_file, read_markdown_template_file, rename_markdown_tree_file,
-    resolve_markdown_path, save_clipboard_attachment, save_clipboard_image,
-    search_markdown_files_for_path, write_markdown_file, write_markdown_template_file,
+    cancel_markdown_files_load, check_pandoc_available, create_markdown_tree_file,
+    create_markdown_tree_folder, delete_markdown_template_file, delete_markdown_tree_file,
+    detect_pandoc_path, export_pandoc_file, export_pdf_file, list_markdown_file_history,
+    list_markdown_files_for_path, load_markdown_files_for_path, move_markdown_tree_file,
+    open_containing_folder, open_markdown_attachment, open_markdown_file_in_new_window,
+    open_markdown_folder_in_new_window, open_markdown_path, read_local_image_file,
+    read_markdown_file, read_markdown_file_history, read_markdown_image_file,
+    read_markdown_template_file, rename_markdown_tree_file, resolve_markdown_path,
+    save_clipboard_attachment, save_clipboard_image, search_markdown_files_for_path,
+    write_markdown_file, write_markdown_template_file, MarkdownTreeLoadState,
 };
 use menu::{
     apply_native_application_menu_for_window_event, create_application_menu,
@@ -163,6 +164,7 @@ pub fn run() {
     let builder = tauri::Builder::default()
         .manage(MarkdownFileWatcherState::default())
         .manage(MarkdownTreeWatcherState::default())
+        .manage(MarkdownTreeLoadState::default())
         .manage(OpenedMarkdownPathsState::default())
         .manage(NativeApplicationMenuState::default())
         .manage(NativeMenuTargetState::default())
@@ -232,6 +234,8 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             list_markdown_files_for_path,
+            load_markdown_files_for_path,
+            cancel_markdown_files_load,
             search_markdown_files_for_path,
             create_markdown_tree_file,
             create_markdown_tree_folder,

--- a/apps/desktop/src-tauri/src/markdown_files.rs
+++ b/apps/desktop/src-tauri/src/markdown_files.rs
@@ -28,6 +28,7 @@ pub(crate) use template::{
     delete_markdown_template_file, read_markdown_template_file, write_markdown_template_file,
 };
 pub(crate) use tree::{
-    create_markdown_tree_file, create_markdown_tree_folder, delete_markdown_tree_file,
-    list_markdown_files_for_path, move_markdown_tree_file, rename_markdown_tree_file,
+    cancel_markdown_files_load, create_markdown_tree_file, create_markdown_tree_folder,
+    delete_markdown_tree_file, list_markdown_files_for_path, load_markdown_files_for_path,
+    move_markdown_tree_file, rename_markdown_tree_file, MarkdownTreeLoadState,
 };

--- a/apps/desktop/src-tauri/src/markdown_files/tree.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/tree.rs
@@ -1,5 +1,10 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 
 use super::asset::allow_asset_directory;
 use super::path::{
@@ -8,6 +13,72 @@ use super::path::{
     normalize_markdown_tree_single_file_name, should_skip_markdown_tree_directory,
 };
 use super::types::{MarkdownFolderEntryKind, MarkdownFolderFile};
+use tauri::Emitter;
+
+const MARKDOWN_TREE_LOAD_EVENT: &str = "markra://markdown-tree-load";
+const MARKDOWN_TREE_INITIAL_LOAD_BATCH_SIZE: usize = 128;
+const MARKDOWN_TREE_LOAD_BATCH_SIZE: usize = 1024;
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn markdown_tree_load_batch_size(first_batch_sent: bool) -> usize {
+    if first_batch_sent {
+        MARKDOWN_TREE_LOAD_BATCH_SIZE
+    } else {
+        MARKDOWN_TREE_INITIAL_LOAD_BATCH_SIZE
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct MarkdownTreeLoadState(Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>);
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MarkdownTreeLoadEvent {
+    request_id: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    files: Vec<MarkdownFolderFile>,
+    #[serde(skip_serializing_if = "is_false")]
+    done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl MarkdownTreeLoadState {
+    fn remember(&self, request_id: String, cancel: Arc<AtomicBool>) -> Result<(), String> {
+        let mut loads = self
+            .0
+            .lock()
+            .map_err(|_| "markdown tree load state lock is poisoned".to_string())?;
+
+        if let Some(existing_cancel) = loads.insert(request_id, cancel) {
+            existing_cancel.store(true, Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
+    fn cancel(&self, request_id: &str) -> Result<(), String> {
+        let mut loads = self
+            .0
+            .lock()
+            .map_err(|_| "markdown tree load state lock is poisoned".to_string())?;
+
+        if let Some(cancel) = loads.remove(request_id) {
+            cancel.store(true, Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
+    fn forget(&self, request_id: &str) {
+        if let Ok(mut loads) = self.0.lock() {
+            loads.remove(request_id);
+        }
+    }
+}
 
 fn collect_markdown_tree_files(
     root: &Path,
@@ -61,6 +132,123 @@ fn collect_markdown_tree_files(
                     &path,
                     MarkdownFolderEntryKind::Attachment,
                 )?);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn emit_markdown_tree_load_event(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    files: Vec<MarkdownFolderFile>,
+    done: bool,
+    error: Option<String>,
+) -> Result<(), String> {
+    app.emit(
+        MARKDOWN_TREE_LOAD_EVENT,
+        MarkdownTreeLoadEvent {
+            request_id: request_id.to_string(),
+            files,
+            done,
+            error,
+        },
+    )
+    .map_err(|emit_error| emit_error.to_string())
+}
+
+fn flush_markdown_tree_load_batch(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    batch: &mut Vec<MarkdownFolderFile>,
+    done: bool,
+) -> Result<(), String> {
+    if batch.is_empty() && !done {
+        return Ok(());
+    }
+
+    emit_markdown_tree_load_event(app, request_id, std::mem::take(batch), done, None)
+}
+
+fn push_markdown_tree_load_file(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    batch: &mut Vec<MarkdownFolderFile>,
+    first_batch_sent: &mut bool,
+    file: MarkdownFolderFile,
+) -> Result<(), String> {
+    batch.push(file);
+    if batch.len() >= markdown_tree_load_batch_size(*first_batch_sent) {
+        flush_markdown_tree_load_batch(app, request_id, batch, false)?;
+        *first_batch_sent = true;
+    }
+
+    Ok(())
+}
+
+fn collect_markdown_tree_files_incrementally(
+    app: &tauri::AppHandle,
+    request_id: &str,
+    cancel: &AtomicBool,
+    root: &Path,
+    directory: &Path,
+    managed_attachment_folder: Option<&str>,
+    batch: &mut Vec<MarkdownFolderFile>,
+    first_batch_sent: &mut bool,
+) -> Result<(), String> {
+    if cancel.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| error.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+
+    entries.sort_by(|a, b| {
+        a.file_name()
+            .to_string_lossy()
+            .to_lowercase()
+            .cmp(&b.file_name().to_string_lossy().to_lowercase())
+    });
+
+    for entry in entries {
+        if cancel.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|error| error.to_string())?;
+
+        if file_type.is_dir() {
+            if !should_skip_markdown_tree_directory(&path) {
+                push_markdown_tree_load_file(
+                    app,
+                    request_id,
+                    batch,
+                    first_batch_sent,
+                    markdown_folder_file(root, &path, MarkdownFolderEntryKind::Folder)?,
+                )?;
+                collect_markdown_tree_files_incrementally(
+                    app,
+                    request_id,
+                    cancel,
+                    root,
+                    &path,
+                    managed_attachment_folder,
+                    batch,
+                    first_batch_sent,
+                )?;
+            }
+            continue;
+        }
+
+        if file_type.is_file() {
+            let kind = markdown_tree_file_kind(&path)?;
+            let file = markdown_folder_file(root, &path, kind)?;
+            if should_include_markdown_tree_file(&file, managed_attachment_folder) {
+                push_markdown_tree_load_file(app, request_id, batch, first_batch_sent, file)?;
             }
         }
     }
@@ -345,6 +533,87 @@ pub(crate) fn list_markdown_files_for_path(
 }
 
 #[tauri::command]
+pub(crate) fn load_markdown_files_for_path(
+    app: tauri::AppHandle,
+    load_state: tauri::State<'_, MarkdownTreeLoadState>,
+    path: String,
+    managed_attachment_folder: Option<String>,
+    request_id: String,
+) -> Result<(), String> {
+    let trimmed_request_id = request_id.trim().to_string();
+    if trimmed_request_id.is_empty() {
+        return Err("Markdown tree load request id is required".to_string());
+    }
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    let task_load_state = load_state.inner().clone();
+    task_load_state.remember(trimmed_request_id.clone(), cancel.clone())?;
+
+    std::thread::spawn(move || {
+        let result = load_markdown_files_for_path_in_background(
+            &app,
+            path,
+            managed_attachment_folder,
+            trimmed_request_id.clone(),
+            cancel,
+        );
+        if let Err(error) = result {
+            let _ = emit_markdown_tree_load_event(
+                &app,
+                &trimmed_request_id,
+                Vec::new(),
+                false,
+                Some(error),
+            );
+        }
+        task_load_state.forget(&trimmed_request_id);
+    });
+
+    Ok(())
+}
+
+fn load_markdown_files_for_path_in_background(
+    app: &tauri::AppHandle,
+    path: String,
+    managed_attachment_folder: Option<String>,
+    request_id: String,
+    cancel: Arc<AtomicBool>,
+) -> Result<(), String> {
+    let source_path = PathBuf::from(path);
+    let root = markdown_tree_root_for_path(&source_path)?;
+    let normalized_managed_attachment_folder =
+        normalize_managed_attachment_folder(managed_attachment_folder.as_deref());
+    let mut batch = Vec::new();
+    let mut first_batch_sent = false;
+
+    allow_asset_directory(app, &root)?;
+    collect_markdown_tree_files_incrementally(
+        app,
+        &request_id,
+        &cancel,
+        &root,
+        &root,
+        normalized_managed_attachment_folder.as_deref(),
+        &mut batch,
+        &mut first_batch_sent,
+    )?;
+
+    if cancel.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+
+    flush_markdown_tree_load_batch(app, &request_id, &mut batch, true)
+}
+
+#[tauri::command]
+pub(crate) fn cancel_markdown_files_load(
+    load_state: tauri::State<'_, MarkdownTreeLoadState>,
+    request_id: String,
+) -> Result<(), String> {
+    load_state.cancel(&request_id)
+}
+
+#[tauri::command]
 pub(crate) fn create_markdown_tree_file(
     root_path: String,
     file_name: String,
@@ -479,6 +748,12 @@ mod tests {
         assert_eq!(file.relative_path, relative_path);
         assert!(file.created_at.is_some());
         assert!(file.modified_at.is_some());
+    }
+
+    #[test]
+    fn uses_a_small_first_load_batch_then_larger_followup_batches() {
+        assert_eq!(markdown_tree_load_batch_size(false), 128);
+        assert_eq!(markdown_tree_load_batch_size(true), 1024);
     }
 
     #[test]

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -86,6 +86,7 @@ export const desktopRuntime = {
     installMarkdownFileDrop: files.installNativeMarkdownFileDrop,
     listenOpenedMarkdownPaths: files.listenNativeOpenedMarkdownPaths,
     listMarkdownFileHistory: files.listNativeMarkdownFileHistory,
+    loadMarkdownFilesForPath: files.loadNativeMarkdownFilesForPath,
     listMarkdownFilesForPath: files.listNativeMarkdownFilesForPath,
     moveMarkdownTreeFile: files.moveNativeMarkdownTreeFile,
     openContainingFolder: files.openNativeContainingFolder,

--- a/apps/desktop/src/runtime/tauri/file.test.ts
+++ b/apps/desktop/src/runtime/tauri/file.test.ts
@@ -15,6 +15,7 @@ import {
   installNativeMarkdownFileDrop,
   listenNativeOpenedMarkdownPaths,
   listNativeMarkdownFileHistory,
+  loadNativeMarkdownFilesForPath,
   listNativeMarkdownFilesForPath,
   moveNativeMarkdownTreeFile,
   openNativeLocalImages,
@@ -510,6 +511,72 @@ describe("native file access", () => {
       managedAttachmentFolder: "media/files",
       path: mockReadmePath
     });
+  });
+
+  it("loads markdown files incrementally through native tree load events", async () => {
+    const unlisten = vi.fn();
+    let emitTreeLoad: (payload: unknown) => unknown = () => {};
+    const batches: Array<Awaited<ReturnType<typeof loadNativeMarkdownFilesForPath>>> = [];
+
+    mockedListen.mockImplementation(async (event, handler) => {
+      if (event === "markra://markdown-tree-load") {
+        emitTreeLoad = (payload) => handler({ payload } as never);
+      }
+
+      return unlisten;
+    });
+    mockedInvoke.mockImplementation(async (command, args) => {
+      if (command === "load_markdown_files_for_path") {
+        const requestId = (args as { requestId: string }).requestId;
+        emitTreeLoad({
+          requestId,
+          files: [
+            { path: "/mock-files/readme.md", relativePath: "readme.md", createdAt: 10, modifiedAt: 20 }
+          ]
+        });
+        emitTreeLoad({
+          requestId,
+          files: [
+            { kind: "asset", path: "/mock-files/assets/pasted-image.png", relativePath: "assets/pasted-image.png" }
+          ],
+          done: true
+        });
+      }
+
+      return undefined;
+    });
+
+    await expect(loadNativeMarkdownFilesForPath(mockFolderPath, {
+      managedAttachmentFolder: "assets",
+      onBatch: (files) => {
+        batches.push(files);
+      }
+    })).resolves.toEqual([
+      { path: "/mock-files/readme.md", name: "readme.md", relativePath: "readme.md", createdAt: 10, modifiedAt: 20 },
+      {
+        kind: "asset",
+        path: "/mock-files/assets/pasted-image.png",
+        name: "pasted-image.png",
+        relativePath: "assets/pasted-image.png"
+      }
+    ]);
+
+    expect(mockedListen).toHaveBeenCalledWith("markra://markdown-tree-load", expect.any(Function));
+    expect(mockedInvoke).toHaveBeenCalledWith("load_markdown_files_for_path", {
+      managedAttachmentFolder: "assets",
+      path: mockFolderPath,
+      requestId: expect.any(String)
+    });
+    expect(batches).toEqual([
+      [{ path: "/mock-files/readme.md", name: "readme.md", relativePath: "readme.md", createdAt: 10, modifiedAt: 20 }],
+      [{
+        kind: "asset",
+        path: "/mock-files/assets/pasted-image.png",
+        name: "pasted-image.png",
+        relativePath: "assets/pasted-image.png"
+      }]
+    ]);
+    expect(unlisten).toHaveBeenCalledTimes(1);
   });
 
   it("creates folders, creates files, moves files, renames files, and deletes files through Tauri commands", async () => {

--- a/apps/desktop/src/runtime/tauri/file.ts
+++ b/apps/desktop/src/runtime/tauri/file.ts
@@ -66,6 +66,13 @@ type MarkdownWorkspaceSearchResponse = Omit<WorkspaceSearchResponse, "results"> 
   results: MarkdownWorkspaceSearchResultResponse[];
 };
 
+type MarkdownFileTreeLoadEventResponse = {
+  done?: boolean;
+  error?: string;
+  files?: MarkdownFolderFileResponse[];
+  requestId: string;
+};
+
 export type NativeMarkdownFile = {
   path: string;
   name: string;
@@ -555,6 +562,11 @@ export type ListNativeMarkdownFilesOptions = {
   managedAttachmentFolder?: string | null;
 };
 
+export type LoadNativeMarkdownFilesForPathOptions = ListNativeMarkdownFilesOptions & {
+  onBatch?: (files: NativeMarkdownFolderFile[]) => unknown;
+  signal?: AbortSignal | null;
+};
+
 export async function listNativeMarkdownFilesForPath(
   path: string,
   options: ListNativeMarkdownFilesOptions = {}
@@ -569,6 +581,109 @@ export async function listNativeMarkdownFilesForPath(
   const files = await invoke<MarkdownFolderFileResponse[]>("list_markdown_files_for_path", args);
 
   return files.map(markdownFolderFileFromResponse);
+}
+
+const markdownFileTreeLoadEvent = "markra://markdown-tree-load";
+let markdownFileTreeLoadRequestIndex = 0;
+
+function nextMarkdownFileTreeLoadRequestId() {
+  markdownFileTreeLoadRequestIndex += 1;
+  return `markdown-tree-load-${Date.now()}-${markdownFileTreeLoadRequestIndex}`;
+}
+
+function canceledMarkdownFileTreeLoadError() {
+  return new Error("Markdown file tree load was canceled.");
+}
+
+export async function loadNativeMarkdownFilesForPath(
+  path: string,
+  options: LoadNativeMarkdownFilesForPathOptions = {}
+): Promise<NativeMarkdownFolderFile[]> {
+  const requestId = nextMarkdownFileTreeLoadRequestId();
+  const allFiles: NativeMarkdownFolderFile[] = [];
+  let removeListener: (() => unknown) | null = null;
+  let abortHandler: EventListener | null = null;
+  let settled = false;
+
+  const cleanup = (cancelNativeLoad: boolean) => {
+    const currentRemoveListener = removeListener;
+    removeListener = null;
+    currentRemoveListener?.();
+
+    if (options.signal && abortHandler) {
+      options.signal.removeEventListener("abort", abortHandler);
+      abortHandler = null;
+    }
+
+    if (cancelNativeLoad) {
+      invoke("cancel_markdown_files_load", { requestId }).catch(() => {});
+    }
+  };
+
+  return new Promise<NativeMarkdownFolderFile[]>((resolve, reject) => {
+    const fail = (error: unknown, cancelNativeLoad = true) => {
+      if (settled) return;
+
+      settled = true;
+      cleanup(cancelNativeLoad);
+      reject(error);
+    };
+    const complete = () => {
+      if (settled) return;
+
+      settled = true;
+      cleanup(false);
+      resolve(allFiles);
+    };
+
+    abortHandler = () => fail(canceledMarkdownFileTreeLoadError());
+
+    if (options.signal?.aborted) {
+      fail(canceledMarkdownFileTreeLoadError());
+      return;
+    }
+
+    options.signal?.addEventListener("abort", abortHandler);
+
+    listen<MarkdownFileTreeLoadEventResponse>(markdownFileTreeLoadEvent, (event) => {
+      const payload = event.payload;
+      if (payload.requestId !== requestId) return;
+
+      if (payload.error) {
+        fail(new Error(payload.error), false);
+        return;
+      }
+
+      const batchFiles = payload.files?.map(markdownFolderFileFromResponse) ?? [];
+      if (batchFiles.length > 0) {
+        allFiles.push(...batchFiles);
+        options.onBatch?.(batchFiles);
+      }
+
+      if (payload.done) complete();
+    }).then((listenerCleanup) => {
+      if (settled) {
+        listenerCleanup();
+        return;
+      }
+
+      removeListener = listenerCleanup;
+      const args: {
+        managedAttachmentFolder?: string | null;
+        path: string;
+        requestId: string;
+      } = { path, requestId };
+      if (options.managedAttachmentFolder !== undefined) {
+        args.managedAttachmentFolder = options.managedAttachmentFolder;
+      }
+
+      invoke("load_markdown_files_for_path", args).catch((error: unknown) => {
+        fail(error);
+      });
+    }).catch((error: unknown) => {
+      fail(error, false);
+    });
+  });
 }
 
 export async function searchNativeMarkdownFilesForPath({

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -43,6 +43,7 @@ import {
   mockedInstallNativeEditorContextMenu,
   mockedInstallNativeMarkdownFileDrop,
   mockedListNativeMarkdownFileHistory,
+  mockedLoadNativeMarkdownFilesForPath,
   mockedListNativeMarkdownFilesForPath,
   mockedListenNativeOpenedMarkdownPaths,
   mockedListenAppEditorPreferencesChanged,
@@ -7202,11 +7203,57 @@ describe("Markra workspace", () => {
     await waitFor(() =>
       expect(mockedListNativeMarkdownFilesForPath).toHaveBeenCalledWith(mockNativePath, defaultFileTreeListOptions)
     );
+    await waitFor(() =>
+      expect(mockedLoadNativeMarkdownFilesForPath).toHaveBeenCalledWith(
+        mockNativePath,
+        expect.objectContaining(defaultFileTreeListOptions)
+      )
+    );
     link!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true }));
 
     expect(await screen.findByText("Opened through a document link.")).toBeInTheDocument();
     expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
     expect(mockedOpenNativeExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("opens relative markdown links before the current folder tree finishes loading", async () => {
+    const guidePath = "/mock-files/docs/guide.md";
+    let finishTreeLoad = () => {};
+    mockOpenMarkdownFile({
+      content: "[Guide](./docs/guide.md)",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation((_path, options = {}) =>
+      new Promise((resolve) => {
+        finishTreeLoad = () => {
+          const files = [{ name: "native.md", path: mockNativePath, relativePath: "native.md" }];
+          if (!options.signal?.aborted) options.onBatch?.(files);
+          resolve(files);
+        };
+      })
+    );
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide\n\nOpened before the tree finished loading.",
+      name: "guide.md",
+      path: guidePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    let link: HTMLAnchorElement | null = null;
+    await waitFor(() => {
+      link = document.querySelector<HTMLAnchorElement>('.ProseMirror a[href="./docs/guide.md"]');
+      expect(link).toHaveTextContent("Guide");
+    });
+    link!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true }));
+
+    expect(await screen.findByText("Opened before the tree finished loading.")).toBeInTheDocument();
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
+    expect(mockedOpenNativeExternalUrl).not.toHaveBeenCalled();
+
+    finishTreeLoad();
   });
 
   it("wires native menu file actions to the current document commands", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -90,13 +90,14 @@ import {
   debug,
   markdownImageDragPayloadForFile,
   markdownImageDragSrcForDocument,
+  pathNameFromPath,
   t,
   type I18nKey
 } from "@markra/shared";
 import { showAppToast } from "./lib/app-toast";
 import { createMarkdownImageSrcResolver, getWordCount } from "@markra/markdown";
 import { buildMarkdownHtmlDocument, exportDocumentFileName, localFileUrlFromPath } from "./lib/document-export";
-import { resolveMarkdownDocumentLinkFile } from "./lib/document-links";
+import { resolveMarkdownDocumentLinkFile, resolveMarkdownDocumentLinkPath } from "./lib/document-links";
 import { saveEditorImage, saveLocalEditorImage } from "./lib/image-upload";
 import { aiCommandSelection, automaticAiSelection } from "./lib/ai-selection";
 import { createWorkspaceChangePlanOperations } from "./lib/workspace-plan-apply";
@@ -1104,10 +1105,16 @@ function WorkspaceApp() {
   }, [activeTabId]);
   const handleOpenEditorLink = useCallback(async (href: string) => {
     const linkedFile = resolveMarkdownDocumentLinkFile(href, document.path, fileTreeFiles);
-    if (linkedFile) {
+    const linkedPath = linkedFile?.path ?? resolveMarkdownDocumentLinkPath(href, document.path);
+    if (linkedPath) {
+      const fallbackFileName = pathNameFromPath(linkedPath);
       captureActiveDocumentViewState();
       setActiveImageFile(null);
-      await openTreeMarkdownFile(linkedFile);
+      await openTreeMarkdownFile(linkedFile ?? {
+        name: fallbackFileName,
+        path: linkedPath,
+        relativePath: fallbackFileName
+      });
       return;
     }
 

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MarkdownFileTreeDrawer } from "./MarkdownFileTreeDrawer";
+import { fileTreeRowHeight } from "./file-tree/file-tree-model";
 import { getMarkdownOutline } from "@markra/markdown";
 import { readNativeClipboardText, showNativeMarkdownFileTreeContextMenu } from "../lib/tauri";
 import type { WorkspaceLinkIndex } from "../lib/workspace-links";
@@ -1695,6 +1696,61 @@ describe("MarkdownFileTreeDrawer", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "notes/note-299.md" })).toBeInTheDocument();
     });
+  });
+
+  it("coalesces virtual file tree scroll updates into one animation frame", () => {
+    const manyNotes = Array.from({ length: 600 }, (_, index) => {
+      const noteNumber = String(index).padStart(3, "0");
+
+      return {
+        name: `note-${noteNumber}.md`,
+        path: `/vault/notes/note-${noteNumber}.md`,
+        relativePath: `notes/note-${noteNumber}.md`
+      };
+    });
+    const notesFolder = { kind: "folder" as const, name: "notes", path: "/vault/notes", relativePath: "notes" };
+    const animationFrames: FrameRequestCallback[] = [];
+    const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    const cancelAnimationFrameSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    try {
+      const { container } = render(
+        <MarkdownFileTreeDrawer
+          currentPath="/vault/notes/note-000.md"
+          files={[notesFolder, ...manyNotes]}
+          open
+          outlineItems={[]}
+          rootName="Obsidian Vault"
+          onOpenFile={() => {}}
+          onSelectOutlineItem={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "notes" }));
+
+      const scroll = container.querySelector(".file-tree-scroll") as HTMLElement;
+      scroll.scrollTop = 40 * fileTreeRowHeight;
+      fireEvent.scroll(scroll);
+      scroll.scrollTop = 120 * fileTreeRowHeight;
+      fireEvent.scroll(scroll);
+      scroll.scrollTop = 240 * fileTreeRowHeight;
+      fireEvent.scroll(scroll);
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole("button", { name: "notes/note-240.md" })).not.toBeInTheDocument();
+
+      act(() => {
+        animationFrames[0]?.(performance.now());
+      });
+
+      expect(screen.getByRole("button", { name: "notes/note-240.md" })).toBeInTheDocument();
+    } finally {
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+    }
   });
 
   it("sorts file tree entries by name, modified time, and created time", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -208,6 +209,18 @@ const sidebarAutoRevealDelayMs = 220;
 const defaultDocumentLinksHeightPercent = 28;
 const minDocumentLinksHeightPercent = 16;
 const maxDocumentLinksHeightPercent = 60;
+
+function requestFileTreeAnimationFrame(callback: FrameRequestCallback) {
+  const scheduler = window.requestAnimationFrame ?? ((frameCallback: FrameRequestCallback) =>
+    window.setTimeout(() => frameCallback(performance.now()), 16));
+
+  return scheduler(callback);
+}
+
+function cancelFileTreeAnimationFrame(handle: number) {
+  const cancel = window.cancelAnimationFrame ?? window.clearTimeout;
+  cancel(handle);
+}
 const documentLinksResizeKeyboardStepPercent = 5;
 const recentFolderPathDisplayMaxLength = 48;
 const fileTreeContextRowSelectionClassName = "select-none [-webkit-user-select:none]";
@@ -495,6 +508,8 @@ export function MarkdownFileTreeDrawer({
   const [fileTreeScrollElement, setFileTreeScrollElement] = useState<HTMLDivElement | null>(null);
   const [fileTreeScrollOffset, setFileTreeScrollOffset] = useState(0);
   const [fileTreeViewportHeight, setFileTreeViewportHeight] = useState(fallbackFileTreeViewportHeight);
+  const pendingFileTreeScrollOffsetRef = useRef(fileTreeScrollOffset);
+  const fileTreeScrollAnimationFrameRef = useRef<number | null>(null);
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set());
   const [hoveredRecentFolderPath, setHoveredRecentFolderPath] = useState<string | null>(null);
   const [focusedRecentFolderActionPath, setFocusedRecentFolderActionPath] = useState<string | null>(null);
@@ -563,6 +578,7 @@ export function MarkdownFileTreeDrawer({
   const fileTreeSortKey = fileTreeSort.key;
   const fileTreeSortDirection = fileTreeSort.direction;
   const fileTreeAssetsVisible = controlledFileTreeAssetsVisible ?? localFileTreeAssetsVisible;
+  const deferredFiles = useDeferredValue(files);
   const updateFileTreeSort = useCallback((sort: FileTreeSort) => {
     if (controlledFileTreeSort === undefined) setLocalFileTreeSort(sort);
     onFileTreeSortChange?.(sort);
@@ -571,7 +587,10 @@ export function MarkdownFileTreeDrawer({
     if (controlledFileTreeAssetsVisible === undefined) setLocalFileTreeAssetsVisible(visible);
     onFileTreeAssetsVisibleChange?.(visible);
   }, [controlledFileTreeAssetsVisible, onFileTreeAssetsVisibleChange]);
-  const fullTree = useMemo(() => buildMarkdownFileTree(files, rootPath, fileTreeSort), [files, rootPath, fileTreeSort]);
+  const fullTree = useMemo(
+    () => buildMarkdownFileTree(deferredFiles, rootPath, fileTreeSort),
+    [deferredFiles, rootPath, fileTreeSort]
+  );
   const assetFilteredTree = useMemo(
     () => fileTreeAssetsVisible ? fullTree : filterMarkdownFileTreeAssets(fullTree),
     [fileTreeAssetsVisible, fullTree]
@@ -627,8 +646,8 @@ export function MarkdownFileTreeDrawer({
     [visibleFileTreeRows]
   );
   const allFileTreeFilePaths = useMemo(
-    () => files.filter((file) => file.kind !== "folder").map((file) => file.path),
-    [files]
+    () => deferredFiles.filter((file) => file.kind !== "folder").map((file) => file.path),
+    [deferredFiles]
   );
   const pathInFileTree = useCallback((path: string | null | undefined, paths: readonly string[]) => (
     paths.some((candidatePath) => sameNativePath(candidatePath, path))
@@ -670,10 +689,27 @@ export function MarkdownFileTreeDrawer({
 
     setFileTreeViewportHeight((current) => current === nextHeight ? current : nextHeight);
   }, [fileTreeScrollElement]);
-  const handleFileTreeScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
-    const nextOffset = Math.max(0, event.currentTarget.scrollTop);
+  const flushFileTreeScrollOffset = useCallback(() => {
+    fileTreeScrollAnimationFrameRef.current = null;
+    const nextOffset = pendingFileTreeScrollOffsetRef.current;
+
     setFileTreeScrollOffset((current) => current === nextOffset ? current : nextOffset);
   }, []);
+  const scheduleFileTreeScrollOffset = useCallback(() => {
+    if (fileTreeScrollAnimationFrameRef.current !== null) return;
+
+    fileTreeScrollAnimationFrameRef.current = requestFileTreeAnimationFrame(flushFileTreeScrollOffset);
+  }, [flushFileTreeScrollOffset]);
+  const cancelPendingFileTreeScrollFrame = useCallback(() => {
+    if (fileTreeScrollAnimationFrameRef.current === null) return;
+
+    cancelFileTreeAnimationFrame(fileTreeScrollAnimationFrameRef.current);
+    fileTreeScrollAnimationFrameRef.current = null;
+  }, []);
+  const handleFileTreeScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
+    pendingFileTreeScrollOffsetRef.current = Math.max(0, event.currentTarget.scrollTop);
+    scheduleFileTreeScrollOffset();
+  }, [scheduleFileTreeScrollOffset]);
   const folderPaths = useMemo(() => collectMarkdownFolderPaths(assetFilteredTree), [assetFilteredTree]);
   const folderTargetPaths = useMemo(() => collectMarkdownFolderTargetPaths(assetFilteredTree), [assetFilteredTree]);
   const availableMarkdownTemplates = useMemo(() => mergeMarkdownTemplates(customTemplates), [customTemplates]);
@@ -701,7 +737,7 @@ export function MarkdownFileTreeDrawer({
   const folderActionsAvailable = fileCreationAvailable || folderCreationAvailable;
   const backgroundContextMenuAvailable = folderActionsAvailable || Boolean(onOpenContainingFolder && rootPath);
   const folderExpansionAvailable = folderPaths.length > 0;
-  const assetVisibilityToggleAvailable = files.some((file) => file.kind === "asset");
+  const assetVisibilityToggleAvailable = deferredFiles.some((file) => file.kind === "asset");
   const allFoldersExpanded = folderExpansionAvailable && folderPaths.every((folderPath) => expandedFolders.has(folderPath));
   const outlineExpansionAvailable = collapsibleOutlineKeys.length > 0;
   const allOutlineItemsCollapsed = outlineExpansionAvailable &&
@@ -825,10 +861,18 @@ export function MarkdownFileTreeDrawer({
   useEffect(() => {
     if (filePanelVisible) return;
 
+    cancelPendingFileTreeScrollFrame();
+    pendingFileTreeScrollOffsetRef.current = 0;
     fileTreeScrollNodeRef.current = null;
     setFileTreeScrollElement(null);
     setFileTreeScrollOffset(0);
-  }, [filePanelVisible]);
+  }, [cancelPendingFileTreeScrollFrame, filePanelVisible]);
+
+  useEffect(() => {
+    return () => {
+      cancelPendingFileTreeScrollFrame();
+    };
+  }, [cancelPendingFileTreeScrollFrame]);
 
   useEffect(() => {
     if (activeSidebarPanel !== "links" || linkPanelAvailable) return;
@@ -1092,6 +1136,8 @@ export function MarkdownFileTreeDrawer({
         scrollElement.scrollTop = Math.max(0, rowBottom - viewportHeight);
       }
 
+      cancelPendingFileTreeScrollFrame();
+      pendingFileTreeScrollOffsetRef.current = scrollElement.scrollTop;
       setFileTreeScrollOffset(scrollElement.scrollTop);
     }
 
@@ -1109,6 +1155,7 @@ export function MarkdownFileTreeDrawer({
   }, [
     filePanelVisible,
     fileTreeViewportHeight,
+    cancelPendingFileTreeScrollFrame,
     pendingRevealPath,
     virtualFileTreeEnabled,
     visibleFileTreeRows

--- a/packages/app/src/components/file-tree/file-tree-model.test.ts
+++ b/packages/app/src/components/file-tree/file-tree-model.test.ts
@@ -1,0 +1,19 @@
+import { buildMarkdownFileTree } from "./file-tree-model";
+
+describe("file tree model", () => {
+  it("reuses a collator instead of calling localeCompare for every name sort comparison", () => {
+    const localeCompareSpy = vi.spyOn(String.prototype, "localeCompare");
+
+    try {
+      buildMarkdownFileTree([
+        { path: "/vault/note-10.md", name: "note-10.md", relativePath: "note-10.md" },
+        { path: "/vault/note-2.md", name: "note-2.md", relativePath: "note-2.md" },
+        { path: "/vault/docs/readme.md", name: "readme.md", relativePath: "docs/readme.md" }
+      ]);
+
+      expect(localeCompareSpy).not.toHaveBeenCalled();
+    } finally {
+      localeCompareSpy.mockRestore();
+    }
+  });
+});

--- a/packages/app/src/components/file-tree/file-tree-model.ts
+++ b/packages/app/src/components/file-tree/file-tree-model.ts
@@ -57,9 +57,13 @@ export const fileTreeVirtualizationThreshold = 200;
 export const fallbackFileTreeViewportHeight = 320;
 
 const fileTreeVirtualOverscanCount = 10;
+const fileTreeNameCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base"
+});
 
 function nodeNameSort(left: TreeNode, right: TreeNode) {
-  return left.name.localeCompare(right.name, undefined, { numeric: true, sensitivity: "base" });
+  return fileTreeNameCollator.compare(left.name, right.name);
 }
 
 function nodeTimestamp(node: TreeNode, key: Exclude<FileTreeSortKey, "name">) {

--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   createNativeMarkdownTreeFile,
   createNativeMarkdownTreeFolder,
   deleteNativeMarkdownTreeFile,
+  loadNativeMarkdownFilesForPath,
   listNativeMarkdownFilesForPath,
   moveNativeMarkdownTreeFile,
   openNativeMarkdownFolder,
@@ -26,6 +28,7 @@ vi.mock("../lib/tauri", () => ({
   createNativeMarkdownTreeFile: vi.fn(),
   createNativeMarkdownTreeFolder: vi.fn(),
   deleteNativeMarkdownTreeFile: vi.fn(),
+  loadNativeMarkdownFilesForPath: vi.fn(),
   listNativeMarkdownFilesForPath: vi.fn(),
   moveNativeMarkdownTreeFile: vi.fn(),
   openNativeMarkdownFolder: vi.fn(),
@@ -56,6 +59,7 @@ vi.mock("../lib/settings/app-settings", () => ({
 const mockedCreateNativeMarkdownTreeFile = vi.mocked(createNativeMarkdownTreeFile);
 const mockedCreateNativeMarkdownTreeFolder = vi.mocked(createNativeMarkdownTreeFolder);
 const mockedDeleteNativeMarkdownTreeFile = vi.mocked(deleteNativeMarkdownTreeFile);
+const mockedLoadNativeMarkdownFilesForPath = vi.mocked(loadNativeMarkdownFilesForPath);
 const mockedListNativeMarkdownFilesForPath = vi.mocked(listNativeMarkdownFilesForPath);
 const mockedMoveNativeMarkdownTreeFile = vi.mocked(moveNativeMarkdownTreeFile);
 const mockedOpenNativeMarkdownFolder = vi.mocked(openNativeMarkdownFolder);
@@ -100,12 +104,18 @@ function mockWorkspaceState(
 
 function FileTreeProbe({
   currentPath = null,
-  managedAttachmentFolder
+  managedAttachmentFolder,
+  onFilesChange
 }: {
   currentPath?: string | null;
   managedAttachmentFolder?: string;
+  onFilesChange?: (files: ReturnType<typeof useMarkdownFileTree>["files"]) => unknown;
 }) {
   const tree = useMarkdownFileTree({ managedAttachmentFolder });
+
+  useEffect(() => {
+    onFilesChange?.(tree.files);
+  }, [onFilesChange, tree.files]);
 
   return (
     <section>
@@ -234,6 +244,7 @@ describe("useMarkdownFileTree", () => {
     mockedCreateNativeMarkdownTreeFile.mockReset();
     mockedCreateNativeMarkdownTreeFolder.mockReset();
     mockedDeleteNativeMarkdownTreeFile.mockReset();
+    mockedLoadNativeMarkdownFilesForPath.mockReset();
     mockedListNativeMarkdownFilesForPath.mockReset();
     mockedMoveNativeMarkdownTreeFile.mockReset();
     mockedOpenNativeMarkdownFolder.mockReset();
@@ -280,6 +291,11 @@ describe("useMarkdownFileTree", () => {
     mockedSaveStoredWorkspaceState.mockResolvedValue(undefined);
     mockedSaveStoredFileTreeSortForWorkspace.mockResolvedValue(undefined);
     mockedWatchNativeMarkdownTree.mockResolvedValue(() => {});
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation((path, options = {}) => {
+      return mockedListNativeMarkdownFilesForPath(path, {
+        managedAttachmentFolder: options.managedAttachmentFolder
+      });
+    });
   });
 
   it("opens a selected markdown folder as the tree root", async () => {
@@ -313,6 +329,156 @@ describe("useMarkdownFileTree", () => {
       name: "vault",
       path: "/vault"
     });
+  });
+
+  it("streams selected folder files before the full tree load resolves", async () => {
+    const folderLoad = createDeferredMarkdownFileList();
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      path: "/vault",
+      name: "vault"
+    });
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation((_path, options = {}) => {
+      options.onBatch?.([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+      ]);
+      return folderLoad.promise;
+    });
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+    expect(screen.getByTestId("root-name")).toHaveTextContent("vault");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+
+    await act(async () => {
+      folderLoad.resolve([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" },
+        { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("docs/guide.md")).toBeInTheDocument();
+  });
+
+  it("buffers follow-up folder load batches before refreshing the tree again", async () => {
+    vi.useFakeTimers();
+
+    const folderLoad = createDeferredMarkdownFileList();
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      path: "/vault",
+      name: "vault"
+    });
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation((_path, options = {}) => {
+      options.onBatch?.([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+      ]);
+      options.onBatch?.([
+        { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
+      ]);
+      options.onBatch?.([
+        { path: "/vault/docs/reference.md", name: "reference.md", relativePath: "docs/reference.md" }
+      ]);
+      return folderLoad.promise;
+    });
+
+    try {
+      render(<FileTreeProbe />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Open folder" }));
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        vi.runOnlyPendingTimers();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText("index.md")).toBeInTheDocument();
+      expect(screen.queryByText("docs/guide.md")).not.toBeInTheDocument();
+      expect(screen.queryByText("docs/reference.md")).not.toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(179);
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("docs/guide.md")).not.toBeInTheDocument();
+      expect(screen.queryByText("docs/reference.md")).not.toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText("docs/guide.md")).toBeInTheDocument();
+      expect(screen.getByText("docs/reference.md")).toBeInTheDocument();
+
+      await act(async () => {
+        folderLoad.resolve([
+          { path: "/vault/index.md", name: "index.md", relativePath: "index.md" },
+          { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" },
+          { path: "/vault/docs/reference.md", name: "reference.md", relativePath: "docs/reference.md" }
+        ]);
+        await Promise.resolve();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips the final file tree update when streamed batches already match the resolved files", async () => {
+    const files = [
+      { path: "/vault/index.md", name: "index.md", relativePath: "index.md" },
+      { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
+    ];
+    const folderLoad = createDeferredMarkdownFileList();
+    const onFilesChange = vi.fn();
+
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation((_path, options = {}) => {
+      options.onBatch?.(files);
+      return folderLoad.promise;
+    });
+
+    render(<FileTreeProbe onFilesChange={onFilesChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore collapsed folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+
+    await act(async () => {
+      folderLoad.resolve(files);
+      await Promise.resolve();
+    });
+
+    const nonEmptyFileUpdates = onFilesChange.mock.calls.filter(([nextFiles]) => nextFiles.length > 0);
+    expect(nonEmptyFileUpdates).toHaveLength(1);
+  });
+
+  it("aborts the previous native file tree load when switching folders", async () => {
+    const firstLoad = createDeferredMarkdownFileList();
+    const secondLoad = createDeferredMarkdownFileList();
+    const firstSignalRef: { current: AbortSignal | null } = { current: null };
+
+    mockedLoadNativeMarkdownFilesForPath
+      .mockImplementationOnce((_path, options = {}) => {
+        firstSignalRef.current = options.signal ?? null;
+        return firstLoad.promise;
+      })
+      .mockImplementationOnce(() => secondLoad.promise);
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore collapsed folder" }));
+
+    await waitFor(() => expect(firstSignalRef.current).not.toBeNull());
+
+    fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
+
+    expect(firstSignalRef.current?.aborted).toBe(true);
   });
 
   it("hides attachment files outside the managed attachment folder while keeping folders visible", async () => {

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -19,7 +19,7 @@ import {
   createNativeMarkdownTreeFile,
   createNativeMarkdownTreeFolder,
   deleteNativeMarkdownTreeFile,
-  listNativeMarkdownFilesForPath,
+  loadNativeMarkdownFilesForPath,
   moveNativeMarkdownTreeFile,
   openNativeMarkdownFolder,
   renameNativeMarkdownTreeFile,
@@ -32,6 +32,7 @@ export const markdownFileTreeDefaultWidth = 288;
 export const markdownFileTreeMinWidth = 220;
 export const markdownFileTreeMaxWidth = 440;
 const openFolderLoadCoalesceMs = 120;
+const fileTreeBatchFlushDelayMs = 180;
 
 function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState>[0]) {
   saveStoredWorkspaceState(patch).catch(() => {});
@@ -100,26 +101,54 @@ type FileTreeRefreshState = {
   promise: Promise<unknown> | null;
   requestId: number;
 };
+type PendingFileTreeBatchFlush = {
+  path: string;
+  requestId: number;
+  timeoutId: number;
+};
 
 function filterManagedAttachmentFiles(
   files: readonly NativeMarkdownFolderFile[],
   managedAttachmentFolder: string | null | undefined
 ) {
   const normalizedManagedAttachmentFolder = normalizeManagedAttachmentFolder(managedAttachmentFolder);
-  const entries = files.map((file) => ({
-    file,
-    relativePath: normalizedTreeRelativePath(file.relativePath)
-  }));
+  const visibleFiles: NativeMarkdownFolderFile[] = [];
 
-  return entries
-    .filter(({ file, relativePath }) => {
-      if (file.kind === "attachment") {
-        return treePathIsBelowFolder(relativePath, normalizedManagedAttachmentFolder);
-      }
+  files.forEach((file) => {
+    if (
+      file.kind === "attachment" &&
+      !treePathIsBelowFolder(normalizedTreeRelativePath(file.relativePath), normalizedManagedAttachmentFolder)
+    ) {
+      return;
+    }
 
-      return true;
-    })
-    .map(({ file }) => file);
+    visibleFiles.push(file);
+  });
+
+  return visibleFiles;
+}
+
+function sameFileTreeFile(left: NativeMarkdownFolderFile, right: NativeMarkdownFolderFile) {
+  return left.path === right.path &&
+    left.relativePath === right.relativePath &&
+    left.name === right.name &&
+    left.kind === right.kind &&
+    left.createdAt === right.createdAt &&
+    left.modifiedAt === right.modifiedAt &&
+    left.sizeBytes === right.sizeBytes;
+}
+
+function sameFileTreeFiles(
+  currentFiles: readonly NativeMarkdownFolderFile[],
+  nextFiles: readonly NativeMarkdownFolderFile[]
+) {
+  if (currentFiles.length !== nextFiles.length) return false;
+
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    if (!sameFileTreeFile(currentFiles[index], nextFiles[index])) return false;
+  }
+
+  return true;
 }
 
 export function useMarkdownFileTree({
@@ -141,6 +170,11 @@ export function useMarkdownFileTree({
   const openingFolderPathRef = useRef<string | null>(null);
   const pendingOpenFolderLoadRef = useRef<PendingOpenFolderLoad | null>(null);
   const fileTreeRefreshStateRef = useRef<FileTreeRefreshState | null>(null);
+  const fileTreeLoadAbortControllerRef = useRef<AbortController | null>(null);
+  const fileTreeFilesRef = useRef<NativeMarkdownFolderFile[]>([]);
+  const fileTreeFilePathSetRef = useRef<Set<string>>(new Set());
+  const pendingFileTreeBatchRef = useRef<NativeMarkdownFolderFile[]>([]);
+  const pendingFileTreeBatchFlushRef = useRef<PendingFileTreeBatchFlush | null>(null);
   const openChangedBeforeWorkspaceRestoreRef = useRef(false);
   const normalizedManagedAttachmentFolder = useMemo(
     () => normalizeManagedAttachmentFolder(managedAttachmentFolder),
@@ -181,12 +215,135 @@ export function useMarkdownFileTree({
     setResizing(false);
   }, []);
 
+  const fileTreeLoadIsCurrent = useCallback((requestId: number, path: string) => (
+    openFolderRequestIdRef.current === requestId &&
+    (!openingFolderPathRef.current || openingFolderPathRef.current === path)
+  ), []);
+
+  const abortCurrentFileTreeLoad = useCallback(() => {
+    const controller = fileTreeLoadAbortControllerRef.current;
+    if (!controller) return;
+
+    fileTreeLoadAbortControllerRef.current = null;
+    controller.abort();
+  }, []);
+
+  const loadFileTreeFilesForPath = useCallback((
+    path: string,
+    options: Parameters<typeof loadNativeMarkdownFilesForPath>[1] = {}
+  ) => {
+    abortCurrentFileTreeLoad();
+
+    const controller = new AbortController();
+    fileTreeLoadAbortControllerRef.current = controller;
+
+    return loadNativeMarkdownFilesForPath(path, {
+      ...options,
+      signal: controller.signal
+    }).finally(() => {
+      if (fileTreeLoadAbortControllerRef.current === controller) {
+        fileTreeLoadAbortControllerRef.current = null;
+      }
+    });
+  }, [abortCurrentFileTreeLoad]);
+
+  const replaceFileTreeFiles = useCallback((
+    nextFiles: readonly NativeMarkdownFolderFile[],
+    options: { transition?: boolean } = {}
+  ) => {
+    if (sameFileTreeFiles(fileTreeFilesRef.current, nextFiles)) return;
+
+    const nextFileTreeFiles = Array.from(nextFiles);
+    fileTreeFilesRef.current = nextFileTreeFiles;
+    fileTreeFilePathSetRef.current = new Set(nextFileTreeFiles.map((file) => file.path));
+
+    const applyFiles = () => {
+      setFiles(nextFileTreeFiles);
+    };
+
+    if (options.transition === false) {
+      applyFiles();
+      return;
+    }
+
+    startTransition(applyFiles);
+  }, []);
+
+  const appendFileTreeBatchFiles = useCallback((batchFiles: readonly NativeMarkdownFolderFile[]) => {
+    if (batchFiles.length === 0) return;
+
+    const nextBatchFiles: NativeMarkdownFolderFile[] = [];
+    const seenPaths = fileTreeFilePathSetRef.current;
+
+    batchFiles.forEach((file) => {
+      if (seenPaths.has(file.path)) return;
+
+      seenPaths.add(file.path);
+      nextBatchFiles.push(file);
+    });
+
+    if (nextBatchFiles.length === 0) return;
+
+    fileTreeFilesRef.current = [...fileTreeFilesRef.current, ...nextBatchFiles];
+    startTransition(() => {
+      setFiles((currentFiles) => [...currentFiles, ...nextBatchFiles]);
+    });
+  }, []);
+
+  const cancelPendingFileTreeBatchFlush = useCallback(() => {
+    if (pendingFileTreeBatchFlushRef.current) {
+      window.clearTimeout(pendingFileTreeBatchFlushRef.current.timeoutId);
+      pendingFileTreeBatchFlushRef.current = null;
+    }
+
+    pendingFileTreeBatchRef.current = [];
+  }, []);
+
+  const flushPendingFileTreeBatch = useCallback((requestId: number, path: string) => {
+    pendingFileTreeBatchFlushRef.current = null;
+    const batchFiles = pendingFileTreeBatchRef.current;
+    pendingFileTreeBatchRef.current = [];
+
+    if (batchFiles.length === 0 || !fileTreeLoadIsCurrent(requestId, path)) return;
+
+    appendFileTreeBatchFiles(batchFiles);
+  }, [appendFileTreeBatchFiles, fileTreeLoadIsCurrent]);
+
+  const schedulePendingFileTreeBatchFlush = useCallback((requestId: number, path: string) => {
+    const pendingFlush = pendingFileTreeBatchFlushRef.current;
+    if (pendingFlush?.requestId === requestId && pendingFlush.path === path) return;
+    if (pendingFlush) window.clearTimeout(pendingFlush.timeoutId);
+
+    const timeoutId = window.setTimeout(() => {
+      flushPendingFileTreeBatch(requestId, path);
+    }, fileTreeBatchFlushDelayMs);
+
+    pendingFileTreeBatchFlushRef.current = { path, requestId, timeoutId };
+  }, [flushPendingFileTreeBatch]);
+
+  const applyLoadedFileTreeBatch = useCallback((
+    batchFiles: readonly NativeMarkdownFolderFile[],
+    requestId: number,
+    path: string,
+    immediate: boolean
+  ) => {
+    if (batchFiles.length === 0 || !fileTreeLoadIsCurrent(requestId, path)) return;
+
+    if (immediate) {
+      appendFileTreeBatchFiles(batchFiles);
+      return;
+    }
+
+    pendingFileTreeBatchRef.current.push(...batchFiles);
+    schedulePendingFileTreeBatchFlush(requestId, path);
+  }, [appendFileTreeBatchFiles, fileTreeLoadIsCurrent, schedulePendingFileTreeBatchFlush]);
+
   const refresh = useCallback(
     async (fallbackPath: string | null = null) => {
       const path = sourcePath ?? fallbackPath;
       const requestId = openFolderRequestIdRef.current;
       if (!path) {
-        setFiles([]);
+        replaceFileTreeFiles([], { transition: false });
         return;
       }
 
@@ -214,26 +371,33 @@ export function useMarkdownFileTree({
           while (true) {
             refreshState.pending = false;
             try {
-              const nextFiles = await listNativeMarkdownFilesForPath(refreshState.path, {
-                managedAttachmentFolder: refreshState.managedAttachmentFolder
+              cancelPendingFileTreeBatchFlush();
+              let firstBatch = true;
+              const nextFiles = await loadFileTreeFilesForPath(refreshState.path, {
+                managedAttachmentFolder: refreshState.managedAttachmentFolder,
+                onBatch: (batchFiles) => {
+                  const immediate = firstBatch;
+                  firstBatch = false;
+                  applyLoadedFileTreeBatch(batchFiles, refreshState.requestId, refreshState.path, immediate);
+                }
               });
               if (fileTreeRefreshStateRef.current !== refreshState) return;
               if (openFolderRequestIdRef.current !== refreshState.requestId) return;
               if (openingFolderPathRef.current && openingFolderPathRef.current !== refreshState.path) return;
 
+              cancelPendingFileTreeBatchFlush();
               loadedFileTreeRequestRef.current = {
                 managedAttachmentFolder: refreshState.managedAttachmentFolder,
                 path: refreshState.path
               };
-              startTransition(() => {
-                setFiles(nextFiles);
-              });
+              replaceFileTreeFiles(nextFiles);
             } catch {
               if (fileTreeRefreshStateRef.current !== refreshState) return;
               if (openFolderRequestIdRef.current !== refreshState.requestId) return;
               if (openingFolderPathRef.current && openingFolderPathRef.current !== refreshState.path) return;
 
-              setFiles([]);
+              cancelPendingFileTreeBatchFlush();
+              replaceFileTreeFiles([], { transition: false });
             }
 
             if (!refreshState.pending) return;
@@ -248,17 +412,26 @@ export function useMarkdownFileTree({
       refreshState.promise = refreshPromise;
       return refreshPromise;
     },
-    [normalizedManagedAttachmentFolder, sourcePath]
+    [
+      applyLoadedFileTreeBatch,
+      cancelPendingFileTreeBatchFlush,
+      loadFileTreeFilesForPath,
+      normalizedManagedAttachmentFolder,
+      replaceFileTreeFiles,
+      sourcePath
+    ]
   );
 
   const setRootFromMarkdownFilePath = useCallback((path: string) => {
     openFolderRequestIdRef.current += 1;
     openingFolderPathRef.current = null;
+    abortCurrentFileTreeLoad();
     pendingOpenFolderLoadRef.current?.cancel();
     pendingOpenFolderLoadRef.current = null;
+    cancelPendingFileTreeBatchFlush();
     setSourcePath(path);
     setRootName(folderNameFromDocumentPath(path));
-  }, []);
+  }, [abortCurrentFileTreeLoad, cancelPendingFileTreeBatchFlush]);
 
   const waitForLatestOpenFolderLoad = useCallback((requestId: number) => {
     pendingOpenFolderLoadRef.current?.cancel();
@@ -308,6 +481,7 @@ export function useMarkdownFileTree({
 
     openFolderRequestIdRef.current = requestId;
     openingFolderPathRef.current = path;
+    abortCurrentFileTreeLoad();
 
     if (options.coalesce) {
       setRootName(folderName);
@@ -323,18 +497,33 @@ export function useMarkdownFileTree({
       pendingOpenFolderLoadRef.current = null;
     }
 
+    loadedFileTreeRequestRef.current = { managedAttachmentFolder: normalizedManagedAttachmentFolder, path };
+    cancelPendingFileTreeBatchFlush();
+    replaceFileTreeFiles([], { transition: false });
+    setSourcePath(path);
+    setRootName(folderName);
+    openChangedBeforeWorkspaceRestoreRef.current = true;
+    setOpen(openTree);
+
     try {
-      nextFiles = await listNativeMarkdownFilesForPath(path, {
-        managedAttachmentFolder: normalizedManagedAttachmentFolder
+      let firstBatch = true;
+      nextFiles = await loadFileTreeFilesForPath(path, {
+        managedAttachmentFolder: normalizedManagedAttachmentFolder,
+        onBatch: (batchFiles) => {
+          const immediate = firstBatch;
+          firstBatch = false;
+          applyLoadedFileTreeBatch(batchFiles, requestId, path, immediate);
+        }
       });
     } catch {
       if (openFolderRequestIdRef.current !== requestId) return null;
 
+      cancelPendingFileTreeBatchFlush();
       openingFolderPathRef.current = null;
       forgetRecentFolder(path);
 
       if (!sourcePath || sourcePath === path) {
-        setFiles([]);
+        replaceFileTreeFiles([], { transition: false });
         setSourcePath(null);
         setRootName("No folder");
         loadedFileTreeRequestRef.current = null;
@@ -351,14 +540,9 @@ export function useMarkdownFileTree({
     if (openFolderRequestIdRef.current !== requestId) return null;
 
     openingFolderPathRef.current = null;
-    setSourcePath(path);
-    setRootName(folderName);
-    openChangedBeforeWorkspaceRestoreRef.current = true;
-    setOpen(openTree);
+    cancelPendingFileTreeBatchFlush();
     loadedFileTreeRequestRef.current = { managedAttachmentFolder: normalizedManagedAttachmentFolder, path };
-    startTransition(() => {
-      setFiles(nextFiles);
-    });
+    replaceFileTreeFiles(nextFiles);
     rememberFolder({ name: folderName, path });
     onWorkspaceSessionChange?.(sessionId);
     // Opening a folder replaces the startup workspace, so clear the previous file path in the same write.
@@ -371,11 +555,17 @@ export function useMarkdownFileTree({
     });
     return { name: folderName, path };
   }, [
+    applyLoadedFileTreeBatch,
+    abortCurrentFileTreeLoad,
+    cancelPendingFileTreeBatchFlush,
     forgetRecentFolder,
+    fileTreeLoadIsCurrent,
+    loadFileTreeFilesForPath,
     normalizedManagedAttachmentFolder,
     onWorkspaceSessionChange,
     open,
     rememberFolder,
+    replaceFileTreeFiles,
     rootName,
     sourcePath,
     waitForLatestOpenFolderLoad
@@ -384,10 +574,12 @@ export function useMarkdownFileTree({
   useEffect(() => {
     return () => {
       openingFolderPathRef.current = null;
+      abortCurrentFileTreeLoad();
       pendingOpenFolderLoadRef.current?.cancel();
       pendingOpenFolderLoadRef.current = null;
+      cancelPendingFileTreeBatchFlush();
     };
-  }, []);
+  }, [abortCurrentFileTreeLoad, cancelPendingFileTreeBatchFlush]);
 
   const openMarkdownFolder = useCallback(async (options: OpenMarkdownFolderOptions = {}) => {
     const folder = await openNativeMarkdownFolder(
@@ -560,7 +752,8 @@ export function useMarkdownFileTree({
 
     if (!sourcePath) {
       loadedFileTreeRequestRef.current = null;
-      setFiles([]);
+      abortCurrentFileTreeLoad();
+      replaceFileTreeFiles([], { transition: false });
       return () => {
         active = false;
       };
@@ -576,21 +769,45 @@ export function useMarkdownFileTree({
     }
 
     loadedFileTreeRequestRef.current = { managedAttachmentFolder: normalizedManagedAttachmentFolder, path: sourcePath };
-    listNativeMarkdownFilesForPath(sourcePath, {
-      managedAttachmentFolder: normalizedManagedAttachmentFolder
+    cancelPendingFileTreeBatchFlush();
+    const requestId = openFolderRequestIdRef.current;
+    let firstBatch = true;
+    loadFileTreeFilesForPath(sourcePath, {
+      managedAttachmentFolder: normalizedManagedAttachmentFolder,
+      onBatch: (batchFiles) => {
+        if (!active) return;
+
+        const immediate = firstBatch;
+        firstBatch = false;
+        applyLoadedFileTreeBatch(batchFiles, requestId, sourcePath, immediate);
+      }
     }).then((nextFiles) => {
-      if (active) setFiles(nextFiles);
+      if (active) {
+        cancelPendingFileTreeBatchFlush();
+        replaceFileTreeFiles(nextFiles);
+      }
     }).catch(() => {
       if (active) {
+        cancelPendingFileTreeBatchFlush();
         loadedFileTreeRequestRef.current = null;
-        setFiles([]);
+        replaceFileTreeFiles([], { transition: false });
       }
     });
 
     return () => {
       active = false;
+      abortCurrentFileTreeLoad();
+      cancelPendingFileTreeBatchFlush();
     };
-  }, [normalizedManagedAttachmentFolder, sourcePath]);
+  }, [
+    applyLoadedFileTreeBatch,
+    abortCurrentFileTreeLoad,
+    cancelPendingFileTreeBatchFlush,
+    loadFileTreeFilesForPath,
+    normalizedManagedAttachmentFolder,
+    replaceFileTreeFiles,
+    sourcePath
+  ]);
 
   useEffect(() => {
     if (!sourcePath) return;

--- a/packages/app/src/lib/document-links.test.ts
+++ b/packages/app/src/lib/document-links.test.ts
@@ -1,7 +1,8 @@
 import {
   documentLinkCompletionFiles,
   markdownDocumentLinkForFile,
-  resolveMarkdownDocumentLinkFile
+  resolveMarkdownDocumentLinkFile,
+  resolveMarkdownDocumentLinkPath
 } from "./document-links";
 
 const workspaceFiles = [
@@ -40,5 +41,15 @@ describe("document links", () => {
       workspaceFiles[2]
     );
     expect(resolveMarkdownDocumentLinkFile("https://example.com", "/mock-files/vault/index.md", workspaceFiles)).toBeNull();
+  });
+
+  it("resolves local markdown link paths without requiring the file tree entry", () => {
+    expect(resolveMarkdownDocumentLinkPath("./docs/Guide%20Notes.md", "/mock-files/vault/index.md")).toBe(
+      "/mock-files/vault/docs/Guide Notes.md"
+    );
+    expect(resolveMarkdownDocumentLinkPath("../Roadmap.markdown#plan", "/mock-files/vault/docs/current.md")).toBe(
+      "/mock-files/vault/Roadmap.markdown"
+    );
+    expect(resolveMarkdownDocumentLinkPath("https://example.com/guide.md", "/mock-files/vault/index.md")).toBeNull();
   });
 });

--- a/packages/app/src/lib/document-links.ts
+++ b/packages/app/src/lib/document-links.ts
@@ -174,10 +174,12 @@ export function resolveMarkdownDocumentLinkFile(
   currentDocumentPath: string | null | undefined,
   files: readonly MarkdownDocumentLinkFile[]
 ) {
-  const hrefPath = localMarkdownHrefPath(href);
-  if (!hrefPath || !markdownDocumentExtensionPattern.test(hrefPath)) return null;
+  const resolvedPath = resolveMarkdownDocumentLinkPath(href, currentDocumentPath);
+  if (!resolvedPath) return null;
 
-  const resolvedPath = resolvePathFromDocument(hrefPath, currentDocumentPath);
+  const hrefPath = localMarkdownHrefPath(href);
+  if (!hrefPath) return null;
+
   const normalizedHrefRelativePath = trimPathSlashes(normalizePathSeparators(hrefPath).replace(/^\.\//u, ""));
 
   return files.find((file) => {
@@ -185,4 +187,14 @@ export function resolveMarkdownDocumentLinkFile(
 
     return normalizeAbsolutePath(file.path) === resolvedPath || normalizePathSeparators(file.relativePath) === normalizedHrefRelativePath;
   }) ?? null;
+}
+
+export function resolveMarkdownDocumentLinkPath(
+  href: string,
+  currentDocumentPath: string | null | undefined
+) {
+  const hrefPath = localMarkdownHrefPath(href);
+  if (!hrefPath || !markdownDocumentExtensionPattern.test(hrefPath)) return null;
+
+  return resolvePathFromDocument(hrefPath, currentDocumentPath);
 }

--- a/packages/app/src/lib/tauri/file.ts
+++ b/packages/app/src/lib/tauri/file.ts
@@ -45,6 +45,11 @@ export type ListNativeMarkdownFilesOptions = {
   managedAttachmentFolder?: string | null;
 };
 
+export type LoadNativeMarkdownFilesForPathOptions = ListNativeMarkdownFilesOptions & {
+  onBatch?: (files: NativeMarkdownFolderFile[]) => unknown;
+  signal?: AbortSignal | null;
+};
+
 export type NativeMarkdownFolder = {
   path: string;
   name: string;
@@ -302,6 +307,20 @@ export function readNativeLocalImageFile(path: string) {
 
 export function listNativeMarkdownFilesForPath(path: string, options: ListNativeMarkdownFilesOptions = {}) {
   return getAppRuntime().files.listMarkdownFilesForPath(path, options);
+}
+
+export async function loadNativeMarkdownFilesForPath(
+  path: string,
+  options: LoadNativeMarkdownFilesForPathOptions = {}
+) {
+  const loadMarkdownFilesForPath = getAppRuntime().files.loadMarkdownFilesForPath;
+  if (loadMarkdownFilesForPath) return loadMarkdownFilesForPath(path, options);
+
+  const files = await listNativeMarkdownFilesForPath(path, {
+    managedAttachmentFolder: options.managedAttachmentFolder
+  });
+  if (!options.signal?.aborted) options.onBatch?.(files);
+  return files;
 }
 
 export function createNativeMarkdownTreeFile(

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -13,6 +13,7 @@ import type {
   CreateNativeMarkdownTreeFileOptions,
   BackupNativeMarkdownFolderInput,
   DownloadNativeWebImageInput,
+  LoadNativeMarkdownFilesForPathOptions,
   ListNativeMarkdownFilesOptions,
   NativeMarkdownDroppedTarget,
   NativeMarkdownFile,
@@ -163,6 +164,10 @@ export type AppFileRuntime = {
   listMarkdownFilesForPath: (
     path: string,
     options?: ListNativeMarkdownFilesOptions
+  ) => Promise<NativeMarkdownFolderFile[]>;
+  loadMarkdownFilesForPath?: (
+    path: string,
+    options?: LoadNativeMarkdownFilesForPathOptions
   ) => Promise<NativeMarkdownFolderFile[]>;
   moveMarkdownTreeFile: (
     rootPath: string,

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -45,6 +45,7 @@ import {
   syncNativeMarkdownFolder,
   uninstallNativeShellCommand,
   installNativeMarkdownFileDrop,
+  loadNativeMarkdownFilesForPath,
   listNativeMarkdownFilesForPath,
   takeNativeOpenedMarkdownPaths,
   toggleNativeWindowFullscreen,
@@ -194,6 +195,7 @@ vi.mock("../lib/tauri", () => ({
   watchNativeMarkdownFile: vi.fn(),
   writeNativeMarkdownTemplateFile: vi.fn(),
   watchNativeMarkdownTree: vi.fn(),
+  loadNativeMarkdownFilesForPath: vi.fn(),
   listNativeMarkdownFilesForPath: vi.fn(),
   takeNativeOpenedMarkdownPaths: vi.fn(),
   installNativeApplicationMenu: vi.fn(),
@@ -832,6 +834,7 @@ export const mockedSyncNativeMarkdownFolder = vi.mocked(syncNativeMarkdownFolder
 export const mockedUninstallNativeShellCommand = vi.mocked(uninstallNativeShellCommand);
 export const mockedInstallNativeMarkdownFileDrop = vi.mocked(installNativeMarkdownFileDrop);
 export const mockedListNativeMarkdownFileHistory = vi.mocked(listNativeMarkdownFileHistory);
+export const mockedLoadNativeMarkdownFilesForPath = vi.mocked(loadNativeMarkdownFilesForPath);
 export const mockedListNativeMarkdownFilesForPath = vi.mocked(listNativeMarkdownFilesForPath);
 export const mockedTakeNativeOpenedMarkdownPaths = vi.mocked(takeNativeOpenedMarkdownPaths);
 export const mockedRenameNativeMarkdownTreeFile = vi.mocked(renameNativeMarkdownTreeFile);
@@ -1030,6 +1033,7 @@ export function installAppTestHarness() {
     mockedSyncNativeMarkdownFolder.mockReset();
     mockedSetNativeEditorWindowRestoreState.mockReset();
     mockedListNativeMarkdownFileHistory.mockReset();
+    mockedLoadNativeMarkdownFilesForPath.mockReset();
     mockedListNativeMarkdownFilesForPath.mockReset();
     mockedTakeNativeOpenedMarkdownPaths.mockReset();
     mockedWatchNativeMarkdownFile.mockReset();
@@ -1137,6 +1141,13 @@ export function installAppTestHarness() {
     mockedReadNativeMarkdownFileHistory.mockRejectedValue(new Error("markdown history file is not mocked"));
     mockedReadNativeLocalImageFile.mockRejectedValue(new Error("local image file is not mocked"));
     mockedListNativeMarkdownFilesForPath.mockResolvedValue([]);
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation(async (path, options = {}) => {
+      const files = await mockedListNativeMarkdownFilesForPath(path, {
+        managedAttachmentFolder: options.managedAttachmentFolder
+      });
+      if (!options.signal?.aborted) options.onBatch?.(files);
+      return files;
+    });
     mockedSearchNativeMarkdownFilesForPath.mockResolvedValue(null);
     mockedTakeNativeOpenedMarkdownPaths.mockResolvedValue([]);
     mockedInstallNativeMarkdownFileDrop.mockResolvedValue(() => {});


### PR DESCRIPTION
## Summary
- add a native incremental markdown tree loader with cancellable background requests
- buffer and dedupe streamed file tree batches before updating React state
- reduce sidebar render pressure with deferred file tree rebuilds, coalesced scroll updates, and a reused name sort collator
- keep watcher refresh coalescing behavior while routing refreshes through the incremental loader

## Why
Large folders can still make the left file tree janky while Markra discovers markdown and asset entries. The previous path reduced initial blocking, but follow-up batches and final list updates could still trigger repeated main-thread tree rebuilds and keep stale native scans running after folder switches.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownFileTree.test.tsx` passed: 33 tests
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownFileTreeDrawer.test.tsx src/components/file-tree/file-tree-model.test.ts` passed: 96 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `pnpm --filter @markra/desktop test` passed: 117 tests
- `pnpm --filter @markra/app test` passed: 1580 tests
- `cargo fmt --check` passed
- `cargo test` passed: 192 tests

## Risk
- Medium: file tree loading now streams through a new Tauri event path, with fallback preserved for runtimes that only support full listing.
- Watcher refresh coalescing from the base branch is preserved and now uses the same incremental load path.
