### PR TITLE
fix(editor): copy table cell text as plain text

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -479,6 +479,35 @@ function dispatchMixedClipboardPaste(view: EditorView, data: { files: File[]; ht
   view.dom.dispatchEvent(event);
 }
 
+function dispatchCopy(view: EditorView) {
+  const data = new Map<string, string>();
+  const event = new Event("copy", {
+    bubbles: true,
+    cancelable: true
+  }) as ClipboardEvent;
+
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      clearData: (type?: string) => {
+        if (type) {
+          data.delete(type);
+          return;
+        }
+
+        data.clear();
+      },
+      getData: (type: string) => data.get(type) ?? "",
+      setData: (type: string, value: string) => {
+        data.set(type, value);
+      }
+    }
+  });
+
+  view.dom.dispatchEvent(event);
+
+  return data;
+}
+
 function pasteFile(view: EditorView, file: File) {
   const event = new Event("paste", {
     bubbles: true,
@@ -10179,6 +10208,27 @@ describe("MarkdownPaper editing", () => {
     selectNode(view, findNodeStartPosition(view, "table"));
 
     expect(selectedPlainClipboardText(view)).toBe(expectedClipboardMarkdown);
+  });
+
+  it("copies selected text inside a table cell as plain text", async () => {
+    const tableMarkdown = ["| Alpha | Beta |", "| --- | --- |", "| Gamma | Delta |"].join("\n");
+    const { view } = await renderEditor(tableMarkdown);
+
+    selectText(view, findTextPosition(view, "Alpha", 1), findTextPosition(view, "Alpha", 4));
+
+    expect(selectedPlainClipboardText(view)).toBe("lph");
+  });
+
+  it("copies selected text inside a table cell without table html", async () => {
+    const tableMarkdown = ["| Alpha | Beta |", "| --- | --- |", "| Gamma | Delta |"].join("\n");
+    const { view } = await renderEditor(tableMarkdown);
+
+    selectText(view, findTextPosition(view, "Alpha"), findTextPosition(view, "Alpha", "Alpha".length));
+
+    const clipboardData = dispatchCopy(view);
+
+    expect(clipboardData.get("text/plain")).toBe("Alpha");
+    expect(clipboardData.get("text/html") ?? "").not.toContain("<table");
   });
 
   it("copies table row clipboard slices as markdown plain text", async () => {

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -22,7 +22,7 @@ import {
 } from "@milkdown/kit/preset/gfm";
 import { Fragment, type Node as ProseNode, type ResolvedPos, type Slice } from "@milkdown/kit/prose/model";
 import type { Selection } from "@milkdown/kit/prose/state";
-import { Plugin } from "@milkdown/kit/prose/state";
+import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { $prose, $remark } from "@milkdown/kit/utils";
 import type { AiSelectionContext } from "@markra/ai";
@@ -604,11 +604,31 @@ type ExternalLinkClickPluginOptions = {
 const markdownDocumentHrefPattern = /\.(md|markdown)(?:[?#].*)?$/iu;
 const markdownImageHrefPattern = /\.(avif|bmp|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/iu;
 const markdownClipboardTableRowNodeNames = new Set(["table_header_row", "table_row"]);
+const markdownClipboardTableCellNodeNames = new Set(["table_cell", "table_header"]);
 
 type MarkdownSerializer = (doc: ProseNode) => string;
 
 function defaultClipboardText(slice: Slice) {
   return slice.content.textBetween(0, slice.content.size, "\n\n");
+}
+
+function tableCellAncestorPosition($pos: ResolvedPos) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    if (markdownClipboardTableCellNodeNames.has($pos.node(depth).type.name)) {
+      return $pos.before(depth);
+    }
+  }
+
+  return null;
+}
+
+function selectionIsInsideSingleTableCell(selection: Selection) {
+  if (!(selection instanceof TextSelection) || selection.empty) return false;
+
+  const fromCellPosition = tableCellAncestorPosition(selection.$from);
+  if (fromCellPosition === null) return false;
+
+  return fromCellPosition === tableCellAncestorPosition(selection.$to);
 }
 
 function fragmentContainsTableMarkdown(fragment: Fragment) {
@@ -663,6 +683,10 @@ function trimSerializerDocumentNewline(markdown: string) {
 }
 
 export function serializeMarkdownClipboardText(slice: Slice, view: EditorView, serializeMarkdown: MarkdownSerializer) {
+  if (selectionIsInsideSingleTableCell(view.state.selection)) {
+    return defaultClipboardText(slice);
+  }
+
   if (!fragmentContainsTableMarkdown(slice.content)) {
     return defaultClipboardText(slice);
   }


### PR DESCRIPTION
## Summary
- Copying a normal text selection inside a single table cell now returns plain text instead of Markdown table text.
- Keep full-table and table-row clipboard serialization as Markdown.
- Add regression coverage for partial cell text, full cell text, table rows, and whole-table copying.

## Why
- The table clipboard serializer treated text selected inside one cell as table-shaped content, so copying text like `Alpha` produced a one-cell Markdown table.
- Users expect partial or full text selection inside one cell to behave like ordinary text copy, while selected cells or tables should retain table formatting.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t "copies selected tables as markdown plain text|copies selected text inside a table cell|copies table row clipboard slices"` passed: 104 test files, 1587 tests.
- `pnpm --filter @markra/app build` passed.

## Risk
- Low. The branch only bypasses table Markdown clipboard serialization for non-empty `TextSelection`s fully contained within one table cell; selected tables and table row slices still use the existing table path.

Closes #458
