### PR TITLE
fix(desktop): guard stale Tauri event cleanup

### DIFF
--- a/apps/desktop/src/runtime/index.test.ts
+++ b/apps/desktop/src/runtime/index.test.ts
@@ -1,0 +1,40 @@
+import { listen } from "@tauri-apps/api/event";
+import { desktopRuntime } from "./index";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: vi.fn(),
+  listen: vi.fn()
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: vi.fn(() => "macos"),
+  version: vi.fn(() => "26.5.1")
+}));
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  load: vi.fn()
+}));
+
+vi.mock("@markra/shared", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@markra/shared")>(),
+  hasTauriRuntime: vi.fn(() => true)
+}));
+
+const mockedListen = vi.mocked(listen);
+
+describe("desktop runtime events", () => {
+  beforeEach(() => {
+    mockedListen.mockReset();
+  });
+
+  it("ignores stale Tauri unlisten failures and only cleans up once", async () => {
+    const cleanup = vi.fn().mockRejectedValue(new Error("undefined is not an object (evaluating 'listeners[eventId].handlerId')"));
+    mockedListen.mockResolvedValue(cleanup);
+
+    const stopListening = await desktopRuntime.events.listen("markra://synthetic-event", () => {});
+
+    await expect(Promise.resolve(stopListening())).resolves.toBeUndefined();
+    await expect(Promise.resolve(stopListening())).resolves.toBeUndefined();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -1,4 +1,4 @@
-import { emit, listen } from "@tauri-apps/api/event";
+import { emit } from "@tauri-apps/api/event";
 import { platform as tauriPlatform, version as tauriVersion, type Platform as TauriPlatform } from "@tauri-apps/plugin-os";
 import { load } from "@tauri-apps/plugin-store";
 import { hasTauriRuntime } from "@markra/shared";
@@ -14,6 +14,7 @@ import * as spellcheck from "./tauri/spellcheck";
 import * as updater from "./tauri/updater";
 import * as webResource from "./tauri/web-resource";
 import * as windowRuntime from "./tauri/window";
+import { listenNativeEvent } from "./tauri/events";
 
 type DesktopPlatform = "macos" | "windows" | "linux";
 
@@ -61,7 +62,7 @@ export const desktopRuntime = {
   events: {
     emit,
     isAvailable: hasTauriRuntime,
-    listen
+    listen: listenNativeEvent
   },
   features: {
     ai: true,

--- a/apps/desktop/src/runtime/tauri/acp.test.ts
+++ b/apps/desktop/src/runtime/tauri/acp.test.ts
@@ -65,7 +65,7 @@ describe("native ACP runtime", () => {
     const handler = vi.fn();
     mockedListen.mockResolvedValue(cleanup);
 
-    await expect(listenNativeAcpAgentMessages(handler)).resolves.toBe(cleanup);
+    const stopListening = await listenNativeAcpAgentMessages(handler);
 
     expect(mockedListen).toHaveBeenCalledWith("markra://acp-agent-message", expect.any(Function));
     const eventHandler = mockedListen.mock.calls[0]?.[1];
@@ -81,6 +81,8 @@ describe("native ACP runtime", () => {
       message: "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}",
       type: "message"
     });
+    await Promise.resolve(stopListening());
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("stops an ACP agent subprocess", async () => {

--- a/apps/desktop/src/runtime/tauri/acp.ts
+++ b/apps/desktop/src/runtime/tauri/acp.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { listenNativeEvent } from "./events";
 
 const acpAgentMessageEvent = "markra://acp-agent-message";
 
@@ -50,7 +50,7 @@ export function stopNativeAcpAgent(connectionId: string) {
 }
 
 export function listenNativeAcpAgentMessages(handler: (event: NativeAcpAgentMessageEvent) => unknown) {
-  return listen<NativeAcpAgentMessageEvent>(acpAgentMessageEvent, (event) => {
+  return listenNativeEvent<NativeAcpAgentMessageEvent>(acpAgentMessageEvent, (event) => {
     handler(event.payload);
   });
 }

--- a/apps/desktop/src/runtime/tauri/events.ts
+++ b/apps/desktop/src/runtime/tauri/events.ts
@@ -1,0 +1,31 @@
+import { listen, type Event, type EventName, type Options } from "@tauri-apps/api/event";
+
+type NativeEventHandler<TPayload> = (event: Event<TPayload>) => unknown;
+type NativeEventCleanup = () => unknown;
+
+export function safeNativeEventCleanup(cleanup: NativeEventCleanup): NativeEventCleanup {
+  let cleaned = false;
+
+  return async () => {
+    if (cleaned) return;
+
+    cleaned = true;
+    try {
+      await cleanup();
+    } catch {
+      // Tauri 2.11 can throw when a listener id was already removed natively.
+    }
+  };
+}
+
+export async function listenNativeEvent<TPayload>(
+  event: EventName,
+  handler: NativeEventHandler<TPayload>,
+  options?: Options
+): Promise<NativeEventCleanup> {
+  const cleanup = options === undefined
+    ? await listen<TPayload>(event, handler)
+    : await listen<TPayload>(event, handler, options);
+
+  return safeNativeEventCleanup(cleanup);
+}

--- a/apps/desktop/src/runtime/tauri/file.ts
+++ b/apps/desktop/src/runtime/tauri/file.ts
@@ -1,9 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { confirm, open, save } from "@tauri-apps/plugin-dialog";
 import { debug, fileNameFromPath } from "@markra/shared";
 import { networkSettingsForNativeRequest } from "./network";
+import { listenNativeEvent, safeNativeEventCleanup } from "./events";
 import type {
   PicGoImageUploadSettings,
   S3ImageUploadSettings,
@@ -445,7 +445,7 @@ export async function takeNativeOpenedMarkdownPaths(): Promise<string[]> {
 }
 
 export async function listenNativeOpenedMarkdownPaths(onPaths: (paths: string[]) => unknown | Promise<unknown>) {
-  return listen<OpenedMarkdownPathsPayload>(openedMarkdownPathsEvent, (event) => {
+  return listenNativeEvent<OpenedMarkdownPathsPayload>(openedMarkdownPathsEvent, (event) => {
     const paths = normalizeOpenedMarkdownPaths(event.payload?.paths);
     if (paths.length === 0) return;
 
@@ -645,7 +645,7 @@ export async function loadNativeMarkdownFilesForPath(
 
     options.signal?.addEventListener("abort", abortHandler);
 
-    listen<MarkdownFileTreeLoadEventResponse>(markdownFileTreeLoadEvent, (event) => {
+    listenNativeEvent<MarkdownFileTreeLoadEventResponse>(markdownFileTreeLoadEvent, (event) => {
       const payload = event.payload;
       if (payload.requestId !== requestId) return;
 
@@ -1453,7 +1453,7 @@ export async function watchNativeMarkdownFile(
   debug(() => ["[markra-history] native watch subscribe", {
     path
   }]);
-  const unlistenFile = await listen<MarkdownFileChangedPayload>(markdownFileChangedEvent, (event) => {
+  const unlistenFile = await listenNativeEvent<MarkdownFileChangedPayload>(markdownFileChangedEvent, (event) => {
     if (event.payload.path !== path) return;
     debug(() => ["[markra-history] native watch file event", {
       path: event.payload.path
@@ -1465,7 +1465,7 @@ export async function watchNativeMarkdownFile(
   try {
     if (onTreeChange) {
       const rootPath = parentPathFromPath(path);
-      unlistenTree = await listen<MarkdownTreeChangedPayload>(markdownTreeChangedEvent, (event) => {
+      unlistenTree = await listenNativeEvent<MarkdownTreeChangedPayload>(markdownTreeChangedEvent, (event) => {
         if (event.payload.rootPath !== rootPath) return;
         debug(() => ["[markra-history] native watch tree event", {
           path: event.payload.path,
@@ -1504,7 +1504,7 @@ export async function watchNativeMarkdownTree(
   onTreeChange: NativeMarkdownTreeChangeHandler
 ) {
   const rootPath = treeRootPathFromPath(path);
-  const unlistenTree = await listen<MarkdownTreeChangedPayload>(markdownTreeChangedEvent, (event) => {
+  const unlistenTree = await listenNativeEvent<MarkdownTreeChangedPayload>(markdownTreeChangedEvent, (event) => {
     if (event.payload.rootPath !== rootPath) return;
     onTreeChange(event.payload.path);
   });
@@ -1524,7 +1524,7 @@ export async function watchNativeMarkdownTree(
 
 export async function installNativeMarkdownFileDrop(onDrop: NativeMarkdownFileDropHandler) {
   try {
-    return await getCurrentWindow().onDragDropEvent((event) => {
+    return safeNativeEventCleanup(await getCurrentWindow().onDragDropEvent((event) => {
       if (event.payload.type !== "drop") return;
       const point = nativeDropPointFromPosition(event.payload.position);
 
@@ -1533,7 +1533,7 @@ export async function installNativeMarkdownFileDrop(onDrop: NativeMarkdownFileDr
 
         onDrop(target);
       }).catch(() => {});
-    });
+    }));
   } catch {
     return () => {};
   }

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -1,4 +1,3 @@
-import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -16,6 +15,7 @@ import {
 import type { MarkdownShortcutMap } from "@markra/editor";
 import type { AppLanguage } from "@markra/shared";
 import type { NativeMarkdownFolderFile } from "./file";
+import { listenNativeEvent } from "./events";
 
 export type NativeMenuHandlers = Partial<Record<NativeStaticMenuCommand, () => unknown | Promise<unknown>>> & {
   clearRecentFiles?: () => unknown | Promise<unknown>;
@@ -140,7 +140,7 @@ function runNativeMenuAction(payload: NativeMenuCommandPayload, handlers: Native
 }
 
 export async function listenNativeApplicationMenuCommands(handlers: NativeMenuHandlers) {
-  return listen<NativeMenuCommandPayload>("markra://menu-command", (event) => {
+  return listenNativeEvent<NativeMenuCommandPayload>("markra://menu-command", (event) => {
     runNativeMenuAction(event.payload, handlers);
   });
 }

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -85,17 +85,19 @@ describe("native window actions", () => {
       onCloseRequested: onCloseRequestedNative
     } as unknown as ReturnType<typeof getCurrentWindow>);
 
-    await expect(listenNativeWindowCloseRequested(onCloseRequested)).resolves.toBe(cleanup);
+    const stopListening = await listenNativeWindowCloseRequested(onCloseRequested);
     const nativeHandler = onCloseRequestedNative.mock.calls[0]?.[0] as ((event: { preventDefault: () => unknown }) => unknown) | undefined;
     if (!nativeHandler) throw new Error("close request listener was not registered");
     const preventDefault = vi.fn();
     await nativeHandler({ preventDefault });
+    await Promise.resolve(stopListening());
 
     expect(onCloseRequestedNative).toHaveBeenCalledWith(expect.any(Function));
     expect(onCloseRequested).toHaveBeenCalledWith({ preventDefault: expect.any(Function) });
     const closeRequestEvent = onCloseRequested.mock.calls[0]?.[0] as { preventDefault: () => unknown } | undefined;
     closeRequestEvent?.preventDefault();
     expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("listens for native app exit requests", async () => {
@@ -103,13 +105,26 @@ describe("native window actions", () => {
     mockedListen.mockImplementation((_event, callback) => Promise.resolve(cleanup));
     const onExitRequested = vi.fn();
 
-    await expect(listenNativeAppExitRequested(onExitRequested)).resolves.toBe(cleanup);
+    const stopListening = await listenNativeAppExitRequested(onExitRequested);
     const onEvent = mockedListen.mock.calls[0]?.[1] as (() => unknown) | undefined;
     if (!onEvent) throw new Error("app exit request listener was not registered");
     onEvent();
+    await Promise.resolve(stopListening());
 
     expect(mockedListen).toHaveBeenCalledWith("markra://app-exit-requested", expect.any(Function));
     expect(onExitRequested).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores stale Tauri unlisten failures for native app exit requests", async () => {
+    const cleanup = vi.fn().mockRejectedValue(new Error("undefined is not an object (evaluating 'listeners[eventId].handlerId')"));
+    mockedListen.mockResolvedValue(cleanup);
+
+    const stopListening = await listenNativeAppExitRequested(() => {});
+
+    await expect(Promise.resolve(stopListening())).resolves.toBeUndefined();
+    await expect(Promise.resolve(stopListening())).resolves.toBeUndefined();
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("confirms and exits the native app", async () => {
@@ -260,15 +275,17 @@ describe("native window actions", () => {
     });
     const onTarget = vi.fn();
 
-    await expect(listenNativeSettingsWindowTarget(onTarget)).resolves.toBe(cleanup);
+    const stopListening = await listenNativeSettingsWindowTarget(onTarget);
     const onEvent = mockedListen.mock.calls[0]?.[1] as ((event: { payload: { target?: unknown } }) => unknown) | undefined;
     if (!onEvent) throw new Error("settings target listener was not registered");
     onEvent({ payload: { target: "exportPandocPath" } });
     onEvent({ payload: { target: "unknown" } });
+    await Promise.resolve(stopListening());
 
     expect(mockedListen).toHaveBeenCalledWith("markra://settings-window-target", expect.any(Function));
     expect(onTarget).toHaveBeenCalledTimes(1);
     expect(onTarget).toHaveBeenCalledWith("exportPandocPath");
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("lists normalized editor window restore states from Tauri", async () => {

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { exit } from "@tauri-apps/plugin-process";
+import { listenNativeEvent, safeNativeEventCleanup } from "./events";
 
 export type NativeSettingsWindowTarget = "exportPandocPath";
 
@@ -52,8 +53,7 @@ export async function listenNativeSettingsWindowTarget(onTarget: (target: Native
     return () => {};
   }
 
-  const { listen } = await import("@tauri-apps/api/event");
-  return listen<NativeSettingsWindowTargetPayload>(nativeSettingsWindowTargetEvent, (event) => {
+  return listenNativeEvent<NativeSettingsWindowTargetPayload>(nativeSettingsWindowTargetEvent, (event) => {
     if (isNativeSettingsWindowTarget(event.payload.target)) {
       onTarget(event.payload.target);
     }
@@ -65,8 +65,7 @@ export async function listenNativeAppExitRequested(onExitRequested: () => unknow
     return () => {};
   }
 
-  const { listen } = await import("@tauri-apps/api/event");
-  return listen(nativeAppExitRequestedEvent, () => onExitRequested());
+  return listenNativeEvent(nativeAppExitRequestedEvent, () => onExitRequested());
 }
 
 export function openNativeExternalUrl(url: string) {
@@ -164,11 +163,11 @@ export async function listenNativeWindowCloseRequested(
   const currentWindow = await getCurrentNativeWindow();
   if (!currentWindow) return () => {};
 
-  return currentWindow.onCloseRequested(async (event) => {
+  return safeNativeEventCleanup(await currentWindow.onCloseRequested(async (event) => {
     await onCloseRequested({
       preventDefault: () => event.preventDefault()
     });
-  });
+  }));
 }
 
 export async function closeNativeWindow() {


### PR DESCRIPTION
## Summary
- Wrap Tauri desktop event listener cleanup so stale native listener ids do not surface as runtime errors.
- Route window, file/watch, drag/drop, menu, ACP, and runtime event listeners through the guarded cleanup helper.
- Add regression coverage for duplicate cleanup and the reported stale listener failure.

## Why
- Tauri 2.11 can throw while unlistening if a listener id has already been removed, matching issue #477's listeners[eventId].handlerId crash.

## Validation
- `apps/desktop/node_modules/.bin/vitest.CMD run src/runtime/index.test.ts src/runtime/tauri/window.test.ts`
- `apps/desktop/node_modules/.bin/vitest.CMD run src/runtime/tauri src/runtime/index.test.ts`
- `apps/desktop/node_modules/.bin/tsc.CMD -p tsconfig.test.json --noEmit`
- `apps/desktop/node_modules/.bin/vitest.CMD run`
- `git diff --check`

## Risk
- Low. Cleanup now remains best-effort and idempotent; if an underlying native unlisten failure is unrelated to a stale listener, that listener may remain until the window/runtime tears down instead of crashing the UI.

Closes #477