### PR TITLE
fix(app): keep full selections visibly highlighted

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { EditorView } from "@codemirror/view";
 import { Editor as MilkdownEditor, editorViewCtx } from "@milkdown/kit/core";
-import { TextSelection } from "@milkdown/kit/prose/state";
+import { AllSelection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView as ProseMirrorEditorView } from "@milkdown/kit/prose/view";
 import { defaultMarkdownShortcuts } from "@markra/editor";
 import desktopPackage from "../package.json";
@@ -6180,6 +6180,50 @@ describe("Markra workspace", () => {
       menuHandlers.editRedo?.();
     });
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).toBeInTheDocument());
+  });
+
+  it("keeps full-document selections visibly highlighted when the selection toolbar opens", async () => {
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      showAiQuickInputOnSelection: false,
+      showAiSelectionToolbarOnSelection: true
+    }));
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+    const { container } = renderApp();
+
+    try {
+      await expectVisibleMilkdownText(container, "Welcome to Markra");
+      await settleEditorUpdates();
+      const visualView = createdEditors.reduce<ProseMirrorEditorView | null>((visibleView, editor) => {
+        if (visibleView) return visibleView;
+
+        try {
+          const view = editor.action((ctx) => ctx.get(editorViewCtx));
+          return container.contains(view.dom) && !view.dom.closest("[hidden]") ? view : null;
+        } catch {
+          return null;
+        }
+      }, null);
+      if (!visualView) throw new Error("Expected a visible Milkdown editor view.");
+
+      act(() => {
+        visualView.focus();
+        visualView.dispatch(visualView.state.tr.setSelection(new AllSelection(visualView.state.doc)));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector(".ProseMirror .markra-ai-selection-hold")).toHaveTextContent(
+          "Welcome to Markra"
+        );
+      });
+    } finally {
+      makeSpy.mockRestore();
+    }
   });
 
   it("inserts the default menu image as an immediately clickable image block", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1534,6 +1534,7 @@ function WorkspaceApp() {
     await aiAgentSessions.refresh();
     openAiAgentPanel();
   }, [activeAiAgentSessionId, aiAgentSessions, createInitializedAiAgentSession, openAiAgentPanel, selectWorkspaceSession]);
+  const holdAiSelection = editor.holdAiSelection;
   const handleTextSelectionChange = useCallback((selection: AiSelectionContext | null) => {
     const automaticSelection = automaticAiSelection(selection);
 
@@ -1601,6 +1602,7 @@ function WorkspaceApp() {
     }
 
     if (showSelectionToolbar) {
+      holdAiSelection(automaticSelection);
       syncAiSelectionToolbarFormattingState();
       setAiSelectionToolbarAnchorIfChanged(
         getEditorSelectionAnchor() ?? selectionAnchorFromDomSelection(window.getSelection())
@@ -1625,6 +1627,7 @@ function WorkspaceApp() {
     editorPreferences.preferences.showAiQuickInputOnSelection,
     editorPreferences.preferences.showAiSelectionToolbarOnSelection,
     getEditorSelectionAnchor,
+    holdAiSelection,
     syncAiSelectionToolbarFormattingState,
     clearAiSelectionToolbarCopySuccess,
     readOnlyMode,
@@ -1633,7 +1636,6 @@ function WorkspaceApp() {
     updateActiveAiSelection
   ]);
   const getEditorSelection = editor.getSelection;
-  const holdAiSelection = editor.holdAiSelection;
   const scrollAiSelectionAboveCommand = editor.scrollAiSelectionAboveCommand;
   const interruptAiCommandPrompt = aiCommand.interruptPrompt;
   const openAiCommand = aiCommand.openAiCommand;


### PR DESCRIPTION
## Summary
- Reuse the existing AI selection hold decoration when the selection toolbar opens.
- Add a regression test for full-document selections keeping a visible highlight.

## Why
- On macOS Tauri, full-document selection could be logically active while the selected background was not painted.

## Validation
- `pnpm --dir packages/app exec vitest run src/App.test.tsx -t "keeps full-document selections visibly highlighted"` passed
- `pnpm --filter @markra/app typecheck:test` passed
- Manually verified Cmd+A in the macOS Tauri app shows the full selection background

## Risk
- Low. This only reuses the existing selection-hold UI path when the selection toolbar is shown.