### PR TITLE
fix(editor): preserve markdown line breaks

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2833,8 +2833,8 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).not.toContain("<br");
   });
 
-  it("renders soft line breaks between formatted paragraph lines", async () => {
-    const source = ["**加黑**：内容 1", "**加黑**：内容 2", "**加黑**：内容 3"].join("\n");
+  it("renders formatted paragraph soft line breaks while preserving source newlines", async () => {
+    const source = ["**Mock bold**: line 1", "**Mock bold**: line 2", "**Mock bold**: line 3"].join("\n");
     const { container, editor, view } = await renderEditor(source);
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const paragraph = container.querySelector(".ProseMirror p");
@@ -2843,6 +2843,25 @@ describe("MarkdownPaper editing", () => {
     expect(paragraph?.querySelectorAll("strong")).toHaveLength(3);
     expect(serializeMarkdown(view.state.doc)).toContain(source);
     expect(serializeMarkdown(view.state.doc)).not.toContain("<br");
+  });
+
+  it("inserts an explicit paragraph line break when pressing Enter inside paragraph text", async () => {
+    const { container, editor, view } = await renderEditor("MockBeforeMockAfter");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "MockBefore", "MockBefore".length));
+
+    expect(pressEnter(view)).toBe(true);
+
+    const paragraph = container.querySelector(".ProseMirror p");
+    expect(view.state.doc.childCount).toBe(1);
+    const hardbreak = view.state.doc.resolve(findTextPosition(view, "MockAfter")).parent.child(1);
+    expect(hardbreak.type.name).toBe("hardbreak");
+    expect(hardbreak.attrs.isInline).toBe(true);
+    expect(hardbreak.attrs.renderLineBreak).toBe(true);
+    expect(paragraph?.querySelector('span.markra-hardbreak[data-type="hardbreak"] br')).toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).toBe("MockBefore<br>MockAfter\n");
+    expect(serializeMarkdown(view.state.doc)).not.toContain("MockBefore\n\nMockAfter");
   });
 
   it("keeps the native caret anchor when leaving display math source at the closing delimiter", async () => {
@@ -4675,7 +4694,7 @@ describe("MarkdownPaper editing", () => {
     restoreLayout();
   });
 
-  it("loads template blank paragraphs from markdown blank lines", async () => {
+  it("loads template blank lines as editable empty paragraphs", async () => {
     const { editor, view } = await renderEditor("# Template\n\n\n\n## Next");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
 
@@ -4683,6 +4702,27 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.doc.child(1).type.name).toBe("paragraph");
     expect(view.state.doc.child(1).content.size).toBe(0);
     expect(serializeMarkdown(view.state.doc)).toBe("# Template\n\n\n\n## Next\n");
+  });
+
+  it("loads multiple paragraph blank lines as editable empty paragraphs", async () => {
+    const source = "First\n\n\n\nSecond";
+    const { editor, view } = await renderEditor(source);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(0).textContent).toBe("First");
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
+    expect(view.state.doc.child(2).textContent).toBe("Second");
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
+  it("loads a triple newline between paragraphs as an editable empty paragraph", async () => {
+    const { view } = await renderEditor("First\n\n\nSecond");
+
+    expect(view.state.doc.childCount).toBe(3);
+    expect(view.state.doc.child(1).type.name).toBe("paragraph");
+    expect(view.state.doc.child(1).content.size).toBe(0);
   });
 
   it("saves blank list items without br tags", async () => {
@@ -9136,9 +9176,8 @@ describe("MarkdownPaper editing", () => {
 
     expect(container.querySelector(".ProseMirror blockquote.markra-callout")).not.toBeInTheDocument();
     const blockquote = container.querySelector(".ProseMirror blockquote");
-    expect(blockquote).toHaveTextContent("[!NOTE]");
-    expect(blockquote).toHaveTextContent("Keep this in mind.");
-    expect(blockquote?.querySelectorAll("br")).toHaveLength(1);
+    expect(blockquote).toHaveTextContent("[!NOTE]Keep this in mind.");
+    expect(blockquote?.querySelector("br")).toBeInTheDocument();
     expect(container.querySelector(".markra-callout-title")).not.toBeInTheDocument();
   });
 

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -142,7 +142,7 @@ const markraHardbreakSchema = hardbreakSchema.extendSchema((previous) => (ctx) =
     toMarkdown: {
       ...baseSchema.toMarkdown,
       runner: (state, node) => {
-        if (node.attrs.renderLineBreak === true && serializerHasOpenNode(state, "tableCell")) {
+        if (node.attrs.renderLineBreak === true && !serializerHasOpenNode(state, "blockquote")) {
           state.addNode("html", undefined, "<br>");
           return;
         }
@@ -162,9 +162,9 @@ function blankParagraphCountBetween(previous: MarkdownTreeNode, next: MarkdownTr
   const nextStartLine = lineNumber(next.position?.start?.line);
   if (previousEndLine === null || nextStartLine === null) return 0;
 
-  // One blank line is the ordinary Markdown block separator; extra pairs represent empty paragraphs.
+  // One blank line is the ordinary Markdown block separator; any extra blank spacing is editable space.
   const blankLines = nextStartLine - previousEndLine - 1;
-  return Math.max(0, Math.floor((blankLines - 1) / 2));
+  return Math.max(0, Math.ceil((blankLines - 1) / 2));
 }
 
 function blankParagraphNode(): MarkdownTreeNode {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1767,7 +1767,7 @@
   }
 
   .markdown-paper p {
-    @apply m-0 mb-4.5;
+    @apply m-0;
     color: var(--editor-text-primary);
   }
 

--- a/packages/editor/src/shortcuts.ts
+++ b/packages/editor/src/shortcuts.ts
@@ -666,6 +666,49 @@ function insertRenderedHardbreak(view: EditorView) {
   return true;
 }
 
+function selectionIsInsideDecoratedSource(view: EditorView) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const sourceSelector = [
+    ".markra-math-source-active",
+    ".markra-live-link-source.markra-md-delimiter",
+    ".markra-live-link-source-label",
+    ".markra-live-image-source.markra-md-delimiter"
+  ].join(", ");
+  const positions = [selection.from, selection.from - 1, selection.from + 1]
+    .filter((position) => position >= 0 && position <= view.state.doc.content.size);
+
+  return positions.some((position) => {
+    const dom = view.domAtPos(position).node;
+    const element = dom.nodeType === 1 ? dom as Element : dom.parentElement;
+    return Boolean(element?.closest(sourceSelector));
+  });
+}
+
+function insertParagraphLineBreak(view: EditorView, paragraph: NodeType, blockquote: NodeType, listItem: NodeType) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+  if (selectionIsInsideDecoratedSource(view)) return false;
+  if (selection.$from.parent.type !== paragraph) return false;
+  if (selectionIsInsideNodeType(selection, blockquote)) return false;
+  if (selectionIsInsideNodeType(selection, listItem)) return false;
+  if (selectionIsInsideTableCell(selection)) return false;
+  if (selection.$from.parentOffset <= 0 || selection.$from.parentOffset >= selection.$from.parent.content.size) return false;
+
+  const hardbreak = view.state.schema.nodes.hardbreak;
+  if (!hardbreak) return false;
+
+  view.dispatch(
+    view.state.tr
+      .replaceSelectionWith(hardbreak.create({ isInline: true, renderLineBreak: true }))
+      .scrollIntoView()
+  );
+  view.focus();
+
+  return true;
+}
+
 export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap = {}) => $prose((ctx) => {
   const strong = strongSchema.type(ctx);
   const emphasis = emphasisSchema.type(ctx);
@@ -702,7 +745,20 @@ export const markraMarkdownShortcuts = (configuredShortcuts: MarkdownShortcutMap
         const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
 
         // Support both Milkdown-style shortcuts and common document-editor aliases.
-        if (event.key === "Enter" && !hasModifier && selectionIsInsideNodeType(view.state.selection, blockquote)) {
+        if (event.key === "Enter" && !hasModifier && !selectionIsInsideNodeType(view.state.selection, blockquote)) {
+          const finalizedLiveMarkdown = finalizeActiveLiveMarkdown(view, liveMarkdownSpecs);
+          if (finalizedLiveMarkdown) {
+            view.focus();
+            event.preventDefault();
+            return true;
+          }
+
+          const handled = insertParagraphLineBreak(view, paragraph, blockquote, listItem);
+          if (handled) {
+            event.preventDefault();
+            return true;
+          }
+        } else if (event.key === "Enter" && !hasModifier && selectionIsInsideNodeType(view.state.selection, blockquote)) {
           const finalizedLiveMarkdown = finalizeActiveLiveMarkdown(view, liveMarkdownSpecs);
           if (finalizedLiveMarkdown) {
             view.focus();


### PR DESCRIPTION
## Summary
- Render inline soft line breaks in MarkdownPaper content while preserving source newlines.
- Serialize explicit WYSIWYG paragraph Enter as <br> without turning every source newline into an HTML break.
- Preserve Markdown blank-line spacing as editable empty paragraphs and include the paragraph style margin adjustment.

## Validation
- pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx --reporter=dot
- pnpm --filter @markra/app build
- git diff --check HEAD~1..HEAD

Fixes #463