### PR TITLE
fix(desktop): avoid stale drag drop listener errors

### DIFF
--- a/apps/desktop/src/runtime/tauri/file.test.ts
+++ b/apps/desktop/src/runtime/tauri/file.test.ts
@@ -1501,9 +1501,15 @@ describe("native file access", () => {
   it("routes dropped markdown files and folders from the native window event", async () => {
     const unlisten = vi.fn();
     const onDrop = vi.fn();
-    let emitDragDrop: (event: unknown) => unknown = () => {};
-    onDragDropEvent.mockImplementation(async (handler) => {
-      emitDragDrop = handler;
+    let emitDragDrop: (payload: unknown) => unknown = () => {};
+    mockedGetCurrentWindow.mockReturnValue({
+      label: "main"
+    } as unknown as ReturnType<typeof getCurrentWindow>);
+    mockedListen.mockImplementation(async (event, handler) => {
+      if (event === "tauri://drag-drop") {
+        emitDragDrop = (payload) => handler({ payload } as never);
+      }
+
       return unlisten;
     });
     mockedInvoke
@@ -1513,9 +1519,8 @@ describe("native file access", () => {
 
     const cleanup = await installNativeMarkdownFileDrop(onDrop);
 
-    emitDragDrop({ payload: { type: "enter", paths: [mockReadmePath] } });
-    emitDragDrop({ payload: { type: "drop", paths: ["/mock-files/archive.zip", mockReadmePath] } });
-    emitDragDrop({ payload: { type: "drop", paths: [mockFolderPath] } });
+    emitDragDrop({ paths: ["/mock-files/archive.zip", mockReadmePath] });
+    emitDragDrop({ paths: [mockFolderPath] });
 
     await vi.waitFor(() => expect(onDrop).toHaveBeenCalledTimes(2));
     expect(onDrop).toHaveBeenNthCalledWith(1, {
@@ -1531,15 +1536,58 @@ describe("native file access", () => {
 
     cleanup();
 
-    expect(unlisten).toHaveBeenCalledTimes(1);
+    expect(unlisten).toHaveBeenCalledTimes(4);
+  });
+
+  it("cleans up native drag drop listeners without leaking stale Tauri listener failures", async () => {
+    const cleanupByEvent = new Map<string, () => unknown>();
+    mockedGetCurrentWindow.mockReturnValue({
+      label: "main"
+    } as unknown as ReturnType<typeof getCurrentWindow>);
+    mockedListen.mockImplementation(async (event) => {
+      const cleanup = vi.fn().mockRejectedValue(new Error("undefined is not an object (evaluating 'listeners[eventId].handlerId')"));
+      cleanupByEvent.set(String(event), cleanup);
+
+      return cleanup;
+    });
+
+    const cleanup = await installNativeMarkdownFileDrop(vi.fn());
+
+    expect(onDragDropEvent).not.toHaveBeenCalled();
+    expect(mockedListen).toHaveBeenCalledWith("tauri://drag-enter", expect.any(Function), {
+      target: { kind: "Window", label: "main" }
+    });
+    expect(mockedListen).toHaveBeenCalledWith("tauri://drag-over", expect.any(Function), {
+      target: { kind: "Window", label: "main" }
+    });
+    expect(mockedListen).toHaveBeenCalledWith("tauri://drag-drop", expect.any(Function), {
+      target: { kind: "Window", label: "main" }
+    });
+    expect(mockedListen).toHaveBeenCalledWith("tauri://drag-leave", expect.any(Function), {
+      target: { kind: "Window", label: "main" }
+    });
+
+    await expect(Promise.resolve(cleanup())).resolves.toBeUndefined();
+    await expect(Promise.resolve(cleanup())).resolves.toBeUndefined();
+
+    expect(cleanupByEvent.get("tauri://drag-enter")).toHaveBeenCalledTimes(1);
+    expect(cleanupByEvent.get("tauri://drag-over")).toHaveBeenCalledTimes(1);
+    expect(cleanupByEvent.get("tauri://drag-drop")).toHaveBeenCalledTimes(1);
+    expect(cleanupByEvent.get("tauri://drag-leave")).toHaveBeenCalledTimes(1);
   });
 
   it("routes dropped image files with their native drop position", async () => {
     const unlisten = vi.fn();
     const onDrop = vi.fn();
-    let emitDragDrop: (event: unknown) => unknown = () => {};
-    onDragDropEvent.mockImplementation(async (handler) => {
-      emitDragDrop = handler;
+    let emitDragDrop: (payload: unknown) => unknown = () => {};
+    mockedGetCurrentWindow.mockReturnValue({
+      label: "main"
+    } as unknown as ReturnType<typeof getCurrentWindow>);
+    mockedListen.mockImplementation(async (event, handler) => {
+      if (event === "tauri://drag-drop") {
+        emitDragDrop = (payload) => handler({ payload } as never);
+      }
+
       return unlisten;
     });
     mockedInvoke.mockRejectedValueOnce(new Error("Unsupported path"));
@@ -1547,11 +1595,8 @@ describe("native file access", () => {
     const cleanup = await installNativeMarkdownFileDrop(onDrop);
 
     emitDragDrop({
-      payload: {
-        type: "drop",
-        paths: ["/mock-files/Diagram.png"],
-        position: { x: 340, y: 160 }
-      }
+      paths: ["/mock-files/Diagram.png"],
+      position: { x: 340, y: 160 }
     });
 
     await vi.waitFor(() => expect(onDrop).toHaveBeenCalledTimes(1));
@@ -1567,7 +1612,91 @@ describe("native file access", () => {
 
     cleanup();
 
-    expect(unlisten).toHaveBeenCalledTimes(1);
+    expect(unlisten).toHaveBeenCalledTimes(4);
+  });
+
+  it("routes dropped image file positions from tagged Tauri physical payloads", async () => {
+    const unlisten = vi.fn();
+    const onDrop = vi.fn();
+    let emitDragDrop: (payload: unknown) => unknown = () => {};
+    mockedGetCurrentWindow.mockReturnValue({
+      label: "main"
+    } as unknown as ReturnType<typeof getCurrentWindow>);
+    mockedListen.mockImplementation(async (event, handler) => {
+      if (event === "tauri://drag-drop") {
+        emitDragDrop = (payload) => handler({ payload } as never);
+      }
+
+      return unlisten;
+    });
+    mockedInvoke.mockRejectedValueOnce(new Error("Unsupported path"));
+
+    const cleanup = await installNativeMarkdownFileDrop(onDrop);
+
+    emitDragDrop({
+      paths: ["/mock-files/Tagged.png"],
+      position: { Physical: { x: 420, y: 180 } }
+    });
+
+    await vi.waitFor(() => expect(onDrop).toHaveBeenCalledTimes(1));
+    expect(onDrop).toHaveBeenCalledWith({
+      kind: "image",
+      name: "Tagged.png",
+      path: "/mock-files/Tagged.png",
+      point: {
+        left: 420,
+        top: 180
+      }
+    });
+
+    cleanup();
+  });
+
+  it("converts physical image drop positions to logical editor coordinates", async () => {
+    const originalDevicePixelRatio = window.devicePixelRatio;
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2
+    });
+
+    try {
+      const unlisten = vi.fn();
+      const onDrop = vi.fn();
+      let emitDragDrop: (payload: unknown) => unknown = () => {};
+      mockedGetCurrentWindow.mockReturnValue({
+        label: "main"
+      } as unknown as ReturnType<typeof getCurrentWindow>);
+      mockedListen.mockImplementation(async (event, handler) => {
+        if (event === "tauri://drag-drop") {
+          emitDragDrop = (payload) => handler({ payload } as never);
+        }
+
+        return unlisten;
+      });
+      mockedInvoke.mockRejectedValueOnce(new Error("Unsupported path"));
+
+      const cleanup = await installNativeMarkdownFileDrop(onDrop);
+
+      emitDragDrop({
+        paths: ["/mock-files/Retina.png"],
+        position: { x: 680, y: 320 }
+      });
+
+      await vi.waitFor(() => expect(onDrop).toHaveBeenCalledTimes(1));
+      expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({
+        point: {
+          left: 340,
+          top: 160
+        }
+      }));
+
+      cleanup();
+    } finally {
+      Object.defineProperty(window, "devicePixelRatio", {
+        configurable: true,
+        value: originalDevicePixelRatio
+      });
+    }
   });
 
   it("opens markdown file and folder paths in a new native window", async () => {

--- a/apps/desktop/src/runtime/tauri/file.ts
+++ b/apps/desktop/src/runtime/tauri/file.ts
@@ -3,7 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { confirm, open, save } from "@tauri-apps/plugin-dialog";
 import { debug, fileNameFromPath } from "@markra/shared";
 import { networkSettingsForNativeRequest } from "./network";
-import { listenNativeEvent, safeNativeEventCleanup } from "./events";
+import { listenNativeEvent } from "./events";
 import type {
   PicGoImageUploadSettings,
   S3ImageUploadSettings,
@@ -306,6 +306,28 @@ type MarkdownTreeChangedPayload = {
   path: string;
   rootPath: string;
 };
+
+type NativeDragDropPositionPayload = {
+  position?: unknown;
+};
+
+type NativeDragDropPathPayload = NativeDragDropPositionPayload & {
+  paths?: unknown;
+};
+
+type NativeDragDropEventPayload =
+  | {
+      paths: string[];
+      position?: unknown;
+      type: "enter" | "drop";
+    }
+  | {
+      position?: unknown;
+      type: "over";
+    }
+  | {
+      type: "leave";
+    };
 
 type ClipboardImageFileResponse = {
   relativePath: string;
@@ -991,7 +1013,10 @@ function imageDropTargetFromPath(path: string, point?: NativeMarkdownDropPoint):
 
 function nativeDropPointFromPosition(position: unknown): NativeMarkdownDropPoint | undefined {
   if (!position || typeof position !== "object") return undefined;
-  const { x, y } = position as { x?: unknown; y?: unknown };
+  const coordinates = "Physical" in position && typeof position.Physical === "object" && position.Physical !== null
+    ? position.Physical
+    : position;
+  const { x, y } = coordinates as { x?: unknown; y?: unknown };
   if (typeof x !== "number" || typeof y !== "number") return undefined;
 
   const scaleFactor = typeof window.devicePixelRatio === "number" && window.devicePixelRatio > 0
@@ -1002,6 +1027,12 @@ function nativeDropPointFromPosition(position: unknown): NativeMarkdownDropPoint
     left: x / scaleFactor,
     top: y / scaleFactor
   };
+}
+
+function normalizeNativeDropPaths(paths: unknown) {
+  if (!Array.isArray(paths)) return [];
+
+  return paths.filter((path): path is string => typeof path === "string");
 }
 
 async function firstDroppedMarkdownTarget(paths: string[], point?: NativeMarkdownDropPoint) {
@@ -1018,6 +1049,67 @@ async function firstDroppedMarkdownTarget(paths: string[], point?: NativeMarkdow
   }
 
   return null;
+}
+
+async function cleanupNativeEventListeners(cleanups: Array<() => unknown>) {
+  await Promise.all(cleanups.map(async (cleanup) => {
+    await cleanup();
+  }));
+}
+
+async function listenNativeWindowDragDropEvent(handler: (event: { payload: NativeDragDropEventPayload }) => unknown) {
+  const currentWindow = getCurrentWindow();
+  const target = { kind: "Window" as const, label: currentWindow.label };
+  const cleanups: Array<() => unknown> = [];
+
+  try {
+    // Tauri's composite onDragDropEvent cleanup can leak stale listener rejections from its internal unlisten calls.
+    cleanups.push(await listenNativeEvent<NativeDragDropPathPayload>("tauri://drag-enter", (event) => {
+      handler({
+        payload: {
+          paths: normalizeNativeDropPaths(event.payload.paths),
+          position: event.payload.position,
+          type: "enter"
+        }
+      });
+    }, { target }));
+    cleanups.push(await listenNativeEvent<NativeDragDropPositionPayload>("tauri://drag-over", (event) => {
+      handler({
+        payload: {
+          position: event.payload.position,
+          type: "over"
+        }
+      });
+    }, { target }));
+    cleanups.push(await listenNativeEvent<NativeDragDropPathPayload>("tauri://drag-drop", (event) => {
+      handler({
+        payload: {
+          paths: normalizeNativeDropPaths(event.payload.paths),
+          position: event.payload.position,
+          type: "drop"
+        }
+      });
+    }, { target }));
+    cleanups.push(await listenNativeEvent<unknown>("tauri://drag-leave", () => {
+      handler({
+        payload: {
+          type: "leave"
+        }
+      });
+    }, { target }));
+  } catch (error) {
+    await cleanupNativeEventListeners(cleanups);
+    throw error;
+  }
+
+  let cleaned = false;
+
+  return async () => {
+    if (cleaned) return;
+
+    cleaned = true;
+    await cleanupNativeEventListeners(cleanups);
+  };
 }
 
 export async function openNativeMarkdownFolder(labels?: NativeMarkdownPickerLabels): Promise<NativeMarkdownFolder | null> {
@@ -1524,7 +1616,7 @@ export async function watchNativeMarkdownTree(
 
 export async function installNativeMarkdownFileDrop(onDrop: NativeMarkdownFileDropHandler) {
   try {
-    return safeNativeEventCleanup(await getCurrentWindow().onDragDropEvent((event) => {
+    return await listenNativeWindowDragDropEvent((event) => {
       if (event.payload.type !== "drop") return;
       const point = nativeDropPointFromPosition(event.payload.position);
 
@@ -1533,7 +1625,7 @@ export async function installNativeMarkdownFileDrop(onDrop: NativeMarkdownFileDr
 
         onDrop(target);
       }).catch(() => {});
-    }));
+    });
   } catch {
     return () => {};
   }


### PR DESCRIPTION
## Summary
- Replace Tauri's composite drag/drop listener with individually registered native event listeners that use Markra's safe cleanup wrapper.
- Preserve markdown file/folder and image drop behavior, including drop coordinates and high-DPI coordinate conversion.
- Add regression coverage for stale Tauri unlisten failures and drag/drop payload edge cases.

## Why
Tauri 2.11 can throw `undefined is not an object (evaluating 'listeners[eventId].handlerId')` when a listener has already been removed natively. The previous fix covered Markra's direct `listenNativeEvent` paths, but file drag/drop still used Tauri's `onDragDropEvent()` composite API, whose internal unlisten calls bypassed that wrapper.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @markra/desktop test -- src/runtime/tauri/file.test.ts` passed: 1 file, 59 tests.
- `pnpm --filter @markra/desktop build` passed: TypeScript, Vite build, and vendor chunk verification.

## Risk
- Low. The change is scoped to desktop native file drag/drop listener registration and keeps the external drop handler contract unchanged.
- Main edge risk is platform-specific Tauri drag/drop payload shape; tests now cover plain `{ x, y }`, tagged `{ Physical: { x, y } }`, stale cleanup rejection, repeated cleanup, file/folder drops, image drops, and high-DPI coordinate conversion.

Fixes #485
