### PR TITLE
fix(app): preserve untitled drafts on update restart

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -2923,6 +2923,62 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("waits for dirty untitled drafts when preparing for an update restart", async () => {
+    const editorMarkdown = "# Scratch\n\nUnsaved restart draft.";
+    let resolveWorkspaceSave!: () => undefined;
+    const workspaceSavePromise = new Promise<undefined>((resolve) => {
+      resolveWorkspaceSave = () => {
+        resolve(undefined);
+        return undefined;
+      };
+    });
+    mockedSaveStoredWorkspaceState.mockImplementation(async (patch) => {
+      if (patch.draftTabs?.some((draft) => draft.content === editorMarkdown)) {
+        return workspaceSavePromise;
+      }
+
+      return undefined;
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    let prepared = false;
+    let preparePromise!: Promise<unknown>;
+    act(() => {
+      preparePromise = result.current.saveDirtyMarkdownFiles().then(() => {
+        prepared = true;
+      });
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(prepared).toBe(false);
+
+    await act(async () => {
+      resolveWorkspaceSave();
+      await preparePromise;
+    });
+
+    expect(mockedSaveNativeMarkdownFile).not.toHaveBeenCalled();
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      activeDraftId: "untitled:0",
+      draftTabs: [
+        {
+          content: editorMarkdown,
+          id: "untitled:0",
+          name: "Untitled.md",
+          path: null
+        }
+      ]
+    });
+  });
+
   it("restores additional editor windows from the saved update-restart snapshot", async () => {
     const firstPath = "/mock-files/vault/first.md";
     const secondPath = "/mock-files/vault/second.md";

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1260,6 +1260,58 @@ describe("useMarkdownDocument", () => {
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
+  it("waits for dirty draft persistence before allowing native window close", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    const editorMarkdown = "# Scratch\n\nClose draft.";
+    let resolveWorkspaceSave!: () => undefined;
+    const workspaceSavePromise = new Promise<undefined>((resolve) => {
+      resolveWorkspaceSave = () => {
+        resolve(undefined);
+        return undefined;
+      };
+    });
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedSaveStoredWorkspaceState.mockImplementation(async (patch) => {
+      if (patch.draftTabs?.some((draft) => draft.content === editorMarkdown)) {
+        return workspaceSavePromise;
+      }
+
+      return undefined;
+    });
+    renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    let closeResolved = false;
+    const preventDefault = vi.fn();
+    const registeredCloseRequestHandler = closeRequestHandler as ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null;
+    if (!registeredCloseRequestHandler) throw new Error("native close request handler was not registered");
+    const closePromise = Promise.resolve(registeredCloseRequestHandler({ preventDefault })).then(() => {
+      closeResolved = true;
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(closeResolved).toBe(false);
+
+    await act(async () => {
+      resolveWorkspaceSave();
+      await closePromise;
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
   it("prompts before web unload when the editor has unsaved markdown", () => {
     const editorMarkdown = "# Scratch\n\nUnsaved web draft.";
     renderHook(() =>
@@ -1381,6 +1433,58 @@ describe("useMarkdownDocument", () => {
     });
 
     expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
+    expect(mockedExitNativeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for dirty draft persistence before exiting the native app", async () => {
+    let appExitHandler: (() => unknown | Promise<unknown>) | null = null;
+    const editorMarkdown = "# Scratch\n\nExit draft.";
+    let resolveWorkspaceSave!: () => undefined;
+    const workspaceSavePromise = new Promise<undefined>((resolve) => {
+      resolveWorkspaceSave = () => {
+        resolve(undefined);
+        return undefined;
+      };
+    });
+    mockedListenNativeAppExitRequested.mockImplementation(async (handler) => {
+      appExitHandler = handler;
+      return () => {};
+    });
+    mockedSaveStoredWorkspaceState.mockImplementation(async (patch) => {
+      if (patch.draftTabs?.some((draft) => draft.content === editorMarkdown)) {
+        return workspaceSavePromise;
+      }
+
+      return undefined;
+    });
+    renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeAppExitRequested).toHaveBeenCalled());
+
+    let exitResolved = false;
+    const registeredAppExitHandler = appExitHandler as (() => unknown | Promise<unknown>) | null;
+    if (!registeredAppExitHandler) throw new Error("native app exit handler was not registered");
+    const exitPromise = Promise.resolve(registeredAppExitHandler()).then(() => {
+      exitResolved = true;
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(exitResolved).toBe(false);
+    expect(mockedExitNativeApp).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveWorkspaceSave();
+      await exitPromise;
+    });
+
     expect(mockedExitNativeApp).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -2979,6 +2979,60 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("waits for pending draft persistence before preparing for an update restart", async () => {
+    const firstMarkdown = "# Scratch\n\nFirst draft.";
+    const latestMarkdown = "# Scratch\n\nLatest restart draft.";
+    const savedDraftContents: string[] = [];
+    let editorMarkdown = firstMarkdown;
+    let resolveFirstWorkspaceSave!: () => undefined;
+    const firstWorkspaceSavePromise = new Promise<undefined>((resolve) => {
+      resolveFirstWorkspaceSave = () => {
+        resolve(undefined);
+        return undefined;
+      };
+    });
+    mockedSaveStoredWorkspaceState.mockImplementation(async (patch) => {
+      const draftContent = patch.draftTabs?.[0]?.content;
+      if (draftContent) savedDraftContents.push(draftContent);
+      if (draftContent === firstMarkdown) return firstWorkspaceSavePromise;
+
+      return undefined;
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    act(() => {
+      result.current.handleMarkdownChange(firstMarkdown);
+    });
+    await waitFor(() => expect(savedDraftContents).toEqual([firstMarkdown]));
+
+    editorMarkdown = latestMarkdown;
+    let prepared = false;
+    let preparePromise!: Promise<unknown>;
+    act(() => {
+      preparePromise = result.current.saveDirtyMarkdownFiles().then(() => {
+        prepared = true;
+      });
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(prepared).toBe(false);
+
+    await act(async () => {
+      resolveFirstWorkspaceSave();
+      await preparePromise;
+    });
+
+    expect(savedDraftContents.at(-1)).toBe(latestMarkdown);
+  });
+
   it("restores additional editor windows from the saved update-restart snapshot", async () => {
     const firstPath = "/mock-files/vault/first.md";
     const secondPath = "/mock-files/vault/second.md";

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -181,8 +181,19 @@ type OpenMarkdownFileOptions = {
   pickerTitle?: string;
 };
 
+let pendingWorkspaceStateSave: Promise<unknown> | null = null;
+
 function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState>[0]) {
-  return saveStoredWorkspaceState(patch).catch(() => {});
+  // Workspace writes are read-modify-write operations; keep draft snapshots ordered.
+  const save = () => saveStoredWorkspaceState(patch).catch(() => {});
+  const savePromise = pendingWorkspaceStateSave
+    ? pendingWorkspaceStateSave.then(save, save)
+    : save();
+  const queuedPromise = savePromise.finally(() => {
+    if (pendingWorkspaceStateSave === queuedPromise) pendingWorkspaceStateSave = null;
+  });
+  pendingWorkspaceStateSave = queuedPromise;
+  return queuedPromise;
 }
 
 function resolveEditorReady(editorReady: boolean | (() => boolean)) {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -182,7 +182,7 @@ type OpenMarkdownFileOptions = {
 };
 
 function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState>[0]) {
-  saveStoredWorkspaceState(patch).catch(() => {});
+  return saveStoredWorkspaceState(patch).catch(() => {});
 }
 
 function resolveEditorReady(editorReady: boolean | (() => boolean)) {
@@ -1543,8 +1543,16 @@ export function useMarkdownDocument({
     if (dirtyFileSavePromiseRef.current) return dirtyFileSavePromiseRef.current;
 
     const savePromise = (async () => {
-      syncActiveDocumentFromEditor();
-      const dirtyTabs = tabsRef.current.filter((tab) => tab.open && tab.dirty && tab.path !== null && !tab.deleted);
+      const syncedDocument = syncActiveDocumentFromEditor();
+      const currentActiveTabId = activeTabIdRef.current;
+      const syncedTabs = currentActiveTabId
+        ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(syncedDocument, tab.id) : tab)
+        : tabsRef.current;
+      tabsRef.current = syncedTabs;
+      // Update relaunches can happen immediately; wait so untitled drafts survive the restart.
+      await persistWorkspaceState(draftWorkspacePatchFromTabs(syncedTabs, currentActiveTabId));
+
+      const dirtyTabs = syncedTabs.filter((tab) => tab.open && tab.dirty && tab.path !== null && !tab.deleted);
       for (const tab of dirtyTabs) {
         await saveMarkdownTabContent(tab, tab.content, { skipHistorySnapshot: true });
       }

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -521,6 +521,25 @@ export function useMarkdownDocument({
     return nextDocument;
   }, [currentMarkdown, editorSyncState, isActiveEditorMarkdownEquivalent, setActiveDocument]);
 
+  const syncActiveDocumentDraftSnapshot = useCallback(() => {
+    const syncedDocument = syncActiveDocumentFromEditor();
+    const currentActiveTabId = activeTabIdRef.current;
+    const syncedTabs = currentActiveTabId
+      ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(syncedDocument, tab.id) : tab)
+      : tabsRef.current;
+    tabsRef.current = syncedTabs;
+
+    return {
+      activeTabId: currentActiveTabId,
+      tabs: syncedTabs
+    };
+  }, [syncActiveDocumentFromEditor]);
+
+  const persistActiveDocumentDraftSnapshot = useCallback(() => {
+    const snapshot = syncActiveDocumentDraftSnapshot();
+    return persistWorkspaceState(draftWorkspacePatchFromTabs(snapshot.tabs, snapshot.activeTabId));
+  }, [syncActiveDocumentDraftSnapshot]);
+
   const hasDiscardableUnsavedChanges = useCallback(() => {
     const current = documentRef.current;
     if (!current.open) return false;
@@ -1554,16 +1573,11 @@ export function useMarkdownDocument({
     if (dirtyFileSavePromiseRef.current) return dirtyFileSavePromiseRef.current;
 
     const savePromise = (async () => {
-      const syncedDocument = syncActiveDocumentFromEditor();
-      const currentActiveTabId = activeTabIdRef.current;
-      const syncedTabs = currentActiveTabId
-        ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(syncedDocument, tab.id) : tab)
-        : tabsRef.current;
-      tabsRef.current = syncedTabs;
+      const snapshot = syncActiveDocumentDraftSnapshot();
       // Update relaunches can happen immediately; wait so untitled drafts survive the restart.
-      await persistWorkspaceState(draftWorkspacePatchFromTabs(syncedTabs, currentActiveTabId));
+      await persistWorkspaceState(draftWorkspacePatchFromTabs(snapshot.tabs, snapshot.activeTabId));
 
-      const dirtyTabs = syncedTabs.filter((tab) => tab.open && tab.dirty && tab.path !== null && !tab.deleted);
+      const dirtyTabs = snapshot.tabs.filter((tab) => tab.open && tab.dirty && tab.path !== null && !tab.deleted);
       for (const tab of dirtyTabs) {
         await saveMarkdownTabContent(tab, tab.content, { skipHistorySnapshot: true });
       }
@@ -1573,7 +1587,7 @@ export function useMarkdownDocument({
 
     dirtyFileSavePromiseRef.current = savePromise;
     return savePromise;
-  }, [saveMarkdownTabContent, syncActiveDocumentFromEditor]);
+  }, [saveMarkdownTabContent, syncActiveDocumentDraftSnapshot]);
 
   const autoSaveDirtyMarkdownTabs = useCallback(async () => {
     try {
@@ -1752,9 +1766,14 @@ export function useMarkdownDocument({
     let cleanup: (() => unknown) | null = null;
 
     listenNativeWindowCloseRequested(async (event) => {
-      syncActiveDocumentFromEditor();
+      const draftPersistence = persistActiveDocumentDraftSnapshot();
       const canDiscard = await confirmCanDiscardCurrentDocument();
-      if (!canDiscard) event.preventDefault();
+      if (!canDiscard) {
+        event.preventDefault();
+        return;
+      }
+
+      await draftPersistence;
     }).then((nextCleanup) => {
       if (active) {
         cleanup = nextCleanup;
@@ -1768,16 +1787,17 @@ export function useMarkdownDocument({
       active = false;
       cleanup?.();
     };
-  }, [confirmCanDiscardCurrentDocument, syncActiveDocumentFromEditor]);
+  }, [confirmCanDiscardCurrentDocument, persistActiveDocumentDraftSnapshot]);
 
   useEffect(() => {
     let active = true;
     let cleanup: (() => unknown) | null = null;
 
     listenNativeAppExitRequested(async () => {
-      syncActiveDocumentFromEditor();
+      const draftPersistence = persistActiveDocumentDraftSnapshot();
       const canDiscard = await confirmCanDiscardCurrentDocument();
       if (canDiscard) {
+        await draftPersistence;
         await beforeNativeAppExit?.();
         await exitNativeApp();
       }
@@ -1794,7 +1814,7 @@ export function useMarkdownDocument({
       active = false;
       cleanup?.();
     };
-  }, [beforeNativeAppExit, confirmCanDiscardCurrentDocument, syncActiveDocumentFromEditor]);
+  }, [beforeNativeAppExit, confirmCanDiscardCurrentDocument, persistActiveDocumentDraftSnapshot]);
 
   useEffect(() => {
     const path = initialMarkdownFilePath();


### PR DESCRIPTION
## Summary
- Wait for dirty workspace draft state before continuing update restart preparation.
- Serialize workspace draft persistence so an older pending draft write cannot overwrite the latest snapshot.
- Wait for draft persistence before allowing native window close or native app exit.
- Add regression coverage for untitled drafts, pending draft writes, update restart, native close, and native app exit.

## Why
- Existing file edits were awaited before relaunch, but untitled documents relied on asynchronous workspace draft writes that could race with the app relaunch.
- Multiple fire-and-forget draft writes could also complete out of order, restoring an older draft after restart.
- The same draft persistence race also applied to native window close and app exit after confirming unsaved changes.
- This keeps unsaved new documents recoverable with their latest content across update-triggered restart and native shutdown paths.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx -t "waits for dirty draft persistence before (allowing native window close|exiting the native app)"` passed
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx` passed: 59 tests
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx src/hooks/useAutoUpdater.test.tsx -t "draft|update restart|preparing for an update restart|restart preparation|dirty existing files|dirty untitled drafts|pending draft persistence|native window close|native app exit|restore"` passed
- `pnpm --filter @markra/app test` passed: 104 files, 1589 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/desktop build` passed

## Risk
- Low. The change orders existing workspace draft persistence calls and waits for that queue only before restart/close/exit paths where the process may disappear immediately.
- Browser `beforeunload` still cannot synchronously await async storage; the handler starts the same draft persistence path and keeps the browser prompt behavior unchanged.

## Related Issues
- Closes #459
