### PR TITLE
fix(app): unclip Windows view mode menu

### DIFF
--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -346,7 +346,8 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
       left: "219px"
     });
-    expect(container.querySelector(".native-titlebar")).toHaveClass("rounded-tl-md", "overflow-hidden");
+    expect(container.querySelector(".native-titlebar")).toHaveClass("rounded-tl-md");
+    expect(container.querySelector(".native-titlebar")).not.toHaveClass("overflow-hidden");
     expect(container.querySelector(".native-titlebar")).not.toHaveClass("border-t");
     expect(container.querySelector(".native-titlebar")).not.toHaveClass("border-l");
     expect(container.querySelector(".native-titlebar")).toHaveClass("transition-[left]");
@@ -943,6 +944,43 @@ describe("NativeTitleBar", () => {
 
     expect(selectViewMode).toHaveBeenCalledWith("immersive");
     expect(screen.queryByRole("menu", { name: "View mode" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the Windows workspace view mode menu outside clipped titlebar overflow", () => {
+    const selectViewMode = vi.fn();
+    render(
+      <NativeTitleBar
+        aiAgentOpen={false}
+        dirty={false}
+        documentName="Draft.md"
+        markdownFilesOpen
+        markdownFilesWidth={220}
+        platform="windows"
+        theme="light"
+        titlebarActions={[
+          { id: "viewMode", visible: true }
+        ]}
+        titleContent={(
+          <div role="tablist" aria-label="Open documents">
+            <button type="button" role="tab" aria-selected="true">Draft.md</button>
+          </div>
+        )}
+        viewMode="focus"
+        onSelectViewMode={selectViewMode}
+        onToggleAiAgent={() => {}}
+        onOpenMarkdown={() => {}}
+        onSaveMarkdown={() => {}}
+        onToggleMarkdownFiles={() => {}}
+        onToggleTheme={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View mode: Focus" }));
+
+    const menu = screen.getByRole("menu", { name: "View mode" });
+
+    expect(menu).toBeInTheDocument();
+    expect(menu.closest(".native-titlebar.overflow-hidden")).toBeNull();
   });
 
   it("closes the workspace view mode menu when the titlebar action is hidden", () => {

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -137,7 +137,7 @@ export function WindowsNativeTitleBar({
   const windowsTitlebarLeft = markdownFilesWidth + (showWindowsAppChrome ? -1 : 1);
   const windowsTitlebarEdgeClassName = showWindowsAppChrome
     ? markdownFilesOpen
-      ? "rounded-tl-md overflow-hidden"
+      ? "rounded-tl-md"
       : "border-t border-(--border-default)"
     : "";
   const windowsTitlebarPositionTransitionClassName = markdownFilesResizing


### PR DESCRIPTION
## Summary
- Remove clipping from the Windows self-drawn titlebar when the markdown file tree is open.
- Keep the existing Windows rounded corner styling while allowing the top-right view mode menu to expand below the titlebar.
- Add a regression test covering the Windows view mode menu under the clipped-titlebar scenario.

## Why
- The view mode popover was rendered inside the Windows titlebar. When the sidebar was open, the titlebar used `overflow-hidden` for the rounded corner, which clipped the dropdown and made the button appear unable to expand.
- macOS and other titlebar paths are unchanged.

## Validation
- `packages/app/node_modules/.bin/vitest.CMD run src/components/NativeTitleBar.test.tsx` passed: 44 tests.
- `packages/app/node_modules/.bin/tsc.CMD -p tsconfig.test.json --noEmit` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

## Risk
- Low. The change is scoped to Windows titlebar styling and keeps the existing rounded corner/divider elements in place.
