### PR TITLE
fix(editor): synthesize live markdown italic style

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2787,6 +2787,8 @@
 
   .markdown-paper .markra-live-mark-emphasis {
     @apply italic;
+    /* CJK system fonts often lack italic faces, so live Markdown needs local style synthesis. */
+    font-synthesis: style;
   }
 
   .markdown-paper .markra-live-mark-strikethrough {


### PR DESCRIPTION
## Summary
- Enable style synthesis for live Markdown emphasis in the editor.
- Keep the change scoped to the document surface so CJK italic and bold italic are visibly slanted while editing.

## Why
- The app disables font synthesis globally, and CJK system fonts often do not ship italic faces. Live Markdown emphasis inherited that global setting, making italic text appear nearly upright.

## Validation
- `pnpm --filter @markra/desktop build` passed.

## Risk
- Low. This is a CSS-only change scoped to `.markdown-paper .markra-live-mark-emphasis`.
