### PR TITLE
fix(desktop): restore editor tabs on reopen

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -75,9 +75,10 @@ use window_state::{
 use windows::{
     apply_main_window_chrome, apply_settings_window_lifecycle, apply_webview_window_chrome,
     apply_window_event_chrome, editor_window_url_for_folder, editor_window_url_for_path,
-    hide_settings_window, mark_settings_window_ready, minimize_current_window,
-    open_blank_editor_window, open_settings_window, prewarm_settings_window,
-    spawn_blank_editor_window, spawn_editor_window, toggle_settings_window,
+    hide_settings_window, is_editor_window_label, mark_settings_window_ready,
+    minimize_current_window, open_blank_editor_window, open_settings_window,
+    prewarm_settings_window, spawn_blank_editor_window, spawn_editor_window,
+    spawn_restorable_editor_window, toggle_settings_window,
 };
 
 const STARTUP_WINDOW_NATIVE_REVEAL_FALLBACK_MS: u64 = 2400;
@@ -128,7 +129,7 @@ fn reveal_or_open_markdown_paths<R: tauri::Runtime>(
 
     let urls = editor_window_urls_for_opened_markdown_paths(&paths);
     if urls.is_empty() {
-        spawn_blank_editor_window(app.clone());
+        spawn_restorable_editor_window(app.clone());
         return;
     }
 
@@ -146,6 +147,12 @@ fn show_main_window_if_hidden<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
         let _ = window.show();
         let _ = window.set_focus();
     }
+}
+
+fn has_visible_editor_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    app.webview_windows().values().any(|window| {
+        is_editor_window_label(window.label()) && window.is_visible().unwrap_or(false)
+    })
 }
 
 fn spawn_startup_window_reveal_fallback<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
@@ -313,6 +320,14 @@ pub fn run() {
             tauri::RunEvent::Opened { urls } => {
                 queue_opened_markdown_paths(app, opened_markdown_paths_from_urls(&urls));
             }
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { .. } => {
+                // Settings may stay visible after prewarm. Treating that as an editor would skip
+                // workspace restore when the user reopens Markra from the Dock.
+                if !has_visible_editor_window(app) {
+                    reveal_or_open_markdown_paths(app, Vec::new(), true);
+                }
+            }
             _ => {}
         });
 }
@@ -445,6 +460,63 @@ mod tests {
         assert!(
             lib_source.contains("reveal_or_open_markdown_paths(&app.handle(), paths, false);"),
             "initial CLI-opened paths should trigger a native window reveal instead of only being queued"
+        );
+    }
+
+    #[test]
+    fn empty_app_reopen_uses_restorable_editor_window() {
+        let lib_source = include_str!("lib.rs");
+        let start = lib_source
+            .find("fn reveal_or_open_markdown_paths")
+            .expect("reveal_or_open_markdown_paths should exist");
+        let end = lib_source[start..]
+            .find("fn show_main_window_if_hidden")
+            .map(|offset| start + offset)
+            .expect("reveal_or_open_markdown_paths should end before show_main_window_if_hidden");
+        let reveal_source = &lib_source[start..end];
+
+        assert!(
+            reveal_source.contains("spawn_restorable_editor_window(app.clone());"),
+            "reopening Markra without a live main window should create a restore-capable editor window"
+        );
+        assert!(
+            !reveal_source.contains("spawn_blank_editor_window(app.clone());"),
+            "empty app reopen should not use index.html?blank=1 because that skips workspace restore"
+        );
+    }
+
+    #[test]
+    fn desktop_handles_macos_reopen_without_visible_windows() {
+        let lib_source = include_str!("lib.rs");
+        let reopen_event = ["tauri::RunEvent::", "Reopen {"].concat();
+        let empty_reveal = ["reveal_or_open_markdown_paths(app, Vec::new(), ", "true);"].concat();
+
+        assert!(
+            lib_source.contains(&reopen_event),
+            "macOS Dock reopen should be handled when all editor windows are closed"
+        );
+        assert!(
+            lib_source.contains("if !has_visible_editor_window(app) {"),
+            "reopen handling should only create a window when no editor window is visible"
+        );
+        assert!(
+            lib_source.contains(&empty_reveal),
+            "macOS Dock reopen should use the restore-capable empty reveal path"
+        );
+    }
+
+    #[test]
+    fn desktop_reopen_ignores_visible_settings_windows() {
+        let lib_source = include_str!("lib.rs");
+        let generic_visible_window_guard = ["if !has", "_visible_windows {"].concat();
+
+        assert!(
+            lib_source.contains("if !has_visible_editor_window(app) {"),
+            "macOS Dock reopen should restore an editor when the only visible window is Settings"
+        );
+        assert!(
+            !lib_source.contains(&generic_visible_window_guard),
+            "macOS Dock reopen should not treat visible Settings windows as visible editor windows"
         );
     }
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -31,6 +31,7 @@ use tauri::{utils::config::Color, Emitter, Manager, WebviewUrl, WebviewWindowBui
 const BLANK_EDITOR_WINDOW_LABEL_PREFIX: &str = "markra-editor-";
 const BLANK_EDITOR_WINDOW_URL: &str = "index.html?blank=1";
 const MAIN_WINDOW_LABEL: &str = "main";
+const RESTORABLE_EDITOR_WINDOW_URL: &str = "index.html";
 #[cfg(test)]
 pub(crate) const MINIMIZE_CURRENT_WINDOW_COMMAND: &str = "minimize_current_window";
 #[cfg(test)]
@@ -158,6 +159,10 @@ fn is_blank_editor_window_label(label: &str) -> bool {
     label.starts_with(BLANK_EDITOR_WINDOW_LABEL_PREFIX)
 }
 
+pub(crate) fn is_editor_window_label(label: &str) -> bool {
+    label == MAIN_WINDOW_LABEL || is_blank_editor_window_label(label)
+}
+
 pub(crate) fn is_settings_window_label(label: &str) -> bool {
     label == SETTINGS_WINDOW_LABEL
 }
@@ -167,7 +172,7 @@ fn should_hide_native_menu_for_window_label_on_platform(platform: &str, label: &
         return true;
     }
 
-    platform == "windows" && (label == MAIN_WINDOW_LABEL || is_blank_editor_window_label(label))
+    platform == "windows" && is_editor_window_label(label)
 }
 
 fn should_hide_native_menu_for_window_label(label: &str) -> bool {
@@ -493,15 +498,12 @@ fn settings_window_url(
     url
 }
 
-pub(crate) fn spawn_editor_window<R>(app: tauri::AppHandle<R>, url: String)
+fn spawn_editor_window_with_label<R>(app: tauri::AppHandle<R>, label: String, url: String)
 where
     R: tauri::Runtime,
 {
-    // Create secondary windows off the menu event thread to avoid WebView2 deadlocks on Windows.
+    // Create editor windows off the menu/reopen event thread to avoid WebView2 deadlocks on Windows.
     std::thread::spawn(move || {
-        let label = next_blank_editor_window_label();
-        debug_assert!(is_blank_editor_window_label(&label));
-
         let builder = WebviewWindowBuilder::new(&app, label, WebviewUrl::App(url.into()))
             .title("")
             .inner_size(1360.0, 800.0)
@@ -527,6 +529,28 @@ where
             }
         }
     });
+}
+
+pub(crate) fn spawn_editor_window<R>(app: tauri::AppHandle<R>, url: String)
+where
+    R: tauri::Runtime,
+{
+    let label = next_blank_editor_window_label();
+    debug_assert!(is_blank_editor_window_label(&label));
+    spawn_editor_window_with_label(app, label, url);
+}
+
+pub(crate) fn spawn_restorable_editor_window<R>(app: tauri::AppHandle<R>)
+where
+    R: tauri::Runtime,
+{
+    // ?blank=1 deliberately opts out of workspace restore. App/Dock reopens need index.html
+    // so the frontend can replay the saved tabs instead of starting an empty document.
+    spawn_editor_window_with_label(
+        app,
+        MAIN_WINDOW_LABEL.to_string(),
+        RESTORABLE_EDITOR_WINDOW_URL.to_string(),
+    );
 }
 
 fn editor_window_transparent() -> bool {
@@ -1450,15 +1474,22 @@ mod tests {
     }
 
     #[test]
+    fn editor_window_labels_exclude_settings_window() {
+        assert!(is_editor_window_label("main"));
+        assert!(is_editor_window_label("markra-editor-1"));
+        assert!(!is_editor_window_label("markra-settings"));
+    }
+
+    #[test]
     fn secondary_editor_windows_become_native_menu_targets_when_created() {
         let source = include_str!("windows.rs");
         let start = source
-            .find("pub(crate) fn spawn_editor_window")
-            .expect("spawn_editor_window should exist");
+            .find("fn spawn_editor_window_with_label")
+            .expect("spawn_editor_window_with_label should exist");
         let end = source[start..]
             .find("fn editor_window_transparent")
             .map(|offset| start + offset)
-            .expect("spawn_editor_window should end before editor_window_transparent");
+            .expect("spawn_editor_window_with_label should end before editor_window_transparent");
         let spawn_editor_window_source = &source[start..end];
 
         assert!(

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -159,6 +159,7 @@ export const desktopRuntime = {
   },
   window: {
     closeWindow: windowRuntime.closeNativeWindow,
+    destroyWindow: windowRuntime.destroyNativeWindow,
     exitApp: windowRuntime.exitNativeApp,
     getCurrentWindowLabel: windowRuntime.getCurrentNativeWindowLabel,
     listEditorWindowRestoreStates: windowRuntime.listNativeEditorWindowRestoreStates,

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -4,6 +4,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { exit } from "@tauri-apps/plugin-process";
 import {
   closeNativeWindow,
+  destroyNativeWindow,
   exitNativeApp,
   getCurrentNativeWindowLabel,
   listenNativeAppExitRequested,
@@ -65,6 +66,15 @@ describe("native window actions", () => {
     await closeNativeWindow();
 
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroys the current Tauri window after app-level close handling", async () => {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    mockedGetCurrentWindow.mockReturnValue({ destroy } as unknown as ReturnType<typeof getCurrentWindow>);
+
+    await destroyNativeWindow();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
   });
 
   it("listens for native window close requests", async () => {

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -176,6 +176,11 @@ export async function closeNativeWindow() {
   await currentWindow?.close();
 }
 
+export async function destroyNativeWindow() {
+  const currentWindow = await getCurrentNativeWindow();
+  await currentWindow?.destroy();
+}
+
 export async function minimizeNativeWindow() {
   if (!("__TAURI_INTERNALS__" in window)) {
     return;

--- a/apps/web/src/runtime/web/window.ts
+++ b/apps/web/src/runtime/web/window.ts
@@ -99,6 +99,18 @@ export function createWebWindowRuntime(
         dispatchBrowserRouteChange(windowTarget);
       }
     },
+    destroyWindow: async () => {
+      const windowTarget = resolveBrowserWindow(options);
+      if (!windowTarget) return;
+
+      windowTarget.close();
+      if (windowTarget.closed) return;
+
+      if (new URLSearchParams(windowTarget.location.search).has("settings")) {
+        windowTarget.history.pushState({}, "", createEditorRouteUrl(windowTarget));
+        dispatchBrowserRouteChange(windowTarget);
+      }
+    },
     listenSettingsWindowTarget: (onTarget) =>
       listenWebSettingsWindowTarget(options.eventTarget ?? resolveBrowserWindow(options), onTarget),
     openExternalUrl: async (url) => {

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -1,6 +1,8 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useMarkdownDocument } from "./useMarkdownDocument";
 import {
+  destroyNativeWindow,
+  listNativeEditorWindowRestoreStates,
   openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
   readNativeMarkdownFile,
@@ -45,6 +47,8 @@ vi.mock("../lib/settings/app-settings", () => ({
 
 vi.mock("../lib/tauri", () => ({
   openNativeMarkdownFolderInNewWindow: vi.fn(),
+  destroyNativeWindow: vi.fn(),
+  listNativeEditorWindowRestoreStates: vi.fn(),
   openNativeMarkdownFileInNewWindow: vi.fn(),
   openNativeMarkdownPath: vi.fn(),
   readNativeMarkdownFile: vi.fn(),
@@ -62,6 +66,8 @@ type MockWindowCloseRequestEvent = {
 };
 
 const mockedOpenNativeMarkdownFileInNewWindow = vi.mocked(openNativeMarkdownFileInNewWindow);
+const mockedDestroyNativeWindow = vi.mocked(destroyNativeWindow);
+const mockedListNativeEditorWindowRestoreStates = vi.mocked(listNativeEditorWindowRestoreStates);
 const mockedOpenNativeMarkdownPath = vi.mocked(openNativeMarkdownPath);
 const mockedReadNativeMarkdownFile = vi.mocked(readNativeMarkdownFile);
 const mockedSaveNativeMarkdownFile = vi.mocked(saveNativeMarkdownFile);
@@ -94,6 +100,8 @@ function createDeferredNativeMarkdownFile() {
 describe("useMarkdownDocument", () => {
   beforeEach(() => {
     window.history.pushState({}, "", "/");
+    mockedDestroyNativeWindow.mockReset();
+    mockedListNativeEditorWindowRestoreStates.mockReset();
     mockedOpenNativeMarkdownPath.mockReset();
     mockedOpenNativeMarkdownFileInNewWindow.mockReset();
     mockedReadNativeMarkdownFile.mockReset();
@@ -133,6 +141,8 @@ describe("useMarkdownDocument", () => {
       name: "saved.md",
       path: "/mock-files/saved.md"
     });
+    mockedDestroyNativeWindow.mockResolvedValue(undefined);
+    mockedListNativeEditorWindowRestoreStates.mockResolvedValue([]);
     mockedExitNativeApp.mockResolvedValue(undefined);
     mockedListenNativeAppExitRequested.mockResolvedValue(() => {});
     mockedListenNativeWindowCloseRequested.mockResolvedValue(() => {});
@@ -1257,7 +1267,118 @@ describe("useMarkdownDocument", () => {
     });
 
     expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
-    expect(preventDefault).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the native window open until the latest clean tab workspace state is persisted", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    const filePath = "/mock-files/guide.md";
+    let resolveWorkspaceSave!: () => undefined;
+    const workspaceSavePromise = new Promise<undefined>((resolve) => {
+      resolveWorkspaceSave = () => {
+        resolve(undefined);
+        return undefined;
+      };
+    });
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedSaveStoredWorkspaceState.mockImplementation(async (patch) => {
+      if (patch.filePath === filePath && patch.openFilePaths?.includes(filePath)) {
+        return workspaceSavePromise;
+      }
+
+      return undefined;
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Guide",
+      name: "guide.md",
+      path: filePath
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: filePath,
+        relativePath: "guide.md"
+      });
+    });
+
+    let closeResolved = false;
+    const preventDefault = vi.fn();
+    const registeredCloseRequestHandler = closeRequestHandler as ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null;
+    if (!registeredCloseRequestHandler) throw new Error("native close request handler was not registered");
+    const closePromise = Promise.resolve(registeredCloseRequestHandler({ preventDefault })).then(() => {
+      closeResolved = true;
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(closeResolved).toBe(false);
+    expect(mockedDestroyNativeWindow).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveWorkspaceSave();
+      await closePromise;
+    });
+
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+  });
+
+  it("returns from native close requests without waiting for the programmatic close to settle", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let settleNativeClose!: () => undefined;
+    const nativeClosePromise = new Promise<undefined>((resolve) => {
+      settleNativeClose = () => {
+        resolve(undefined);
+        return undefined;
+      };
+    });
+    mockedDestroyNativeWindow.mockReturnValue(nativeClosePromise);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    let closeRequestResolved = false;
+    const preventDefault = vi.fn();
+    const registeredCloseRequestHandler = closeRequestHandler as ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null;
+    if (!registeredCloseRequestHandler) throw new Error("native close request handler was not registered");
+    const closeRequestPromise = Promise.resolve(registeredCloseRequestHandler({ preventDefault })).then(() => {
+      closeRequestResolved = true;
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(closeRequestResolved).toBe(true));
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+
+    settleNativeClose();
+    await closeRequestPromise;
   });
 
   it("waits for dirty draft persistence before allowing native window close", async () => {
@@ -1309,7 +1430,8 @@ describe("useMarkdownDocument", () => {
       await closePromise;
     });
 
-    expect(preventDefault).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
   });
 
   it("prompts before web unload when the editor has unsaved markdown", () => {
@@ -1433,6 +1555,41 @@ describe("useMarkdownDocument", () => {
     });
 
     expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "guide.md" }));
+    expect(mockedExitNativeApp).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists native editor window restore snapshots before exiting the app", async () => {
+    let appExitHandler: (() => unknown | Promise<unknown>) | null = null;
+    const openWindows = [
+      {
+        filePath: "/mock-files/secondary.md",
+        label: "markra-editor-1",
+        openFilePaths: ["/mock-files/secondary.md"]
+      }
+    ];
+    mockedListenNativeAppExitRequested.mockImplementation(async (handler) => {
+      appExitHandler = handler;
+      return () => {};
+    });
+    mockedListNativeEditorWindowRestoreStates.mockResolvedValue(openWindows);
+    renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeAppExitRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      if (!appExitHandler) throw new Error("native app exit handler was not registered");
+      await appExitHandler();
+    });
+
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({ openWindows });
     expect(mockedExitNativeApp).toHaveBeenCalledTimes(1);
   });
 
@@ -1914,8 +2071,7 @@ describe("useMarkdownDocument", () => {
       expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
         fileTreeOpen: false,
         folderName: null,
-        folderPath: null,
-        openFilePaths: []
+        folderPath: null
       })
     );
     expect(result.current.document).toMatchObject({
@@ -1928,7 +2084,7 @@ describe("useMarkdownDocument", () => {
     expect(mockedConsumeWelcomeDocumentState).not.toHaveBeenCalled();
   });
 
-  it("does not restore document tabs from a deleted folder workspace", async () => {
+  it("keeps a blank document when the restored folder and files no longer open", async () => {
     const guidePath = "/mock-files/deleted-notes/guide.md";
     const notesPath = "/mock-files/deleted-notes/notes.md";
     const onTreeRootFromFolderPath = vi.fn(async () => null);
@@ -1957,12 +2113,12 @@ describe("useMarkdownDocument", () => {
       expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
         fileTreeOpen: false,
         folderName: null,
-        folderPath: null,
-        openFilePaths: []
+        folderPath: null
       })
     );
 
-    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalled();
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(guidePath);
+    expect(mockedReadNativeMarkdownFile).toHaveBeenCalledWith(notesPath);
     expect(result.current.tabs).toEqual([expect.objectContaining({
       name: "Untitled.md",
       path: null
@@ -1974,6 +2130,115 @@ describe("useMarkdownDocument", () => {
       open: true,
       path: null
     });
+  });
+
+  it("restores saved files when the saved folder root no longer opens", async () => {
+    const guidePath = "/mock-files/metadata-root/guide.md";
+    const notesPath = "/mock-files/metadata-root/notes.md";
+    const onTreeRootFromFilePath = vi.fn();
+    const onTreeRootFromFolderPath = vi.fn(async () => null);
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-skipped-folder-tabs",
+      filePath: notesPath,
+      fileTreeOpen: true,
+      folderName: "metadata-root",
+      folderPath: "/mock-files/metadata-root",
+      openFilePaths: [guidePath, notesPath]
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => {
+      if (path === guidePath) {
+        return {
+          content: "# Guide",
+          name: "guide.md",
+          path
+        };
+      }
+
+      return {
+        content: "# Notes",
+        name: "notes.md",
+        path
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath,
+        onTreeRootFromFolderPath,
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.tabs.map((tab) => tab.name)).toEqual(["guide.md", "notes.md"]));
+
+    expect(result.current.document).toMatchObject({
+      content: "# Notes",
+      dirty: false,
+      name: "notes.md",
+      open: true,
+      path: notesPath
+    });
+    expect(onTreeRootFromFolderPath).toHaveBeenCalledWith(
+      "/mock-files/metadata-root",
+      "metadata-root",
+      "session-skipped-folder-tabs",
+      false,
+      true
+    );
+    expect(onTreeRootFromFilePath).not.toHaveBeenCalled();
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+      fileTreeOpen: false,
+      folderName: null,
+      folderPath: null
+    });
+  });
+
+  it("restores saved files without waiting for the saved folder root to finish opening", async () => {
+    const guidePath = "/mock-files/slow-root/guide.md";
+    const notesPath = "/mock-files/slow-root/notes.md";
+    const onTreeRootFromFolderPath = vi.fn(() => new Promise<null>(() => {}));
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-slow-folder-tabs",
+      filePath: notesPath,
+      fileTreeOpen: true,
+      folderName: "slow-root",
+      folderPath: "/mock-files/slow-root",
+      openFilePaths: [guidePath, notesPath]
+    });
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
+      content: path === notesPath ? "# Notes" : "# Guide",
+      name: path === notesPath ? "notes.md" : "guide.md",
+      path
+    }));
+
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath,
+        preferencesReady: true,
+        restoreWorkspaceOnStartup: true
+      })
+    );
+
+    await waitFor(() => expect(result.current.tabs.map((tab) => tab.name)).toEqual(["guide.md", "notes.md"]));
+
+    expect(result.current.document).toMatchObject({
+      content: "# Notes",
+      name: "notes.md",
+      path: notesPath
+    });
+    expect(onTreeRootFromFolderPath).toHaveBeenCalledWith(
+      "/mock-files/slow-root",
+      "slow-root",
+      "session-slow-folder-tabs",
+      false,
+      true
+    );
   });
 
   it("restores open markdown document tabs from the last workspace", async () => {
@@ -2531,7 +2796,8 @@ describe("useMarkdownDocument", () => {
     });
 
     expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
-    expect(preventDefault).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
     expect(result.current.document).toMatchObject({
       content: "# Guide\n\nSaved",
       dirty: false,
@@ -2799,7 +3065,12 @@ describe("useMarkdownDocument", () => {
       });
 
       expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
-      expect(preventDefault).not.toHaveBeenCalled();
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        vi.advanceTimersByTime(0);
+        await Promise.resolve();
+      });
+      expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1);
       expect(result.current.document).toMatchObject({
         content: "# Guide\n\nAutosaved edit.",
         dirty: false,

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -17,7 +17,9 @@ import {
 } from "../lib/settings/app-settings";
 import { getMarkdownOutline, getWordCount, type MarkdownOutlineItem } from "@markra/markdown";
 import {
+  destroyNativeWindow,
   exitNativeApp,
+  listNativeEditorWindowRestoreStates,
   openNativeMarkdownFolderInNewWindow,
   openNativeMarkdownFileInNewWindow,
   openNativeMarkdownPath,
@@ -275,6 +277,8 @@ export function useMarkdownDocument({
   const workspaceSessionIdRef = useRef<string | null>(null);
   const openedFromNativeRef = useRef(false);
   const startupWorkspaceRestoreAttemptedRef = useRef(false);
+  const nativeWindowCloseAllowedRef = useRef(false);
+  const nativeWindowCloseScheduledRef = useRef(false);
   const dirtyFileSavePromiseRef = useRef<Promise<unknown> | null>(null);
   const editorSyncStateRef = useRef<EditorSyncState | null>(null);
   if (editorSyncStateRef.current === null) editorSyncStateRef.current = createEditorSyncState();
@@ -539,6 +543,17 @@ export function useMarkdownDocument({
     const snapshot = syncActiveDocumentDraftSnapshot();
     return persistWorkspaceState(draftWorkspacePatchFromTabs(snapshot.tabs, snapshot.activeTabId));
   }, [syncActiveDocumentDraftSnapshot]);
+
+  const persistNativeEditorWindowRestoreSnapshot = useCallback(async () => {
+    try {
+      // The native window list only lives in the current process. Copy it into settings
+      // before an app-driven exit so secondary editor windows survive restart.
+      const openWindows = await listNativeEditorWindowRestoreStates();
+      await persistWorkspaceState({ openWindows });
+    } catch {
+      // Snapshot persistence is best-effort; the current window state is still saved independently.
+    }
+  }, []);
 
   const hasDiscardableUnsavedChanges = useCallback(() => {
     const current = documentRef.current;
@@ -1766,14 +1781,30 @@ export function useMarkdownDocument({
     let cleanup: (() => unknown) | null = null;
 
     listenNativeWindowCloseRequested(async (event) => {
-      const draftPersistence = persistActiveDocumentDraftSnapshot();
-      const canDiscard = await confirmCanDiscardCurrentDocument();
-      if (!canDiscard) {
-        event.preventDefault();
+      if (nativeWindowCloseAllowedRef.current) {
+        nativeWindowCloseAllowedRef.current = false;
+        nativeWindowCloseScheduledRef.current = false;
         return;
       }
 
+      event.preventDefault();
+      if (nativeWindowCloseScheduledRef.current) return;
+
+      const draftPersistence = persistActiveDocumentDraftSnapshot();
+      const canDiscard = await confirmCanDiscardCurrentDocument();
+      if (!canDiscard) return;
+
       await draftPersistence;
+      nativeWindowCloseScheduledRef.current = true;
+      window.setTimeout(() => {
+        // The close request was already intercepted for persistence. Destroy the window after
+        // saving so Tauri does not re-enter the same close confirmation path.
+        nativeWindowCloseAllowedRef.current = true;
+        destroyNativeWindow().catch(() => {
+          nativeWindowCloseAllowedRef.current = false;
+          nativeWindowCloseScheduledRef.current = false;
+        });
+      }, 0);
     }).then((nextCleanup) => {
       if (active) {
         cleanup = nextCleanup;
@@ -1798,6 +1829,7 @@ export function useMarkdownDocument({
       const canDiscard = await confirmCanDiscardCurrentDocument();
       if (canDiscard) {
         await draftPersistence;
+        await persistNativeEditorWindowRestoreSnapshot();
         await beforeNativeAppExit?.();
         await exitNativeApp();
       }
@@ -1814,7 +1846,7 @@ export function useMarkdownDocument({
       active = false;
       cleanup?.();
     };
-  }, [beforeNativeAppExit, confirmCanDiscardCurrentDocument, persistActiveDocumentDraftSnapshot]);
+  }, [beforeNativeAppExit, confirmCanDiscardCurrentDocument, persistActiveDocumentDraftSnapshot, persistNativeEditorWindowRestoreSnapshot]);
 
   useEffect(() => {
     const path = initialMarkdownFilePath();
@@ -1930,27 +1962,46 @@ export function useMarkdownDocument({
           assignWorkspaceSessionId(sessionId);
 
           if (workspace.folderPath) {
-            const folderResult = await onTreeRootFromFolderPath(
-              workspace.folderPath,
-              workspace.folderName ?? workspace.folderPath,
+            const folderPath = workspace.folderPath;
+            const folderName = workspace.folderName ?? folderPath;
+            const handleRestoredFolderResult = (folderResult: unknown) => {
+              if (folderResult === null || folderResult === false) {
+                persistWorkspaceState({
+                  fileTreeOpen: false,
+                  folderName: null,
+                  folderPath: null
+                });
+                return;
+              }
+
+              if (restoreFilePaths.length === 0) clearOpenDocument({ persistWorkspace: false });
+            };
+            const restoreFolderRoot = () => onTreeRootFromFolderPath(
+              folderPath,
+              folderName,
               sessionId,
               restoreFilePaths.length === 0,
               workspace.fileTreeOpen
             );
-            if (!active) return;
 
-            if (folderResult === null || folderResult === false) {
-              persistWorkspaceState({
-                fileTreeOpen: false,
-                folderName: null,
-                folderPath: null,
-                openFilePaths: []
-              });
-              restoreFilePaths = [];
-              restoredWorkspace = true;
+            // Some saved roots, such as metadata folders, can make tree loading stall. Restoring
+            // files independently prevents the app from staying on Untitled.md while the tree waits.
+            restoredWorkspace = true;
+
+            if (restoreFilePaths.length > 0) {
+              // File restoration should not wait for potentially slow or skipped tree roots.
+              Promise.resolve()
+                .then(restoreFolderRoot)
+                .then((folderResult) => {
+                  if (active) handleRestoredFolderResult(folderResult);
+                })
+                .catch(() => {
+                  if (active) handleRestoredFolderResult(null);
+                });
             } else {
-              if (restoreFilePaths.length === 0) clearOpenDocument({ persistWorkspace: false });
-              restoredWorkspace = true;
+              const folderResult = await Promise.resolve().then(restoreFolderRoot);
+              if (!active) return;
+              handleRestoredFolderResult(folderResult);
             }
           }
 
@@ -1958,7 +2009,7 @@ export function useMarkdownDocument({
             const restoredFiles = await restoreNativeMarkdownFiles(
               restoreFilePaths,
               activeRestoreFilePath,
-              !restoredWorkspace,
+              !workspace.folderPath && !restoredWorkspace,
               sessionId
             );
             if (!active) return;

--- a/packages/app/src/lib/tauri/window.ts
+++ b/packages/app/src/lib/tauri/window.ts
@@ -71,6 +71,10 @@ export function closeNativeWindow() {
   return getAppRuntime().window.closeWindow();
 }
 
+export function destroyNativeWindow() {
+  return getAppRuntime().window.destroyWindow();
+}
+
 export function minimizeNativeWindow() {
   return getAppRuntime().window.minimizeWindow();
 }

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -331,6 +331,7 @@ export type AppFeatureRuntime = {
 
 export type AppWindowRuntime = {
   closeWindow: () => Promise<unknown>;
+  destroyWindow: () => Promise<unknown>;
   exitApp: () => Promise<unknown>;
   getCurrentWindowLabel: () => Promise<string | null>;
   listEditorWindowRestoreStates: () => Promise<NativeEditorWindowRestoreState[]>;
@@ -533,6 +534,7 @@ export function createDefaultAppRuntime(): AppRuntime {
     },
     window: {
       closeWindow: async () => undefined,
+      destroyWindow: async () => undefined,
       exitApp: async () => undefined,
       getCurrentWindowLabel: async () => "main",
       listEditorWindowRestoreStates: async () => [],

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -12,6 +12,7 @@ import {
   getNativeShellCommandStatus,
   installNativeShellCommand,
   closeNativeWindow,
+  destroyNativeWindow,
   exitNativeApp,
   hideSettingsWindow,
   markSettingsWindowReady,
@@ -23,6 +24,7 @@ import {
   openNativeMarkdownPath,
   listenNativeAppExitRequested,
   listenNativeWindowCloseRequested,
+  listNativeEditorWindowRestoreStates,
   listenNativeOpenedMarkdownPaths,
   listNativeMarkdownFileHistory,
   readNativeLocalImageFile,
@@ -202,11 +204,13 @@ vi.mock("../lib/tauri", () => ({
   installNativeEditorContextMenu: vi.fn(),
   openNativeExternalUrl: vi.fn(),
   closeNativeWindow: vi.fn(),
+  destroyNativeWindow: vi.fn(),
   hideSettingsWindow: vi.fn(),
   markSettingsWindowReady: vi.fn(),
   exitNativeApp: vi.fn(),
   listenNativeAppExitRequested: vi.fn(),
   listenNativeWindowCloseRequested: vi.fn(),
+  listNativeEditorWindowRestoreStates: vi.fn(),
   openSettingsWindow: vi.fn(),
   prewarmSettingsWindow: vi.fn(),
   setNativeWindowTitle: vi.fn(),
@@ -847,10 +851,12 @@ export const mockedOpenSettingsWindow = vi.mocked(openSettingsWindow);
 export const mockedPrewarmSettingsWindow = vi.mocked(prewarmSettingsWindow);
 export const mockedOpenNativeExternalUrl = vi.mocked(openNativeExternalUrl);
 export const mockedCloseNativeWindow = vi.mocked(closeNativeWindow);
+export const mockedDestroyNativeWindow = vi.mocked(destroyNativeWindow);
 export const mockedToggleNativeWindowFullscreen = vi.mocked(toggleNativeWindowFullscreen);
 export const mockedExitNativeApp = vi.mocked(exitNativeApp);
 export const mockedListenNativeAppExitRequested = vi.mocked(listenNativeAppExitRequested);
 export const mockedListenNativeWindowCloseRequested = vi.mocked(listenNativeWindowCloseRequested);
+export const mockedListNativeEditorWindowRestoreStates = vi.mocked(listNativeEditorWindowRestoreStates);
 export const mockedCheckNativeAppUpdate = vi.mocked(checkNativeAppUpdate);
 export const mockedResolveDesktopOsVersion = vi.mocked(resolveDesktopOsVersion);
 export const mockedResolveDesktopPlatform = vi.mocked(resolveDesktopPlatform);
@@ -1043,6 +1049,7 @@ export function installAppTestHarness() {
     mockedInstallNativeEditorContextMenu.mockReset();
     mockedOpenNativeExternalUrl.mockReset();
     mockedCloseNativeWindow.mockReset();
+    mockedDestroyNativeWindow.mockReset();
     mockedShowNativeWindow.mockReset();
     mockedHideSettingsWindow.mockReset();
     mockedMarkSettingsWindowReady.mockReset();
@@ -1050,6 +1057,7 @@ export function installAppTestHarness() {
     mockedExitNativeApp.mockReset();
     mockedListenNativeAppExitRequested.mockReset();
     mockedListenNativeWindowCloseRequested.mockReset();
+    mockedListNativeEditorWindowRestoreStates.mockReset();
     mockedCheckNativeAppUpdate.mockReset();
     mockedResolveDesktopOsVersion.mockReset();
     mockedResolveDesktopPlatform.mockReset();
@@ -1157,6 +1165,7 @@ export function installAppTestHarness() {
     mockedInstallNativeEditorContextMenu.mockResolvedValue(() => {});
     mockedOpenNativeExternalUrl.mockResolvedValue(undefined);
     mockedCloseNativeWindow.mockResolvedValue(undefined);
+    mockedDestroyNativeWindow.mockResolvedValue(undefined);
     mockedShowNativeWindow.mockResolvedValue(undefined);
     mockedHideSettingsWindow.mockResolvedValue(undefined);
     mockedMarkSettingsWindowReady.mockResolvedValue(undefined);
@@ -1164,6 +1173,7 @@ export function installAppTestHarness() {
     mockedExitNativeApp.mockResolvedValue(undefined);
     mockedListenNativeAppExitRequested.mockResolvedValue(() => {});
     mockedListenNativeWindowCloseRequested.mockResolvedValue(() => {});
+    mockedListNativeEditorWindowRestoreStates.mockResolvedValue([]);
     mockedDownloadNativeWebImage.mockResolvedValue(new File([new Uint8Array([1, 2, 3])], "web-image.png", {
       type: "image/png"
     }));


### PR DESCRIPTION
## Summary
- restore Dock/app reopens through a restorable editor window instead of the blank-window URL
- keep visible Settings windows from suppressing editor workspace restore on macOS reopen
- restore saved file tabs independently from saved folder tree loading so a slow/skipped root does not leave the app on `Untitled.md`
- persist native editor-window snapshots before app exit and destroy windows only after draft persistence on close

## Why
- `?blank=1` intentionally opts out of workspace restore, so using it for app/Dock reopen starts an empty document.
- The prewarmed Settings window can stay visible, but it is not an editor window and should not block editor restoration.
- Some saved roots, including metadata folders, can stall tree loading; file tabs still need to restore from saved paths.

## Validation
- `pnpm --filter @markra/app exec vitest run src/hooks/useMarkdownDocument.test.tsx --reporter dot` (64 passed)
- `pnpm --filter @markra/desktop exec vitest run src/runtime/tauri/window.test.ts --reporter dot` (20 passed)
- `cargo test --lib` (196 passed)
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `pnpm build`
- Manual `pnpm tauri dev` check restored the saved `.codex/edge-debug.md` tab as `edge-debug.md`.

## Risk
- Touches native window close/reopen restore behavior; covered by focused frontend, runtime, and Rust tests plus a manual desktop reopen check.
