### PR TITLE
[codex] add native command failure logs

### DIFF
--- a/apps/desktop/src-tauri/src/image_upload.rs
+++ b/apps/desktop/src-tauri/src/image_upload.rs
@@ -67,6 +67,12 @@ pub(crate) struct ImageUploadTargets {
     pub(crate) upload_url: Url,
 }
 
+#[derive(Debug)]
+struct ImageUploadCollectionTarget {
+    diagnostic_path: String,
+    url: Url,
+}
+
 #[tauri::command]
 pub(crate) async fn upload_webdav_image(
     request: WebDavImageUploadRequest,
@@ -100,22 +106,32 @@ async fn execute_webdav_image_upload(
         &request.public_base_url,
         &file_name,
     )?;
+    let upload_target = image_upload_diagnostic_target(&request.upload_path, &file_name);
     let client = image_upload_http_client(request.network.as_ref())?;
 
-    for collection_url in webdav_collection_urls(&request.server_url, &request.upload_path)? {
+    for target in webdav_collection_targets(&request.server_url, &request.upload_path)? {
         let response = apply_basic_auth(
-            client.request(webdav_mkcol_method()?, collection_url),
+            client.request(webdav_mkcol_method()?, target.url),
             &request.username,
             &request.password,
         )
         .send()
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            image_upload_request_error(
+                "WebDAV image folder creation",
+                "MKCOL",
+                &target.diagnostic_path,
+                error,
+            )
+        })?;
 
         if !(response.status().is_success() || response.status().as_u16() == 405) {
-            return Err(format!(
-                "WebDAV collection could not be created: HTTP {}",
-                response.status().as_u16()
+            return Err(image_upload_status_error(
+                "WebDAV image folder creation",
+                "MKCOL",
+                &target.diagnostic_path,
+                response.status().as_u16(),
             ));
         }
     }
@@ -130,12 +146,16 @@ async fn execute_webdav_image_upload(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| {
+        image_upload_request_error("WebDAV image upload", "PUT", &upload_target, error)
+    })?;
 
     if !response.status().is_success() {
-        return Err(format!(
-            "WebDAV image upload failed: HTTP {}",
-            response.status().as_u16()
+        return Err(image_upload_status_error(
+            "WebDAV image upload",
+            "PUT",
+            &upload_target,
+            response.status().as_u16(),
         ));
     }
 
@@ -151,6 +171,7 @@ async fn execute_picgo_image_upload(
     let extension = uploaded_image_extension(&request.mime_type)?;
     let file_name = uploaded_image_file_name(&request.file_name, extension)?;
     let upload_url = picgo_upload_endpoint_url(&request.server_url, &request.secret)?;
+    let upload_target = "/upload";
     let file_part = multipart::Part::bytes(request.bytes)
         .file_name(file_name)
         .mime_str(&request.mime_type)
@@ -161,16 +182,22 @@ async fn execute_picgo_image_upload(
         .multipart(form)
         .send()
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            image_upload_request_error("PicGo image upload", "POST", upload_target, error)
+        })?;
 
     if !response.status().is_success() {
-        return Err(format!(
-            "PicGo image upload failed: HTTP {}",
-            response.status().as_u16()
+        return Err(image_upload_status_error(
+            "PicGo image upload",
+            "POST",
+            upload_target,
+            response.status().as_u16(),
         ));
     }
 
-    let response_body = response.text().await.map_err(|error| error.to_string())?;
+    let response_body = response.text().await.map_err(|error| {
+        image_upload_request_error("PicGo image upload", "POST", upload_target, error)
+    })?;
 
     parse_picgo_upload_response(&response_body)
 }
@@ -179,6 +206,7 @@ async fn execute_s3_image_upload(request: S3ImageUploadRequest) -> Result<Upload
     validate_image_bytes(&request.bytes)?;
     let extension = uploaded_image_extension(&request.mime_type)?;
     let file_name = uploaded_image_file_name(&request.file_name, extension)?;
+    let upload_target = image_upload_diagnostic_target(&request.upload_path, &file_name);
     let bucket = normalize_s3_bucket(&request.bucket)?;
     let access_key_id = required_trimmed(&request.access_key_id, "S3 access key ID")?;
     let region = required_trimmed(&request.region, "S3 region")?;
@@ -212,12 +240,16 @@ async fn execute_s3_image_upload(request: S3ImageUploadRequest) -> Result<Upload
         .body(request.bytes)
         .send()
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            image_upload_request_error("S3 image upload", "PUT", &upload_target, error)
+        })?;
 
     if !response.status().is_success() {
-        return Err(format!(
-            "S3 image upload failed: HTTP {}",
-            response.status().as_u16()
+        return Err(image_upload_status_error(
+            "S3 image upload",
+            "PUT",
+            &upload_target,
+            response.status().as_u16(),
         ));
     }
 
@@ -331,6 +363,56 @@ fn image_upload_http_client(network: Option<&NetworkSettings>) -> Result<Client,
     .map_err(|error| error.to_string())
 }
 
+fn image_upload_status_error(action: &str, method: &str, target: &str, status: u16) -> String {
+    format!(
+        "{action} failed: {method} {}: HTTP {status}",
+        image_upload_diagnostic_path(target)
+    )
+}
+
+fn image_upload_request_error(
+    action: &str,
+    method: &str,
+    target: &str,
+    error: impl std::fmt::Display,
+) -> String {
+    format!(
+        "{action} failed: {method} {}: {error}",
+        image_upload_diagnostic_path(target)
+    )
+}
+
+fn image_upload_diagnostic_target(upload_path: &str, file_name: &str) -> String {
+    let upload_path = upload_path.trim().trim_matches('/').replace('\\', "/");
+    let raw_target = if upload_path.is_empty() {
+        file_name.to_string()
+    } else {
+        format!("{upload_path}/{file_name}")
+    };
+
+    image_upload_diagnostic_path(&raw_target)
+}
+
+fn image_upload_diagnostic_path(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim();
+
+    if normalized.is_empty() {
+        "<root>".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
 fn apply_basic_auth(builder: RequestBuilder, username: &str, password: &str) -> RequestBuilder {
     if username.is_empty() && password.is_empty() {
         return builder;
@@ -354,19 +436,21 @@ fn webdav_mkcol_method() -> Result<Method, String> {
     Method::from_bytes(b"MKCOL").map_err(|error| error.to_string())
 }
 
-fn webdav_collection_urls(server_url: &str, upload_path: &str) -> Result<Vec<Url>, String> {
+fn webdav_collection_targets(
+    server_url: &str,
+    upload_path: &str,
+) -> Result<Vec<ImageUploadCollectionTarget>, String> {
     let segments = normalize_upload_path_segments(upload_path)?;
-    let mut urls = Vec::with_capacity(segments.len());
+    let mut targets = Vec::with_capacity(segments.len());
 
     for index in 0..segments.len() {
-        urls.push(remote_url_with_segments(
-            server_url,
-            &segments[..=index],
-            "",
-        )?);
+        targets.push(ImageUploadCollectionTarget {
+            diagnostic_path: image_upload_diagnostic_path(&segments[..=index].join("/")),
+            url: remote_url_with_segments(server_url, &segments[..=index], "")?,
+        });
     }
 
-    Ok(urls)
+    Ok(targets)
 }
 
 fn image_upload_url(base_url: &str, upload_path: &str, file_name: &str) -> Result<Url, String> {
@@ -814,6 +898,51 @@ mod tests {
         assert_eq!(
             targets.public_url,
             "https://blocknews-dev.oss-cn-hangzhou.aliyuncs.com/Notes/pasted-image.png"
+        );
+    }
+
+    #[test]
+    fn formats_image_upload_status_errors_with_request_context() {
+        assert_eq!(
+            image_upload_status_error("WebDAV image folder creation", "MKCOL", "images", 409),
+            "WebDAV image folder creation failed: MKCOL images: HTTP 409"
+        );
+        assert_eq!(
+            image_upload_status_error("WebDAV image upload", "PUT", "notes/pasted-image.png", 507),
+            "WebDAV image upload failed: PUT notes/pasted-image.png: HTTP 507"
+        );
+        assert_eq!(
+            image_upload_status_error("PicGo image upload", "POST", "/upload", 500),
+            "PicGo image upload failed: POST /upload: HTTP 500"
+        );
+        assert_eq!(
+            image_upload_status_error("S3 image upload", "PUT", "notes/pasted-image.png", 403),
+            "S3 image upload failed: PUT notes/pasted-image.png: HTTP 403"
+        );
+    }
+
+    #[test]
+    fn formats_image_upload_request_errors_with_request_context() {
+        assert_eq!(
+            image_upload_request_error(
+                "PicGo image upload",
+                "POST",
+                "notes\nbad/pasted-image.png",
+                "connection reset"
+            ),
+            "PicGo image upload failed: POST notes bad/pasted-image.png: connection reset"
+        );
+    }
+
+    #[test]
+    fn builds_image_upload_diagnostic_targets() {
+        assert_eq!(
+            image_upload_diagnostic_target("", "pasted-image.png"),
+            "pasted-image.png"
+        );
+        assert_eq!(
+            image_upload_diagnostic_target("notes\nbad", "pasted-image.png"),
+            "notes bad/pasted-image.png"
         );
     }
 }

--- a/apps/desktop/src-tauri/src/remote_sync.rs
+++ b/apps/desktop/src-tauri/src/remote_sync.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_MATCH, IF_NONE_MATCH, LAST_MODIFIED};
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH, LAST_MODIFIED};
 use reqwest::{Client, Method, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -510,7 +510,7 @@ async fn list_webdav_remote_files(
             else {
                 continue;
             };
-            if relative_path.is_empty() {
+            if should_skip_webdav_listing_path(&relative_path, &directory_path) {
                 continue;
             }
             if relative_path
@@ -545,6 +545,10 @@ async fn list_webdav_remote_files(
     }
 
     Ok(files)
+}
+
+fn should_skip_webdav_listing_path(relative_path: &str, directory_path: &str) -> bool {
+    relative_path.is_empty() || relative_path == directory_path
 }
 
 async fn propfind_webdav_directory(
@@ -881,10 +885,7 @@ async fn delete_webdav_file(
     )
     .await?;
     let response = apply_basic_auth(
-        apply_webdav_match_precondition(
-            client.request(webdav_delete_method()?, file_url),
-            expected_remote_identity,
-        ),
+        client.request(webdav_delete_method()?, file_url),
         &request.username,
         &request.password,
     )
@@ -1018,7 +1019,7 @@ async fn ensure_remote_sync_identity(
 ) -> Result<(), String> {
     let actual_identity =
         webdav_file_identity_optional(client, request, relative_path, file_url).await?;
-    if actual_identity.as_deref() == expected_identity {
+    if same_optional_remote_identity(actual_identity.as_deref(), expected_identity) {
         return Ok(());
     }
 
@@ -1044,14 +1045,10 @@ async fn download_webdav_file(
         Some(expected_remote_identity),
     )
     .await?;
-    let response = apply_basic_auth(
-        apply_webdav_match_precondition(client.get(file_url), expected_remote_identity),
-        &request.username,
-        &request.password,
-    )
-    .send()
-    .await
-    .map_err(|error| webdav_request_error("download", "GET", relative_path, error))?;
+    let response = apply_basic_auth(client.get(file_url), &request.username, &request.password)
+        .send()
+        .await
+        .map_err(|error| webdav_request_error("download", "GET", relative_path, error))?;
 
     if !response.status().is_success() {
         return Err(webdav_status_error(
@@ -1132,7 +1129,7 @@ fn plan_webdav_file_sync(
             let Some(manifest) = manifest else {
                 return WebDavFileSyncAction::Download;
             };
-            if remote == manifest.remote_etag {
+            if same_remote_identity(remote, &manifest.remote_etag) {
                 WebDavFileSyncAction::DeleteRemote
             } else {
                 WebDavFileSyncAction::Download
@@ -1144,7 +1141,7 @@ fn plan_webdav_file_sync(
                 return WebDavFileSyncAction::Conflict;
             };
             let local_changed = local != manifest.local_hash;
-            let remote_changed = remote != manifest.remote_etag;
+            let remote_changed = !same_remote_identity(remote, &manifest.remote_etag);
 
             match (local_changed, remote_changed) {
                 (false, false) => WebDavFileSyncAction::Skip,
@@ -1175,21 +1172,11 @@ fn apply_webdav_remote_precondition(
     builder: RequestBuilder,
     expected_remote_identity: Option<&str>,
 ) -> RequestBuilder {
-    let Some(expected_remote_identity) = expected_remote_identity else {
+    if expected_remote_identity.is_none() {
         return builder.header(IF_NONE_MATCH, "*");
-    };
-
-    apply_webdav_match_precondition(builder, expected_remote_identity)
-}
-
-fn apply_webdav_match_precondition(
-    builder: RequestBuilder,
-    expected_remote_identity: &str,
-) -> RequestBuilder {
-    if let Some(etag) = webdav_etag_precondition(expected_remote_identity) {
-        return builder.header(IF_MATCH, etag);
     }
 
+    // Some WebDAV servers expose weak/strong ETag variants across methods, so rely on the explicit identity probe above.
     builder
 }
 
@@ -1257,22 +1244,37 @@ fn webdav_diagnostic_relative_path(relative_path: &str) -> String {
     }
 }
 
-fn webdav_etag_precondition(identity: &str) -> Option<&str> {
+fn same_optional_remote_identity(actual: Option<&str>, expected: Option<&str>) -> bool {
+    match (actual, expected) {
+        (Some(actual), Some(expected)) => same_remote_identity(actual, expected),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn same_remote_identity(left: &str, right: &str) -> bool {
+    canonical_webdav_etag_identity(left) == canonical_webdav_etag_identity(right)
+}
+
+fn canonical_webdav_etag_identity(identity: &str) -> &str {
     let trimmed = identity.trim();
-    if trimmed.is_empty()
-        || trimmed.starts_with("modified:")
-        || trimmed.starts_with("len:")
-        || trimmed.starts_with("sha256:")
-    {
-        return None;
+    let weak_value = trimmed
+        .strip_prefix("W/")
+        .or_else(|| trimmed.strip_prefix("w/"));
+
+    if let Some(value) = weak_value {
+        let value = value.trim_start();
+        if value.starts_with('"') {
+            return value;
+        }
     }
 
-    Some(trimmed)
+    trimmed
 }
 
 fn remote_identity(etag: Option<&str>, last_modified: Option<&str>, size: u64) -> String {
     if let Some(etag) = etag.map(str::trim).filter(|value| !value.is_empty()) {
-        return etag.to_string();
+        return canonical_webdav_etag_identity(etag).to_string();
     }
 
     if let Some(last_modified) = last_modified
@@ -1564,6 +1566,43 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_webdav_weak_etags_for_remote_identity() {
+        assert_eq!(
+            remote_identity(Some(" W/\"8-656032d37efc2\" "), None, 8),
+            "\"8-656032d37efc2\""
+        );
+    }
+
+    #[test]
+    fn treats_weak_and_strong_webdav_etag_variants_as_same_remote_identity() {
+        let action = plan_webdav_file_sync(
+            Some("local-old"),
+            Some("\"8-656032d37efc2\""),
+            Some(&SyncManifestEntry {
+                local_hash: "local-old".to_string(),
+                remote_etag: "W/\"8-656032d37efc2\"".to_string(),
+            }),
+        );
+
+        assert_eq!(action, WebDavFileSyncAction::Skip);
+    }
+
+    #[test]
+    fn omits_webdav_if_match_after_explicit_remote_identity_check() {
+        let client = Client::new();
+        let request = apply_webdav_remote_precondition(
+            client
+                .put("https://dav.example.test/base/draft.md")
+                .body("hello"),
+            Some("\"8-656032d37efc2\""),
+        )
+        .build()
+        .expect("request should be built");
+
+        assert!(request.headers().get("if-match").is_none());
+    }
+
+    #[test]
     fn formats_webdav_http_errors_with_request_context() {
         assert_eq!(
             webdav_status_error("folder creation", "MKCOL", "notes", 409),
@@ -1626,6 +1665,14 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(diagnostic_paths, vec!["notes", "notes/2026"]);
+    }
+
+    #[test]
+    fn skips_current_collection_href_when_listing_nested_webdav_directory() {
+        assert!(should_skip_webdav_listing_path("", ""));
+        assert!(should_skip_webdav_listing_path("notes", "notes"));
+        assert!(!should_skip_webdav_listing_path("notes/draft.md", "notes"));
+        assert!(!should_skip_webdav_listing_path("notes/child", "notes"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/remote_sync.rs
+++ b/apps/desktop/src-tauri/src/remote_sync.rs
@@ -73,6 +73,12 @@ struct WebDavPropResponse {
     last_modified: Option<String>,
 }
 
+#[derive(Debug)]
+struct WebDavCollectionTarget {
+    relative_path: String,
+    url: Url,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum WebDavFileSyncAction {
     Conflict,
@@ -122,7 +128,7 @@ async fn execute_webdav_sync(request: WebDavSyncRequest) -> Result<WebDavSyncSum
         match action {
             WebDavFileSyncAction::Upload => {
                 let local = local_file
-                    .ok_or_else(|| "Local sync file is missing during upload".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Local", "upload", &relative_path))?;
                 let remote_identity = upload_webdav_file(
                     &client,
                     &request,
@@ -144,7 +150,7 @@ async fn execute_webdav_sync(request: WebDavSyncRequest) -> Result<WebDavSyncSum
             }
             WebDavFileSyncAction::Download => {
                 let remote = remote_file
-                    .ok_or_else(|| "Remote sync file is missing during download".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Remote", "download", &relative_path))?;
                 let hash = download_webdav_file(
                     &client,
                     &request,
@@ -167,13 +173,13 @@ async fn execute_webdav_sync(request: WebDavSyncRequest) -> Result<WebDavSyncSum
             }
             WebDavFileSyncAction::DeleteLocal => {
                 let local = local_file
-                    .ok_or_else(|| "Local sync file is missing during delete".to_string())?;
-                delete_local_sync_file(&local.path, &local.hash)?;
+                    .ok_or_else(|| sync_file_missing_error("Local", "delete", &relative_path))?;
+                delete_local_sync_file(&local.path, &local.hash, &relative_path)?;
                 manifest.entries.remove(&relative_path);
             }
             WebDavFileSyncAction::DeleteRemote => {
                 let remote = remote_file
-                    .ok_or_else(|| "Remote sync file is missing during delete".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Remote", "delete", &relative_path))?;
                 delete_webdav_file(
                     &client,
                     &request,
@@ -186,9 +192,9 @@ async fn execute_webdav_sync(request: WebDavSyncRequest) -> Result<WebDavSyncSum
             }
             WebDavFileSyncAction::Skip => {
                 let local = local_file
-                    .ok_or_else(|| "Local sync file is missing during skip".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Local", "skip", &relative_path))?;
                 let remote = remote_file
-                    .ok_or_else(|| "Remote sync file is missing during skip".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Remote", "skip", &relative_path))?;
                 summary.skipped_files += 1;
                 manifest.entries.insert(
                     relative_path,
@@ -200,15 +206,20 @@ async fn execute_webdav_sync(request: WebDavSyncRequest) -> Result<WebDavSyncSum
             }
             WebDavFileSyncAction::Conflict => {
                 let local = local_file
-                    .ok_or_else(|| "Local sync file is missing during conflict".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Local", "conflict", &relative_path))?;
                 let remote = remote_file
-                    .ok_or_else(|| "Remote sync file is missing during conflict".to_string())?;
+                    .ok_or_else(|| sync_file_missing_error("Remote", "conflict", &relative_path))?;
                 let conflict_path = local.path.with_file_name(remote_conflict_file_name(
                     local
                         .path
                         .file_name()
                         .and_then(|name| name.to_str())
-                        .ok_or_else(|| "Local sync file name is invalid".to_string())?,
+                        .ok_or_else(|| {
+                            format!(
+                                "Local sync file name is invalid: {}",
+                                webdav_diagnostic_relative_path(&relative_path)
+                            )
+                        })?,
                     &timestamp,
                 ));
                 download_webdav_file(
@@ -412,20 +423,24 @@ async fn ensure_webdav_root_collections(
     client: &Client,
     request: &WebDavSyncRequest,
 ) -> Result<(), String> {
-    for collection_url in webdav_collection_urls(&request.server_url, &request.remote_path)? {
+    for target in webdav_collection_targets(&request.server_url, &request.remote_path)? {
         let response = apply_basic_auth(
-            client.request(webdav_mkcol_method()?, collection_url),
+            client.request(webdav_mkcol_method()?, target.url),
             &request.username,
             &request.password,
         )
         .send()
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            webdav_request_error("folder creation", "MKCOL", &target.relative_path, error)
+        })?;
 
         if !(response.status().is_success() || response.status().as_u16() == 405) {
-            return Err(format!(
-                "WebDAV sync folder could not be created: HTTP {}",
-                response.status().as_u16()
+            return Err(webdav_status_error(
+                "folder creation",
+                "MKCOL",
+                &target.relative_path,
+                response.status().as_u16(),
             ));
         }
     }
@@ -433,19 +448,21 @@ async fn ensure_webdav_root_collections(
     Ok(())
 }
 
-fn webdav_collection_urls(server_url: &str, remote_path: &str) -> Result<Vec<Url>, String> {
+fn webdav_collection_targets(
+    server_url: &str,
+    remote_path: &str,
+) -> Result<Vec<WebDavCollectionTarget>, String> {
     let segments = normalize_remote_path_segments(remote_path)?;
-    let mut urls = Vec::with_capacity(segments.len());
+    let mut targets = Vec::with_capacity(segments.len());
 
     for index in 0..segments.len() {
-        urls.push(webdav_url_with_segments(
-            server_url,
-            &segments[..=index],
-            true,
-        )?);
+        targets.push(WebDavCollectionTarget {
+            relative_path: segments[..=index].join("/"),
+            url: webdav_url_with_segments(server_url, &segments[..=index], true)?,
+        });
     }
 
-    Ok(urls)
+    Ok(targets)
 }
 
 fn webdav_url_with_segments(
@@ -476,16 +493,21 @@ async fn list_webdav_remote_files(
     root_url: &Url,
 ) -> Result<BTreeMap<String, RemoteSyncFile>, String> {
     let mut files = BTreeMap::new();
-    let mut directories = vec![root_url.clone()];
+    let mut directories = vec![(root_url.clone(), String::new())];
 
-    while let Some(directory_url) = directories.pop() {
-        let responses = propfind_webdav_directory(client, request, &directory_url).await?;
+    while let Some((directory_url, directory_path)) = directories.pop() {
+        let responses =
+            propfind_webdav_directory(client, request, &directory_url, &directory_path).await?;
 
         for response in responses {
             if response.href.trim().is_empty() {
                 continue;
             }
-            let Some(relative_path) = remote_relative_path(root_url, &response.href)? else {
+            let Some(relative_path) =
+                remote_relative_path(root_url, &response.href).map_err(|error| {
+                    webdav_request_error("listing", "PROPFIND depth=1", &directory_path, error)
+                })?
+            else {
                 continue;
             };
             if relative_path.is_empty() {
@@ -499,7 +521,12 @@ async fn list_webdav_remote_files(
             }
 
             if response.is_collection {
-                directories.push(webdav_child_url(root_url, &relative_path, true)?);
+                directories.push((
+                    webdav_child_url(root_url, &relative_path, true).map_err(|error| {
+                        webdav_request_error("listing", "PROPFIND depth=1", &relative_path, error)
+                    })?,
+                    relative_path.clone(),
+                ));
             } else {
                 let size = response.content_length.unwrap_or(0);
                 files.insert(
@@ -524,6 +551,7 @@ async fn propfind_webdav_directory(
     client: &Client,
     request: &WebDavSyncRequest,
     directory_url: &Url,
+    relative_path: &str,
 ) -> Result<Vec<WebDavPropResponse>, String> {
     let response = apply_basic_auth(
         client
@@ -546,18 +574,23 @@ async fn propfind_webdav_directory(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| webdav_request_error("listing", "PROPFIND depth=1", relative_path, error))?;
 
     if !(response.status().is_success() || response.status().as_u16() == 207) {
-        return Err(format!(
-            "WebDAV sync listing failed: HTTP {}",
-            response.status().as_u16()
+        return Err(webdav_status_error(
+            "listing",
+            "PROPFIND depth=1",
+            relative_path,
+            response.status().as_u16(),
         ));
     }
 
-    let body = response.text().await.map_err(|error| error.to_string())?;
+    let body = response.text().await.map_err(|error| {
+        webdav_request_error("listing", "PROPFIND depth=1", relative_path, error)
+    })?;
 
     parse_webdav_propfind_response(&body)
+        .map_err(|error| webdav_request_error("listing", "PROPFIND depth=1", relative_path, error))
 }
 
 fn parse_webdav_propfind_response(body: &str) -> Result<Vec<WebDavPropResponse>, String> {
@@ -740,7 +773,10 @@ async fn ensure_webdav_parent_collections(
 
     for index in 0..parent_segments.len() {
         let collection_path = parent_segments[..=index].join("/");
-        let collection_url = webdav_child_url(root_url, &collection_path, true)?;
+        let collection_url =
+            webdav_child_url(root_url, &collection_path, true).map_err(|error| {
+                webdav_request_error("folder creation", "MKCOL", &collection_path, error)
+            })?;
         let response = apply_basic_auth(
             client.request(webdav_mkcol_method()?, collection_url),
             &request.username,
@@ -748,12 +784,16 @@ async fn ensure_webdav_parent_collections(
         )
         .send()
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            webdav_request_error("folder creation", "MKCOL", &collection_path, error)
+        })?;
 
         if !(response.status().is_success() || response.status().as_u16() == 405) {
-            return Err(format!(
-                "WebDAV sync folder could not be created: HTTP {}",
-                response.status().as_u16()
+            return Err(webdav_status_error(
+                "folder creation",
+                "MKCOL",
+                &collection_path,
+                response.status().as_u16(),
             ));
         }
     }
@@ -770,12 +810,21 @@ async fn upload_webdav_file(
     expected_remote_identity: Option<&str>,
 ) -> Result<String, String> {
     ensure_webdav_parent_collections(client, request, root_url, relative_path).await?;
-    let file_url = webdav_child_url(root_url, relative_path, false)?;
-    let bytes = fs::read(&local_file.path).map_err(|error| error.to_string())?;
+    let file_url = webdav_child_url(root_url, relative_path, false)
+        .map_err(|error| webdav_request_error("upload", "PUT", relative_path, error))?;
+    let bytes = fs::read(&local_file.path)
+        .map_err(|error| local_sync_file_error("read", relative_path, error))?;
     if sha256_hex(&bytes) != local_file.hash {
-        return Err("Local sync file changed during sync".to_string());
+        return Err(sync_file_changed_error("Local", relative_path));
     }
-    ensure_remote_sync_identity(client, request, &file_url, expected_remote_identity).await?;
+    ensure_remote_sync_identity(
+        client,
+        request,
+        relative_path,
+        &file_url,
+        expected_remote_identity,
+    )
+    .await?;
     let response = apply_basic_auth(
         apply_webdav_remote_precondition(
             client
@@ -789,12 +838,14 @@ async fn upload_webdav_file(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| webdav_request_error("upload", "PUT", relative_path, error))?;
 
     if !response.status().is_success() {
-        return Err(format!(
-            "WebDAV sync upload failed: HTTP {}",
-            response.status().as_u16()
+        return Err(webdav_status_error(
+            "upload",
+            "PUT",
+            relative_path,
+            response.status().as_u16(),
         ));
     }
 
@@ -807,7 +858,7 @@ async fn upload_webdav_file(
         return Ok(remote_identity(Some(etag), None, local_file.size));
     }
 
-    webdav_file_identity(client, request, &file_url, local_file.size)
+    webdav_file_identity(client, request, relative_path, &file_url, local_file.size)
         .await
         .or_else(|_| Ok(format!("sha256:{}", local_file.hash)))
 }
@@ -819,8 +870,16 @@ async fn delete_webdav_file(
     relative_path: &str,
     expected_remote_identity: &str,
 ) -> Result<(), String> {
-    let file_url = webdav_child_url(root_url, relative_path, false)?;
-    ensure_remote_sync_identity(client, request, &file_url, Some(expected_remote_identity)).await?;
+    let file_url = webdav_child_url(root_url, relative_path, false)
+        .map_err(|error| webdav_request_error("delete", "DELETE", relative_path, error))?;
+    ensure_remote_sync_identity(
+        client,
+        request,
+        relative_path,
+        &file_url,
+        Some(expected_remote_identity),
+    )
+    .await?;
     let response = apply_basic_auth(
         apply_webdav_match_precondition(
             client.request(webdav_delete_method()?, file_url),
@@ -831,21 +890,24 @@ async fn delete_webdav_file(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| webdav_request_error("delete", "DELETE", relative_path, error))?;
 
     if response.status().is_success() || response.status().as_u16() == 404 {
         return Ok(());
     }
 
-    Err(format!(
-        "WebDAV sync delete failed: HTTP {}",
-        response.status().as_u16()
+    Err(webdav_status_error(
+        "delete",
+        "DELETE",
+        relative_path,
+        response.status().as_u16(),
     ))
 }
 
 async fn webdav_file_identity(
     client: &Client,
     request: &WebDavSyncRequest,
+    relative_path: &str,
     file_url: &Url,
     fallback_size: u64,
 ) -> Result<String, String> {
@@ -856,12 +918,14 @@ async fn webdav_file_identity(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| webdav_request_error("metadata", "HEAD", relative_path, error))?;
 
     if !response.status().is_success() {
-        return Err(format!(
-            "WebDAV sync metadata failed: HTTP {}",
-            response.status().as_u16()
+        return Err(webdav_status_error(
+            "metadata",
+            "HEAD",
+            relative_path,
+            response.status().as_u16(),
         ));
     }
 
@@ -886,6 +950,7 @@ async fn webdav_file_identity(
 async fn webdav_file_identity_optional(
     client: &Client,
     request: &WebDavSyncRequest,
+    relative_path: &str,
     file_url: &Url,
 ) -> Result<Option<String>, String> {
     let response = apply_basic_auth(
@@ -909,21 +974,27 @@ async fn webdav_file_identity_optional(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| webdav_request_error("metadata", "PROPFIND depth=0", relative_path, error))?;
 
     if response.status().as_u16() == 404 {
         return Ok(None);
     }
 
     if !(response.status().is_success() || response.status().as_u16() == 207) {
-        return Err(format!(
-            "WebDAV sync metadata failed: HTTP {}",
-            response.status().as_u16()
+        return Err(webdav_status_error(
+            "metadata",
+            "PROPFIND depth=0",
+            relative_path,
+            response.status().as_u16(),
         ));
     }
 
-    let body = response.text().await.map_err(|error| error.to_string())?;
-    let responses = parse_webdav_propfind_response(&body)?;
+    let body = response.text().await.map_err(|error| {
+        webdav_request_error("metadata", "PROPFIND depth=0", relative_path, error)
+    })?;
+    let responses = parse_webdav_propfind_response(&body).map_err(|error| {
+        webdav_request_error("metadata", "PROPFIND depth=0", relative_path, error)
+    })?;
     let Some(response) = responses
         .into_iter()
         .find(|response| !response.is_collection)
@@ -941,15 +1012,17 @@ async fn webdav_file_identity_optional(
 async fn ensure_remote_sync_identity(
     client: &Client,
     request: &WebDavSyncRequest,
+    relative_path: &str,
     file_url: &Url,
     expected_identity: Option<&str>,
 ) -> Result<(), String> {
-    let actual_identity = webdav_file_identity_optional(client, request, file_url).await?;
+    let actual_identity =
+        webdav_file_identity_optional(client, request, relative_path, file_url).await?;
     if actual_identity.as_deref() == expected_identity {
         return Ok(());
     }
 
-    Err("Remote sync file changed during sync".to_string())
+    Err(sync_file_changed_error("Remote", relative_path))
 }
 
 async fn download_webdav_file(
@@ -961,8 +1034,16 @@ async fn download_webdav_file(
     expected_local_hash: Option<&str>,
     expected_remote_identity: &str,
 ) -> Result<String, String> {
-    let file_url = webdav_child_url(root_url, relative_path, false)?;
-    ensure_remote_sync_identity(client, request, &file_url, Some(expected_remote_identity)).await?;
+    let file_url = webdav_child_url(root_url, relative_path, false)
+        .map_err(|error| webdav_request_error("download", "GET", relative_path, error))?;
+    ensure_remote_sync_identity(
+        client,
+        request,
+        relative_path,
+        &file_url,
+        Some(expected_remote_identity),
+    )
+    .await?;
     let response = apply_basic_auth(
         apply_webdav_match_precondition(client.get(file_url), expected_remote_identity),
         &request.username,
@@ -970,46 +1051,65 @@ async fn download_webdav_file(
     )
     .send()
     .await
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| webdav_request_error("download", "GET", relative_path, error))?;
 
     if !response.status().is_success() {
-        return Err(format!(
-            "WebDAV sync download failed: HTTP {}",
-            response.status().as_u16()
+        return Err(webdav_status_error(
+            "download",
+            "GET",
+            relative_path,
+            response.status().as_u16(),
         ));
     }
 
-    let bytes = response.bytes().await.map_err(|error| error.to_string())?;
-    ensure_local_sync_identity(target_path, expected_local_hash)?;
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|error| webdav_request_error("download", "GET", relative_path, error))?;
+    ensure_local_sync_identity(target_path, expected_local_hash, relative_path)?;
     if let Some(parent) = target_path.parent() {
-        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        fs::create_dir_all(parent)
+            .map_err(|error| local_sync_file_error("folder creation", relative_path, error))?;
     }
-    fs::write(target_path, &bytes).map_err(|error| error.to_string())?;
+    fs::write(target_path, &bytes)
+        .map_err(|error| local_sync_file_error("write", relative_path, error))?;
 
     Ok(sha256_hex(&bytes))
 }
 
-fn ensure_local_sync_identity(path: &Path, expected_hash: Option<&str>) -> Result<(), String> {
+fn ensure_local_sync_identity(
+    path: &Path,
+    expected_hash: Option<&str>,
+    relative_path: &str,
+) -> Result<(), String> {
     match expected_hash {
         Some(expected_hash) => {
-            let bytes = fs::read(path).map_err(|error| error.to_string())?;
+            let bytes = fs::read(path)
+                .map_err(|error| local_sync_file_error("read", relative_path, error))?;
             if sha256_hex(&bytes) == expected_hash {
                 return Ok(());
             }
         }
         None => {
-            if !path.try_exists().map_err(|error| error.to_string())? {
+            if !path
+                .try_exists()
+                .map_err(|error| local_sync_file_error("stat", relative_path, error))?
+            {
                 return Ok(());
             }
         }
     }
 
-    Err("Local sync file changed during sync".to_string())
+    Err(sync_file_changed_error("Local", relative_path))
 }
 
-fn delete_local_sync_file(path: &Path, expected_hash: &str) -> Result<(), String> {
-    ensure_local_sync_identity(path, Some(expected_hash))?;
-    fs::remove_file(path).map_err(|error| error.to_string())
+fn delete_local_sync_file(
+    path: &Path,
+    expected_hash: &str,
+    relative_path: &str,
+) -> Result<(), String> {
+    ensure_local_sync_identity(path, Some(expected_hash), relative_path)?;
+    fs::remove_file(path).map_err(|error| local_sync_file_error("delete", relative_path, error))
 }
 
 fn plan_webdav_file_sync(
@@ -1091,6 +1191,70 @@ fn apply_webdav_match_precondition(
     }
 
     builder
+}
+
+fn webdav_status_error(action: &str, method: &str, relative_path: &str, status: u16) -> String {
+    format!(
+        "WebDAV sync {action} failed: {method} {}: HTTP {status}",
+        webdav_diagnostic_relative_path(relative_path)
+    )
+}
+
+fn webdav_request_error(
+    action: &str,
+    method: &str,
+    relative_path: &str,
+    error: impl std::fmt::Display,
+) -> String {
+    format!(
+        "WebDAV sync {action} failed: {method} {}: {error}",
+        webdav_diagnostic_relative_path(relative_path)
+    )
+}
+
+fn sync_file_changed_error(side: &str, relative_path: &str) -> String {
+    format!(
+        "{side} sync file changed during sync: {}",
+        webdav_diagnostic_relative_path(relative_path)
+    )
+}
+
+fn sync_file_missing_error(side: &str, action: &str, relative_path: &str) -> String {
+    format!(
+        "{side} sync file is missing during {action}: {}",
+        webdav_diagnostic_relative_path(relative_path)
+    )
+}
+
+fn local_sync_file_error(
+    action: &str,
+    relative_path: &str,
+    error: impl std::fmt::Display,
+) -> String {
+    format!(
+        "Local sync file {action} failed: {}: {error}",
+        webdav_diagnostic_relative_path(relative_path)
+    )
+}
+
+fn webdav_diagnostic_relative_path(relative_path: &str) -> String {
+    let normalized = relative_path
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim();
+
+    if normalized.is_empty() {
+        "<root>".to_string()
+    } else {
+        normalized.to_string()
+    }
 }
 
 fn webdav_etag_precondition(identity: &str) -> Option<&str> {
@@ -1384,10 +1548,11 @@ mod tests {
         let target = root.join("draft.md");
         write_test_file(&target, "current contents");
 
-        let error = ensure_local_sync_identity(&target, Some(&sha256_hex(b"old contents")))
-            .expect_err("changed local file should be rejected");
+        let error =
+            ensure_local_sync_identity(&target, Some(&sha256_hex(b"old contents")), "draft.md")
+                .expect_err("changed local file should be rejected");
 
-        assert!(error.contains("Local sync file changed during sync"));
+        assert_eq!(error, "Local sync file changed during sync: draft.md");
     }
 
     #[test]
@@ -1396,6 +1561,71 @@ mod tests {
             remote_identity(None, Some("Sun, 07 Jun 2026 02:00:00 GMT"), 128),
             "modified:Sun, 07 Jun 2026 02:00:00 GMT;len:128"
         );
+    }
+
+    #[test]
+    fn formats_webdav_http_errors_with_request_context() {
+        assert_eq!(
+            webdav_status_error("folder creation", "MKCOL", "notes", 409),
+            "WebDAV sync folder creation failed: MKCOL notes: HTTP 409"
+        );
+        assert_eq!(
+            webdav_status_error("listing", "PROPFIND depth=1", "", 400),
+            "WebDAV sync listing failed: PROPFIND depth=1 <root>: HTTP 400"
+        );
+        assert_eq!(
+            webdav_status_error("metadata", "PROPFIND depth=0", "notes/draft.md", 400),
+            "WebDAV sync metadata failed: PROPFIND depth=0 notes/draft.md: HTTP 400"
+        );
+        assert_eq!(
+            webdav_status_error("metadata", "HEAD", "folder/image.png", 405),
+            "WebDAV sync metadata failed: HEAD folder/image.png: HTTP 405"
+        );
+        assert_eq!(
+            webdav_status_error("upload", "PUT", "folder/image.png", 507),
+            "WebDAV sync upload failed: PUT folder/image.png: HTTP 507"
+        );
+        assert_eq!(
+            webdav_status_error("download", "GET", "folder/image.png", 503),
+            "WebDAV sync download failed: GET folder/image.png: HTTP 503"
+        );
+        assert_eq!(
+            webdav_status_error("delete", "DELETE", "folder/image.png", 423),
+            "WebDAV sync delete failed: DELETE folder/image.png: HTTP 423"
+        );
+    }
+
+    #[test]
+    fn formats_webdav_transport_and_file_guard_errors_with_context() {
+        assert_eq!(
+            webdav_request_error(
+                "listing",
+                "PROPFIND depth=1",
+                "folder\nbad",
+                "mock transport"
+            ),
+            "WebDAV sync listing failed: PROPFIND depth=1 folder bad: mock transport"
+        );
+        assert_eq!(
+            sync_file_changed_error("Remote", "notes/draft.md"),
+            "Remote sync file changed during sync: notes/draft.md"
+        );
+        assert_eq!(
+            sync_file_changed_error("Local", ""),
+            "Local sync file changed during sync: <root>"
+        );
+    }
+
+    #[test]
+    fn builds_webdav_collection_targets_with_diagnostic_paths() {
+        let targets = webdav_collection_targets("https://dav.example.test/base/", "notes/2026")
+            .expect("collection targets should be built");
+        let diagnostic_paths = targets
+            .iter()
+            .map(|target| target.relative_path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(diagnostic_paths, vec!["notes", "notes/2026"]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/spellcheck_dictionary.rs
+++ b/apps/desktop/src-tauri/src/spellcheck_dictionary.rs
@@ -135,6 +135,7 @@ async fn download_dictionary_bytes(
     request: &SpellcheckDictionaryRequest,
 ) -> Result<Vec<u8>, String> {
     let mut url = validated_web_resource_url(&request.url, false)?;
+    let target = dictionary_download_diagnostic_target(&request.id);
     let client = apply_network_settings(
         reqwest::Client::builder()
             .redirect(Policy::none())
@@ -151,7 +152,7 @@ async fn download_dictionary_bytes(
             .get(url.clone())
             .send()
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| dictionary_download_request_error("GET", &target, error))?;
         let status = response.status();
 
         if status.is_redirection() {
@@ -166,9 +167,10 @@ async fn download_dictionary_bytes(
         }
 
         if !status.is_success() {
-            return Err(format!(
-                "Spellcheck dictionary download failed: HTTP {}",
-                status.as_u16()
+            return Err(dictionary_download_status_error(
+                "GET",
+                &target,
+                status.as_u16(),
             ));
         }
 
@@ -182,7 +184,10 @@ async fn download_dictionary_bytes(
             }
         }
 
-        let bytes = response.bytes().await.map_err(|error| error.to_string())?;
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| dictionary_download_request_error("GET", &target, error))?;
         if bytes.len() as u64 > SPELLCHECK_DICTIONARY_MAX_BYTES {
             return Err("Spellcheck dictionary is too large.".to_string());
         }
@@ -191,6 +196,48 @@ async fn download_dictionary_bytes(
     }
 
     Err("Spellcheck dictionary download followed too many redirects.".to_string())
+}
+
+fn dictionary_download_status_error(method: &str, target: &str, status: u16) -> String {
+    format!(
+        "Spellcheck dictionary download failed: {method} {}: HTTP {status}",
+        dictionary_download_diagnostic_path(target)
+    )
+}
+
+fn dictionary_download_request_error(
+    method: &str,
+    target: &str,
+    error: impl std::fmt::Display,
+) -> String {
+    format!(
+        "Spellcheck dictionary download failed: {method} {}: {error}",
+        dictionary_download_diagnostic_path(target)
+    )
+}
+
+fn dictionary_download_diagnostic_target(id: &str) -> String {
+    dictionary_download_diagnostic_path(&format!("dictionary {id}"))
+}
+
+fn dictionary_download_diagnostic_path(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim();
+
+    if normalized.is_empty() {
+        "dictionary".to_string()
+    } else {
+        normalized.to_string()
+    }
 }
 
 fn dictionary_cache_matches_sha256(cache_path: &Path, sha256: &str) -> Result<bool, String> {
@@ -311,6 +358,26 @@ mod tests {
         assert!(!dictionary_cache_matches_sha256(&cache_path, "abc123").unwrap());
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn formats_dictionary_download_status_errors_with_request_context() {
+        assert_eq!(
+            dictionary_download_status_error("GET", "dictionary en-US", 404),
+            "Spellcheck dictionary download failed: GET dictionary en-US: HTTP 404"
+        );
+        assert_eq!(
+            dictionary_download_request_error("GET", "dictionary en-US", "timeout"),
+            "Spellcheck dictionary download failed: GET dictionary en-US: timeout"
+        );
+    }
+
+    #[test]
+    fn builds_dictionary_download_diagnostic_targets() {
+        assert_eq!(
+            dictionary_download_diagnostic_target("en-US\nprivate"),
+            "dictionary en-US private"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/web_http.rs
+++ b/apps/desktop/src-tauri/src/web_http.rs
@@ -134,7 +134,7 @@ async fn execute_web_image_download(
             .get(url.clone())
             .send()
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| web_image_download_request_error("GET", "remote image", error))?;
         let status = response.status();
 
         if status.is_redirection() {
@@ -149,9 +149,10 @@ async fn execute_web_image_download(
         }
 
         if !status.is_success() {
-            return Err(format!(
-                "Web image download failed: HTTP {}",
-                status.as_u16()
+            return Err(web_image_download_status_error(
+                "GET",
+                "remote image",
+                status.as_u16(),
             ));
         }
 
@@ -167,7 +168,10 @@ async fn execute_web_image_download(
 
         let mime_type = web_image_mime_type(response.headers().get(CONTENT_TYPE), &url)?;
         let file_name = web_image_file_name(&url, &mime_type);
-        let bytes = response.bytes().await.map_err(|error| error.to_string())?;
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|error| web_image_download_request_error("GET", "remote image", error))?;
         if bytes.len() as u64 > WEB_IMAGE_MAX_BYTES {
             return Err("Web image is too large to paste into the document.".to_string());
         }
@@ -287,6 +291,44 @@ fn image_extension_from_mime_type(mime_type: &str) -> &'static str {
         "image/svg+xml" => "svg",
         "image/webp" => "webp",
         _ => "png",
+    }
+}
+
+fn web_image_download_status_error(method: &str, target: &str, status: u16) -> String {
+    format!(
+        "Web image download failed: {method} {}: HTTP {status}",
+        web_image_download_diagnostic_target(target)
+    )
+}
+
+fn web_image_download_request_error(
+    method: &str,
+    target: &str,
+    error: impl std::fmt::Display,
+) -> String {
+    format!(
+        "Web image download failed: {method} {}: {error}",
+        web_image_download_diagnostic_target(target)
+    )
+}
+
+fn web_image_download_diagnostic_target(target: &str) -> String {
+    let normalized = target
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    let normalized = normalized.trim();
+
+    if normalized.is_empty() {
+        "remote image".to_string()
+    } else {
+        normalized.to_string()
     }
 }
 
@@ -425,6 +467,18 @@ mod tests {
             .expect_err("non-image content type should be rejected");
 
         assert!(error.contains("not an image"));
+    }
+
+    #[test]
+    fn formats_web_image_download_status_errors_with_request_context() {
+        assert_eq!(
+            web_image_download_status_error("GET", "remote image", 404),
+            "Web image download failed: GET remote image: HTTP 404"
+        );
+        assert_eq!(
+            web_image_download_request_error("GET", "remote image", "timeout"),
+            "Web image download failed: GET remote image: timeout"
+        );
     }
 
     #[test]

--- a/apps/desktop/src/runtime/tauri/invoke.test.ts
+++ b/apps/desktop/src/runtime/tauri/invoke.test.ts
@@ -37,11 +37,56 @@ describe("invokeNative", () => {
       error
     );
 
-    expect(consoleError).toHaveBeenCalledWith("[native command failed]", {
+    expect(consoleError).toHaveBeenCalledWith("[native command failed]", expect.objectContaining({
+      args: "{\"serverUrl\":\"[redacted]\"}",
       command: "sync_webdav_markdown_folder",
-      error
+      error: "backend failed"
+    }));
+
+    consoleError.mockRestore();
+  });
+
+  it("emits sanitized runtime diagnostics for every native command failure", async () => {
+    const error = "S3 image upload failed: PUT pasted-image.png: HTTP 403";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const dispatchEvent = vi.spyOn(window, "dispatchEvent");
+    mockedInvoke.mockRejectedValue(error);
+
+    await expect(invokeNative("upload_s3_image", {
+      request: {
+        endpointUrl: "https://s3.example.test/private",
+        fileName: "pasted-image.png",
+        secretAccessKey: "synthetic-secret",
+        sourcePath: "/Users/example/private-note.md"
+      }
+    })).rejects.toBe(error);
+
+    const diagnosticEvent = dispatchEvent.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.type === "markra:runtime-diagnostic") as CustomEvent | undefined;
+    expect(diagnosticEvent?.detail).toMatchObject({
+      area: "storage",
+      details: {
+        args: expect.stringContaining("pasted-image.png"),
+        command: "upload_s3_image",
+        error
+      },
+      level: "error",
+      message: "Native command failed"
     });
 
+    const diagnosticDetails = JSON.stringify(diagnosticEvent?.detail);
+    expect(diagnosticDetails).not.toContain("synthetic-secret");
+    expect(diagnosticDetails).not.toContain("s3.example.test");
+    expect(diagnosticDetails).not.toContain("/Users/example");
+
+    expect(consoleError).toHaveBeenCalledWith("[native command failed]", expect.objectContaining({
+      args: expect.stringContaining("pasted-image.png"),
+      command: "upload_s3_image",
+      error
+    }));
+
+    dispatchEvent.mockRestore();
     consoleError.mockRestore();
   });
 });

--- a/apps/desktop/src/runtime/tauri/invoke.ts
+++ b/apps/desktop/src/runtime/tauri/invoke.ts
@@ -1,6 +1,12 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import {
+  diagnosticErrorMessage,
+  runtimeDiagnosticEvent,
+  sanitizeDiagnosticDetails
+} from "@markra/shared";
 
 type NativeInvokeArgs = Parameters<typeof tauriInvoke>[1];
+type NativeCommandFailureArea = "ai" | "backup" | "file" | "settings" | "storage" | "sync" | "system" | "update";
 
 export async function invokeNative<T>(command: string, args?: NativeInvokeArgs): Promise<T> {
   try {
@@ -11,7 +17,60 @@ export async function invokeNative<T>(command: string, args?: NativeInvokeArgs):
 
     return await tauriInvoke<T>(command, args);
   } catch (error) {
-    console.error("[native command failed]", { command, error });
+    const details = nativeCommandFailureDetails(command, args, error);
+    dispatchNativeCommandFailureDiagnostic(command, details);
+    console.error("[native command failed]", details);
     throw error;
   }
+}
+
+function nativeCommandFailureDetails(command: string, args: NativeInvokeArgs | undefined, error: unknown) {
+  const rawDetails: Record<string, unknown> = {
+    command,
+    error: diagnosticErrorMessage(error)
+  };
+  if (args !== undefined) {
+    rawDetails.args = args;
+  }
+
+  return sanitizeDiagnosticDetails(rawDetails) ?? {};
+}
+
+function dispatchNativeCommandFailureDiagnostic(
+  command: string,
+  details: ReturnType<typeof nativeCommandFailureDetails>
+) {
+  if (typeof window === "undefined" || typeof CustomEvent === "undefined") return;
+
+  window.dispatchEvent(new CustomEvent(runtimeDiagnosticEvent, {
+    detail: {
+      area: nativeCommandFailureArea(command),
+      details,
+      level: "error",
+      message: "Native command failed"
+    }
+  }));
+}
+
+function nativeCommandFailureArea(command: string): NativeCommandFailureArea {
+  if (command.includes("sync")) return "sync";
+  if (command.includes("backup")) return "backup";
+  if (command.includes("update")) return "update";
+  if (command.includes("s3") || command.includes("picgo") || command.includes("webdav_image")) return "storage";
+  if (command.startsWith("request_ai") || command.startsWith("request_native_chat") || command.includes("_acp_")) {
+    return "ai";
+  }
+  if (command.includes("settings") || command.includes("shell_command")) return "settings";
+  if (
+    command.includes("clipboard")
+    || command.includes("file")
+    || command.includes("folder")
+    || command.includes("image")
+    || command.includes("markdown")
+    || command.includes("pandoc")
+  ) {
+    return "file";
+  }
+
+  return "system";
 }

--- a/packages/app/src/lib/runtime-log.test.ts
+++ b/packages/app/src/lib/runtime-log.test.ts
@@ -99,6 +99,51 @@ describe("runtime log", () => {
     expect(formatted).not.toContain("C:\\Users\\example");
   });
 
+  it("captures structured native command diagnostics with redacted details", () => {
+    const uninstall = installRuntimeLogCapture();
+
+    try {
+      window.dispatchEvent(new CustomEvent("markra:runtime-diagnostic", {
+        detail: {
+          area: "storage",
+          details: {
+            args: {
+              request: {
+                endpointUrl: "https://s3.example.test/private",
+                fileName: "pasted-image.png",
+                secretAccessKey: "synthetic-secret",
+                sourcePath: "/Users/example/private-note.md"
+              }
+            },
+            command: "upload_s3_image",
+            error: "S3 image upload failed: PUT pasted-image.png: HTTP 403"
+          },
+          level: "error",
+          message: "Native command failed"
+        }
+      }));
+    } finally {
+      uninstall();
+    }
+
+    const entries = listRuntimeLogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      area: "storage",
+      level: "error",
+      message: "Native command failed"
+    });
+
+    const formatted = formatRuntimeLogEntries(entries);
+    expect(formatted).toContain("ERROR storage Native command failed");
+    expect(formatted).toContain("command: upload_s3_image");
+    expect(formatted).toContain("S3 image upload failed: PUT pasted-image.png: HTTP 403");
+    expect(formatted).toContain("pasted-image.png");
+    expect(formatted).not.toContain("synthetic-secret");
+    expect(formatted).not.toContain("s3.example.test");
+    expect(formatted).not.toContain("/Users/example");
+  });
+
   it("does not recursively log console errors raised while writing a log entry", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const dispatchSpy = vi.spyOn(window, "dispatchEvent").mockImplementation((event) => {

--- a/packages/app/src/lib/runtime-log.ts
+++ b/packages/app/src/lib/runtime-log.ts
@@ -1,3 +1,12 @@
+import {
+  diagnosticErrorMessage,
+  runtimeDiagnosticEvent,
+  sanitizeDiagnosticDetails,
+  sanitizeDiagnosticText,
+  stringifyDiagnosticValue,
+  type DiagnosticDetailValue
+} from "@markra/shared";
+
 type RuntimeLogLevel = "error" | "info" | "warn";
 type RuntimeLogArea =
   | "ai"
@@ -9,7 +18,7 @@ type RuntimeLogArea =
   | "sync"
   | "system"
   | "update";
-type RuntimeLogDetailValue = boolean | number | string | null;
+type RuntimeLogDetailValue = DiagnosticDetailValue;
 export type RuntimeLogEntry = {
   area: RuntimeLogArea;
   details?: Record<string, RuntimeLogDetailValue>;
@@ -20,6 +29,7 @@ export type RuntimeLogEntry = {
 };
 
 type RuntimeLogEntryInput = {
+  area?: RuntimeLogArea;
   details?: Record<string, unknown>;
   level: RuntimeLogLevel;
   message: string;
@@ -34,11 +44,6 @@ type RuntimeLogErrorInput = {
 const runtimeLogStorageKey = "markra.runtimeLog.entries";
 const runtimeLogChangedEvent = "markra:runtime-log-changed";
 const defaultRuntimeLogEntryLimit = 200;
-const runtimeLogDetailTextLimit = 1200;
-const redactedValue = "[redacted]";
-const sensitiveDetailKeyPattern = /(?:authorization|endpoint|host|key|password|path|secret|token|url|user)/iu;
-const urlPattern = /https?:\/\/[^\s]+/giu;
-const absolutePathPattern = /(?:\/Users|\/home|\/private|[A-Za-z]:\\)[^\s]+/gu;
 const runtimeLogAreas = [
   "ai",
   "backup",
@@ -59,11 +64,11 @@ let installedRuntimeLogCaptureCleanup: (() => unknown) | null = null;
 function appendRuntimeLogEntry(input: RuntimeLogEntryInput) {
   const timestamp = new Date();
   const entry: RuntimeLogEntry = {
-    area: "system",
-    details: sanitizeRuntimeLogDetails(input.details),
+    area: input.area ?? "system",
+    details: sanitizeDiagnosticDetails(input.details),
     id: createRuntimeLogEntryId(timestamp),
     level: input.level,
-    message: sanitizeRuntimeLogText(input.message),
+    message: sanitizeDiagnosticText(input.message),
     timestamp: normalizeRuntimeLogTimestamp(timestamp)
   };
   const entries = [...listRuntimeLogEntries(), entry].slice(-defaultRuntimeLogEntryLimit);
@@ -77,7 +82,7 @@ function appendRuntimeLogError(input: RuntimeLogErrorInput) {
   return appendRuntimeLogEntry({
     details: {
       ...input.details,
-      error: runtimeLogErrorMessage(input.error)
+      error: diagnosticErrorMessage(input.error)
     },
     level: "error",
     message: input.message
@@ -112,9 +117,17 @@ export function installRuntimeLogCapture() {
 
   window.addEventListener("error", handleError);
   window.addEventListener("unhandledrejection", handleUnhandledRejection);
+  const handleRuntimeDiagnostic = (event: Event) => {
+    const input = runtimeDiagnosticEntryInput(event);
+    if (!input) return;
+
+    appendRuntimeLogEntry(input);
+  };
+  window.addEventListener(runtimeDiagnosticEvent, handleRuntimeDiagnostic);
   cleanupCallbacks.push(() => {
     window.removeEventListener("error", handleError);
     window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+    window.removeEventListener(runtimeDiagnosticEvent, handleRuntimeDiagnostic);
   });
 
   const originalWarn = console.warn;
@@ -126,7 +139,7 @@ export function installRuntimeLogCapture() {
       try {
         appendRuntimeLogEntry({
           details: {
-            arguments: stringifyRuntimeLogValue(args.length === 1 ? args[0] : args)
+            arguments: stringifyDiagnosticValue(args.length === 1 ? args[0] : args)
           },
           level: "warn",
           message: "Console warning"
@@ -144,7 +157,7 @@ export function installRuntimeLogCapture() {
       try {
         appendRuntimeLogEntry({
           details: {
-            arguments: stringifyRuntimeLogValue(args.length === 1 ? args[0] : args)
+            arguments: stringifyDiagnosticValue(args.length === 1 ? args[0] : args)
           },
           level: "error",
           message: "Console error"
@@ -279,12 +292,37 @@ function normalizeRuntimeLogEntry(value: unknown): RuntimeLogEntry | null {
 
   return {
     area: candidate.area,
-    details: sanitizeRuntimeLogDetails(candidate.details),
+    details: sanitizeDiagnosticDetails(candidate.details),
     id: candidate.id,
     level: candidate.level,
-    message: sanitizeRuntimeLogText(candidate.message),
+    message: sanitizeDiagnosticText(candidate.message),
     timestamp: candidate.timestamp
   };
+}
+
+function runtimeDiagnosticEntryInput(event: Event): RuntimeLogEntryInput | null {
+  const detail = "detail" in event ? (event as CustomEvent<unknown>).detail : null;
+  if (!isRuntimeDiagnosticRecord(detail)) return null;
+
+  const message = typeof detail.message === "string" && detail.message.trim()
+    ? detail.message
+    : "Runtime diagnostic";
+  const details = isRuntimeDiagnosticDetails(detail.details) ? detail.details : undefined;
+
+  return {
+    area: isRuntimeLogArea(detail.area) ? detail.area : "system",
+    details,
+    level: isRuntimeLogLevel(detail.level) ? detail.level : "info",
+    message
+  };
+}
+
+function isRuntimeDiagnosticRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRuntimeDiagnosticDetails(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isRuntimeLogArea(value: unknown): value is RuntimeLogArea {
@@ -295,92 +333,9 @@ function isRuntimeLogLevel(value: unknown): value is RuntimeLogLevel {
   return value === "error" || value === "info" || value === "warn";
 }
 
-function runtimeLogErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    const message = error.message.trim() || error.name;
-
-    return sanitizeRuntimeLogText(message);
-  }
-
-  if (typeof error === "string") return sanitizeRuntimeLogText(error);
-
-  return stringifyRuntimeLogValue(error);
-}
-
 function releaseRuntimeLogCapture() {
   runtimeLogCaptureInstallCount = Math.max(0, runtimeLogCaptureInstallCount - 1);
   if (runtimeLogCaptureInstallCount > 0) return;
 
   installedRuntimeLogCaptureCleanup?.();
-}
-
-function sanitizeRuntimeLogDetails(details: RuntimeLogEntryInput["details"]) {
-  if (!details) return undefined;
-
-  const sanitizedDetails: Record<string, RuntimeLogDetailValue> = {};
-  for (const [key, value] of Object.entries(details)) {
-    sanitizedDetails[key] = sensitiveDetailKeyPattern.test(key)
-      ? redactedValue
-      : sanitizeRuntimeLogValue(value);
-  }
-
-  return sanitizedDetails;
-}
-
-function sanitizeRuntimeLogValue(value: unknown): RuntimeLogDetailValue {
-  if (value === null) return null;
-  if (typeof value === "boolean" || typeof value === "number") return value;
-  if (typeof value === "string") return sanitizeRuntimeLogText(value);
-
-  return stringifyRuntimeLogValue(value);
-}
-
-function sanitizeRuntimeLogText(value: string) {
-  return limitRuntimeLogText(value
-    .replace(urlPattern, redactedValue)
-    .replace(absolutePathPattern, redactedValue)
-    .trim());
-}
-
-function stringifyRuntimeLogValue(value: unknown): string {
-  if (typeof value === "string") return sanitizeRuntimeLogText(value);
-  if (typeof value === "number" || typeof value === "boolean" || value === null) return String(value);
-  if (typeof value === "bigint") return value.toString();
-  if (typeof value === "undefined") return "undefined";
-  if (typeof value === "symbol") return value.toString();
-  if (typeof value === "function") return `[function ${value.name || "anonymous"}]`;
-
-  const seen = new WeakSet<object>();
-
-  try {
-    const serialized = JSON.stringify(value, (key, currentValue) => {
-      if (key && sensitiveDetailKeyPattern.test(key)) return redactedValue;
-      if (currentValue instanceof Error) {
-        return {
-          message: runtimeLogErrorMessage(currentValue),
-          name: sanitizeRuntimeLogText(currentValue.name)
-        };
-      }
-      if (typeof currentValue === "string") return sanitizeRuntimeLogText(currentValue);
-      if (typeof currentValue === "bigint") return currentValue.toString();
-      if (typeof currentValue === "function") return `[function ${currentValue.name || "anonymous"}]`;
-      if (typeof currentValue === "symbol") return currentValue.toString();
-      if (typeof currentValue === "object" && currentValue !== null) {
-        if (seen.has(currentValue)) return "[circular]";
-        seen.add(currentValue);
-      }
-
-      return currentValue;
-    });
-
-    return limitRuntimeLogText(serialized ?? String(value));
-  } catch {
-    return sanitizeRuntimeLogText(String(value));
-  }
-}
-
-function limitRuntimeLogText(value: string) {
-  return value.length > runtimeLogDetailTextLimit
-    ? `${value.slice(0, runtimeLogDetailTextLimit)}...[truncated]`
-    : value;
 }

--- a/packages/shared/src/diagnostics.ts
+++ b/packages/shared/src/diagnostics.ts
@@ -1,0 +1,94 @@
+export type DiagnosticDetailValue = boolean | number | string | null;
+
+export const runtimeDiagnosticEvent = "markra:runtime-diagnostic";
+
+const diagnosticDetailTextLimit = 1200;
+const redactedValue = "[redacted]";
+const sensitiveDetailKeyPattern = /(?:authorization|endpoint|host|key|password|path|secret|token|url|user)/iu;
+const urlPattern = /https?:\/\/[^\s]+/giu;
+const absolutePathPattern = /(?:\/Users|\/home|\/private|[A-Za-z]:\\)[^\s]+/gu;
+const controlCharacterPattern = /[\u0000-\u001f\u007f]/gu;
+
+export function sanitizeDiagnosticDetails(details: Record<string, unknown> | undefined) {
+  if (!details) return undefined;
+
+  const sanitizedDetails: Record<string, DiagnosticDetailValue> = {};
+  for (const [key, value] of Object.entries(details)) {
+    sanitizedDetails[key] = sensitiveDetailKeyPattern.test(key)
+      ? redactedValue
+      : sanitizeDiagnosticValue(value);
+  }
+
+  return sanitizedDetails;
+}
+
+export function sanitizeDiagnosticText(value: string) {
+  return limitDiagnosticText(value
+    .replace(urlPattern, redactedValue)
+    .replace(absolutePathPattern, redactedValue)
+    .replace(controlCharacterPattern, " ")
+    .trim());
+}
+
+export function diagnosticErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    const message = error.message.trim() || error.name;
+
+    return sanitizeDiagnosticText(message);
+  }
+
+  if (typeof error === "string") return sanitizeDiagnosticText(error);
+
+  return stringifyDiagnosticValue(error);
+}
+
+export function stringifyDiagnosticValue(value: unknown): string {
+  if (typeof value === "string") return sanitizeDiagnosticText(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return String(value);
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "undefined") return "undefined";
+  if (typeof value === "symbol") return value.toString();
+  if (typeof value === "function") return `[function ${value.name || "anonymous"}]`;
+
+  const seen = new WeakSet<object>();
+
+  try {
+    const serialized = JSON.stringify(value, (key, currentValue) => {
+      if (key && sensitiveDetailKeyPattern.test(key)) return redactedValue;
+      if (currentValue instanceof Error) {
+        return {
+          message: diagnosticErrorMessage(currentValue),
+          name: sanitizeDiagnosticText(currentValue.name)
+        };
+      }
+      if (typeof currentValue === "string") return sanitizeDiagnosticText(currentValue);
+      if (typeof currentValue === "bigint") return currentValue.toString();
+      if (typeof currentValue === "function") return `[function ${currentValue.name || "anonymous"}]`;
+      if (typeof currentValue === "symbol") return currentValue.toString();
+      if (typeof currentValue === "object" && currentValue !== null) {
+        if (seen.has(currentValue)) return "[circular]";
+        seen.add(currentValue);
+      }
+
+      return currentValue;
+    });
+
+    return limitDiagnosticText(serialized ?? String(value));
+  } catch {
+    return sanitizeDiagnosticText(String(value));
+  }
+}
+
+function sanitizeDiagnosticValue(value: unknown): DiagnosticDetailValue {
+  if (value === null) return null;
+  if (typeof value === "boolean" || typeof value === "number") return value;
+  if (typeof value === "string") return sanitizeDiagnosticText(value);
+
+  return stringifyDiagnosticValue(value);
+}
+
+function limitDiagnosticText(value: string) {
+  return value.length > diagnosticDetailTextLimit
+    ? `${value.slice(0, diagnosticDetailTextLimit)}...[truncated]`
+    : value;
+}

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -11,6 +11,9 @@ import {
   normalizedExternalAutolinkUrl,
   parentPathFromPath,
   pathNameFromPath,
+  runtimeDiagnosticEvent,
+  sanitizeDiagnosticDetails,
+  sanitizeDiagnosticText,
   stableTextKey
 } from ".";
 
@@ -109,5 +112,27 @@ describe("utilities", () => {
     expect(normalizedExternalAutolinkUrl("https://example.test first")).toBeNull();
     expect(normalizedExternalAutolinkUrl("javascript:alert(1)")).toBeNull();
     expect(normalizedExternalAutolinkUrl("file:///mock-files/secret.md")).toBeNull();
+  });
+
+  it("redacts diagnostic details without losing useful context", () => {
+    expect(runtimeDiagnosticEvent).toBe("markra:runtime-diagnostic");
+    expect(sanitizeDiagnosticText("failed at https://s3.example.test/private /Users/example/private-note.md")).toBe(
+      "failed at [redacted] [redacted]"
+    );
+    expect(sanitizeDiagnosticDetails({
+      command: "upload_s3_image",
+      endpointUrl: "https://s3.example.test/private",
+      password: "synthetic-secret",
+      payload: {
+        fileName: "pasted-image.png",
+        secretAccessKey: "synthetic-secret",
+        sourcePath: "/Users/example/private-note.md"
+      }
+    })).toEqual({
+      command: "upload_s3_image",
+      endpointUrl: "[redacted]",
+      password: "[redacted]",
+      payload: "{\"fileName\":\"pasted-image.png\",\"secretAccessKey\":\"[redacted]\",\"sourcePath\":\"[redacted]\"}"
+    });
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export type { DocumentState } from "./document.ts";
 export * from "./debug.ts";
+export * from "./diagnostics.ts";
 export * from "./i18n/index.ts";
 export * from "./keyboard-shortcuts.ts";
 export * from "./markdown-callout.ts";


### PR DESCRIPTION
## Summary
- add a shared diagnostic sanitizer/event and capture structured native command failures in the runtime log
- update the Tauri invoke wrapper so every native command failure emits sanitized command, args, and error details
- expand remote failure messages for WebDAV sync, image upload providers, web image downloads, and spellcheck dictionary downloads with operation, method, target, and HTTP status context

## Validation
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `pnpm --filter @markra/shared typecheck:test`
- `pnpm --filter @markra/app typecheck:test`
- `pnpm --filter @markra/desktop typecheck:test`
- `pnpm --filter @markra/shared test`
- `pnpm --filter @markra/app test`
- `pnpm --filter @markra/desktop test`
- `git diff --check`
- backend old HTTP wording scan: no matches for `failed: HTTP`, `upload failed: HTTP`, or `download failed: HTTP` under `apps/desktop/src-tauri/src`

## Risk
- native command console errors now log sanitized error strings instead of raw Error objects to avoid leaking paths, URLs, or secrets
- user-facing backend error text is more specific, so snapshots or downstream string matching may need to use the new format