### PR TITLE
fix(editor): render pasted markdown source as rich content

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -3260,6 +3260,91 @@ describe("MarkdownPaper editing", () => {
     ));
   });
 
+  it("adapts pasted markdown source into rich editor content", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, editor, view } = await renderEditor("", { onMarkdownChange });
+    const markdownSource = [
+      "# Pasted title",
+      "",
+      "A **bold** line with [a link](https://example.test).",
+      "",
+      "- First",
+      "- Second",
+      "",
+      "![Diagram](assets/diagram.png)"
+    ].join("\n");
+
+    expect(pasteText(view, markdownSource)).toBe(true);
+
+    expect(container.querySelector(".ProseMirror h1")).toHaveTextContent("Pasted title");
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(container.querySelector<HTMLAnchorElement>('.ProseMirror a[href="https://example.test"]')).toHaveTextContent(
+      "a link"
+    );
+    expect(container.querySelectorAll(".ProseMirror li")).toHaveLength(2);
+    expect(container.querySelector<HTMLImageElement>('.ProseMirror img[src="assets/diagram.png"]')).toHaveAttribute(
+      "alt",
+      "Diagram"
+    );
+    expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("**bold**");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("# Pasted title");
+    expect(serializeMarkdown(view.state.doc)).toContain("A **bold** line with [a link](https://example.test).");
+    expect(serializeMarkdown(view.state.doc)).toContain("![Diagram](assets/diagram.png)");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining("# Pasted title")));
+  });
+
+  it("adapts markdown source when the clipboard also includes source-shaped html", async () => {
+    const { container, editor, view } = await renderEditor("");
+    const markdownSource = [
+      "# Pasted title",
+      "",
+      "A **bold** line with [a link](https://example.test)."
+    ].join("\n");
+
+    dispatchMixedClipboardPaste(view, {
+      files: [],
+      html: [
+        '<pre class="editor-clipboard">',
+        '<span># Pasted title</span>',
+        "<br>",
+        "<br>",
+        '<span>A **bold** line with [a link](https://example.test).</span>',
+        "</pre>"
+      ].join(""),
+      plainText: markdownSource
+    });
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror h1")).toHaveTextContent("Pasted title"));
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(container.querySelector<HTMLAnchorElement>('.ProseMirror a[href="https://example.test"]')).toHaveTextContent(
+      "a link"
+    );
+    expect(container.querySelector(".ProseMirror")?.textContent).not.toContain("**bold**");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain("A **bold** line with [a link](https://example.test).");
+  });
+
+  it("adapts pasted inline markdown source inside the current paragraph", async () => {
+    const { container, editor, view } = await renderEditor("Intro");
+    moveCursor(view, findTextPosition(view, "Intro", "Intro".length));
+
+    expect(pasteText(view, " with **bold** and [link](https://example.test)")).toBe(true);
+
+    expect(container.querySelector(".ProseMirror p")).toHaveTextContent("Intro with bold and link");
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(container.querySelector<HTMLAnchorElement>('.ProseMirror a[href="https://example.test"]')).toHaveTextContent(
+      "link"
+    );
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toContain(
+      "Intro with **bold** and [link](https://example.test)"
+    );
+  });
+
   it("transfers remote images from pasted web HTML through the image save pipeline", async () => {
     const onMarkdownChange = vi.fn();
     const onSaveRemoteClipboardImage = vi.fn().mockResolvedValue({

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -37,6 +37,7 @@ import {
   markraListTogglePlugin,
   markraLinkImageLivePlugin,
   markraLiveMarkdownPlugin,
+  markraMarkdownSourcePastePlugin,
   markraMarkdownShortcuts,
   markraMathCaretAnchorSuppressionPlugin,
   markraMathPlugin,
@@ -482,6 +483,7 @@ function MilkdownEditorSurface({
         .use(markraSlashCommands(slashCommandLabels, { callout: githubAlertsEnabled }))
         .use(markraMathSourcePlugin)
         .use(markraMarkdownShortcuts(normalizedMarkdownShortcuts))
+        .use(markraMarkdownSourcePastePlugin)
         .use(markraCodeBlockPlugin)
         .use(markraMathCaretAnchorSuppressionPlugin)
         .use(markraMathPlugin)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -13,6 +13,7 @@ export * from "./heading-toggle.ts";
 export * from "./input-rules.ts";
 export * from "./link-image-rules.ts";
 export * from "./list-toggle.ts";
+export * from "./markdown-source-paste.ts";
 export * from "./mermaid.ts";
 export * from "./math.ts";
 export * from "./raw-html.ts";

--- a/packages/editor/src/markdown-source-paste.ts
+++ b/packages/editor/src/markdown-source-paste.ts
@@ -1,0 +1,113 @@
+import { ParserReady, parserCtx } from "@milkdown/kit/core";
+import { Fragment, Slice, type Node as ProseNode } from "@milkdown/kit/prose/model";
+import { Plugin, PluginKey, TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $proseAsync } from "@milkdown/kit/utils";
+
+const markdownSourcePasteKey = new PluginKey("markraMarkdownSourcePaste");
+
+const markdownSourcePatterns = [
+  /(^|\n)\s{0,3}#{1,6}\s+\S/u,
+  /(^|\n)\s{0,3}(?:[-+*]|\d+[.)])\s+\S/u,
+  /(^|\n)\s{0,3}>\s+\S/u,
+  /(^|\n)\s{0,3}(?:```|~~~)/u,
+  /(^|\n)\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*($|\n)/u,
+  /(^|\n)\s{0,3}\|.+\|\s*\n\s{0,3}\|(?:\s*:?-+:?\s*\|)+/u,
+  /!\[[^\]\n]*\]\([^)]+\)/u,
+  /(^|[\s([{])\[[^\]\n]+\]\([^)]+\)/u,
+  /(^|[\s([{])\*\*[^*\n]+?\*\*/u,
+  /(^|[\s([{])__[^_\n]+?__/u,
+  /(^|[\s([{])`[^`\n]+?`(?!`)/u
+];
+
+function clipboardPlainText(event: ClipboardEvent) {
+  return event.clipboardData?.getData("text/plain") ?? "";
+}
+
+function clipboardHasFiles(event: ClipboardEvent) {
+  return Boolean(event.clipboardData?.files?.length);
+}
+
+function isStandaloneUrl(text: string) {
+  return /^https?:\/\/\S+$/u.test(text.trim());
+}
+
+function looksLikeMarkdownSource(text: string) {
+  const normalizedText = text.replace(/\r\n?/g, "\n");
+  const trimmedText = normalizedText.trim();
+  if (!trimmedText || isStandaloneUrl(trimmedText)) return false;
+
+  return markdownSourcePatterns.some((pattern) => pattern.test(normalizedText));
+}
+
+function inlineWhitespace(text: string) {
+  return {
+    leading: text.match(/^[ \t]+/u)?.[0] ?? "",
+    trailing: text.match(/[ \t]+$/u)?.[0] ?? ""
+  };
+}
+
+function fragmentNodes(fragment: Fragment) {
+  const nodes: ProseNode[] = [];
+  fragment.forEach((node) => {
+    nodes.push(node);
+  });
+  return nodes;
+}
+
+function inlineParagraphSlice(view: EditorView, parsedDocument: ProseNode, sourceText: string) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection)) return null;
+  if (!selection.$from.sameParent(selection.$to)) return null;
+  if (!selection.$from.parent.inlineContent) return null;
+  if (parsedDocument.childCount !== 1) return null;
+
+  const child = parsedDocument.firstChild;
+  if (!child || child.type.name !== "paragraph") return null;
+
+  const { leading, trailing } = inlineWhitespace(sourceText);
+  if (!leading && !trailing) return new Slice(child.content, 0, 0);
+
+  const nodes = fragmentNodes(child.content);
+  if (leading) nodes.unshift(view.state.schema.text(leading));
+  if (trailing) nodes.push(view.state.schema.text(trailing));
+
+  return new Slice(Fragment.fromArray(nodes), 0, 0);
+}
+
+export const markraMarkdownSourcePastePlugin = $proseAsync(async (ctx) => {
+  await ctx.wait(ParserReady);
+  const parseMarkdown = ctx.get(parserCtx);
+
+  return new Plugin({
+    key: markdownSourcePasteKey,
+    props: {
+      handlePaste(view, event) {
+        if (!view.editable) return false;
+        if (view.state.selection.$from.parent.type.spec.code) return false;
+        if (clipboardHasFiles(event)) return false;
+
+        const text = clipboardPlainText(event);
+        if (!looksLikeMarkdownSource(text)) return false;
+
+        let parsedDocument: ProseNode;
+        try {
+          parsedDocument = parseMarkdown(text);
+        } catch {
+          return false;
+        }
+
+        const slice = inlineParagraphSlice(view, parsedDocument, text) ?? new Slice(parsedDocument.content, 0, 0);
+        event.preventDefault();
+        view.dispatch(
+          view.state.tr
+            .replaceSelection(slice)
+            .scrollIntoView()
+            .setMeta("paste", true)
+            .setMeta("uiEvent", "paste")
+        );
+        return true;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Milkdown paste plugin that detects Markdown source on the plain-text clipboard and inserts it as rich editor content.
- Handle source-shaped HTML clipboard payloads, such as highlighted `<pre>` snippets, by preferring the Markdown plain text.
- Cover block, inline, and mixed HTML/plain-text Markdown paste paths in `MarkdownPaper` tests.

## Why
- WYSIWYG mode should paste Markdown source as preview-style editor content instead of preserving raw `#`, `**`, list, link, or image syntax in the document surface.

## Validation
- `corepack pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx` passed: 436 tests.
- `corepack pnpm --filter @markra/app build` passed.
- `corepack pnpm --filter @markra/editor build` passed.
- `corepack pnpm --filter @markra/app typecheck:test` passed.
- `corepack pnpm --filter @markra/editor typecheck:test` passed.
- `git diff --check origin/main...HEAD` passed.

## Risk
- Markdown detection is heuristic-based, but it skips file clipboard data, code-block selections, and standalone URL pastes so existing image/attachment/link paste flows remain covered by the existing MarkdownPaper suite.