### PR TITLE
ci(rust): reduce Cargo cache overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,15 +154,10 @@ jobs:
           rustup component add rustfmt
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/git
-            ~/.cargo/registry
-            apps/desktop/src-tauri/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          workspaces: |
+            apps/desktop/src-tauri -> target
 
       - name: Check formatting
         run: cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check


### PR DESCRIPTION
## Summary

- replace the raw Cargo directories and full Tauri `target` cache with `Swatinem/rust-cache@v2`
- scope dependency-aware caching to `apps/desktop/src-tauri -> target`
- let the action prune workspace crates, incremental artifacts, and stale dependency outputs

## Motivation

A recent warm CI run restored roughly 5.6 GB of Cargo data: the cache step took 69 seconds while the Rust test step took 13 seconds. Restoring the full `target` directory was the dominant cost of the Tauri job.

## Measured CI results

| Metric | Previous cache | New warm cache | Change |
| --- | ---: | ---: | ---: |
| Cache archive | 5,597 MB | 460 MB | -91.8% |
| Cache step | 69s | 11s | -58s |
| Rust test step | 13s | 29s | +16s |
| Tauri Rust job | 97s | 59s | -38s (-39%) |

The dependency-aware cache intentionally rebuilds the workspace crate, but the much smaller restore more than offsets that cost. The cold-cache validation also passed: it compiled dependencies in 82 seconds and saved the pruned 460 MB archive in about 16 seconds.

CI evidence: [cold run](https://github.com/markrahq/markra/actions/runs/29070636894/attempts/1), [warm run](https://github.com/markrahq/markra/actions/runs/29070636894/attempts/2).

## Validation

- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- parsed `.github/workflows/ci.yml` successfully with Ruby YAML
- verified the `workspaces` input against the `Swatinem/rust-cache@v2` action metadata
- cold and warm GitHub Actions runs both passed