### PR TITLE
fix(app): show full selection without selection helpers

### DIFF
--- a/packages/ai/src/agent/inline.ts
+++ b/packages/ai/src/agent/inline.ts
@@ -26,6 +26,7 @@ export type AiTargetScope = "block" | "selection" | "suggestion";
 
 export type AiSelectionContext = {
   cursor?: number;
+  fullDocument?: boolean;
   from: number;
   source?: "block" | "selection";
   text: string;

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -472,6 +472,24 @@ function getVisibleProseMirrorView(
   return visualView;
 }
 
+function findEditorTextPosition(view: ProseMirrorEditorView, text: string, offset = 0) {
+  let result: number | null = null;
+
+  view.state.doc.descendants((node, nodePosition) => {
+    if (result !== null || !node.isText) return true;
+
+    const textOffset = node.text?.indexOf(text) ?? -1;
+    if (textOffset < 0) return true;
+
+    result = nodePosition + textOffset + offset;
+    return false;
+  });
+
+  if (result === null) throw new Error(`Text not found in editor: ${text}`);
+
+  return result;
+}
+
 describe("Markra workspace", () => {
   it("marks macOS 27 windows for the WebKit scrolling workaround", async () => {
     mockedResolveDesktopPlatform.mockReturnValue("macos");
@@ -6270,6 +6288,141 @@ describe("Markra workspace", () => {
           "Welcome to Markra"
         );
       });
+    } finally {
+      makeSpy.mockRestore();
+    }
+  });
+
+  it("keeps macOS full-document selections visible when selection helpers are disabled", async () => {
+    const runtime = createDefaultAppRuntime();
+    configureAppRuntime({
+      ...runtime,
+      events: {
+        ...runtime.events,
+        isAvailable: () => true
+      }
+    });
+    mockedResolveDesktopPlatform.mockReturnValue("macos");
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      showAiQuickInputOnSelection: false,
+      showAiSelectionToolbarOnSelection: false
+    }));
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+    const { container } = renderApp();
+
+    try {
+      await expectVisibleMilkdownText(container, "Welcome to Markra");
+      await settleEditorUpdates();
+      const visualView = getVisibleProseMirrorView(container, createdEditors);
+
+      act(() => {
+        visualView.focus();
+        visualView.dispatch(visualView.state.tr.setSelection(new AllSelection(visualView.state.doc)));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector(".ProseMirror .markra-ai-selection-hold")).toHaveTextContent(
+          "Welcome to Markra"
+        );
+      });
+    } finally {
+      makeSpy.mockRestore();
+    }
+  });
+
+  it("keeps macOS full-document selections visible when AI features are disabled", async () => {
+    const runtime = createDefaultAppRuntime();
+    configureAppRuntime({
+      ...runtime,
+      events: {
+        ...runtime.events,
+        isAvailable: () => true
+      },
+      features: {
+        ...runtime.features,
+        ai: false
+      }
+    });
+    mockedResolveDesktopPlatform.mockReturnValue("macos");
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      showAiQuickInputOnSelection: false,
+      showAiSelectionToolbarOnSelection: false
+    }));
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+    const { container } = renderApp();
+
+    try {
+      await expectVisibleMilkdownText(container, "Welcome to Markra");
+      await settleEditorUpdates();
+      const visualView = getVisibleProseMirrorView(container, createdEditors);
+
+      act(() => {
+        visualView.focus();
+        visualView.dispatch(visualView.state.tr.setSelection(new AllSelection(visualView.state.doc)));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector(".ProseMirror .markra-ai-selection-hold")).toHaveTextContent(
+          "Welcome to Markra"
+        );
+      });
+    } finally {
+      makeSpy.mockRestore();
+    }
+  });
+
+  it("does not add a fallback highlight over macOS partial text selections", async () => {
+    const runtime = createDefaultAppRuntime();
+    configureAppRuntime({
+      ...runtime,
+      events: {
+        ...runtime.events,
+        isAvailable: () => true
+      }
+    });
+    mockedResolveDesktopPlatform.mockReturnValue("macos");
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      showAiQuickInputOnSelection: false,
+      showAiSelectionToolbarOnSelection: true
+    }));
+    const createdEditors: Array<ReturnType<typeof MilkdownEditor.make>> = [];
+    const originalMake = MilkdownEditor.make.bind(MilkdownEditor);
+    const makeSpy = vi.spyOn(MilkdownEditor, "make").mockImplementation(() => {
+      const editor = originalMake();
+      createdEditors.push(editor);
+      return editor;
+    });
+    const { container } = renderApp();
+
+    try {
+      await expectVisibleMilkdownText(container, "Welcome to Markra");
+      await settleEditorUpdates();
+      const visualView = getVisibleProseMirrorView(container, createdEditors);
+      const from = findEditorTextPosition(visualView, "Welcome");
+
+      act(() => {
+        visualView.focus();
+        visualView.dispatch(visualView.state.tr.setSelection(TextSelection.create(
+          visualView.state.doc,
+          from,
+          from + "Welcome".length
+        )));
+      });
+
+      await settleEditorUpdates();
+      expect(container.querySelector(".ProseMirror .markra-ai-selection-hold")).not.toBeInTheDocument();
     } finally {
       makeSpy.mockRestore();
     }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1538,24 +1538,18 @@ function WorkspaceApp() {
   const holdAiSelection = editor.holdAiSelection;
   const handleTextSelectionChange = useCallback((selection: AiSelectionContext | null) => {
     const automaticSelection = automaticAiSelection(selection);
+    const holdNativeFullSelection = Boolean(
+      automaticSelection?.source === "selection" &&
+      automaticSelection.fullDocument &&
+      desktopPlatform === "macos" &&
+      nativeRuntimeAvailable
+    );
 
     updateSelectedWordCount(selection?.source === "selection" ? selection.text : null);
     updateActiveAiSelection(automaticSelection);
     clearAiSelectionToolbarCopySuccess();
     setAiSelectionToolbarActiveActions([]);
     setAiSelectionToolbarHeadingLevel(null);
-
-    if (!aiFeatureEnabled) {
-      setAiSelectionToolbarAnchor(null);
-      editor.clearAiSelection();
-      return;
-    }
-
-    if (readOnlyMode) {
-      setAiSelectionToolbarAnchor(null);
-      editor.clearAiSelection();
-      return;
-    }
 
     if (!selection?.text.trim()) {
       setAiSelectionToolbarAnchor(null);
@@ -1571,7 +1565,22 @@ function WorkspaceApp() {
       return;
     }
 
-    editor.clearAiSelection();
+    // Windows and browsers already paint native selections; this fallback covers the macOS Tauri full-selection paint gap.
+    if (holdNativeFullSelection) {
+      holdAiSelection(automaticSelection);
+    } else {
+      editor.clearAiSelection();
+    }
+
+    if (!aiFeatureEnabled) {
+      setAiSelectionToolbarAnchor(null);
+      return;
+    }
+
+    if (readOnlyMode) {
+      setAiSelectionToolbarAnchor(null);
+      return;
+    }
 
     const hideInlineAiCommandForAgentPanel = shouldHideAiCommandForAiAgentPanel({
       aiAgentOpen,
@@ -1603,8 +1612,6 @@ function WorkspaceApp() {
     }
 
     if (showSelectionToolbar) {
-      // Windows and browsers already paint native selections; this fallback covers the macOS Tauri paint gap.
-      if (desktopPlatform === "macos" && nativeRuntimeAvailable) holdAiSelection(automaticSelection);
       syncAiSelectionToolbarFormattingState();
       setAiSelectionToolbarAnchorIfChanged(
         getEditorSelectionAnchor() ?? selectionAnchorFromDomSelection(window.getSelection())

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -12,7 +12,7 @@ vi.mock("mermaid", () => ({
 import type { Editor } from "@milkdown/kit/core";
 import { editorViewCtx, parserCtx, serializerCtx } from "@milkdown/kit/core";
 import { Fragment, Slice, type Node as ProseNode } from "@milkdown/kit/prose/model";
-import { NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
+import { AllSelection, NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { MarkdownPaper } from "./MarkdownPaper";
 import {
@@ -6267,6 +6267,22 @@ describe("MarkdownPaper editing", () => {
       source: "block",
       text: "First paragraph.",
       to
+    });
+    await settleMarkdownListener();
+  });
+
+  it("marks full-document selections in AI context", async () => {
+    const { view } = await renderEditor("# Title\n\nFirst paragraph.");
+
+    view.dispatch(view.state.tr.setSelection(new AllSelection(view.state.doc)));
+
+    expect(readAiSelectionContextFromView(view)).toEqual({
+      cursor: view.state.doc.content.size,
+      from: 0,
+      fullDocument: true,
+      source: "selection",
+      text: "Title\nFirst paragraph.",
+      to: view.state.doc.content.size
     });
     await settleMarkdownListener();
   });

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -503,7 +503,9 @@ export function markraTextSelectionObserverPlugin(
       if (!options.force && signature === lastSignature) return;
 
       lastSignature = signature;
+      const fullDocument = selection.from === 0 && selection.to === view.state.doc.content.size;
       onTextSelectionChange({
+        ...(fullDocument ? { fullDocument: true } : {}),
         from: selection.from,
         source: "selection",
         text,

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -312,8 +312,11 @@ export function readAiSelectionContextFromView(view: EditorView): AiSelectionCon
   const { doc, selection } = view.state;
 
   if (!selection.empty) {
+    const fullDocument = selection.from === 0 && selection.to === doc.content.size;
+
     return {
       cursor: selection.to,
+      ...(fullDocument ? { fullDocument: true } : {}),
       from: selection.from,
       source: "selection",
       text: doc.textBetween(selection.from, selection.to, "\n"),


### PR DESCRIPTION
## Summary
- Mark editor selection contexts when they cover the full document.
- Move the macOS native full-selection fallback out of the selection-toolbar-only branch.
- Keep Windows/browser surfaces on native selection painting to avoid duplicate backgrounds.
- Emit the optional `fullDocument` marker only for true full-document selections.

## Why
- Full-document selection on macOS Tauri still lost its visible background when selection helper UI was disabled or AI UI was unavailable.

## Validation
- `pnpm --dir packages/app exec vitest run src/App.test.tsx -t "full-document selections|selection helpers are disabled|AI features are disabled|partial text selections" --reporter=dot` passed
- `pnpm --dir packages/app exec vitest run src/components/MarkdownPaper.test.tsx -t "full-document selections|current text block|notifies when the user selects text|selection callback" --reporter=dot` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/ai test` passed

## Risk
- Medium-low. The fallback is limited to macOS native full-document selections, and partial selections continue to use native selection painting.