### PR TITLE
fix(app): keep selection toolbar inside viewport

### DIFF
--- a/packages/app/src/components/AiSelectionToolbar.test.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.test.tsx
@@ -38,6 +38,35 @@ describe("AiSelectionToolbar", () => {
     expect(screen.getByRole("button", { name: "Translate" })).toBeInTheDocument();
   });
 
+  it("places itself below the selection near the viewport top", () => {
+    render(
+      <AiSelectionToolbar
+        anchor={{
+          bottom: 30,
+          left: 240,
+          right: 420,
+          top: 10
+        }}
+        language="en"
+        open
+        onCopySelection={vi.fn()}
+        onInsertLink={vi.fn()}
+        onOpenCommand={vi.fn()}
+        onRunFormattingAction={vi.fn()}
+        onRunAction={vi.fn()}
+      />
+    );
+
+    const toolbar = screen.getByRole("toolbar", { name: "AI quick actions" });
+
+    expect(toolbar).toHaveStyle({
+      left: "330px",
+      top: "42px"
+    });
+    expect(toolbar).toHaveClass("translate-y-0");
+    expect(toolbar).not.toHaveClass("-translate-y-full");
+  });
+
   it("renders basic selection tools and routes them to editor commands", () => {
     const onRunFormattingAction = vi.fn();
     const onInsertLink = vi.fn();

--- a/packages/app/src/components/AiSelectionToolbar.tsx
+++ b/packages/app/src/components/AiSelectionToolbar.tsx
@@ -93,6 +93,23 @@ type AiSelectionToolbarProps = {
 };
 
 const toolbarOffsetPx = 12;
+const toolbarViewportMarginPx = 12;
+const toolbarHeightPx = 42;
+
+function selectionToolbarPlacement(anchor: SelectionAnchor) {
+  return anchor.top - toolbarOffsetPx - toolbarHeightPx >= toolbarViewportMarginPx ? "top" : "bottom";
+}
+
+function selectionToolbarTop(anchor: SelectionAnchor, placement: ReturnType<typeof selectionToolbarPlacement>) {
+  if (placement === "top") {
+    return Math.round(anchor.top - toolbarOffsetPx);
+  }
+
+  const viewportHeight = typeof window === "undefined" ? Number.POSITIVE_INFINITY : window.innerHeight;
+  const maxTop = Math.max(toolbarViewportMarginPx, viewportHeight - toolbarViewportMarginPx - toolbarHeightPx);
+
+  return Math.round(Math.max(toolbarViewportMarginPx, Math.min(anchor.bottom + toolbarOffsetPx, maxTop)));
+}
 
 const aiSelectionActions: AiSelectionAction[] = [
   {
@@ -309,10 +326,12 @@ export function AiSelectionToolbar({
     : label("menu.headingLevel");
   const copyLabel = label(copySucceeded ? "app.aiCopied" : "app.aiCopy");
   const translationTargetLanguage = aiTranslationLanguageName(language);
+  const toolbarPlacement = selectionToolbarPlacement(anchor);
   const style: CSSProperties = {
     left: `${Math.round((anchor.left + anchor.right) / 2)}px`,
-    top: `${Math.max(12, Math.round(anchor.top - toolbarOffsetPx))}px`
+    top: `${selectionToolbarTop(anchor, toolbarPlacement)}px`
   };
+  const toolbarPlacementClass = toolbarPlacement === "top" ? "-translate-y-full" : "translate-y-0";
   const headingLevelMenu =
     headingLevelMenuOpen && headingLevelMenuStyle && typeof document !== "undefined"
       ? createPortal(
@@ -362,7 +381,7 @@ export function AiSelectionToolbar({
 
   return (
     <section
-      className="ai-selection-toolbar pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full animate-[markra-ai-float-in_160ms_ease-out_both] motion-reduce:animate-none"
+      className={`ai-selection-toolbar pointer-events-none fixed z-50 -translate-x-1/2 ${toolbarPlacementClass} animate-[markra-ai-float-in_160ms_ease-out_both] motion-reduce:animate-none`}
       ref={toolbarRef}
       style={style}
       role="toolbar"


### PR DESCRIPTION
## Summary
- Reposition the AI selection toolbar below selected text when there is not enough space above it.
- Clamp the below-selection position so the toolbar stays inside the viewport.
- Add regression coverage for selections near the top edge.

## Validation
- `.\\node_modules\\.bin\\vitest.CMD run src/components/AiSelectionToolbar.test.tsx src/lib/selection-anchor.test.ts src/hooks/useSelectionToolbarAnchorRefresh.test.tsx` passed, 20 tests
- `.\\node_modules\\.bin\\tsc.CMD -p tsconfig.test.json --noEmit` passed
- `.\\node_modules\\.bin\\tsc.CMD -p tsconfig.build.json --noEmit` passed
- `git diff --check` passed

## Risk
- Low. The change is scoped to AI selection toolbar placement and preserves the existing above-selection placement when there is enough room.
