### PR TITLE
ci: split frontend checks into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  frontend:
-    name: Frontend
+  frontend-tests:
+    name: Frontend Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -44,11 +44,85 @@ jobs:
       - name: Test
         run: pnpm test
 
+  frontend-test-typecheck:
+    name: Frontend Test Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Typecheck tests
         run: pnpm run typecheck:test
 
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Build
         run: pnpm build
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - frontend-tests
+      - frontend-test-typecheck
+      - frontend-build
+    if: always()
+
+    steps:
+      - name: Check frontend jobs
+        run: |
+          if [ "${{ needs.frontend-tests.result }}" != "success" ]; then
+            echo "Frontend Tests result: ${{ needs.frontend-tests.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.frontend-test-typecheck.result }}" != "success" ]; then
+            echo "Frontend Test Typecheck result: ${{ needs.frontend-test-typecheck.result }}"
+            exit 1
+          fi
+          if [ "${{ needs.frontend-build.result }}" != "success" ]; then
+            echo "Frontend Build result: ${{ needs.frontend-build.result }}"
+            exit 1
+          fi
 
   tauri-rust:
     name: Tauri Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,23 @@ concurrency:
 
 jobs:
   frontend-tests:
-    name: Frontend Tests
+    name: Frontend Tests (${{ matrix.package }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - "@markra/desktop"
+          - "@markra/web"
+          - "@markra/ai"
+          - "@markra/app"
+          - "@markra/editor"
+          - "@markra/markdown"
+          - "@markra/providers"
+          - "@markra/scripts"
+          - "@markra/shared"
+          - "@markra/ui"
 
     steps:
       - name: Checkout
@@ -42,7 +56,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test
-        run: pnpm test
+        run: pnpm --filter "${{ matrix.package }}" test
 
   frontend-test-typecheck:
     name: Frontend Test Typecheck


### PR DESCRIPTION
## Summary
- split the frontend CI workflow into separate test, test typecheck, and build jobs
- run frontend unit tests as a per-workspace package matrix for all 10 packages with `test` scripts
- keep the existing `Frontend` check as a small aggregate job for branch protection compatibility
- leave the Tauri Rust job unchanged

## Why
- PRs still run the full frontend validation set, but independent frontend checks and package-level unit tests can finish in parallel instead of serially.

## Validation
- `corepack pnpm dlx github-actionlint .github\workflows\ci.yml` passed
- `git diff --check -- .github\workflows\ci.yml` passed
- workflow structure assertion script passed
- test matrix assertion script matched 10 workspace packages with `test` scripts

## Risk
- Uses more total runner setup time because each frontend job installs dependencies separately, but reduces PR wall-clock time when tests/typecheck/build dominate.
