### PR TITLE
fix(app): reduce long markdown editor jank

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -50,6 +50,7 @@ import type {
   ExtendedSyntaxPreferences,
   TableColumnWidthModePreference
 } from "../lib/settings/app-settings";
+import { deferredMarkdownChangeDelayMs } from "../lib/deferred-markdown-change";
 
 const tableColumnWidthModeLabel = "Column width mode";
 
@@ -133,7 +134,7 @@ async function renderEditor(
 
 async function settleMarkdownListener() {
   await new Promise((resolve) => {
-    window.setTimeout(resolve, 250);
+    window.setTimeout(resolve, 250 + deferredMarkdownChangeDelayMs);
   });
 }
 

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -67,6 +67,7 @@ import {
 import { matchesKeyboardShortcutEvent, t, type AppLanguage } from "@markra/shared";
 import type { ExtendedSyntaxPreferences, TableColumnWidthModePreference } from "../lib/settings/app-settings";
 import type { MarkdownDocumentLinkFile } from "../lib/document-links";
+import { createDeferredMarkdownChangeEmitter } from "../lib/deferred-markdown-change";
 import { markraDocumentLinkCompletionPlugin } from "./document-link-completion";
 import {
   markraCommonmark,
@@ -247,6 +248,7 @@ function MilkdownEditorSurface({
   const spellcheckMenuViewRef = useRef<EditorView | null>(null);
   const onAddSpellcheckIgnoredWordRef = useRef(onAddSpellcheckIgnoredWord);
   const workspaceFilesRef = useRef(workspaceFiles ?? []);
+  const deferredMarkdownChangeRef = useRef<ReturnType<typeof createDeferredMarkdownChangeEmitter<() => unknown>> | null>(null);
   const [spellcheckMenu, setSpellcheckMenu] = useState<SpellcheckSuggestionMenuState | null>(null);
   const externalLinkOpeningEnabled = Boolean(openExternalUrl || openLocalAttachment);
   const markdownDocumentLabel = t(language, "app.markdownDocument");
@@ -257,6 +259,11 @@ function MilkdownEditorSurface({
     () => normalizeMarkdownShortcuts(markdownShortcuts),
     [shortcutsSignature]
   );
+  if (deferredMarkdownChangeRef.current === null) {
+    deferredMarkdownChangeRef.current = createDeferredMarkdownChangeEmitter((emitMarkdownChange) => {
+      emitMarkdownChange();
+    });
+  }
   const tableControlLabels = {
     addColumnRight: t(language, "editor.table.addColumnRight"),
     addRowBelow: t(language, "editor.table.addRowBelow"),
@@ -367,6 +374,14 @@ function MilkdownEditorSurface({
   }, [workspaceFiles]);
 
   useEffect(() => {
+    const deferredMarkdownChange = deferredMarkdownChangeRef.current;
+
+    return () => {
+      deferredMarkdownChange?.flush();
+    };
+  }, []);
+
+  useEffect(() => {
     if (!spellcheckMenu) return;
 
     const closeOnEscape = (event: KeyboardEvent) => {
@@ -446,15 +461,25 @@ function MilkdownEditorSurface({
           }));
           ctx.get(listenerCtx).updated((editorCtx, doc) => {
             try {
+              const deferredMarkdownChange = deferredMarkdownChangeRef.current;
+              if (!deferredMarkdownChange) return;
+
               const view = editorCtx.get(editorViewCtx);
-              onMarkdownChangeRef.current(
-                serializeLinkImageLiveMarkdown(
-                  view.state.doc === doc ? doc : view.state.doc,
-                  editorCtx.get(serializerCtx),
-                  linkSchema.type(editorCtx),
-                  imageSchema.type(editorCtx)
-                )
-              );
+              const markdownDocument = view.state.doc === doc ? doc : view.state.doc;
+              const serializeMarkdown = editorCtx.get(serializerCtx);
+              const link = linkSchema.type(editorCtx);
+              const image = imageSchema.type(editorCtx);
+
+              // Serializing the whole ProseMirror document on every transaction is the hot path for long files.
+              deferredMarkdownChange.schedule(() => {
+                try {
+                  onMarkdownChangeRef.current(
+                    serializeLinkImageLiveMarkdown(markdownDocument, serializeMarkdown, link, image)
+                  );
+                } catch {
+                  // Milkdown can flush a delayed update after teardown in tests or fast window closes.
+                }
+              });
             } catch {
               // Milkdown can flush a delayed update after teardown in tests or fast window closes.
             }

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -133,6 +133,33 @@ describe("MarkdownSourceEditor", () => {
     expect(view.state.doc.toString()).toBe("# External");
   });
 
+  it("does not report scroll events caused by externally synced content", () => {
+    const handleScroll = vi.fn();
+    const { container, rerender } = render(
+      <MarkdownSourceEditor
+        content="# First"
+        onChange={() => {}}
+        onScroll={handleScroll}
+      />
+    );
+    const sourceScroll = container.querySelector<HTMLElement>(".paper-scroll");
+    expect(sourceScroll).toBeInTheDocument();
+
+    fireEvent.scroll(sourceScroll!);
+    expect(handleScroll).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MarkdownSourceEditor
+        content="# External"
+        onChange={() => {}}
+        onScroll={handleScroll}
+      />
+    );
+    fireEvent.scroll(sourceScroll!);
+
+    expect(handleScroll).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps externally synced content when autofocus changes", () => {
     const { container, rerender } = render(
       <MarkdownSourceEditor

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -207,6 +207,8 @@ export function MarkdownSourceEditor({
   const contentAttributesCompartmentRef = useRef(new Compartment());
   const editableCompartmentRef = useRef(new Compartment());
   const searchCompartmentRef = useRef(new Compartment());
+  const externalContentScrollSuppressedRef = useRef(false);
+  const externalContentScrollRestoreFrameRef = useRef<number | null>(null);
   const resolvedContentWidth = contentWidthPx ?? editorContentWidthPixels[contentWidth];
   const editorFontFamilyCss = editorFontFamilyCssValue(editorFontFamily);
   const sourceLabel = t(language, "app.markdownSource");
@@ -239,6 +241,21 @@ export function MarkdownSourceEditor({
   useEffect(() => {
     onUndoRef.current = onUndo;
   }, [onUndo]);
+
+  useEffect(() => {
+    return () => {
+      if (externalContentScrollRestoreFrameRef.current !== null) {
+        window.cancelAnimationFrame(externalContentScrollRestoreFrameRef.current);
+        externalContentScrollRestoreFrameRef.current = null;
+      }
+    };
+  }, []);
+
+  const handlePaperScroll = (event: UIEvent<HTMLElement>) => {
+    if (externalContentScrollSuppressedRef.current) return;
+
+    onScroll?.(event);
+  };
 
   const extensions = useMemo(
     () => [
@@ -317,6 +334,9 @@ export function MarkdownSourceEditor({
     if (currentContent === content) return;
 
     const cursor = Math.min(view.state.selection.main.head, content.length);
+    const scrollElement = view.dom.closest<HTMLElement>(".paper-scroll");
+    const scrollTop = scrollElement?.scrollTop ?? 0;
+    externalContentScrollSuppressedRef.current = true;
     view.dispatch({
       annotations: [externalSourceUpdate.of(true), Transaction.addToHistory.of(false)],
       changes: {
@@ -325,6 +345,22 @@ export function MarkdownSourceEditor({
         to: view.state.doc.length
       },
       selection: EditorSelection.cursor(cursor)
+    });
+
+    if (!scrollElement) {
+      externalContentScrollSuppressedRef.current = false;
+      return;
+    }
+
+    // Split panes synchronize user scrolls; external text sync must not bounce the active visual pane.
+    scrollElement.scrollTop = scrollTop;
+    if (externalContentScrollRestoreFrameRef.current !== null) {
+      window.cancelAnimationFrame(externalContentScrollRestoreFrameRef.current);
+    }
+    externalContentScrollRestoreFrameRef.current = window.requestAnimationFrame(() => {
+      externalContentScrollRestoreFrameRef.current = null;
+      if (scrollElement.isConnected) scrollElement.scrollTop = scrollTop;
+      externalContentScrollSuppressedRef.current = false;
     });
   }, [content]);
 
@@ -359,7 +395,7 @@ export function MarkdownSourceEditor({
     <section
       className="paper-scroll h-full min-h-0 overflow-x-hidden overflow-y-auto overscroll-none bg-transparent"
       aria-label={t(language, "app.writingSurface")}
-      onScroll={onScroll}
+      onScroll={handlePaperScroll}
       ref={scrollRef}
     >
       <article

--- a/packages/app/src/lib/deferred-markdown-change.test.ts
+++ b/packages/app/src/lib/deferred-markdown-change.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDeferredMarkdownChangeEmitter,
+  deferredMarkdownChangeDelayMs,
+  deferredMarkdownChangeMaxWaitMs
+} from "./deferred-markdown-change";
+
+describe("deferred markdown change emitter", () => {
+  it("coalesces rapid changes and emits only the latest content after a short pause", () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const emitter = createDeferredMarkdownChangeEmitter<string>(emit);
+
+    emitter.schedule("# Lesson\n\nFirst");
+    emitter.schedule("# Lesson\n\nSecond");
+
+    vi.advanceTimersByTime(deferredMarkdownChangeDelayMs - 1);
+    expect(emit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith("# Lesson\n\nSecond");
+
+    emitter.destroy();
+    vi.useRealTimers();
+  });
+
+  it("emits pending content at the max wait while continuous changes keep arriving", () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const emitter = createDeferredMarkdownChangeEmitter<string>(emit);
+
+    emitter.schedule("Draft 0");
+    for (let index = 1; index <= 5; index += 1) {
+      vi.advanceTimersByTime(deferredMarkdownChangeDelayMs - 1);
+      emitter.schedule(`Draft ${index}`);
+    }
+
+    vi.advanceTimersByTime(deferredMarkdownChangeMaxWaitMs - ((deferredMarkdownChangeDelayMs - 1) * 5) - 1);
+    expect(emit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith("Draft 5");
+
+    emitter.destroy();
+    vi.useRealTimers();
+  });
+
+  it("flushes pending content immediately and cancels scheduled timers", () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const emitter = createDeferredMarkdownChangeEmitter<string>(emit);
+
+    emitter.schedule("Synthetic draft");
+    emitter.flush();
+    vi.runAllTimers();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith("Synthetic draft");
+
+    emitter.destroy();
+    vi.useRealTimers();
+  });
+});

--- a/packages/app/src/lib/deferred-markdown-change.ts
+++ b/packages/app/src/lib/deferred-markdown-change.ts
@@ -1,0 +1,83 @@
+export const deferredMarkdownChangeDelayMs = 120;
+export const deferredMarkdownChangeMaxWaitMs = 600;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+type DeferredMarkdownChangeEmitterOptions = {
+  clearTimer?: (handle: TimerHandle) => unknown;
+  delayMs?: number;
+  maxWaitMs?: number;
+  setTimer?: (callback: () => unknown, delayMs: number) => TimerHandle;
+};
+
+function defaultSetTimer(callback: () => unknown, delayMs: number) {
+  return setTimeout(callback, delayMs);
+}
+
+function defaultClearTimer(handle: TimerHandle) {
+  clearTimeout(handle);
+}
+
+export function createDeferredMarkdownChangeEmitter<T>(
+  emit: (content: T) => unknown,
+  options: DeferredMarkdownChangeEmitterOptions = {}
+) {
+  const delayMs = options.delayMs ?? deferredMarkdownChangeDelayMs;
+  const maxWaitMs = Math.max(delayMs, options.maxWaitMs ?? deferredMarkdownChangeMaxWaitMs);
+  const setTimer = options.setTimer ?? defaultSetTimer;
+  const clearTimer = options.clearTimer ?? defaultClearTimer;
+  let delayTimer: TimerHandle | null = null;
+  let maxWaitTimer: TimerHandle | null = null;
+  let hasPendingContent = false;
+  let pendingContent: T | null = null;
+  let destroyed = false;
+
+  const clearDelayTimer = () => {
+    if (delayTimer === null) return;
+
+    clearTimer(delayTimer);
+    delayTimer = null;
+  };
+
+  const clearMaxWaitTimer = () => {
+    if (maxWaitTimer === null) return;
+
+    clearTimer(maxWaitTimer);
+    maxWaitTimer = null;
+  };
+
+  const flush = () => {
+    clearDelayTimer();
+    clearMaxWaitTimer();
+    if (destroyed || !hasPendingContent) return;
+
+    const content = pendingContent as T;
+    pendingContent = null;
+    hasPendingContent = false;
+    emit(content);
+  };
+
+  const schedule = (content: T) => {
+    if (destroyed) return;
+
+    pendingContent = content;
+    hasPendingContent = true;
+    clearDelayTimer();
+    delayTimer = setTimer(flush, delayMs);
+    if (maxWaitTimer === null) maxWaitTimer = setTimer(flush, maxWaitMs);
+  };
+
+  const destroy = () => {
+    destroyed = true;
+    pendingContent = null;
+    hasPendingContent = false;
+    clearDelayTimer();
+    clearMaxWaitTimer();
+  };
+
+  return {
+    destroy,
+    flush,
+    schedule
+  };
+}


### PR DESCRIPTION
## Summary

- defer visual editor Markdown serialization so rapid edits coalesce before updating React document state
- preserve source editor scroll and suppress programmatic scroll events during external sync to prevent split-pane bounce
- add coverage for deferred Markdown change emission and external source sync scroll suppression

## Validation

- `pnpm --filter @markra/app test -- src/components/MarkdownSourceEditor.test.tsx` (110 files, 1657 tests)
- `pnpm --filter @markra/app build`
- `pnpm --filter @markra/app typecheck:test`
- `git diff --check origin/main...HEAD`

## Risk

- visual editor document state is intentionally coalesced by up to 600ms; save/close paths still read current editor content directly