### PR TITLE
fix(editor): keep hr markers literal in task items

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -2128,6 +2128,84 @@ describe("MarkdownPaper editing", () => {
   });
 
   it.each([
+    { expectedMarkdown: "- [ ] \\---\n", source: "- [ ] ---", text: "---" },
+    { expectedMarkdown: "- [x] \\---\n", source: "- [x] ---", text: "---" },
+    { expectedMarkdown: "- [ ] \\----\n", source: "- [ ] ----", text: "----" },
+    { expectedMarkdown: "- [ ] \\_\\_\\_&#x20;\n", source: "- [ ] ___ ", text: "___" },
+    { expectedMarkdown: "- [ ] \\*\\*\\*&#x20;\n", source: "- [ ] *** ", text: "***" }
+  ])("keeps typed thematic break marker $text as text inside task list items", async ({ expectedMarkdown, source, text }) => {
+    const { container, editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, source);
+
+    const checkbox = container.querySelector<HTMLInputElement>('.ProseMirror input[type="checkbox"]');
+
+    expect(checkbox).toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror hr")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror li")).toHaveTextContent(text);
+    expect(serializeMarkdown(view.state.doc)).toBe(expectedMarkdown);
+  });
+
+  it.each([
+    { source: "- [ ] \\---", text: "---" },
+    { source: "- [ ] \\----", text: "----" },
+    { source: "- [ ] \\_\\_\\_&#x20;", text: "___" },
+    { source: "- [ ] \\*\\*\\*&#x20;", text: "***" }
+  ])("loads escaped thematic break marker $text as task list text", async ({ source, text }) => {
+    const { container } = await renderEditor(source);
+
+    expect(container.querySelector(".ProseMirror hr")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror li")).toHaveTextContent(text);
+  });
+
+  it("keeps typed thematic break markers as text inside blockquoted task list items", async () => {
+    const { container, editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "> - [ ] ---");
+
+    expect(container.querySelector(".ProseMirror blockquote hr")).not.toBeInTheDocument();
+    expect(container.querySelector(".ProseMirror blockquote li")).toHaveTextContent("---");
+    expect(serializeMarkdown(view.state.doc)).toBe("> - [ ] \\---\n");
+  });
+
+  it.each(["---", "___ ", "*** "])(
+    "turns typed thematic break marker %s into a horizontal rule outside task list items",
+    async (source) => {
+      const { container, editor, view } = await renderEditor();
+      const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+      typeText(view, source);
+
+      expect(container.querySelector(".ProseMirror hr")).toBeInTheDocument();
+      expect(serializeMarkdown(view.state.doc)).toBe("***\n");
+    }
+  );
+
+  it("turns typed thematic break markers into a horizontal rule inside ordinary list items", async () => {
+    const { container, editor, view } = await renderEditor();
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    typeText(view, "- ---");
+
+    expect(container.querySelector(".ProseMirror li hr")).toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).toContain("***");
+  });
+
+  it("turns typed thematic break markers into a horizontal rule inside ordinary nested lists below task items", async () => {
+    const { container, editor, view } = await renderEditor("- [ ] Parent\n  - Child");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    moveCursor(view, findTextPosition(view, "Child", "Child".length));
+    expect(pressEnter(view)).toBe(true);
+    typeText(view, "---");
+
+    expect(container.querySelector(".ProseMirror li li hr")).toBeInTheDocument();
+    expect(serializeMarkdown(view.state.doc)).toContain("***");
+  });
+
+  it.each([
     {
       label: "YAML",
       source: [

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -3,7 +3,9 @@ import {
   emphasisSchema,
   hardbreakAttr,
   hardbreakSchema,
+  hrSchema,
   imageSchema,
+  insertHrInputRule,
   inputRules as commonmarkInputRules,
   keymap as commonmarkKeymap,
   plugins as commonmarkPlugins,
@@ -21,10 +23,11 @@ import {
   strikethroughSchema
 } from "@milkdown/kit/preset/gfm";
 import { Fragment, type Node as ProseNode, type ResolvedPos, type Slice } from "@milkdown/kit/prose/model";
+import { InputRule } from "@milkdown/kit/prose/inputrules";
 import type { Selection } from "@milkdown/kit/prose/state";
 import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
-import { $prose, $remark } from "@milkdown/kit/utils";
+import { $inputRule, $prose, $remark } from "@milkdown/kit/utils";
 import type { AiSelectionContext } from "@markra/ai";
 import { parseMarkdownCalloutMarker } from "@markra/shared";
 import { readAiSelectionContextFromView } from "../hooks/useEditorController";
@@ -335,6 +338,34 @@ const markraMarkdownStyleRemarkPlugin = $remark<"markraMarkdownStyleRemark", und
   () => markraMarkdownStyleRemark
 );
 
+function positionIsInsideTaskListItem($pos: ResolvedPos) {
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (node.type.name === "list_item") return node.attrs.checked !== null;
+  }
+
+  return false;
+}
+
+function selectionIsInsideTaskListItem(selection: Selection) {
+  return [selection.$from, selection.$to].every(positionIsInsideTaskListItem);
+}
+
+const markraInsertHrInputRule = $inputRule((ctx) =>
+  new InputRule(/^(?:---|___\s|\*\*\*\s)$/, (state, match, start, end) => {
+    if (selectionIsInsideTaskListItem(state.selection)) return null;
+
+    const { tr } = state;
+    if (match[0]) tr.replaceWith(start - 1, end, hrSchema.type(ctx).create());
+
+    return tr;
+  })
+);
+
+const markraCommonmarkInputRules = commonmarkInputRules.map((plugin) =>
+  plugin === insertHrInputRule ? markraInsertHrInputRule : plugin
+);
+
 export const markraCommonmark = [
   markraMarkdownStyleRemarkPlugin,
   markraBlankParagraphRemarkPlugin,
@@ -344,7 +375,7 @@ export const markraCommonmark = [
   markraStrongSchema,
   markraBlockImageSchema,
   markraHardbreakSchema,
-  commonmarkInputRules,
+  markraCommonmarkInputRules,
   commonmarkCommands,
   commonmarkKeymap,
   commonmarkPlugins.filter((plugin) =>

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -870,7 +870,9 @@
   }
 
   .markdown-paper .markra-task-list-checkbox {
-    @apply mt-1 h-4 w-4 shrink-0 cursor-pointer rounded-sm border border-(--border-strong) accent-(--accent);
+    @apply h-4 w-4 shrink-0 cursor-pointer rounded-sm border border-(--border-strong) accent-(--accent);
+    line-height: inherit;
+    margin-top: calc((1lh - 1rem) / 2);
   }
 
   .markdown-paper .markra-task-list-checkbox:disabled {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -175,6 +175,19 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .markra-list-collapsed-content");
   });
 
+  it("centers task list checkboxes against the current text line", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const checkboxStart = styles.indexOf(".markdown-paper .markra-task-list-checkbox {");
+    const checkboxEnd = styles.indexOf(".markdown-paper .markra-task-list-checkbox:disabled", checkboxStart);
+    const checkboxStyles = styles.slice(checkboxStart, checkboxEnd);
+
+    expect(checkboxStart).toBeGreaterThanOrEqual(0);
+    expect(checkboxEnd).toBeGreaterThan(checkboxStart);
+    expect(checkboxStyles).toContain("line-height: inherit;");
+    expect(checkboxStyles).toContain("margin-top: calc((1lh - 1rem) / 2);");
+    expect(checkboxStyles).not.toContain("mt-1");
+  });
+
   it("uses distinct unordered list markers for nested editor lists", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 


### PR DESCRIPTION
## Summary
- Prevent Milkdown's horizontal-rule input rule from firing inside task list items, so typed `---`, `----`, `___ `, and `*** ` stay as task text and serialize with the expected escaping.
- Keep normal horizontal-rule behavior in paragraphs, ordinary list items, and nested ordinary lists below task items.
- Align task list checkboxes against the current text line instead of using a fixed margin.

## Validation
- `vitest run src/styles.test.ts` passed: 42 tests
- `vitest run src/components/MarkdownPaper.test.tsx` passed: 484 tests
- `tsc -p tsconfig.test.json --noEmit` passed
- `corepack pnpm --filter @markra/app build` passed
- `git diff --check` passed

## Risk
- The horizontal-rule input rule is intentionally suppressed only when the nearest list item is a task item; ordinary and nested non-task list items keep the existing rule.

Closes #479
