### PR TITLE
fix(editor): preserve identifier underscores in markdown source

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7120,6 +7120,19 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("serializes intraword underscores in identifiers without escaping them", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("MOCK_CODE1, SAMPLE_CODE2, ORDER_BOX", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " ok");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("MOCK_CODE1, SAMPLE_CODE2, ORDER_BOX ok");
+  });
+
   it("keeps escaped literal asterisks between inline code visible", async () => {
     const source = "`n!`/`(n1!` \\* `n2!` \\* ... \\* `nk!`)";
     const { container } = await renderEditor(source);

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7133,6 +7133,47 @@ describe("MarkdownPaper editing", () => {
     expect(markdown).toBe("MOCK_CODE1, SAMPLE_CODE2, ORDER_BOX ok");
   });
 
+  it("serializes unicode and numeric intraword underscores without escaping them", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("字段_CODE1, CODE_123, 字段_名称", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " ok");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("字段_CODE1, CODE_123, 字段_名称 ok");
+  });
+
+  it("keeps escaped underscore emphasis literals while restoring identifier underscores", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("\\_literal\\_ MOCK_CODE1", { onMarkdownChange });
+
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    typeText(view, " ok");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("\\_literal\\_ MOCK_CODE1 ok");
+  });
+
+  it("keeps escaped underscores inside code while restoring identifier underscores", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("`MOCK\\_CODE1` SAMPLE_CODE2\n\n```sql\nSELECT MOCK\\_CODE1\n```", {
+      onMarkdownChange
+    });
+
+    moveCursor(view, findTextPosition(view, "SAMPLE_CODE2", "SAMPLE_CODE2".length));
+    typeText(view, " ok");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("`MOCK\\_CODE1` SAMPLE_CODE2 ok\n\n```sql\nSELECT MOCK\\_CODE1\n```");
+  });
+
   it("keeps escaped literal asterisks between inline code visible", async () => {
     const source = "`n!`/`(n1!` \\* `n2!` \\* ... \\* `nk!`)";
     const { container } = await renderEditor(source);

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -861,6 +861,7 @@ export function finalizeActiveLiveMarkdown(view: EditorView, specs: LiveMarkdown
 }
 
 const hasRestorableLiveMarkdownDelimiterPattern = /\\[*_~`=]/u;
+const escapedIntrawordUnderscorePattern = /(?<=[\p{L}\p{N}])\\_(?=[\p{L}\p{N}])/gu;
 const restorableLiveMarkdownDelimiterCharacters = new Set(["*", "_", "~", "`", "="]);
 const singleRestorableLiveMarkdownDelimiters = new Set(["*", "_", "~", "`", "="]);
 
@@ -1059,12 +1060,14 @@ function findSerializedMarkdownCandidate(markdown: string, candidates: string[],
   return match;
 }
 
+function restoreIntrawordEscapedUnderscores(markdown: string) {
+  return markdown.replace(escapedIntrawordUnderscorePattern, "_");
+}
+
 export function restoreEscapedLiveMarkdownSource(markdown: string, state: EditorState, specs: LiveMarkdownSpec[]) {
   if (!hasRestorableLiveMarkdownDelimiterPattern.test(markdown)) return markdown;
 
   const operations = serializedMarkdownOperations(state, specs);
-  if (operations.length === 0) return markdown;
-
   const { protectedMarkdown, protectedSegments } = protectMarkdownCode(markdown);
   let restored = "";
   let markdownCursor = 0;
@@ -1079,7 +1082,7 @@ export function restoreEscapedLiveMarkdownSource(markdown: string, state: Editor
   }
 
   restored += protectedMarkdown.slice(markdownCursor);
-  return restoreProtectedMarkdownSegments(restored, protectedSegments);
+  return restoreProtectedMarkdownSegments(restoreIntrawordEscapedUnderscores(restored), protectedSegments);
 }
 
 export function setLiveMarkdownSourceContext(


### PR DESCRIPTION
## Summary
- Restore serializer-escaped underscores when they appear inside identifier-like words such as `MOCK_CODE1` and `ORDER_BOX`.
- Keep the restoration scoped outside protected code spans and fenced code blocks.
- Add regression coverage for ASCII, Unicode, numeric identifier underscores, escaped underscore literals, inline code, and fenced code.

## Why
- The Markdown serializer escapes `_` in plain text, which surfaced source output like `MOCK\_CODE1` even though intraword underscores are safe literal Markdown.
- Escaped Markdown delimiters such as `\_literal\_` still need to remain escaped, so the fix only restores underscores between letters or numbers.

## Validation
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx` passed, 488 tests
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `git diff --check` passed

## Risk
- Low to moderate: touches Markdown serialization post-processing. Regression tests cover live Markdown delimiters, escaped literals, source replacements, inline code, fenced code, duplicate escaped text, Unicode identifiers, and numeric identifiers.

Closes #492
