### PR TITLE
fix(editor): preserve live markdown source serialization

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -6894,6 +6894,107 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it.each([
+    { source: "*示例*", kind: "emphasis", expected: "*示例*" },
+    { source: "_示例_", kind: "emphasis", expected: "_示例_" },
+    { source: "**示例**，123123", kind: "strong", expected: "**示例**，123123" },
+    { source: "__示例__", kind: "strong", expected: "__示例__" },
+    { source: "~~示例~~", kind: "strikethrough", expected: "~~示例~~" },
+    { source: "==示例==", kind: "highlight", expected: "==示例==" },
+    { source: "`示例`", kind: "inlineCode", expected: "`示例`" }
+  ])("serializes typed live $kind markdown without escaping delimiters", async ({ source, kind, expected }) => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    typeText(view, source);
+
+    expectLiveMark(container, kind, "示例");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe(expected);
+  });
+
+  it.each(["*", "_", "~", "`", "="])("serializes a typed %s delimiter without escaping it", async (delimiter) => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("", { onMarkdownChange });
+
+    typeText(view, delimiter);
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe(delimiter);
+  });
+
+  it.each(["\\*\\*literal\\*\\*", "\\_literal\\_", "\\~\\~literal\\~\\~", "\\=\\=literal\\=\\=", "\\`literal\\`"])(
+    "keeps escaped literal markdown escaped while serializing later edits",
+    async (source) => {
+      const onMarkdownChange = vi.fn();
+      const { view } = await renderEditor(source, { onMarkdownChange });
+
+      moveCursor(view, findLastTextBlockEndCursor(view));
+      typeText(view, " after");
+
+      await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+      const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+      expect(markdown).toBe(`${source} after`);
+    }
+  );
+
+  it("keeps a single escaped markdown delimiter escaped while serializing later edits", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("\\*", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, "x");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("\\*x");
+  });
+
+  it("keeps escaped code content intact while serializing later edits", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("`\\*` tail", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " after");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("`\\*` tail after");
+  });
+
+  it("keeps identical escaped literals separate from live markdown while serializing later edits", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("\\*literal\\*\n\n*literal*", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " after");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("\\*literal\\*\n\n*literal* after");
+  });
+
+  it("keeps identical escaped code content separate from live markdown while serializing later edits", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("`\\*literal\\*`\n\n*literal*", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " after");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("`\\*literal\\*`\n\n*literal* after");
+  });
+
   it("keeps intraword underscores in identifiers as plain text", async () => {
     const { container, view } = await renderEditor("user_info_data user__meta__data");
 
@@ -7761,6 +7862,20 @@ describe("MarkdownPaper editing", () => {
       expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
     }
 
+    await settleMarkdownListener();
+  });
+
+  it("keeps IME text plain when stale strong marks carry into a new paragraph", async () => {
+    const { editor, view } = await renderEditor("**mock**");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const strong = view.state.schema.marks.strong;
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    expect(pressEnter(view)).toBe(true);
+    view.dispatch(view.state.tr.setStoredMarks([strong.create()]));
+    insertTextThroughInputHandler(view, "示例");
+
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**mock**\n\n示例");
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -30,8 +30,10 @@ import {
   defaultMarkdownShortcuts,
   findSearchMatchesInDoc,
   findVisibleSearchMatchesInState,
+  markraLiveMarkdownSpecs,
   mermaidThemeFromElement,
   scrollAiEditorPreviewIntoView,
+  setLiveMarkdownSourceContext,
   showAiEditorPreview,
   showAiSelectionHold,
   updateSearchDecorations,
@@ -6993,6 +6995,31 @@ describe("MarkdownPaper editing", () => {
 
     const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
     expect(markdown).toBe("`\\*literal\\*`\n\n*literal* after");
+  });
+
+  it("keeps escaped source markdown literal after replacing the visual document", async () => {
+    const onMarkdownChange = vi.fn();
+    const { editor, view } = await renderEditor("mock", { onMarkdownChange });
+    const transaction = editor.action((ctx) => {
+      const sourceMarkdown = "\\*\\*12\\*\\*";
+      const sourceDocument = ctx.get(parserCtx)(sourceMarkdown);
+      return setLiveMarkdownSourceContext(
+        view.state.tr
+          .replace(0, view.state.doc.content.size, new Slice(sourceDocument.content, 0, 0))
+          .setMeta("addToHistory", false),
+        markraLiveMarkdownSpecs(ctx),
+        sourceMarkdown
+      );
+    });
+
+    view.dispatch(transaction);
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, "x");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("\\*\\*12\\*\\*x");
   });
 
   it("keeps intraword underscores in identifiers as plain text", async () => {

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -37,6 +37,7 @@ import {
   markraListTogglePlugin,
   markraLinkImageLivePlugin,
   markraLiveMarkdownPlugin,
+  markraLiveMarkdownSpecs,
   markraMarkdownSourcePastePlugin,
   markraMarkdownShortcuts,
   markraMathCaretAnchorSuppressionPlugin,
@@ -54,6 +55,7 @@ import {
   getActiveSpellcheckMatch,
   normalizeMarkdownShortcuts,
   replaceSpellcheckMatch,
+  restoreEscapedLiveMarkdownSource,
   serializeLinkImageLiveMarkdown,
   updateSpellcheckOptions,
   type MarkdownShortcutMap,
@@ -465,16 +467,22 @@ function MilkdownEditorSurface({
               if (!deferredMarkdownChange) return;
 
               const view = editorCtx.get(editorViewCtx);
-              const markdownDocument = view.state.doc === doc ? doc : view.state.doc;
+              const markdownState = view.state;
+              const markdownDocument = markdownState.doc === doc ? doc : markdownState.doc;
               const serializeMarkdown = editorCtx.get(serializerCtx);
               const link = linkSchema.type(editorCtx);
               const image = imageSchema.type(editorCtx);
+              const liveMarkdownSpecs = markraLiveMarkdownSpecs(editorCtx, { highlight: highlightSyntaxEnabled });
 
               // Serializing the whole ProseMirror document on every transaction is the hot path for long files.
               deferredMarkdownChange.schedule(() => {
                 try {
                   onMarkdownChangeRef.current(
-                    serializeLinkImageLiveMarkdown(markdownDocument, serializeMarkdown, link, image)
+                    restoreEscapedLiveMarkdownSource(
+                      serializeLinkImageLiveMarkdown(markdownDocument, serializeMarkdown, link, image),
+                      markdownState,
+                      liveMarkdownSpecs
+                    )
                   );
                 } catch {
                   // Milkdown can flush a delayed update after teardown in tests or fast window closes.

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { editorViewCtx, parserCtx, serializerCtx, type Editor } from "@milkdown/kit/core";
 import { imageSchema, linkSchema } from "@milkdown/kit/preset/commonmark";
-import { Fragment, Slice, type Node as ProseNode, type NodeType } from "@milkdown/kit/prose/model";
+import { Fragment, Slice, type MarkType, type Node as ProseNode, type NodeType } from "@milkdown/kit/prose/model";
 import { NodeSelection, Selection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import type { AiDiffResult, AiDocumentAnchor, AiHeadingAnchor, AiSelectionContext } from "@markra/ai";
@@ -13,8 +13,10 @@ import {
   confirmAiEditorResultApplied,
   listAiEditorPreviewResults,
   findVisibleSearchMatchesInState,
+  markraLiveMarkdownSpecs,
   scrollAiEditorPreviewIntoView,
   scrollSearchMatchIntoView,
+  restoreEscapedLiveMarkdownSource,
   serializeLinkImageLiveMarkdown,
   showAiEditorPreview,
   showAiSelectionHold,
@@ -92,6 +94,20 @@ function comparableSerializedMarkdown(markdown: string) {
     .replace(/\r\n?/gu, "\n")
     .replace(/[ \t]+$/gmu, "")
     .trim();
+}
+
+function serializeCurrentEditorMarkdown(
+  view: EditorView,
+  serializeMarkdown: (doc: ProseNode) => string,
+  link: MarkType,
+  image: NodeType,
+  liveMarkdownSpecs: ReturnType<typeof markraLiveMarkdownSpecs>
+) {
+  return restoreEscapedLiveMarkdownSource(
+    serializeLinkImageLiveMarkdown(view.state.doc, serializeMarkdown, link, image),
+    view.state,
+    liveMarkdownSpecs
+  );
 }
 
 type EditorReadyOptions = {
@@ -475,11 +491,12 @@ export function useEditorController() {
     try {
       return editorRef.current?.action((ctx) => {
         const view = ctx.get(editorViewCtx);
-        return serializeLinkImageLiveMarkdown(
-          view.state.doc,
+        return serializeCurrentEditorMarkdown(
+          view,
           ctx.get(serializerCtx),
           linkSchema.type(ctx),
-          imageSchema.type(ctx)
+          imageSchema.type(ctx),
+          markraLiveMarkdownSpecs(ctx)
         );
       }) ?? fallbackContent;
     } catch {
@@ -498,7 +515,13 @@ export function useEditorController() {
         const serializer = ctx.get(serializerCtx);
         const link = linkSchema.type(ctx);
         const image = imageSchema.type(ctx);
-        const currentMarkdown = serializeLinkImageLiveMarkdown(view.state.doc, serializer, link, image);
+        const currentMarkdown = serializeCurrentEditorMarkdown(
+          view,
+          serializer,
+          link,
+          image,
+          markraLiveMarkdownSpecs(ctx)
+        );
         const parsedMarkdown = serializeLinkImageLiveMarkdown(parseMarkdown(markdown), serializer, link, image);
 
         return comparableSerializedMarkdown(currentMarkdown) === comparableSerializedMarkdown(parsedMarkdown);
@@ -528,7 +551,13 @@ export function useEditorController() {
         const serializer = ctx.get(serializerCtx);
         const link = linkSchema.type(ctx);
         const image = imageSchema.type(ctx);
-        const currentMarkdown = serializeLinkImageLiveMarkdown(view.state.doc, serializer, link, image);
+        const currentMarkdown = serializeCurrentEditorMarkdown(
+          view,
+          serializer,
+          link,
+          image,
+          markraLiveMarkdownSpecs(ctx)
+        );
         if (comparableSerializedMarkdown(currentMarkdown) === comparableSerializedMarkdown(markdown)) {
           if (
             options.addToHistory &&

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -18,6 +18,7 @@ import {
   scrollSearchMatchIntoView,
   restoreEscapedLiveMarkdownSource,
   serializeLinkImageLiveMarkdown,
+  setLiveMarkdownSourceContext,
   showAiEditorPreview,
   showAiSelectionHold,
   updateSearchDecorations,
@@ -515,12 +516,13 @@ export function useEditorController() {
         const serializer = ctx.get(serializerCtx);
         const link = linkSchema.type(ctx);
         const image = imageSchema.type(ctx);
+        const liveMarkdownSpecs = markraLiveMarkdownSpecs(ctx);
         const currentMarkdown = serializeCurrentEditorMarkdown(
           view,
           serializer,
           link,
           image,
-          markraLiveMarkdownSpecs(ctx)
+          liveMarkdownSpecs
         );
         const parsedMarkdown = serializeLinkImageLiveMarkdown(parseMarkdown(markdown), serializer, link, image);
 
@@ -551,12 +553,13 @@ export function useEditorController() {
         const serializer = ctx.get(serializerCtx);
         const link = linkSchema.type(ctx);
         const image = imageSchema.type(ctx);
+        const liveMarkdownSpecs = markraLiveMarkdownSpecs(ctx);
         const currentMarkdown = serializeCurrentEditorMarkdown(
           view,
           serializer,
           link,
           image,
-          markraLiveMarkdownSpecs(ctx)
+          liveMarkdownSpecs
         );
         if (comparableSerializedMarkdown(currentMarkdown) === comparableSerializedMarkdown(markdown)) {
           if (
@@ -565,15 +568,23 @@ export function useEditorController() {
             comparableSerializedMarkdown(options.historyBaselineMarkdown) !== comparableSerializedMarkdown(markdown)
           ) {
             const baselineDocument = parseMarkdown(options.historyBaselineMarkdown);
-            const baselineTransaction = view.state.tr
-              .replace(0, view.state.doc.content.size, new Slice(baselineDocument.content, 0, 0))
-              .setMeta("addToHistory", false);
+            const baselineTransaction = setLiveMarkdownSourceContext(
+              view.state.tr
+                .replace(0, view.state.doc.content.size, new Slice(baselineDocument.content, 0, 0))
+                .setMeta("addToHistory", false),
+              liveMarkdownSpecs,
+              options.historyBaselineMarkdown
+            );
             view.dispatch(baselineTransaction);
 
             const parsedDocument = parseMarkdown(markdown);
             const selectionPosition = Math.min(view.state.selection.from, parsedDocument.content.size);
-            const historyTransaction = view.state.tr
-              .replace(0, view.state.doc.content.size, new Slice(parsedDocument.content, 0, 0));
+            const historyTransaction = setLiveMarkdownSourceContext(
+              view.state.tr
+                .replace(0, view.state.doc.content.size, new Slice(parsedDocument.content, 0, 0)),
+              liveMarkdownSpecs,
+              markdown
+            );
 
             historyTransaction.setSelection(TextSelection.near(historyTransaction.doc.resolve(selectionPosition))).scrollIntoView();
             view.dispatch(historyTransaction);
@@ -595,8 +606,12 @@ export function useEditorController() {
 
         const parsedDocument = parseMarkdown(markdown);
         const selectionPosition = Math.min(view.state.selection.from, parsedDocument.content.size);
-        const tr = view.state.tr
-          .replace(0, view.state.doc.content.size, new Slice(parsedDocument.content, 0, 0));
+        const tr = setLiveMarkdownSourceContext(
+          view.state.tr
+            .replace(0, view.state.doc.content.size, new Slice(parsedDocument.content, 0, 0)),
+          liveMarkdownSpecs,
+          markdown
+        );
 
         if (!options.addToHistory) {
           tr.setMeta("addToHistory", false);

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -1082,6 +1082,16 @@ export function restoreEscapedLiveMarkdownSource(markdown: string, state: Editor
   return restoreProtectedMarkdownSegments(restored, protectedSegments);
 }
 
+export function setLiveMarkdownSourceContext(
+  transaction: Transaction,
+  specs: LiveMarkdownSpec[],
+  markdown: string
+) {
+  return transaction.setMeta(liveMarkdownKey, {
+    suppressedLiteralRanges: findSuppressedLiteralRanges(transaction.doc, specs, markdown)
+  } satisfies Partial<LiveMarkdownPluginState>);
+}
+
 function moveCursorOverLiveMarkdownDelimiter(
   view: EditorView,
   specs: LiveMarkdownSpec[],
@@ -1304,7 +1314,10 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       }),
       apply: (tr, value, _oldState, newState): LiveMarkdownPluginState => {
         const meta = tr.getMeta(liveMarkdownKey) as Partial<LiveMarkdownPluginState> | undefined;
-        const suppressedLiteralRanges = mapSuppressedLiteralRanges(value.suppressedLiteralRanges, tr);
+        const suppressedLiteralRanges =
+          meta && "suppressedLiteralRanges" in meta
+            ? meta.suppressedLiteralRanges ?? []
+            : mapSuppressedLiteralRanges(value.suppressedLiteralRanges, tr);
         if (meta && "exitedFoldedRange" in meta) {
           return {
             suppressActiveAt: null,

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -235,7 +235,7 @@ function mapSuppressedLiteralRanges(
 
   return ranges.flatMap((range) => {
     const from = tr.mapping.map(range.from, -1);
-    const to = tr.mapping.map(range.to, 1);
+    const to = tr.mapping.map(range.to, -1);
 
     if (to <= from) return [];
 
@@ -415,6 +415,27 @@ function insertTextAfterExitedFoldedMarkdown(
   if (selection.from !== pluginState?.exitedFoldedRange?.cursor) return false;
 
   const marks = selection.$from.marks().filter((mark) => !markTypes.includes(mark.type));
+  const insertedText = view.state.schema.text(text, marks);
+  const transaction = view.state.tr.replaceSelectionWith(insertedText, false).setStoredMarks(marks);
+
+  view.dispatch(transaction.scrollIntoView());
+  return true;
+}
+
+function insertMulticharTextWithoutStaleManagedMarks(
+  view: EditorView,
+  text: string,
+  markTypes: MarkType[]
+) {
+  // IME commits can arrive after an empty paragraph inherits stale inline marks from a nearby live Markdown span.
+  if (Array.from(text).length <= 1) return false;
+
+  const { selection, storedMarks } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+  if (!emptyTextblockSelection(view.state)) return false;
+  if (!hasManagedMark(storedMarks, markTypes)) return false;
+
+  const marks = storedMarks?.filter((mark) => !markTypes.includes(mark.type)) ?? [];
   const insertedText = view.state.schema.text(text, marks);
   const transaction = view.state.tr.replaceSelectionWith(insertedText, false).setStoredMarks(marks);
 
@@ -839,6 +860,228 @@ export function finalizeActiveLiveMarkdown(view: EditorView, specs: LiveMarkdown
   return true;
 }
 
+const hasRestorableLiveMarkdownDelimiterPattern = /\\[*_~`=]/u;
+const restorableLiveMarkdownDelimiterCharacters = new Set(["*", "_", "~", "`", "="]);
+const singleRestorableLiveMarkdownDelimiters = new Set(["*", "_", "~", "`", "="]);
+
+type SerializedMarkdownOperation = {
+  candidates: string[];
+  from: number;
+  replacement: string;
+  to: number;
+};
+
+type ProtectedMarkdownSegment = {
+  placeholder: string;
+  value: string;
+};
+
+function hasRestorableLiveMarkdownDelimiter(text: string) {
+  return Array.from(text).some((character) => restorableLiveMarkdownDelimiterCharacters.has(character));
+}
+
+function escapedLiveMarkdownDelimiters(text: string) {
+  return text.replace(/([*_~`=])/gu, "\\$1");
+}
+
+function escapedLiteralMarkdownSource(source: string, marker: string) {
+  const content = source.slice(marker.length, source.length - marker.length);
+  return `${escapedMarkerSource(marker)}${content}${escapedMarkerSource(marker)}`;
+}
+
+function serializedLiveMarkdownCandidates(source: string, marker: string) {
+  const candidates = [escapedLiveMarkdownDelimiters(source)];
+
+  // The Markdown serializer only needs one escaped leading "=" to keep a highlight-looking literal inert.
+  if (marker === "=".repeat(marker.length)) {
+    candidates.push(`\\${source}`);
+  }
+
+  return [...new Set(candidates)];
+}
+
+function escapedLiteralMarkdownOperation(
+  state: EditorState,
+  range: SuppressedLiteralMarkdownRange
+): SerializedMarkdownOperation | null {
+  const source = state.doc.textBetween(range.from, range.to);
+  if (!hasRestorableLiveMarkdownDelimiter(source)) return null;
+
+  return {
+    candidates: serializedLiveMarkdownCandidates(source, range.marker),
+    from: range.from,
+    replacement: escapedLiteralMarkdownSource(source, range.marker),
+    to: range.to
+  };
+}
+
+function singleDelimiterOperation(
+  node: ProseNode,
+  blockStart: number,
+  specs: LiveMarkdownSpec[]
+): SerializedMarkdownOperation | null {
+  const source = node.textContent;
+  if (!singleRestorableLiveMarkdownDelimiters.has(source)) return null;
+  if (!textRangeAvoidsMarks(node, 0, source.length, getMarkTypesForKind(specs, "inlineCode"))) return null;
+
+  return {
+    candidates: [`\\${source}`],
+    from: blockStart,
+    replacement: source,
+    to: blockStart + source.length
+  };
+}
+
+function liveMarkdownOperation(
+  node: ProseNode,
+  blockStart: number,
+  range: LiveMarkdownRange
+): SerializedMarkdownOperation {
+  const source = node.textContent.slice(range.from, range.to);
+
+  return {
+    candidates: serializedLiveMarkdownCandidates(source, range.marker),
+    from: blockStart + range.from,
+    replacement: source,
+    to: blockStart + range.to
+  };
+}
+
+function serializedMarkdownOperations(state: EditorState, specs: LiveMarkdownSpec[]) {
+  const pluginState = liveMarkdownKey.getState(state) as LiveMarkdownPluginState | undefined;
+  const suppressedLiteralRanges = pluginState?.suppressedLiteralRanges ?? [];
+  const operations: SerializedMarkdownOperation[] = [];
+
+  for (const range of suppressedLiteralRanges) {
+    const operation = escapedLiteralMarkdownOperation(state, range);
+    if (operation) operations.push(operation);
+  }
+
+  state.doc.descendants((node, position) => {
+    if (!node.isTextblock || node.type.spec.code) return;
+
+    const blockStart = position + 1;
+    const singleOperation = singleDelimiterOperation(node, blockStart, specs);
+    if (singleOperation) operations.push(singleOperation);
+
+    for (const range of getLiveMarkdownRangesInTextblock(node, specs)) {
+      const from = blockStart + range.from;
+      const to = blockStart + range.to;
+      if (isSuppressedLiteralRange(suppressedLiteralRanges, from, to, range.marker)) continue;
+
+      operations.push(liveMarkdownOperation(node, blockStart, range));
+    }
+  });
+
+  return operations.sort((left, right) => left.from - right.from || right.to - left.to);
+}
+
+function protectMarkdownSegment(value: string, protectedSegments: ProtectedMarkdownSegment[]) {
+  const placeholder = `\u0000markra-protected-markdown-${protectedSegments.length}\u0000`;
+  protectedSegments.push({ placeholder, value });
+  return placeholder;
+}
+
+function protectFencedCodeBlocks(markdown: string, protectedSegments: ProtectedMarkdownSegment[]) {
+  return markdown.replace(
+    /(^|\n)([ \t]{0,3})(`{3,}|~{3,})[^\n]*(?:\n[\s\S]*?\n[ \t]{0,3}\3[ \t]*(?=\n|$))/g,
+    (match) => protectMarkdownSegment(match, protectedSegments)
+  );
+}
+
+function protectInlineCodeSpans(markdown: string, protectedSegments: ProtectedMarkdownSegment[]) {
+  let protectedMarkdown = "";
+  let index = 0;
+
+  while (index < markdown.length) {
+    const character = markdown[index];
+    if (character === "\\") {
+      protectedMarkdown += markdown.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+
+    if (character !== "`") {
+      protectedMarkdown += character;
+      index += 1;
+      continue;
+    }
+
+    const openingStart = index;
+    while (markdown[index] === "`") index += 1;
+
+    const marker = markdown.slice(openingStart, index);
+    const closingStart = markdown.indexOf(marker, index);
+    if (closingStart < 0) {
+      protectedMarkdown += marker;
+      continue;
+    }
+
+    const closingEnd = closingStart + marker.length;
+    protectedMarkdown += protectMarkdownSegment(markdown.slice(openingStart, closingEnd), protectedSegments);
+    index = closingEnd;
+  }
+
+  return protectedMarkdown;
+}
+
+function protectMarkdownCode(markdown: string) {
+  const protectedSegments: ProtectedMarkdownSegment[] = [];
+  const protectedMarkdown = protectInlineCodeSpans(
+    protectFencedCodeBlocks(markdown, protectedSegments),
+    protectedSegments
+  );
+
+  return { protectedMarkdown, protectedSegments };
+}
+
+function restoreProtectedMarkdownSegments(markdown: string, protectedSegments: ProtectedMarkdownSegment[]) {
+  let restored = markdown;
+
+  for (const { placeholder, value } of protectedSegments) {
+    restored = restored.split(placeholder).join(value);
+  }
+
+  return restored;
+}
+
+function findSerializedMarkdownCandidate(markdown: string, candidates: string[], from: number) {
+  let match: { index: number; value: string } | null = null;
+
+  for (const value of candidates) {
+    const index = markdown.indexOf(value, from);
+    if (index < 0) continue;
+    if (!match || index < match.index || (index === match.index && value.length > match.value.length)) {
+      match = { index, value };
+    }
+  }
+
+  return match;
+}
+
+export function restoreEscapedLiveMarkdownSource(markdown: string, state: EditorState, specs: LiveMarkdownSpec[]) {
+  if (!hasRestorableLiveMarkdownDelimiterPattern.test(markdown)) return markdown;
+
+  const operations = serializedMarkdownOperations(state, specs);
+  if (operations.length === 0) return markdown;
+
+  const { protectedMarkdown, protectedSegments } = protectMarkdownCode(markdown);
+  let restored = "";
+  let markdownCursor = 0;
+
+  for (const operation of operations) {
+    const match = findSerializedMarkdownCandidate(protectedMarkdown, operation.candidates, markdownCursor);
+    if (!match) continue;
+
+    restored += protectedMarkdown.slice(markdownCursor, match.index);
+    restored += operation.replacement;
+    markdownCursor = match.index + match.value.length;
+  }
+
+  restored += protectedMarkdown.slice(markdownCursor);
+  return restoreProtectedMarkdownSegments(restored, protectedSegments);
+}
+
 function moveCursorOverLiveMarkdownDelimiter(
   view: EditorView,
   specs: LiveMarkdownSpec[],
@@ -1149,7 +1392,9 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           pluginState?.suppressedLiteralRanges ?? []
         );
       },
-      handleTextInput: (view, _from, _to, text) => insertTextAfterExitedFoldedMarkdown(view, text, managedMarkTypes),
+      handleTextInput: (view, _from, _to, text) =>
+        insertMulticharTextWithoutStaleManagedMarks(view, text, managedMarkTypes) ||
+        insertTextAfterExitedFoldedMarkdown(view, text, managedMarkTypes),
       handleKeyDown: (view, event) => {
         const hasModifier = event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
 


### PR DESCRIPTION
## Summary
- Restore live Markdown delimiters after visual editor serialization without touching escaped literals or code spans.
- Preserve escaped literal context when source Markdown replaces the visual document.
- Keep deferred Markdown sync tied to the captured editor state so serialized text and live ranges stay aligned.
- Prevent stale managed marks from formatting multi-character IME commits in empty paragraphs.

## Why
- Milkdown serializes Markdown punctuation in plain text as escaped characters, so live Markdown source such as `**你好**` could sync as `\*\*你好\*\*`.
- Source edits such as `\*\*12\*\*` must remain literal after syncing back through the visual editor.
- A broad unescape would corrupt intentional literal escapes and inline code, so this scopes restoration to known live Markdown ranges.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx` passed, 469 tests
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed

## Risk
- Moderate: touches visual editor Markdown serialization and source sync. Regression tests cover live delimiters, escaped literals, source replacements, inline code, duplicate escaped text, and IME stale mark handling.
