### PR TITLE
fix(app): preserve file tree on refresh failure

### DIFF
--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -626,6 +626,48 @@ describe("useMarkdownFileTree", () => {
     expect(screen.getByText("docs/added.md")).toBeInTheDocument();
   });
 
+  it("preserves the loaded file tree when a native watcher refresh rejects", async () => {
+    let emitTreeChange: (path: string) => unknown | Promise<unknown> = () => {};
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      path: "/vault",
+      name: "vault"
+    });
+    mockedLoadNativeMarkdownFilesForPath
+      .mockResolvedValueOnce([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" },
+        { path: "/vault/docs/guide.md", name: "guide.md", relativePath: "docs/guide.md" }
+      ])
+      .mockImplementationOnce((_path, options = {}) => {
+        options.onBatch?.([
+          { path: "/vault/docs/partial.md", name: "partial.md", relativePath: "docs/partial.md" }
+        ]);
+
+        return Promise.reject(new Error("transient file tree load failure"));
+      });
+    mockedWatchNativeMarkdownTree.mockImplementation(async (_rootPath, onTreeChange) => {
+      emitTreeChange = onTreeChange;
+      return () => {};
+    });
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open folder" }));
+
+    expect(await screen.findByText("index.md")).toBeInTheDocument();
+    expect(screen.getByText("docs/guide.md")).toBeInTheDocument();
+    await waitFor(() => expect(mockedWatchNativeMarkdownTree).toHaveBeenCalledWith("/vault", expect.any(Function)));
+
+    await act(async () => {
+      await emitTreeChange("/vault/docs/partial.md");
+    });
+
+    expect(screen.getByText("index.md")).toBeInTheDocument();
+    expect(screen.getByText("docs/guide.md")).toBeInTheDocument();
+    expect(screen.queryByText("docs/partial.md")).not.toBeInTheDocument();
+    expect(screen.getByTestId("root-name")).toHaveTextContent("vault");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+  });
+
   it("coalesces native tree watcher refreshes while a refresh is in flight", async () => {
     let emitTreeChange: (path: string) => unknown | Promise<unknown> = () => {};
     const firstRefresh = createDeferredMarkdownFileList();

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -370,6 +370,7 @@ export function useMarkdownFileTree({
         try {
           while (true) {
             refreshState.pending = false;
+            const filesBeforeRefresh = fileTreeFilesRef.current;
             try {
               cancelPendingFileTreeBatchFlush();
               let firstBatch = true;
@@ -397,7 +398,8 @@ export function useMarkdownFileTree({
               if (openingFolderPathRef.current && openingFolderPathRef.current !== refreshState.path) return;
 
               cancelPendingFileTreeBatchFlush();
-              replaceFileTreeFiles([], { transition: false });
+              // A failed refresh cannot prove the folder is empty, so keep the last trusted tree.
+              replaceFileTreeFiles(filesBeforeRefresh, { transition: false });
             }
 
             if (!refreshState.pending) return;


### PR DESCRIPTION
## Summary
- Preserve the last successfully loaded file tree when a native watcher refresh fails.
- Restore the pre-refresh tree if a failing incremental refresh emitted partial batches.
- Add regression coverage for transient watcher refresh failures.

## Why
- A transient scan failure under memory pressure could make the sidebar show an empty folder even though the root stayed open.

## Validation
- `corepack pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownFileTree.test.tsx --testNamePattern "preserves the loaded file tree"` passed.
- `corepack pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownFileTree.test.tsx` passed: 34 tests.
- `corepack pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Low. After a failed refresh, the sidebar may briefly show the previous tree until the next successful watcher refresh.

Closes #466
