### PR TITLE
fix(app): track clean visual markdown baselines

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -578,6 +578,7 @@ function WorkspaceApp() {
   const runEditorShortcut = editor.runEditorShortcut;
   const getEditorSelectionAnchor = editor.getSelectionAnchor;
   const getEditorSelectionFormattingState = editor.getSelectionFormattingState;
+  const getMarkdownFromEditor = editor.getMarkdownFromEditor;
   const setEditorSelectionHeadingLevel = editor.setSelectionHeadingLevel;
   const showEditorSearchMatches = editor.showSearchMatches;
   const toggleEditorSelectionHighlight = editor.toggleSelectionHighlight;
@@ -746,6 +747,7 @@ function WorkspaceApp() {
     replaceOpenDocumentFile,
     replaceMovedOpenDocumentFile,
     recentFiles: recentMarkdownFiles,
+    rememberMarkdownTabVisualBaseline,
     restoreDocumentContent,
     saveCurrentDocumentContent,
     saveCurrentDocument,
@@ -830,10 +832,21 @@ function WorkspaceApp() {
       mainVisualEditorsRef.current.delete(tabId);
     }
 
+    const tab = readyEditor ? documentTabs.find((candidate) => candidate.id === tabId) : null;
+    if (readyEditor && tab && !tab.dirty) {
+      rememberMarkdownTabVisualBaseline(tabId, getMarkdownFromEditor(readyEditor, tab.content));
+    }
+
     if (tabId === activeTabId) {
       handleVisualEditorReady(readyEditor, options);
     }
-  }, [activeTabId, handleVisualEditorReady]);
+  }, [
+    activeTabId,
+    documentTabs,
+    getMarkdownFromEditor,
+    handleVisualEditorReady,
+    rememberMarkdownTabVisualBaseline
+  ]);
   useEffect(() => {
     if (!activeTabId) {
       handleVisualEditorReady(null);

--- a/packages/app/src/hooks/markdown-document/document-model.ts
+++ b/packages/app/src/hooks/markdown-document/document-model.ts
@@ -176,8 +176,166 @@ function normalizeComparableMarkdownHeadings(content: string) {
   return normalized.join("\n");
 }
 
+type MarkdownListItemStart = {
+  indent: string;
+  kind: "bullet" | "ordered";
+  quotePrefix: string;
+};
+
+function markdownBlockquotePrefixKey(line: string | undefined) {
+  const match = /^((?:>\s*)+)/u.exec(line ?? "");
+  return match ? ">".repeat(match[1]!.split(">").length - 1) : "";
+}
+
+function markdownListContentStart(line: string | undefined) {
+  const source = line ?? "";
+  const quoteMatch = /^((?:>\s*)+)/u.exec(source);
+  return quoteMatch ? quoteMatch[0].length : 0;
+}
+
+function markdownListItemStart(line: string | undefined): MarkdownListItemStart | null {
+  const source = line ?? "";
+  const contentStart = markdownListContentStart(source);
+  const match = /^([ ]{0,3})(?:[-+*]|\d{1,9}[.)])\s+/u.exec(source.slice(contentStart));
+  if (!match) return null;
+
+  return {
+    indent: match[1] ?? "",
+    kind: /^\s{0,3}\d/u.test(source.slice(contentStart)) ? "ordered" : "bullet",
+    quotePrefix: markdownBlockquotePrefixKey(source)
+  };
+}
+
+function matchingSimpleListItems(
+  previousListItem: MarkdownListItemStart | null,
+  nextListItem: MarkdownListItemStart | null,
+  spacerQuotePrefix: string
+) {
+  return Boolean(
+    previousListItem &&
+    nextListItem &&
+    previousListItem.indent === nextListItem.indent &&
+    previousListItem.kind === nextListItem.kind &&
+    previousListItem.quotePrefix === nextListItem.quotePrefix &&
+    previousListItem.quotePrefix === spacerQuotePrefix
+  );
+}
+
+function isComparableMarkdownListSpacer(line: string, previousLine: string | undefined, nextLine: string | undefined) {
+  const quotePrefix = markdownBlockquotePrefixKey(line);
+  const unquotedContent = quotePrefix ? line.replace(/^((?:>\s*)+)/u, "") : line;
+  if (unquotedContent.trim() !== "") return false;
+
+  return matchingSimpleListItems(
+    markdownListItemStart(previousLine),
+    markdownListItemStart(nextLine),
+    quotePrefix
+  );
+}
+
+function normalizeComparableMarkdownListSpacing(content: string) {
+  const lines = content.split("\n");
+  const normalized: string[] = [];
+  let fencedMarker: "`" | "~" | null = null;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? "";
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/u);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]!.startsWith("~") ? "~" : "`";
+      if (!fencedMarker) {
+        fencedMarker = marker;
+      } else if (fencedMarker === marker) {
+        fencedMarker = null;
+      }
+
+      normalized.push(line);
+      continue;
+    }
+
+    // Milkdown may serialize adjacent one-line list items without the spacer line;
+    // keep that clean-file rewrite from becoming an unsaved edit.
+    const isSimpleListSpacer =
+      !fencedMarker &&
+      isComparableMarkdownListSpacer(line, normalized[normalized.length - 1], lines[lineIndex + 1]);
+
+    if (!isSimpleListSpacer) normalized.push(line);
+  }
+
+  return normalized.join("\n");
+}
+
+function isMarkdownWordCharacter(character: string | undefined) {
+  return character !== undefined && /[\p{L}\p{N}]/u.test(character);
+}
+
+function normalizeComparableMarkdownLineEscapes(line: string) {
+  let normalized = "";
+
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] === "`") {
+      const runStart = index;
+      while (line[index + 1] === "`") index += 1;
+
+      const marker = line.slice(runStart, index + 1);
+      const closingIndex = line.indexOf(marker, index + 1);
+      if (closingIndex >= 0) {
+        normalized += line.slice(runStart, closingIndex + marker.length);
+        index = closingIndex + marker.length - 1;
+        continue;
+      }
+
+      normalized += line.slice(runStart, index + 1);
+      continue;
+    }
+
+    if (
+      line[index] === "\\" &&
+      line[index + 1] === "_" &&
+      isMarkdownWordCharacter(line[index - 1]) &&
+      isMarkdownWordCharacter(line[index + 2])
+    ) {
+      // Milkdown escapes intraword underscores even though CommonMark treats them as literal text.
+      normalized += "_";
+      index += 1;
+      continue;
+    }
+
+    normalized += line[index];
+  }
+
+  return normalized;
+}
+
+function normalizeComparableMarkdownEscapes(content: string) {
+  const lines = content.split("\n");
+  const normalized: string[] = [];
+  let fencedMarker: "`" | "~" | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/u);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]!.startsWith("~") ? "~" : "`";
+      if (!fencedMarker) {
+        fencedMarker = marker;
+      } else if (fencedMarker === marker) {
+        fencedMarker = null;
+      }
+
+      normalized.push(line);
+      continue;
+    }
+
+    normalized.push(fencedMarker ? line : normalizeComparableMarkdownLineEscapes(line));
+  }
+
+  return normalized.join("\n");
+}
+
 function comparableMarkdown(content: string) {
-  return normalizeComparableMarkdownHeadings(content)
+  return normalizeComparableMarkdownEscapes(
+    normalizeComparableMarkdownListSpacing(normalizeComparableMarkdownHeadings(content))
+  )
     .replace(/[ \t]+$/gmu, "")
     .trim();
 }

--- a/packages/app/src/hooks/markdown-document/editor-sync.ts
+++ b/packages/app/src/hooks/markdown-document/editor-sync.ts
@@ -9,18 +9,39 @@ type SavedVisualEditorStaleContent = {
 
 export function createEditorSyncState() {
   const cleanVisualContentBeforeDirty = new Map<string, string>();
+  const cleanVisualMarkdownBaseline = new Map<string, string>();
   const savedVisualEditorStaleContent = new Map<string, SavedVisualEditorStaleContent>();
 
   function clear(tabId: string | null | undefined) {
     if (!tabId) return;
 
     cleanVisualContentBeforeDirty.delete(tabId);
+    cleanVisualMarkdownBaseline.delete(tabId);
     savedVisualEditorStaleContent.delete(tabId);
   }
 
   function clearAll() {
     cleanVisualContentBeforeDirty.clear();
+    cleanVisualMarkdownBaseline.clear();
     savedVisualEditorStaleContent.clear();
+  }
+
+  function clearCleanVisualMarkdownBaseline(tabId: string | null | undefined) {
+    if (!tabId) return;
+
+    cleanVisualMarkdownBaseline.delete(tabId);
+  }
+
+  function isCleanVisualMarkdownBaseline(tabId: string | null | undefined, editorContent: string) {
+    if (!tabId) return false;
+
+    return cleanVisualMarkdownBaseline.get(tabId) === editorContent;
+  }
+
+  function rememberCleanVisualMarkdownBaseline(tabId: string | null | undefined, editorContent: string) {
+    if (!tabId) return;
+
+    cleanVisualMarkdownBaseline.set(tabId, editorContent);
   }
 
   function isSavedVisualEditorStaleContent(
@@ -73,8 +94,11 @@ export function createEditorSyncState() {
   return {
     clear,
     clearAll,
+    clearCleanVisualMarkdownBaseline,
+    isCleanVisualMarkdownBaseline,
     isSavedVisualEditorStaleContent,
     rememberCleanVisualContentBeforeDirty,
+    rememberCleanVisualMarkdownBaseline,
     rememberSavedVisualEditorStaleContent
   };
 }

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -491,9 +491,9 @@ export function useEditorController() {
   const editorRef = useRef<Editor | null>(null);
   const focusTimerRef = useRef<number | null>(null);
 
-  const getCurrentMarkdown = useCallback((fallbackContent: string) => {
+  const getMarkdownFromEditor = useCallback((editor: Editor, fallbackContent: string) => {
     try {
-      return editorRef.current?.action((ctx) => {
+      return editor.action((ctx) => {
         const view = ctx.get(editorViewCtx);
         return serializeCurrentEditorMarkdown(
           view,
@@ -502,11 +502,16 @@ export function useEditorController() {
           imageSchema.type(ctx),
           markraLiveMarkdownSpecs(ctx)
         );
-      }) ?? fallbackContent;
+      });
     } catch {
       return fallbackContent;
     }
   }, []);
+
+  const getCurrentMarkdown = useCallback((fallbackContent: string) => {
+    const editor = editorRef.current;
+    return editor ? getMarkdownFromEditor(editor, fallbackContent) : fallbackContent;
+  }, [getMarkdownFromEditor]);
 
   const isCurrentMarkdownEquivalent = useCallback((markdown: string) => {
     try {
@@ -1229,6 +1234,7 @@ export function useEditorController() {
     getDocumentEndPosition,
     getHeadingAnchors,
     getCurrentMarkdown,
+    getMarkdownFromEditor,
     isCurrentMarkdownEquivalent,
     getSelection,
     getSelectionAnchor,

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -291,6 +291,253 @@ describe("useMarkdownDocument", () => {
     expect(result.current.document.name).toBe("second.md");
   });
 
+  it("does not ask to discard a clean file when the visual editor tightens loose list spacing", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = [
+      "# Guide",
+      "",
+      "- First point.",
+      "",
+      "- Second point."
+    ].join("\n");
+    const visualMarkdown = [
+      "# Guide",
+      "",
+      "- First point.",
+      "- Second point."
+    ].join("\n");
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "guide.md",
+      path: "/mock-files/guide.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "guide.md",
+        path: "/mock-files/guide.md",
+        relativePath: "guide.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "guide.md"
+    });
+  });
+
+  it("does not ask to discard a clean file when the visual editor escapes intraword underscores", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = "Token sequence x_1 reaches x_T.";
+    const visualMarkdown = "Token sequence x\\_1 reaches x\\_T.";
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "tokens.md",
+      path: "/mock-files/tokens.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "tokens.md",
+        path: "/mock-files/tokens.md",
+        relativePath: "tokens.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "tokens.md"
+    });
+  });
+
+  it("uses fallback markdown equivalence before treating a live editor mismatch as unsaved", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = "Workspace user_info entry.";
+    const visualMarkdown = "Workspace user\\_info entry.";
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "workspace.md",
+      path: "/mock-files/workspace.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: () => false,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "workspace.md",
+        path: "/mock-files/workspace.md",
+        relativePath: "workspace.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "workspace.md"
+    });
+  });
+
+  it("does not ask to discard a clean file when the visual editor tightens callout list spacing", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = [
+      "> [!NOTE]",
+      ">",
+      "> - First point.",
+      ">",
+      "> - Second point."
+    ].join("\n");
+    const visualMarkdown = [
+      "> [!NOTE]",
+      ">",
+      "> - First point.",
+      "> - Second point."
+    ].join("\n");
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: editorMarkdown,
+      name: "callout.md",
+      path: "/mock-files/callout.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "callout.md",
+        path: "/mock-files/callout.md",
+        relativePath: "callout.md"
+      });
+    });
+
+    editorMarkdown = visualMarkdown;
+    act(() => {
+      result.current.handleMarkdownChange(visualMarkdown, { surface: "visual" });
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+    expect(result.current.document).toMatchObject({
+      content: visualMarkdown,
+      dirty: false,
+      name: "callout.md"
+    });
+  });
+
   it("keeps a clean tab unmodified when the editor reports an equivalent markdown update", async () => {
     mockedReadNativeMarkdownFile.mockResolvedValueOnce({
       content: "* Clean content.",

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -471,6 +471,168 @@ describe("useMarkdownDocument", () => {
     });
   });
 
+  it("uses a clean visual baseline when checking close prompts", async () => {
+    let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
+    let editorMarkdown = "Serialized clean baseline.";
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedListenNativeWindowCloseRequested.mockImplementation(async (handler) => {
+      closeRequestHandler = handler;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "Original clean source.",
+      name: "baseline.md",
+      path: "/mock-files/baseline.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: () => editorMarkdown,
+        isCurrentMarkdownEquivalent: () => false,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await waitFor(() => expect(mockedListenNativeWindowCloseRequested).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "baseline.md",
+        path: "/mock-files/baseline.md",
+        relativePath: "baseline.md"
+      });
+    });
+
+    act(() => {
+      result.current.rememberMarkdownTabVisualBaseline(result.current.activeTabId!, editorMarkdown);
+    });
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      if (!closeRequestHandler) throw new Error("native close request handler was not registered");
+      await closeRequestHandler({ preventDefault });
+    });
+
+    expect(confirmDiscardUnsavedChanges).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedDestroyNativeWindow).toHaveBeenCalledTimes(1));
+
+    editorMarkdown = "User edited content.";
+    act(() => {
+      result.current.handleMarkdownChange(editorMarkdown, { surface: "visual" });
+    });
+
+    await act(async () => {
+      const canDiscard = await result.current.confirmCanDiscardCurrentDocument();
+      expect(canDiscard).toBe(false);
+    });
+
+    expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "baseline.md" }));
+  });
+
+  it("clears a clean visual baseline after an undoable disk reload", async () => {
+    let emitExternalChange: (path: string) => unknown | Promise<unknown> = () => {};
+    mockedWatchNativeMarkdownFile.mockImplementation(async (_path, onChange) => {
+      emitExternalChange = onChange;
+      return () => {};
+    });
+    mockedReadNativeMarkdownFile
+      .mockResolvedValueOnce({
+        content: "Original clean source.",
+        name: "baseline.md",
+        path: "/mock-files/baseline.md"
+      })
+      .mockResolvedValueOnce({
+        content: "Changed on disk.",
+        name: "baseline.md",
+        path: "/mock-files/baseline.md"
+      });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onActiveDiskFileContentChange: () => true,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "baseline.md",
+        path: "/mock-files/baseline.md",
+        relativePath: "baseline.md"
+      });
+    });
+    await waitFor(() => expect(mockedWatchNativeMarkdownFile).toHaveBeenCalled());
+
+    act(() => {
+      result.current.rememberMarkdownTabVisualBaseline(result.current.activeTabId!, "Original clean source.");
+    });
+    await act(async () => {
+      await emitExternalChange("/mock-files/baseline.md");
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("Original clean source.", { surface: "visual" });
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "Original clean source.",
+      dirty: true,
+      name: "baseline.md"
+    });
+  });
+
+  it("keeps source edits dirty even when markdown renders equivalently", async () => {
+    const confirmDiscardUnsavedChanges = vi.fn(() => false);
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "Source token x_p.",
+      name: "source.md",
+      path: "/mock-files/source.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        confirmDiscardUnsavedChanges,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        isCurrentMarkdownEquivalent: () => false,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "source.md",
+        path: "/mock-files/source.md",
+        relativePath: "source.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("Source token x\\_p.", { surface: "source" });
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "Source token x\\_p.",
+      dirty: true,
+      name: "source.md"
+    });
+
+    await act(async () => {
+      const canDiscard = await result.current.confirmCanDiscardCurrentDocument();
+      expect(canDiscard).toBe(false);
+    });
+
+    expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "source.md" }));
+  });
+
   it("does not ask to discard a clean file when the visual editor tightens callout list spacing", async () => {
     let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
     let editorMarkdown = [

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -510,12 +510,14 @@ export function useMarkdownDocument({
     ) {
       return current;
     }
+    if (!current.dirty && editorSyncState.isCleanVisualMarkdownBaseline(currentActiveTabId, content)) return current;
 
     const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
     const nextDocument =
       !current.dirty && (editorContentEquivalent === true || isEquivalentEditorMarkdown(current.content, content))
         ? { ...current, content, dirty: false }
         : { ...current, content, dirty: true };
+    if (!current.dirty && nextDocument.dirty) editorSyncState.clearCleanVisualMarkdownBaseline(currentActiveTabId);
 
     const nextTabs = currentActiveTabId
       ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
@@ -566,6 +568,7 @@ export function useMarkdownDocument({
 
       const editorMarkdown = currentMarkdown();
       if (editorSyncState.isSavedVisualEditorStaleContent(activeTabIdRef.current, current.content, editorMarkdown)) return false;
+      if (editorSyncState.isCleanVisualMarkdownBaseline(activeTabIdRef.current, editorMarkdown)) return false;
       if (isEquivalentEditorMarkdown(editorMarkdown, current.content)) return false;
       if (editorContentEquivalent === false && current.path !== null) return true;
 
@@ -591,6 +594,9 @@ export function useMarkdownDocument({
     if (!current.dirty && editorSyncState.isSavedVisualEditorStaleContent(tabId, current.content, content)) {
       return current.content;
     }
+    if (!current.dirty && editorSyncState.isCleanVisualMarkdownBaseline(tabId, content)) {
+      return current.content;
+    }
 
     return content;
   }, [currentMarkdown, editorSyncState]);
@@ -612,6 +618,14 @@ export function useMarkdownDocument({
     if (options.documentRevision !== undefined && options.documentRevision !== current.revision) return;
     if (!current.open || current.content === content) return;
     const currentActiveTabId = activeTabIdRef.current;
+    if (
+      !current.dirty &&
+      options.surface === "visual" &&
+      editorSyncState.isCleanVisualMarkdownBaseline(currentActiveTabId, content)
+    ) {
+      return;
+    }
+    const canKeepEquivalentMarkdownClean = options.surface !== "source";
     const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
     if (
       !current.dirty &&
@@ -626,9 +640,12 @@ export function useMarkdownDocument({
       editorSyncState.rememberCleanVisualContentBeforeDirty(currentActiveTabId, current.content, content, options.surface);
     }
     const nextDocument =
-      !current.dirty && (editorContentEquivalent === true || isEquivalentEditorMarkdown(current.content, content))
+      !current.dirty &&
+      canKeepEquivalentMarkdownClean &&
+      (editorContentEquivalent === true || isEquivalentEditorMarkdown(current.content, content))
         ? { ...current, content, dirty: false }
         : { ...current, content, dirty: true };
+    if (!current.dirty && nextDocument.dirty) editorSyncState.clearCleanVisualMarkdownBaseline(currentActiveTabId);
 
     const nextTabs = currentActiveTabId
       ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
@@ -655,17 +672,29 @@ export function useMarkdownDocument({
         if (
           !tab.dirty &&
           options.surface === "visual" &&
+          editorSyncState.isCleanVisualMarkdownBaseline(tab.id, content)
+        ) {
+          return tab;
+        }
+        if (
+          !tab.dirty &&
+          options.surface === "visual" &&
           options.documentRevision !== undefined &&
           !isEquivalentEditorMarkdown(tab.content, content)
         ) {
           return tab;
         }
         if (!tab.dirty) editorSyncState.rememberCleanVisualContentBeforeDirty(tab.id, tab.content, content, options.surface);
+        const canKeepEquivalentMarkdownClean = options.surface !== "source";
+        const contentEquivalent = canKeepEquivalentMarkdownClean && isEquivalentEditorMarkdown(tab.content, content);
+        if (!tab.dirty && !contentEquivalent) {
+          editorSyncState.clearCleanVisualMarkdownBaseline(tab.id);
+        }
 
         return {
           ...tab,
           content,
-          dirty: tab.dirty || !isEquivalentEditorMarkdown(tab.content, content)
+          dirty: tab.dirty || !contentEquivalent
         };
       });
 
@@ -674,6 +703,14 @@ export function useMarkdownDocument({
       return nextTabs;
     });
   }, [editorSyncState, handleMarkdownChange]);
+
+  const rememberMarkdownTabVisualBaseline = useCallback((tabId: string, content: string) => {
+    const tab = tabsRef.current.find((candidate) => candidate.id === tabId);
+    if (!tab || !tab.open || tab.dirty) return false;
+
+    editorSyncState.rememberCleanVisualMarkdownBaseline(tabId, content);
+    return true;
+  }, [editorSyncState]);
 
   const restoreDocumentContent = useCallback((content: string) => {
     const current = documentRef.current;
@@ -856,6 +893,9 @@ export function useMarkdownDocument({
       tab.id === targetTab.id ? createDocumentTab(nextDocument, tab.id) : tab
     );
 
+    // A disk reload moves the clean reference forward; an old visual baseline would hide
+    // undoing back to the previous disk content as a real unsaved edit.
+    editorSyncState.clearCleanVisualMarkdownBaseline(targetTab.id);
     tabsRef.current = nextTabs;
     setTabs(nextTabs);
     if (activeTabChanged) {
@@ -871,7 +911,7 @@ export function useMarkdownDocument({
       tabId: targetTab.id
     }]);
     return true;
-  }, [onActiveDiskFileContentChange]);
+  }, [editorSyncState, onActiveDiskFileContentChange]);
 
   const refreshCleanOpenTabFromDisk = useCallback((path: string, reason: string) => {
     const currentTab = tabsRef.current.find((tab) => tab.path !== null && sameNativePath(tab.path, path));
@@ -2227,6 +2267,7 @@ export function useMarkdownDocument({
     handleMarkdownChange,
     handleMarkdownTabChange,
     handleSaveClick,
+    rememberMarkdownTabVisualBaseline,
     openMarkdownFile,
     openRecentMarkdownFile,
     openTreeMarkdownFileInBackground,

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -566,9 +566,10 @@ export function useMarkdownDocument({
 
       const editorMarkdown = currentMarkdown();
       if (editorSyncState.isSavedVisualEditorStaleContent(activeTabIdRef.current, current.content, editorMarkdown)) return false;
+      if (isEquivalentEditorMarkdown(editorMarkdown, current.content)) return false;
       if (editorContentEquivalent === false && current.path !== null) return true;
 
-      return !isEquivalentEditorMarkdown(editorMarkdown, current.content) && (current.path !== null || editorMarkdown.trim().length > 0);
+      return current.path !== null || editorMarkdown.trim().length > 0;
     }
     if (current.path) return true;
 


### PR DESCRIPTION
## Summary
- remember each clean tab's visual-editor markdown baseline when Milkdown becomes ready
- treat that baseline as clean for close/save checks while preserving source-mode textual edits as dirty
- clear stale visual baselines after undoable disk reloads so external-change undo still marks the document dirty

## Why
This is the broader follow-up to #499. Instead of enumerating every serializer-only Markdown difference, it records the visual editor's own clean serialization for a tab and compares future visual emissions against that baseline.

## Validation
- `pnpm --filter @markra/app test -- src/hooks/useMarkdownDocument.test.tsx` passed: 71 tests
- `pnpm --filter @markra/app test -- src/App.test.tsx` passed: 204 tests
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed

## Risk
- This changes dirty-state bookkeeping around visual editor readiness, save, close, and native watcher reloads. Added regression coverage for clean visual baselines, source-mode equivalence staying dirty, and undoable disk reloads clearing stale baselines.
