### PR TITLE
feat(editor): show image upload placeholders

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -446,13 +446,17 @@ function pressShortcut(
 }
 
 function pasteImage(view: EditorView, image: File) {
+  return pasteImages(view, [image]);
+}
+
+function pasteImages(view: EditorView, images: File[]) {
   const event = new Event("paste", {
     bubbles: true,
     cancelable: true
   }) as ClipboardEvent;
   Object.defineProperty(event, "clipboardData", {
     value: {
-      files: [image],
+      files: images,
       getData: () => ""
     }
   });
@@ -3324,6 +3328,108 @@ describe("MarkdownPaper editing", () => {
     });
     expect(container.querySelector(".ProseMirror img")).not.toBeInTheDocument();
     expect(serializeMarkdown(view.state.doc)).not.toContain("Uploading image");
+  });
+
+  it("keeps typed text when an empty-selection image upload finishes later", async () => {
+    const pendingSave = createDeferred<{ alt: string; src: string } | null>();
+    const onSaveClipboardImage = vi.fn(() => pendingSave.promise);
+    const image = new File([new Uint8Array([1, 2, 3])], "Delayed Upload.png", { type: "image/png" });
+    const { container, editor, view } = await renderEditor("", { onSaveClipboardImage });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(pasteImage(view, image)).toBe(true);
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).toBeInTheDocument());
+
+    typeText(view, "Typed while waiting");
+
+    await act(async () => {
+      pendingSave.resolve({
+        alt: "Delayed upload",
+        src: "assets/delayed-upload.png"
+      });
+      await pendingSave.promise;
+    });
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).not.toBeInTheDocument());
+    expect(container.querySelector<HTMLImageElement>('img[src="assets/delayed-upload.png"]')).toHaveAttribute(
+      "alt",
+      "Delayed upload"
+    );
+    expect(serializeMarkdown(view.state.doc)).toContain("Typed while waiting");
+    expect(serializeMarkdown(view.state.doc)).toContain("![Delayed upload](assets/delayed-upload.png)");
+  });
+
+  it("replaces selected text when a pasted clipboard image upload finishes", async () => {
+    const pendingSave = createDeferred<{ alt: string; src: string } | null>();
+    const onSaveClipboardImage = vi.fn(() => pendingSave.promise);
+    const image = new File([new Uint8Array([1, 2, 3])], "Selection Upload.png", { type: "image/png" });
+    const { container, editor, view } = await renderEditor("Replace this text", { onSaveClipboardImage });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    selectText(view, findTextPosition(view, "Replace"), findTextPosition(view, "text", "text".length));
+    expect(pasteImage(view, image)).toBe(true);
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).toBeInTheDocument());
+
+    await act(async () => {
+      pendingSave.resolve({
+        alt: "Selection upload",
+        src: "assets/selection-upload.png"
+      });
+      await pendingSave.promise;
+    });
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).not.toBeInTheDocument());
+    expect(container.querySelector<HTMLImageElement>('img[src="assets/selection-upload.png"]')).toHaveAttribute(
+      "alt",
+      "Selection upload"
+    );
+    expect(serializeMarkdown(view.state.doc)).toContain("![Selection upload](assets/selection-upload.png)");
+    expect(serializeMarkdown(view.state.doc)).not.toContain("Replace this text");
+  });
+
+  it("keeps multiple pasted image placeholders in upload order", async () => {
+    const firstSave = createDeferred<{ alt: string; src: string } | null>();
+    const secondSave = createDeferred<{ alt: string; src: string } | null>();
+    const saves = [firstSave, secondSave];
+    let saveIndex = 0;
+    const onSaveClipboardImage = vi.fn(() => saves[saveIndex++]?.promise ?? Promise.resolve(null));
+    const firstImage = new File([new Uint8Array([1])], "First Upload.png", { type: "image/png" });
+    const secondImage = new File([new Uint8Array([2])], "Second Upload.png", { type: "image/png" });
+    const { container, editor, view } = await renderEditor("", { onSaveClipboardImage });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(pasteImages(view, [firstImage, secondImage])).toBe(true);
+
+    await waitFor(() => expect(container.querySelectorAll(".ProseMirror .markra-image-upload-placeholder")).toHaveLength(2));
+    expect(onSaveClipboardImage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstSave.resolve({
+        alt: "First upload",
+        src: "assets/first-upload.png"
+      });
+      await firstSave.promise;
+    });
+
+    await waitFor(() => expect(onSaveClipboardImage).toHaveBeenCalledTimes(2));
+    expect(container.querySelectorAll(".ProseMirror .markra-image-upload-placeholder")).toHaveLength(1);
+
+    await act(async () => {
+      secondSave.resolve({
+        alt: "Second upload",
+        src: "assets/second-upload.png"
+      });
+      await secondSave.promise;
+    });
+
+    await waitFor(() => expect(container.querySelectorAll(".ProseMirror .markra-image-upload-placeholder")).toHaveLength(0));
+    const imageAlts = Array.from(container.querySelectorAll<HTMLImageElement>(".ProseMirror img")).map(
+      (imageNode) => imageNode.alt
+    );
+    expect(imageAlts).toEqual(["First upload", "Second upload"]);
+    expect(serializeMarkdown(view.state.doc).indexOf("![First upload](assets/first-upload.png)")).toBeLessThan(
+      serializeMarkdown(view.state.doc).indexOf("![Second upload](assets/second-upload.png)")
+    );
   });
 
   it("lets pasted spreadsheet tables use structured clipboard data instead of the bitmap preview", async () => {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -460,6 +460,17 @@ function pasteImage(view: EditorView, image: File) {
   return view.someProp("handlePaste", (handler) => handler(view, event, view.state.selection.content()));
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => unknown;
+  let reject!: (reason?: unknown) => unknown;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject, resolve };
+}
+
 function dispatchMixedClipboardPaste(view: EditorView, data: { files: File[]; html?: string; plainText?: string }) {
   const event = new Event("paste", {
     bubbles: true,
@@ -3255,6 +3266,64 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain("![Screenshot](assets/pasted-image.png)");
     expect(serializeMarkdown(view.state.doc)).not.toContain("!\\[Screenshot\\]\\(assets/pasted-image.png\\)");
     await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining("![Screenshot](assets/pasted-image.png)")));
+  });
+
+  it("shows an inline upload placeholder while pasted clipboard images are saving", async () => {
+    const onMarkdownChange = vi.fn();
+    const pendingSave = createDeferred<{ alt: string; src: string } | null>();
+    const onSaveClipboardImage = vi.fn(() => pendingSave.promise);
+    const image = new File([new Uint8Array([1, 2, 3])], "Mock Upload.png", { type: "image/png" });
+    const { container, editor, view } = await renderEditor("", { onMarkdownChange, onSaveClipboardImage });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(pasteImage(view, image)).toBe(true);
+
+    await waitFor(() => expect(onSaveClipboardImage).toHaveBeenCalledWith(image));
+    const placeholder = container.querySelector<HTMLElement>(".ProseMirror .markra-image-upload-placeholder");
+    expect(placeholder).toBeInTheDocument();
+    expect(placeholder).toHaveTextContent("Uploading image...");
+    expect(serializeMarkdown(view.state.doc)).not.toContain("Uploading image");
+
+    await act(async () => {
+      pendingSave.resolve({
+        alt: "Mock upload",
+        src: "assets/mock-upload.png"
+      });
+      await pendingSave.promise;
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).not.toBeInTheDocument();
+    });
+    expect(container.querySelector<HTMLImageElement>('img[src="assets/mock-upload.png"]')).toHaveAttribute(
+      "alt",
+      "Mock upload"
+    );
+    expect(serializeMarkdown(view.state.doc)).toContain("![Mock upload](assets/mock-upload.png)");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalledWith(expect.stringContaining("![Mock upload](assets/mock-upload.png)")));
+  });
+
+  it("removes the inline upload placeholder when pasted clipboard image saving is skipped", async () => {
+    const pendingSave = createDeferred<{ alt: string; src: string } | null>();
+    const onSaveClipboardImage = vi.fn(() => pendingSave.promise);
+    const image = new File([new Uint8Array([1, 2, 3])], "Skipped Upload.png", { type: "image/png" });
+    const { container, editor, view } = await renderEditor("", { onSaveClipboardImage });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(pasteImage(view, image)).toBe(true);
+
+    await waitFor(() => expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).toBeInTheDocument());
+
+    await act(async () => {
+      pendingSave.resolve(null);
+      await pendingSave.promise;
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector(".ProseMirror .markra-image-upload-placeholder")).not.toBeInTheDocument();
+    });
+    expect(container.querySelector(".ProseMirror img")).not.toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).not.toContain("Uploading image");
   });
 
   it("lets pasted spreadsheet tables use structured clipboard data instead of the bitmap preview", async () => {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2569,6 +2569,23 @@
     user-select: none;
   }
 
+  .markdown-paper .markra-image-upload-placeholder {
+    @apply my-6 inline-flex min-h-18 max-w-full items-center gap-2 rounded-[3px] border border-dashed border-(--border-default) bg-(--bg-secondary) px-3.5 py-3 text-[0.92em] font-medium text-(--text-secondary);
+    cursor: progress;
+    user-select: none;
+    vertical-align: middle;
+  }
+
+  .markdown-paper .markra-image-upload-placeholder-spinner {
+    @apply block size-4 shrink-0 rounded-full border-2 border-(--border-default);
+    animation: markra-ai-preview-spin 0.82s linear infinite;
+    border-top-color: var(--accent);
+  }
+
+  .markdown-paper .markra-image-upload-placeholder-label {
+    @apply min-w-0 truncate;
+  }
+
   .markdown-paper .markra-image-node-source::selection {
     background: color-mix(in srgb, var(--accent) 28%, transparent);
   }
@@ -3499,6 +3516,10 @@
     }
 
     .markdown-paper .markra-ai-preview-spinner {
+      animation: none;
+    }
+
+    .markdown-paper .markra-image-upload-placeholder-spinner {
       animation: none;
     }
   }

--- a/packages/editor/src/clipboard-images.ts
+++ b/packages/editor/src/clipboard-images.ts
@@ -1,7 +1,7 @@
 import { imageSchema, linkSchema } from "@milkdown/kit/preset/commonmark";
 import { Fragment, type MarkType, type Node as ProseNode, type NodeType, type Schema, type Slice } from "@milkdown/kit/prose/model";
-import { Plugin, Selection, TextSelection, type SelectionBookmark } from "@milkdown/kit/prose/state";
-import type { EditorView } from "@milkdown/kit/prose/view";
+import { Plugin, PluginKey, Selection, TextSelection, type SelectionBookmark, type Transaction } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
 import {
   markdownImageDragSrcForDocument,
@@ -49,6 +49,38 @@ type ImageInsertionRange = {
   from: number;
   to: number;
 };
+
+type ImageUploadPlaceholderReplaceMode = "dynamic" | "range";
+
+type ImageUploadPlaceholder = {
+  from: number;
+  id: string;
+  position: number;
+  replaceMode: ImageUploadPlaceholderReplaceMode;
+  to: number;
+};
+
+type ImageUploadPlaceholderState = {
+  decorations: DecorationSet;
+  placeholders: ImageUploadPlaceholder[];
+};
+
+type ImageUploadPlaceholderMeta =
+  | {
+      placeholders: ImageUploadPlaceholder[];
+      type: "add";
+    }
+  | {
+      ids: string[];
+      type: "remove";
+    };
+
+const imageUploadPlaceholderKey = new PluginKey<ImageUploadPlaceholderState>("markra-clipboard-image-upload-placeholder");
+const emptyImageUploadPlaceholderState: ImageUploadPlaceholderState = {
+  decorations: DecorationSet.empty,
+  placeholders: []
+};
+let nextImageUploadPlaceholderSequence = 0;
 
 const droppedPlainMarkdownImagePattern = /^!\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)$/u;
 
@@ -200,6 +232,176 @@ function imageInsertionRangeForSelection(selection: Selection): ImageInsertionRa
   };
 }
 
+function createImageUploadPlaceholderId() {
+  nextImageUploadPlaceholderSequence += 1;
+  return `markra-image-upload-${nextImageUploadPlaceholderSequence}`;
+}
+
+function clampDocumentPosition(position: number, docSize: number) {
+  return Math.max(0, Math.min(docSize, position));
+}
+
+function createImageUploadPlaceholderElement(ownerDocument: Document, id: string) {
+  const placeholder = ownerDocument.createElement("span");
+  placeholder.className = "markra-image-upload-placeholder";
+  placeholder.contentEditable = "false";
+  placeholder.dataset.markraImageUploadPlaceholder = id;
+  placeholder.setAttribute("aria-live", "polite");
+  placeholder.setAttribute("role", "status");
+
+  const spinner = ownerDocument.createElement("span");
+  spinner.className = "markra-image-upload-placeholder-spinner";
+  spinner.setAttribute("aria-hidden", "true");
+
+  const label = ownerDocument.createElement("span");
+  label.className = "markra-image-upload-placeholder-label";
+  label.textContent = "Uploading image...";
+
+  placeholder.append(spinner, label);
+  return placeholder;
+}
+
+function buildImageUploadPlaceholderDecorations(doc: ProseNode, placeholders: ImageUploadPlaceholder[]) {
+  if (!placeholders.length) return DecorationSet.empty;
+
+  return DecorationSet.create(
+    doc,
+    placeholders.map((placeholder) =>
+      Decoration.widget(
+        clampDocumentPosition(placeholder.position, doc.content.size),
+        (view) => createImageUploadPlaceholderElement(view.dom.ownerDocument, placeholder.id),
+        {
+          key: placeholder.id,
+          side: -1
+        }
+      )
+    )
+  );
+}
+
+function mapImageUploadPlaceholder(
+  placeholder: ImageUploadPlaceholder,
+  transaction: Transaction
+): ImageUploadPlaceholder | null {
+  if (!transaction.docChanged) return placeholder;
+
+  const docSize = transaction.doc.content.size;
+  const position = clampDocumentPosition(transaction.mapping.map(placeholder.position, 1), docSize);
+  const from = clampDocumentPosition(transaction.mapping.map(placeholder.from, 1), docSize);
+  const to = clampDocumentPosition(transaction.mapping.map(placeholder.to, -1), docSize);
+  if (from > to) return null;
+
+  return {
+    ...placeholder,
+    from,
+    position,
+    to
+  };
+}
+
+function applyImageUploadPlaceholderTransaction(
+  transaction: Transaction,
+  previous: ImageUploadPlaceholderState
+): ImageUploadPlaceholderState {
+  const meta = transaction.getMeta(imageUploadPlaceholderKey) as ImageUploadPlaceholderMeta | undefined;
+  const mappedPlaceholders = previous.placeholders.flatMap((placeholder) => {
+    const mapped = mapImageUploadPlaceholder(placeholder, transaction);
+    return mapped ? [mapped] : [];
+  });
+
+  let placeholders = mappedPlaceholders;
+  if (meta?.type === "add") {
+    placeholders = [...placeholders, ...meta.placeholders];
+  } else if (meta?.type === "remove") {
+    const removedIds = new Set(meta.ids);
+    placeholders = placeholders.filter((placeholder) => !removedIds.has(placeholder.id));
+  }
+
+  return {
+    decorations: buildImageUploadPlaceholderDecorations(transaction.doc, placeholders),
+    placeholders
+  };
+}
+
+function imageUploadPlaceholderPositionForSelection(selection: Selection, range: ImageInsertionRange) {
+  return selection.empty ? selection.from : range.from;
+}
+
+function addImageUploadPlaceholders(
+  view: EditorView,
+  count: number,
+  bookmark: SelectionBookmark
+) {
+  if (count <= 0) return [];
+
+  const selection = bookmark.resolve(view.state.doc);
+  const range = imageInsertionRangeForSelection(selection);
+  const position = clampDocumentPosition(
+    imageUploadPlaceholderPositionForSelection(selection, range),
+    view.state.doc.content.size
+  );
+  const placeholders = Array.from({ length: count }, () => ({
+    from: range.from,
+    id: createImageUploadPlaceholderId(),
+    position,
+    // Recompute empty selections at completion so typing while an upload is pending is not overwritten.
+    replaceMode: selection.empty ? "dynamic" : "range",
+    to: range.to
+  } satisfies ImageUploadPlaceholder));
+
+  view.dispatch(
+    view.state.tr
+      .setMeta(imageUploadPlaceholderKey, {
+        placeholders,
+        type: "add"
+      } satisfies ImageUploadPlaceholderMeta)
+      .scrollIntoView()
+  );
+
+  return placeholders.map((placeholder) => placeholder.id);
+}
+
+function removeImageUploadPlaceholders(view: EditorView, ids: string[]) {
+  if (!ids.length) return;
+
+  view.dispatch(
+    view.state.tr.setMeta(imageUploadPlaceholderKey, {
+      ids,
+      type: "remove"
+    } satisfies ImageUploadPlaceholderMeta)
+  );
+}
+
+function currentImageUploadPlaceholder(view: EditorView, id: string) {
+  return imageUploadPlaceholderKey.getState(view.state)?.placeholders.find((placeholder) => placeholder.id === id) ?? null;
+}
+
+function textSelectionAtPosition(doc: ProseNode, position: number) {
+  const resolvedPosition = doc.resolve(clampDocumentPosition(position, doc.content.size));
+  const nearbySelection = Selection.near(resolvedPosition);
+  return nearbySelection instanceof TextSelection ? nearbySelection : null;
+}
+
+function imageUploadPlaceholderReplacementRange(doc: ProseNode, placeholder: ImageUploadPlaceholder) {
+  if (placeholder.replaceMode === "range") {
+    return {
+      from: clampDocumentPosition(placeholder.from, doc.content.size),
+      to: clampDocumentPosition(placeholder.to, doc.content.size)
+    };
+  }
+
+  const selection = textSelectionAtPosition(doc, placeholder.position);
+  if (!selection) {
+    const position = clampDocumentPosition(placeholder.position, doc.content.size);
+    return {
+      from: position,
+      to: position
+    };
+  }
+
+  return imageInsertionRangeForSelection(selection);
+}
+
 function isRemoteImageSrc(value: unknown): value is string {
   if (typeof value !== "string") return false;
 
@@ -335,16 +537,30 @@ async function saveAndInsertClipboardImages(
   image: NodeType,
   bookmark: SelectionBookmark = view.state.selection.getBookmark()
 ) {
-  const savedImages: SavedClipboardImage[] = [];
+  const placeholderIds = addImageUploadPlaceholders(view, files.length, bookmark);
 
-  for (const file of files) {
-    const savedImage = await saveClipboardImage(file);
-    if (savedImage) savedImages.push(savedImage);
+  for (let index = 0; index < files.length; index += 1) {
+    const file = files[index];
+    const placeholderId = placeholderIds[index];
+    if (!file || !placeholderId) continue;
+
+    let savedImage: SavedClipboardImage | null = null;
+    try {
+      savedImage = await saveClipboardImage(file);
+    } catch (error) {
+      removeImageUploadPlaceholders(view, placeholderIds.slice(index));
+      throw error;
+    }
+
+    if (!savedImage) {
+      removeImageUploadPlaceholders(view, [placeholderId]);
+      continue;
+    }
+
+    if (!replaceImageUploadPlaceholder(view, placeholderId, savedImage, image)) {
+      insertSavedClipboardImages(view, [savedImage], image, bookmark);
+    }
   }
-
-  if (!savedImages.length) return;
-
-  insertSavedClipboardImages(view, savedImages, image, bookmark);
 }
 
 async function saveAndInsertClipboardAttachments(
@@ -383,6 +599,32 @@ function insertSavedClipboardImages(
   view.focus();
 }
 
+function replaceImageUploadPlaceholder(
+  view: EditorView,
+  placeholderId: string,
+  savedImage: SavedClipboardImage,
+  image: NodeType
+) {
+  const placeholder = currentImageUploadPlaceholder(view, placeholderId);
+  if (!placeholder) return false;
+
+  const fragment = createImageFragment([savedImage], image);
+  const range = imageUploadPlaceholderReplacementRange(view.state.doc, placeholder);
+  const transaction = view.state.tr
+    .replaceWith(range.from, range.to, fragment)
+    .setMeta(imageUploadPlaceholderKey, {
+      ids: [placeholderId],
+      type: "remove"
+    } satisfies ImageUploadPlaceholderMeta)
+    .scrollIntoView();
+  const cursor = Math.min(transaction.doc.content.size, range.from + fragment.size);
+
+  transaction.setSelection(Selection.near(transaction.doc.resolve(cursor), -1));
+  view.dispatch(transaction);
+  view.focus();
+  return true;
+}
+
 function insertSavedClipboardAttachments(
   view: EditorView,
   savedAttachments: SavedClipboardAttachment[],
@@ -411,8 +653,10 @@ export function markraClipboardImagePluginWithOptions(
     const image = imageSchema.type(ctx);
     const link = linkSchema.type(ctx);
 
-    return new Plugin({
+    return new Plugin<ImageUploadPlaceholderState>({
+      key: imageUploadPlaceholderKey,
       props: {
+        decorations: (state) => imageUploadPlaceholderKey.getState(state)?.decorations ?? DecorationSet.empty,
         handlePaste: (view, event, slice) => {
           const files = clipboardImageFiles(event);
           if (files.length && !clipboardHasStructuredTableData(event)) {
@@ -496,6 +740,14 @@ export function markraClipboardImagePluginWithOptions(
             console.error("[markra-clipboard-images] failed to insert dropped attachment", error);
           });
           return true;
+        }
+      },
+      state: {
+        init() {
+          return emptyImageUploadPlaceholderState;
+        },
+        apply(transaction, previous) {
+          return applyImageUploadPlaceholderTransaction(transaction, previous);
         }
       }
     });


### PR DESCRIPTION
## Summary
- Show an inline editor upload placeholder while pasted or dropped clipboard images are saving.
- Replace the placeholder with the uploaded image on success and remove it when saving is skipped.
- Add placeholder styling and tests to keep the temporary state out of serialized Markdown.

## Why
- Gives users visible feedback during remote image uploads so paste/drop actions do not feel lost or unresponsive.

## Validation
- `pnpm --filter @markra/app test -- src/components/MarkdownPaper.test.tsx -t "upload"` passed (1605 tests)
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- `pnpm --filter @markra/editor test` passed (12 tests)
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/desktop build` passed

## Edge Cases Checked
- Pending upload placeholders do not serialize into Markdown.
- Empty-selection uploads preserve text typed while the upload is pending.
- Selected text is replaced once the image upload finishes.
- Multiple pasted images keep placeholder/image order.
- Skipped image saves remove the placeholder without inserting an image.

## Risk
- Placeholder position mapping is the sensitive path when users edit while an image upload is pending; the implementation recomputes empty-selection replacements at completion to avoid overwriting newly typed text.

Closes #464
