### PR TITLE
fix(app): avoid dirty prompts for equivalent markdown

### DIFF
--- a/packages/app/src/hooks/markdown-document/document-model.ts
+++ b/packages/app/src/hooks/markdown-document/document-model.ts
@@ -176,8 +176,166 @@ function normalizeComparableMarkdownHeadings(content: string) {
   return normalized.join("\n");
 }
 
+type MarkdownListItemStart = {
+  indent: string;
+  kind: "bullet" | "ordered";
+  quotePrefix: string;
+};
+
+function markdownBlockquotePrefixKey(line: string | undefined) {
+  const match = /^((?:>\s*)+)/u.exec(line ?? "");
+  return match ? ">".repeat(match[1]!.split(">").length - 1) : "";
+}
+
+function markdownListContentStart(line: string | undefined) {
+  const source = line ?? "";
+  const quoteMatch = /^((?:>\s*)+)/u.exec(source);
+  return quoteMatch ? quoteMatch[0].length : 0;
+}
+
+function markdownListItemStart(line: string | undefined): MarkdownListItemStart | null {
+  const source = line ?? "";
+  const contentStart = markdownListContentStart(source);
+  const match = /^([ ]{0,3})(?:[-+*]|\d{1,9}[.)])\s+/u.exec(source.slice(contentStart));
+  if (!match) return null;
+
+  return {
+    indent: match[1] ?? "",
+    kind: /^\s{0,3}\d/u.test(source.slice(contentStart)) ? "ordered" : "bullet",
+    quotePrefix: markdownBlockquotePrefixKey(source)
+  };
+}
+
+function matchingSimpleListItems(
+  previousListItem: MarkdownListItemStart | null,
+  nextListItem: MarkdownListItemStart | null,
+  spacerQuotePrefix: string
+) {
+  return Boolean(
+    previousListItem &&
+    nextListItem &&
+    previousListItem.indent === nextListItem.indent &&
+    previousListItem.kind === nextListItem.kind &&
+    previousListItem.quotePrefix === nextListItem.quotePrefix &&
+    previousListItem.quotePrefix === spacerQuotePrefix
+  );
+}
+
+function isComparableMarkdownListSpacer(line: string, previousLine: string | undefined, nextLine: string | undefined) {
+  const quotePrefix = markdownBlockquotePrefixKey(line);
+  const unquotedContent = quotePrefix ? line.replace(/^((?:>\s*)+)/u, "") : line;
+  if (unquotedContent.trim() !== "") return false;
+
+  return matchingSimpleListItems(
+    markdownListItemStart(previousLine),
+    markdownListItemStart(nextLine),
+    quotePrefix
+  );
+}
+
+function normalizeComparableMarkdownListSpacing(content: string) {
+  const lines = content.split("\n");
+  const normalized: string[] = [];
+  let fencedMarker: "`" | "~" | null = null;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? "";
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/u);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]!.startsWith("~") ? "~" : "`";
+      if (!fencedMarker) {
+        fencedMarker = marker;
+      } else if (fencedMarker === marker) {
+        fencedMarker = null;
+      }
+
+      normalized.push(line);
+      continue;
+    }
+
+    // Milkdown may serialize adjacent one-line list items without the spacer line;
+    // keep that clean-file rewrite from becoming an unsaved edit.
+    const isSimpleListSpacer =
+      !fencedMarker &&
+      isComparableMarkdownListSpacer(line, normalized[normalized.length - 1], lines[lineIndex + 1]);
+
+    if (!isSimpleListSpacer) normalized.push(line);
+  }
+
+  return normalized.join("\n");
+}
+
+function isMarkdownWordCharacter(character: string | undefined) {
+  return character !== undefined && /[\p{L}\p{N}]/u.test(character);
+}
+
+function normalizeComparableMarkdownLineEscapes(line: string) {
+  let normalized = "";
+
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] === "`") {
+      const runStart = index;
+      while (line[index + 1] === "`") index += 1;
+
+      const marker = line.slice(runStart, index + 1);
+      const closingIndex = line.indexOf(marker, index + 1);
+      if (closingIndex >= 0) {
+        normalized += line.slice(runStart, closingIndex + marker.length);
+        index = closingIndex + marker.length - 1;
+        continue;
+      }
+
+      normalized += line.slice(runStart, index + 1);
+      continue;
+    }
+
+    if (
+      line[index] === "\\" &&
+      line[index + 1] === "_" &&
+      isMarkdownWordCharacter(line[index - 1]) &&
+      isMarkdownWordCharacter(line[index + 2])
+    ) {
+      // Milkdown escapes intraword underscores even though CommonMark treats them as literal text.
+      normalized += "_";
+      index += 1;
+      continue;
+    }
+
+    normalized += line[index];
+  }
+
+  return normalized;
+}
+
+function normalizeComparableMarkdownEscapes(content: string) {
+  const lines = content.split("\n");
+  const normalized: string[] = [];
+  let fencedMarker: "`" | "~" | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/u);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]!.startsWith("~") ? "~" : "`";
+      if (!fencedMarker) {
+        fencedMarker = marker;
+      } else if (fencedMarker === marker) {
+        fencedMarker = null;
+      }
+
+      normalized.push(line);
+      continue;
+    }
+
+    normalized.push(fencedMarker ? line : normalizeComparableMarkdownLineEscapes(line));
+  }
+
+  return normalized.join("\n");
+}
+
 function comparableMarkdown(content: string) {
-  return normalizeComparableMarkdownHeadings(content)
+  return normalizeComparableMarkdownEscapes(
+    normalizeComparableMarkdownListSpacing(normalizeComparableMarkdownHeadings(content))
+  )
     .replace(/[ \t]+$/gmu, "")
     .trim();
 }

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -291,6 +291,253 @@ describe("useMarkdownDocument", () => {
     expect(result.current.document.name).toBe("second.md");
   });
 
+  it("does not ask to discard a clean file when the visual editor tightens loose list spacing", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = [
+      "# Guide",
+      "",
+      "- First point.",
+      "",
+      "- Second point."
+    ].join("\n");
+    const visualMarkdown = [
+      "# Guide",
+      "",
+      "- First point.",
+      "- Second point."
+    ].join("\n");
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "guide.md"
+    });
+  });
+
+  it("does not ask to discard a clean file when the visual editor escapes intraword underscores", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = "Token sequence x_1 reaches x_T.";
+    const visualMarkdown = "Token sequence x\\_1 reaches x\\_T.";
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "tokens.md",
+      path: "/mock-files/tokens.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "tokens.md",
+        path: "/mock-files/tokens.md",
+        relativePath: "tokens.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "tokens.md"
+    });
+  });
+
+  it("uses fallback markdown equivalence before treating a live editor mismatch as unsaved", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = "Workspace user_info entry.";
+    const visualMarkdown = "Workspace user\\_info entry.";
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "workspace.md",
+      path: "/mock-files/workspace.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: () => false,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "workspace.md",
+        path: "/mock-files/workspace.md",
+        relativePath: "workspace.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "workspace.md"
+    });
+  });
+
+  it("does not ask to discard a clean file when the visual editor tightens callout list spacing", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = [
+      "> [!NOTE]",
+      ">",
+      "> - First point.",
+      ">",
+      "> - Second point."
+    ].join("\n");
+    const visualMarkdown = [
+      "> [!NOTE]",
+      ">",
+      "> - First point.",
+      "> - Second point."
+    ].join("\n");
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "callout.md",
+      path: "/mock-files/callout.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "callout.md",
+        path: "/mock-files/callout.md",
+        relativePath: "callout.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "callout.md"
+    });
+  });
+
   it("keeps a clean tab unmodified when the editor reports an equivalent markdown update", async () => {
     mockedReadNativeMarkdownFile.mockResolvedValueOnce({
       content: "* Clean content.",

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -566,9 +566,10 @@ export function useMarkdownDocument({
 
       const editorMarkdown = currentMarkdown();
       if (editorSyncState.isSavedVisualEditorStaleContent(activeTabIdRef.current, current.content, editorMarkdown)) return false;
+      if (isEquivalentEditorMarkdown(editorMarkdown, current.content)) return false;
       if (editorContentEquivalent === false && current.path !== null) return true;
 
-      return !isEquivalentEditorMarkdown(editorMarkdown, current.content) && (current.path !== null || editorMarkdown.trim().length > 0);
+      return current.path !== null || editorMarkdown.trim().length > 0;
     }
     if (current.path) return true;
 


### PR DESCRIPTION
## Summary
- Treat editor-only Markdown serialization changes as clean when checking dirty state.
- Normalize known equivalent visual serialization shapes: intraword escaped underscores and tightened simple list spacing, including blockquote/callout lists.
- Ensure native close confirmation checks fallback Markdown equivalence before prompting.

## Why
Visual editor serialization can rewrite unchanged Markdown, such as `x_p` to `x\_p`, which caused clean documents to prompt for unsaved changes.

## Validation
- `pnpm --filter @markra/app test -- src/hooks/useMarkdownDocument.test.tsx` passed: 68 tests
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed

## Risk
- Low. Scope is limited to dirty-state equivalence and close-prompt logic.
- Source-only edits that only add equivalent intraword underscore escapes may be treated as no semantic change.