### PR TITLE
fix(app): keep first folder load alive after file root

### DIFF
--- a/packages/app/src/hooks/useMarkdownFileTree.test.tsx
+++ b/packages/app/src/hooks/useMarkdownFileTree.test.tsx
@@ -152,6 +152,12 @@ function FileTreeProbe({
       >
         Restore collapsed folder
       </button>
+      <button
+        type="button"
+        onClick={() => tree.openFolderPath("/vault", "vault")}
+      >
+        Open vault path
+      </button>
       <button type="button" onClick={() => tree.setRootFromMarkdownFilePath("/mock-workspaces/notes/daily.md")}>
         Use file root
       </button>
@@ -479,6 +485,68 @@ describe("useMarkdownFileTree", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open second docs folder" }));
 
     expect(firstSignalRef.current?.aborted).toBe(true);
+  });
+
+  it("keeps the first selected folder load alive when switching from a file root", async () => {
+    const fileRootLoad = createDeferredMarkdownFileList();
+    const folderLoad = createDeferredMarkdownFileList();
+    const folderSignalRef: { current: AbortSignal | null } = { current: null };
+
+    mockedLoadNativeMarkdownFilesForPath.mockImplementation((path, options = {}) => {
+      if (path === "/mock-workspaces/notes/daily.md") {
+        options.signal?.addEventListener("abort", () => {
+          fileRootLoad.resolve([]);
+        });
+        return fileRootLoad.promise;
+      }
+
+      if (path === "/vault") {
+        folderSignalRef.current = options.signal ?? null;
+        options.signal?.addEventListener("abort", () => {
+          folderLoad.resolve([]);
+        });
+        return folderLoad.promise;
+      }
+
+      return Promise.resolve([]);
+    });
+
+    render(<FileTreeProbe />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Use file root" }));
+    await waitFor(() =>
+      expect(mockedLoadNativeMarkdownFilesForPath).toHaveBeenCalledWith(
+        "/mock-workspaces/notes/daily.md",
+        expect.objectContaining({
+          managedAttachmentFolder: "assets",
+          signal: expect.any(AbortSignal)
+        })
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open vault path" }));
+
+    await waitFor(() =>
+      expect(mockedLoadNativeMarkdownFilesForPath).toHaveBeenCalledWith(
+        "/vault",
+        expect.objectContaining({
+          managedAttachmentFolder: "assets",
+          signal: expect.any(AbortSignal)
+        })
+      )
+    );
+    expect(folderSignalRef.current?.aborted).toBe(false);
+
+    await act(async () => {
+      folderLoad.resolve([
+        { path: "/vault/index.md", name: "index.md", relativePath: "index.md" }
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("index.md")).toBeInTheDocument();
+    expect(screen.getByTestId("root-name")).toHaveTextContent("vault");
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
   });
 
   it("hides attachment files outside the managed attachment folder while keeping folders visible", async () => {

--- a/packages/app/src/hooks/useMarkdownFileTree.ts
+++ b/packages/app/src/hooks/useMarkdownFileTree.ts
@@ -220,13 +220,18 @@ export function useMarkdownFileTree({
     (!openingFolderPathRef.current || openingFolderPathRef.current === path)
   ), []);
 
-  const abortCurrentFileTreeLoad = useCallback(() => {
-    const controller = fileTreeLoadAbortControllerRef.current;
+  const abortFileTreeLoad = useCallback((controller: AbortController | null) => {
     if (!controller) return;
 
-    fileTreeLoadAbortControllerRef.current = null;
+    if (fileTreeLoadAbortControllerRef.current === controller) {
+      fileTreeLoadAbortControllerRef.current = null;
+    }
     controller.abort();
   }, []);
+
+  const abortCurrentFileTreeLoad = useCallback(() => {
+    abortFileTreeLoad(fileTreeLoadAbortControllerRef.current);
+  }, [abortFileTreeLoad]);
 
   const loadFileTreeFilesForPath = useCallback((
     path: string,
@@ -774,7 +779,7 @@ export function useMarkdownFileTree({
     cancelPendingFileTreeBatchFlush();
     const requestId = openFolderRequestIdRef.current;
     let firstBatch = true;
-    loadFileTreeFilesForPath(sourcePath, {
+    const loadPromise = loadFileTreeFilesForPath(sourcePath, {
       managedAttachmentFolder: normalizedManagedAttachmentFolder,
       onBatch: (batchFiles) => {
         if (!active) return;
@@ -783,7 +788,10 @@ export function useMarkdownFileTree({
         firstBatch = false;
         applyLoadedFileTreeBatch(batchFiles, requestId, sourcePath, immediate);
       }
-    }).then((nextFiles) => {
+    });
+    const loadController = fileTreeLoadAbortControllerRef.current;
+
+    loadPromise.then((nextFiles) => {
       if (active) {
         cancelPendingFileTreeBatchFlush();
         replaceFileTreeFiles(nextFiles);
@@ -798,11 +806,12 @@ export function useMarkdownFileTree({
 
     return () => {
       active = false;
-      abortCurrentFileTreeLoad();
+      abortFileTreeLoad(loadController);
       cancelPendingFileTreeBatchFlush();
     };
   }, [
     applyLoadedFileTreeBatch,
+    abortFileTreeLoad,
     abortCurrentFileTreeLoad,
     cancelPendingFileTreeBatchFlush,
     loadFileTreeFilesForPath,


### PR DESCRIPTION
## Summary
- Scope file-tree effect cleanup to the load controller that the effect started.
- Keep a newly selected folder load alive when switching from a single markdown file root.
- Add regression coverage for the first file-root to folder-root switch.

## Why
When Markra is opened on a single markdown file, the file tree can briefly load with that file path as its root. If the user then opens a folder, the new folder load starts before React runs the cleanup for the previous file-root effect.

That cleanup used to call the generic current-load abort helper, so it could abort the newly started folder load instead of only the old file-root load. Once that happened, the UI had already cleared the open document and switched the source path, leaving an empty workspace. A second folder open worked because the stale file-root cleanup no longer existed.

## Validation
- `D:\Codes\markra\packages\app\node_modules\.bin\vitest.CMD run src/hooks/useMarkdownFileTree.test.tsx` passed, 35 tests.
- `corepack pnpm --filter @markra/app typecheck:test` passed.
- `git diff --check` passed.

## Risk
- Low. Explicit current-load abort behavior is unchanged; the narrower cleanup only prevents an old effect from canceling a newer load.

Closes #478
