### PR TITLE
feat(update): surface available version in settings

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3541,7 +3541,8 @@ function WorkspaceApp() {
   const appUpdater = useAutoUpdater(appLanguage.language, updaterFeatureEnabled && appLanguage.ready && !editorPreferences.loading, {
     autoCheck: updaterFeatureEnabled && editorPreferences.preferences.autoUpdateEnabled,
     beforeRestart: saveDirtyMarkdownFiles,
-    confirmRestart: confirmCanDiscardCurrentDocument
+    confirmRestart: confirmCanDiscardCurrentDocument,
+    currentVersion: appVersion
   });
   const nativeMenuHandlers = useNativeMenuHandlers({
     checkForUpdates: updaterFeatureEnabled ? appUpdater.checkForUpdates : undefined,

--- a/packages/app/src/components/SettingsWindow.tsx
+++ b/packages/app/src/components/SettingsWindow.tsx
@@ -152,7 +152,8 @@ export function SettingsWindow() {
     : undefined;
   useDefaultContextMenuBlocker();
   const updater = useAutoUpdater(appLanguage.language, appFeatures.updater && appLanguage.ready, {
-    autoCheck: false
+    autoCheck: false,
+    currentVersion: appVersion
   });
   useEffect(() => {
     if (!settingsStartupReady) return;

--- a/packages/app/src/components/SettingsWindow.tsx
+++ b/packages/app/src/components/SettingsWindow.tsx
@@ -220,7 +220,7 @@ export function SettingsWindow() {
           {activeSettingsCategory === "general" ? (
             <GeneralSettings
               appVersion={appVersion}
-              availableUpdateVersion={updater.availableUpdate?.version ?? null}
+              availableUpdateVersion={updater.availableUpdateVersion}
               preferences={editorPreferences}
               language={appLanguage.language}
               translate={translate}

--- a/packages/app/src/components/SettingsWindow.tsx
+++ b/packages/app/src/components/SettingsWindow.tsx
@@ -220,6 +220,7 @@ export function SettingsWindow() {
           {activeSettingsCategory === "general" ? (
             <GeneralSettings
               appVersion={appVersion}
+              availableUpdateVersion={updater.availableUpdate?.version ?? null}
               preferences={editorPreferences}
               language={appLanguage.language}
               translate={translate}

--- a/packages/app/src/components/settings/GeneralSettings.test.tsx
+++ b/packages/app/src/components/settings/GeneralSettings.test.tsx
@@ -4,6 +4,26 @@ import { defaultEditorPreferences } from "../../lib/settings/app-settings";
 import { GeneralSettings } from "./GeneralSettings";
 
 describe("GeneralSettings", () => {
+  it("shows an available update prompt in the manual update settings", () => {
+    const props = {
+      appVersion: "0.0.7",
+      availableUpdateVersion: "0.0.8",
+      language: "en" as const,
+      preferences: defaultEditorPreferences,
+      translate,
+      welcomeReset: false,
+      onCheckForUpdates: vi.fn(),
+      onResetWelcomeDocument: vi.fn(),
+      onSelectLanguage: vi.fn(),
+      onUpdatePreferences: vi.fn()
+    };
+
+    render(<GeneralSettings {...props} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Markra 0.0.8 is available.");
+    expect(screen.getByRole("button", { name: "Check for updates" })).toBeInTheDocument();
+  });
+
   it("toggles automatic update checks", () => {
     const onUpdatePreferences = vi.fn();
 

--- a/packages/app/src/components/settings/GeneralSettings.tsx
+++ b/packages/app/src/components/settings/GeneralSettings.tsx
@@ -124,6 +124,7 @@ function ShellCommandActions({
 
 export function GeneralSettings({
   appVersion,
+  availableUpdateVersion = null,
   language,
   onCheckForUpdates,
   onInstallShellCommand,
@@ -140,6 +141,7 @@ export function GeneralSettings({
   welcomeReset
 }: {
   appVersion: string;
+  availableUpdateVersion?: string | null;
   language: AppLanguage;
   onCheckForUpdates: () => unknown;
   onInstallShellCommand?: () => unknown;
@@ -156,6 +158,9 @@ export function GeneralSettings({
   welcomeReset: boolean;
 }) {
   const shellCommandEnabled = Boolean(onInstallShellCommand && onRefreshShellCommand && onUninstallShellCommand);
+  const availableUpdateMessage = availableUpdateVersion
+    ? translate("app.updateAvailable").replace("{version}", availableUpdateVersion)
+    : null;
 
   return (
     <>
@@ -297,6 +302,11 @@ export function GeneralSettings({
               </SettingsButton>
             }
           />
+          {availableUpdateMessage ? (
+            <p className="m-0 px-0 py-3 text-[12px] leading-5 font-[560] text-(--accent)" role="status">
+              {availableUpdateMessage}
+            </p>
+          ) : null}
         </SettingsSection>
       ) : null}
     </>

--- a/packages/app/src/hooks/useAutoUpdater.test.tsx
+++ b/packages/app/src/hooks/useAutoUpdater.test.tsx
@@ -139,6 +139,13 @@ describe("useAutoUpdater", () => {
     expect(mockedShowAppToast).not.toHaveBeenCalled();
     expectUpdateLogEntry({
       details: {
+        automatic: true
+      },
+      level: "info",
+      message: "Automatic update check started"
+    });
+    expectUpdateLogEntry({
+      details: {
         automatic: true,
         result: "current"
       },

--- a/packages/app/src/hooks/useAutoUpdater.test.tsx
+++ b/packages/app/src/hooks/useAutoUpdater.test.tsx
@@ -27,15 +27,23 @@ function AutoUpdaterHarness({
   beforeRestart,
   checkIntervalMs,
   confirmRestart,
+  currentVersion = "0.0.6",
   language = "en"
 }: {
   autoCheck?: boolean;
   beforeRestart?: () => Promise<unknown>;
   checkIntervalMs?: number;
   confirmRestart?: () => Promise<boolean>;
+  currentVersion?: string;
   language?: "en" | "zh-CN";
 }) {
-  const updater = useAutoUpdater(language, true, { autoCheck, beforeRestart, checkIntervalMs, confirmRestart });
+  const updater = useAutoUpdater(language, true, {
+    autoCheck,
+    beforeRestart,
+    checkIntervalMs,
+    confirmRestart,
+    currentVersion
+  });
 
   return (
     <>
@@ -61,8 +69,8 @@ function DisabledUpdaterHarness() {
   );
 }
 
-function PassiveUpdatePromptHarness() {
-  const updater = useAutoUpdater("en", true, { autoCheck: false });
+function PassiveUpdatePromptHarness({ currentVersion = "0.0.6" }: { currentVersion?: string }) {
+  const updater = useAutoUpdater("en", true, { autoCheck: false, currentVersion });
 
   return updater.availableUpdateVersion ? (
     <p role="status">Available version: {updater.availableUpdateVersion}</p>
@@ -210,6 +218,19 @@ describe("useAutoUpdater", () => {
     render(<PassiveUpdatePromptHarness />);
 
     expect(screen.getByRole("status")).toHaveTextContent("Available version: 0.0.7");
+  });
+
+  it("ignores a discovered update version from a previous app version", async () => {
+    mockedCheckNativeAppUpdate.mockResolvedValue(createUpdate());
+
+    const { unmount } = render(<AutoUpdaterHarness currentVersion="0.0.6" />);
+
+    expect(await screen.findByRole("button", { name: "Install update" })).toBeInTheDocument();
+    unmount();
+
+    render(<PassiveUpdatePromptHarness currentVersion="0.0.7" />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("installs a background-discovered update after the user starts it", async () => {

--- a/packages/app/src/hooks/useAutoUpdater.test.tsx
+++ b/packages/app/src/hooks/useAutoUpdater.test.tsx
@@ -61,6 +61,14 @@ function DisabledUpdaterHarness() {
   );
 }
 
+function PassiveUpdatePromptHarness() {
+  const updater = useAutoUpdater("en", true, { autoCheck: false });
+
+  return updater.availableUpdateVersion ? (
+    <p role="status">Available version: {updater.availableUpdateVersion}</p>
+  ) : null;
+}
+
 function createUpdate(overrides: Partial<NativeAppUpdate> = {}): NativeAppUpdate {
   return {
     body: "Release notes",
@@ -118,6 +126,7 @@ function expectUpdateLogEntry(entry: Partial<RuntimeLogEntry>) {
 describe("useAutoUpdater", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    window.localStorage.clear();
     clearRuntimeLogEntries();
     resetAppLogBackendWriterForTests();
     mockedShowAppToast.mockReset();
@@ -126,6 +135,7 @@ describe("useAutoUpdater", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    window.localStorage.clear();
     clearRuntimeLogEntries();
     resetAppLogBackendWriterForTests();
   });
@@ -173,6 +183,33 @@ describe("useAutoUpdater", () => {
       level: "info",
       message: "Automatic update check completed"
     });
+  });
+
+  it("shares a background-discovered update version with passive updater instances", async () => {
+    mockedCheckNativeAppUpdate.mockResolvedValue(createUpdate());
+
+    render(
+      <>
+        <AutoUpdaterHarness />
+        <PassiveUpdatePromptHarness />
+      </>
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Available version: 0.0.7");
+    expect(mockedShowAppToast).not.toHaveBeenCalled();
+  });
+
+  it("keeps a background-discovered update version for settings opened later", async () => {
+    mockedCheckNativeAppUpdate.mockResolvedValue(createUpdate());
+
+    const { unmount } = render(<AutoUpdaterHarness />);
+
+    expect(await screen.findByRole("button", { name: "Install update" })).toBeInTheDocument();
+    unmount();
+
+    render(<PassiveUpdatePromptHarness />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Available version: 0.0.7");
   });
 
   it("installs a background-discovered update after the user starts it", async () => {

--- a/packages/app/src/hooks/useAutoUpdater.ts
+++ b/packages/app/src/hooks/useAutoUpdater.ts
@@ -1,6 +1,11 @@
 import { createElement, useCallback, useEffect, useRef, useState } from "react";
 import { diagnosticErrorMessage, t, type AppLanguage } from "@markra/shared";
 import { UpdateProgressToast } from "../components/UpdateProgressToast";
+import {
+  clearDiscoveredAppUpdateVersion,
+  setDiscoveredAppUpdateVersion,
+  useDiscoveredAppUpdateVersion
+} from "../lib/app-update-state";
 import { appLogger } from "../lib/app-logger";
 import { showAppToast } from "../lib/app-toast";
 import { checkNativeAppUpdate, type NativeAppUpdate, type NativeAppUpdateProgress } from "../lib/tauri/updater";
@@ -62,6 +67,7 @@ function logUpdateCheckFailed(error: unknown, automatic: boolean) {
 
 export function useAutoUpdater(language: AppLanguage, enabled = true, options: AutoUpdaterOptions = {}) {
   const [availableUpdate, setAvailableUpdate] = useState<NativeAppUpdate | null>(null);
+  const discoveredAppUpdateVersion = useDiscoveredAppUpdateVersion();
   const checkingRef = useRef(false);
   const downloadingRef = useRef(false);
   const downloadedUpdateRef = useRef<NativeAppUpdate | null>(null);
@@ -141,6 +147,7 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
         onProgress: (progress) => showDownloadProgress(update, progress)
       });
       setAvailableUpdate((currentUpdate) => currentUpdate?.version === update.version ? null : currentUpdate);
+      clearDiscoveredAppUpdateVersion(update.version);
       showReadyToRestart(update);
     } catch {
       if (options.notifyFailure) {
@@ -163,6 +170,7 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
 
   const showAvailableUpdate = useCallback((update: NativeAppUpdate, options: { notify: boolean }) => {
     setAvailableUpdate(update);
+    setDiscoveredAppUpdateVersion(update.version);
     if (!options.notify) return;
 
     showAppToast({
@@ -205,6 +213,7 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
       }
 
       setAvailableUpdate(null);
+      clearDiscoveredAppUpdateVersion();
       logUpdateCheckCompleted(null, false);
       showAppToast({
         id: appUpdateToastId,
@@ -240,6 +249,7 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
           logUpdateCheckCompleted(update, true);
         } else {
           setAvailableUpdate(null);
+          clearDiscoveredAppUpdateVersion();
           logUpdateCheckCompleted(null, true);
         }
       } catch (error) {
@@ -261,6 +271,7 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
 
   return {
     availableUpdate,
+    availableUpdateVersion: availableUpdate?.version ?? discoveredAppUpdateVersion,
     checkForUpdates,
     installAvailableUpdate
   };

--- a/packages/app/src/hooks/useAutoUpdater.ts
+++ b/packages/app/src/hooks/useAutoUpdater.ts
@@ -231,6 +231,7 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
       if (checkingRef.current || downloadingRef.current) return;
 
       checkingRef.current = true;
+      appLogger.info("update", "Automatic update check started", { automatic: true });
       try {
         const update = await checkNativeAppUpdate();
         if (cancelled) return;

--- a/packages/app/src/hooks/useAutoUpdater.ts
+++ b/packages/app/src/hooks/useAutoUpdater.ts
@@ -19,6 +19,7 @@ export type AutoUpdaterOptions = {
   checkIntervalMs?: number;
   confirmInstall?: () => boolean | Promise<boolean>;
   confirmRestart?: () => boolean | Promise<boolean>;
+  currentVersion?: string;
 };
 
 function formatUpdateMessage(message: string, update: NativeAppUpdate, progress?: NativeAppUpdateProgress) {
@@ -67,7 +68,8 @@ function logUpdateCheckFailed(error: unknown, automatic: boolean) {
 
 export function useAutoUpdater(language: AppLanguage, enabled = true, options: AutoUpdaterOptions = {}) {
   const [availableUpdate, setAvailableUpdate] = useState<NativeAppUpdate | null>(null);
-  const discoveredAppUpdateVersion = useDiscoveredAppUpdateVersion();
+  const currentVersion = options.currentVersion;
+  const discoveredAppUpdateVersion = useDiscoveredAppUpdateVersion(currentVersion);
   const checkingRef = useRef(false);
   const downloadingRef = useRef(false);
   const downloadedUpdateRef = useRef<NativeAppUpdate | null>(null);
@@ -170,7 +172,10 @@ export function useAutoUpdater(language: AppLanguage, enabled = true, options: A
 
   const showAvailableUpdate = useCallback((update: NativeAppUpdate, options: { notify: boolean }) => {
     setAvailableUpdate(update);
-    setDiscoveredAppUpdateVersion(update.version);
+    setDiscoveredAppUpdateVersion({
+      currentVersion: update.currentVersion,
+      version: update.version
+    });
     if (!options.notify) return;
 
     showAppToast({

--- a/packages/app/src/lib/app-update-state.test.ts
+++ b/packages/app/src/lib/app-update-state.test.ts
@@ -1,0 +1,52 @@
+import {
+  clearDiscoveredAppUpdateVersion,
+  getDiscoveredAppUpdateVersion,
+  setDiscoveredAppUpdateVersion
+} from "./app-update-state";
+
+const discoveredAppUpdateVersionStorageKey = "markra.discoveredAppUpdate.version";
+
+describe("app update state", () => {
+  beforeEach(() => {
+    setDiscoveredAppUpdateVersion(null);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    setDiscoveredAppUpdateVersion(null);
+    window.localStorage.clear();
+  });
+
+  it("returns discovered update versions only for the matching current app version", () => {
+    setDiscoveredAppUpdateVersion({
+      currentVersion: "0.0.6",
+      version: "0.0.7"
+    });
+
+    expect(getDiscoveredAppUpdateVersion("0.0.6")).toBe("0.0.7");
+    expect(getDiscoveredAppUpdateVersion("0.0.7")).toBeNull();
+  });
+
+  it("ignores malformed stored update state", () => {
+    setDiscoveredAppUpdateVersion({
+      currentVersion: "0.0.6",
+      version: "0.0.7"
+    });
+    window.localStorage.setItem(discoveredAppUpdateVersionStorageKey, "0.0.7");
+
+    expect(getDiscoveredAppUpdateVersion("0.0.6")).toBeNull();
+  });
+
+  it("does not clear a newer discovered update when an older install finishes", () => {
+    setDiscoveredAppUpdateVersion({
+      currentVersion: "0.0.6",
+      version: "0.0.8"
+    });
+
+    clearDiscoveredAppUpdateVersion("0.0.7");
+    expect(getDiscoveredAppUpdateVersion("0.0.6")).toBe("0.0.8");
+
+    clearDiscoveredAppUpdateVersion("0.0.8");
+    expect(getDiscoveredAppUpdateVersion("0.0.6")).toBeNull();
+  });
+});

--- a/packages/app/src/lib/app-update-state.ts
+++ b/packages/app/src/lib/app-update-state.ts
@@ -3,13 +3,32 @@ import { useSyncExternalStore } from "react";
 const discoveredAppUpdateVersionStorageKey = "markra.discoveredAppUpdate.version";
 const discoveredAppUpdateVersionChangedEvent = "markra:discovered-app-update-version-changed";
 
-let fallbackDiscoveredAppUpdateVersion: string | null = null;
+type DiscoveredAppUpdate = {
+  currentVersion: string;
+  version: string;
+};
+
+let fallbackDiscoveredAppUpdate: DiscoveredAppUpdate | null = null;
 
 function normalizeDiscoveredAppUpdateVersion(value: unknown) {
   if (typeof value !== "string") return null;
 
   const version = value.trim();
   return version.length > 0 ? version : null;
+}
+
+function normalizeDiscoveredAppUpdate(value: unknown): DiscoveredAppUpdate | null {
+  if (typeof value !== "object" || value === null) return null;
+
+  const candidate = value as Partial<DiscoveredAppUpdate>;
+  const version = normalizeDiscoveredAppUpdateVersion(candidate.version);
+  const currentVersion = normalizeDiscoveredAppUpdateVersion(candidate.currentVersion);
+  if (!version || !currentVersion) return null;
+
+  return {
+    currentVersion,
+    version
+  };
 }
 
 function getStorage() {
@@ -28,26 +47,50 @@ function notifyDiscoveredAppUpdateVersionChanged() {
   window.dispatchEvent(new CustomEvent(discoveredAppUpdateVersionChangedEvent));
 }
 
-export function getDiscoveredAppUpdateVersion() {
+export function getDiscoveredAppUpdateVersion(currentVersion?: string | null) {
+  const update = getDiscoveredAppUpdate(currentVersion);
+
+  return update?.version ?? null;
+}
+
+function getDiscoveredAppUpdate(currentVersion?: string | null) {
   const storage = getStorage();
-  if (!storage) return fallbackDiscoveredAppUpdateVersion;
+  if (!storage) return filterDiscoveredAppUpdate(fallbackDiscoveredAppUpdate, currentVersion);
+
+  let rawUpdate: string | null = null;
+  try {
+    rawUpdate = storage.getItem(discoveredAppUpdateVersionStorageKey);
+  } catch {
+    return filterDiscoveredAppUpdate(fallbackDiscoveredAppUpdate, currentVersion);
+  }
+
+  if (!rawUpdate) return filterDiscoveredAppUpdate(fallbackDiscoveredAppUpdate, currentVersion);
 
   try {
-    return normalizeDiscoveredAppUpdateVersion(storage.getItem(discoveredAppUpdateVersionStorageKey));
+    const update = normalizeDiscoveredAppUpdate(JSON.parse(rawUpdate));
+
+    return filterDiscoveredAppUpdate(update, currentVersion);
   } catch {
-    return fallbackDiscoveredAppUpdateVersion;
+    return null;
   }
 }
 
-export function setDiscoveredAppUpdateVersion(version: string | null) {
-  const normalizedVersion = normalizeDiscoveredAppUpdateVersion(version);
-  fallbackDiscoveredAppUpdateVersion = normalizedVersion;
+function filterDiscoveredAppUpdate(update: DiscoveredAppUpdate | null, currentVersion?: string | null) {
+  const normalizedCurrentVersion = normalizeDiscoveredAppUpdateVersion(currentVersion);
+  if (normalizedCurrentVersion && update?.currentVersion !== normalizedCurrentVersion) return null;
+
+  return update;
+}
+
+export function setDiscoveredAppUpdateVersion(update: DiscoveredAppUpdate | null) {
+  const normalizedUpdate = normalizeDiscoveredAppUpdate(update);
+  fallbackDiscoveredAppUpdate = normalizedUpdate;
 
   const storage = getStorage();
   if (storage) {
     try {
-      if (normalizedVersion) {
-        storage.setItem(discoveredAppUpdateVersionStorageKey, normalizedVersion);
+      if (normalizedUpdate) {
+        storage.setItem(discoveredAppUpdateVersionStorageKey, JSON.stringify(normalizedUpdate));
       } else {
         storage.removeItem(discoveredAppUpdateVersionStorageKey);
       }
@@ -60,8 +103,8 @@ export function setDiscoveredAppUpdateVersion(version: string | null) {
 }
 
 export function clearDiscoveredAppUpdateVersion(version?: string) {
-  const currentVersion = getDiscoveredAppUpdateVersion();
-  if (version && currentVersion && currentVersion !== version) return;
+  const update = getDiscoveredAppUpdate();
+  if (version && update && update.version !== version) return;
 
   setDiscoveredAppUpdateVersion(null);
 }
@@ -82,6 +125,10 @@ function subscribeDiscoveredAppUpdateVersion(listener: () => unknown) {
   };
 }
 
-export function useDiscoveredAppUpdateVersion() {
-  return useSyncExternalStore(subscribeDiscoveredAppUpdateVersion, getDiscoveredAppUpdateVersion, () => null);
+export function useDiscoveredAppUpdateVersion(currentVersion?: string | null) {
+  return useSyncExternalStore(
+    subscribeDiscoveredAppUpdateVersion,
+    () => getDiscoveredAppUpdate(currentVersion)?.version ?? null,
+    () => null
+  );
 }

--- a/packages/app/src/lib/app-update-state.ts
+++ b/packages/app/src/lib/app-update-state.ts
@@ -1,0 +1,87 @@
+import { useSyncExternalStore } from "react";
+
+const discoveredAppUpdateVersionStorageKey = "markra.discoveredAppUpdate.version";
+const discoveredAppUpdateVersionChangedEvent = "markra:discovered-app-update-version-changed";
+
+let fallbackDiscoveredAppUpdateVersion: string | null = null;
+
+function normalizeDiscoveredAppUpdateVersion(value: unknown) {
+  if (typeof value !== "string") return null;
+
+  const version = value.trim();
+  return version.length > 0 ? version : null;
+}
+
+function getStorage() {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function notifyDiscoveredAppUpdateVersionChanged() {
+  if (typeof window === "undefined") return;
+
+  window.dispatchEvent(new CustomEvent(discoveredAppUpdateVersionChangedEvent));
+}
+
+export function getDiscoveredAppUpdateVersion() {
+  const storage = getStorage();
+  if (!storage) return fallbackDiscoveredAppUpdateVersion;
+
+  try {
+    return normalizeDiscoveredAppUpdateVersion(storage.getItem(discoveredAppUpdateVersionStorageKey));
+  } catch {
+    return fallbackDiscoveredAppUpdateVersion;
+  }
+}
+
+export function setDiscoveredAppUpdateVersion(version: string | null) {
+  const normalizedVersion = normalizeDiscoveredAppUpdateVersion(version);
+  fallbackDiscoveredAppUpdateVersion = normalizedVersion;
+
+  const storage = getStorage();
+  if (storage) {
+    try {
+      if (normalizedVersion) {
+        storage.setItem(discoveredAppUpdateVersionStorageKey, normalizedVersion);
+      } else {
+        storage.removeItem(discoveredAppUpdateVersionStorageKey);
+      }
+    } catch {
+      // Keep the in-memory fallback so the current window still updates even when storage is unavailable.
+    }
+  }
+
+  notifyDiscoveredAppUpdateVersionChanged();
+}
+
+export function clearDiscoveredAppUpdateVersion(version?: string) {
+  const currentVersion = getDiscoveredAppUpdateVersion();
+  if (version && currentVersion && currentVersion !== version) return;
+
+  setDiscoveredAppUpdateVersion(null);
+}
+
+function subscribeDiscoveredAppUpdateVersion(listener: () => unknown) {
+  if (typeof window === "undefined") return () => {};
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === discoveredAppUpdateVersionStorageKey) listener();
+  };
+
+  window.addEventListener(discoveredAppUpdateVersionChangedEvent, listener);
+  window.addEventListener("storage", handleStorage);
+
+  return () => {
+    window.removeEventListener(discoveredAppUpdateVersionChangedEvent, listener);
+    window.removeEventListener("storage", handleStorage);
+  };
+}
+
+export function useDiscoveredAppUpdateVersion() {
+  return useSyncExternalStore(subscribeDiscoveredAppUpdateVersion, getDiscoveredAppUpdateVersion, () => null);
+}


### PR DESCRIPTION
## Summary
- Log when automatic background update checks start, so release logs show whether the check was triggered.
- Store the discovered update version from automatic or manual checks in shared app state.
- Show that discovered version in Settings > General > Updates, including when the update was found automatically before or while Settings is open.
- Filter discovered versions by the app version that found them, so stale prompts do not survive upgrades or malformed stored state.

## Why
- A start log makes it easier to distinguish "never checked" from "checked and failed/completed elsewhere".
- The settings manual update area should show a passive in-panel new-version prompt when any updater instance has found a new version.
- Persisted update prompts need to be tied to the current app version to avoid showing an already-installed version after restart.

## Validation
- `pnpm test`
- `pnpm typecheck:test`
- `pnpm build`
- `git diff --check`

## Risk
- The settings prompt is passive and keeps the existing install/download flow unchanged.
- The shared state stores only version metadata and clears it when checks report current or when the matching update has been downloaded.
- Malformed or legacy stored update state is ignored instead of being shown.
