### PR TITLE
fix(editor): preserve inline boundary typing sessions

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8080,7 +8080,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("snaps finalized formatting edge clicks to the mark boundary", async () => {
+  it("keeps finalized formatting edge clicks on their visual side", async () => {
     const { container, editor, unmount, view } = await renderEditor("alpha **bold** omega");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
@@ -8114,8 +8114,8 @@ describe("MarkdownPaper editing", () => {
 
     typeText(view, "!");
 
-    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
-    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold!");
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold!** omega");
     unmount();
 
     const before = await renderEditor("alpha **bold** omega");
@@ -8150,8 +8150,227 @@ describe("MarkdownPaper editing", () => {
 
     typeText(before.view, "!");
 
+    expect(before.container.querySelector(".ProseMirror strong")).toHaveTextContent("!bold");
+    expect(beforeSerializer(before.view.state.doc).trimEnd()).toBe("alpha **!bold** omega");
+    await settleMarkdownListener();
+  });
+
+  it("keeps clicks just outside finalized formatting edges outside the mark", async () => {
+    const after = await renderEditor("alpha **bold** omega");
+    const afterSerializer = after.editor.action((ctx) => ctx.get(serializerCtx));
+    const afterParagraph = after.container.querySelector<HTMLElement>(".ProseMirror p");
+    const afterStrong = after.container.querySelector<HTMLElement>(".ProseMirror strong");
+
+    expect(afterParagraph).toBeInTheDocument();
+    expect(afterStrong).toHaveTextContent("bold");
+    mockInlineElementRect(afterStrong!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    const rightOutsideClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 149,
+      clientY: 22
+    });
+    Object.defineProperty(rightOutsideClick, "target", {
+      configurable: true,
+      value: afterParagraph
+    });
+    const rightHandled = after.view.someProp(
+      "handleDOMEvents",
+      (handlers) => handlers.mousedown?.(after.view, rightOutsideClick)
+    );
+
+    expect(rightHandled).toBe(true);
+    typeText(after.view, "!");
+
+    expect(after.container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(afterSerializer(after.view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
+    after.unmount();
+
+    const before = await renderEditor("alpha **bold** omega");
+    const beforeSerializer = before.editor.action((ctx) => ctx.get(serializerCtx));
+    const beforeParagraph = before.container.querySelector<HTMLElement>(".ProseMirror p");
+    const beforeStrong = before.container.querySelector<HTMLElement>(".ProseMirror strong");
+
+    expect(beforeParagraph).toBeInTheDocument();
+    expect(beforeStrong).toHaveTextContent("bold");
+    mockInlineElementRect(beforeStrong!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    const leftOutsideClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 99,
+      clientY: 22
+    });
+    Object.defineProperty(leftOutsideClick, "target", {
+      configurable: true,
+      value: beforeParagraph
+    });
+    const leftHandled = before.view.someProp(
+      "handleDOMEvents",
+      (handlers) => handlers.mousedown?.(before.view, leftOutsideClick)
+    );
+
+    expect(leftHandled).toBe(true);
+    typeText(before.view, "!");
+
     expect(before.container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
     expect(beforeSerializer(before.view.state.doc).trimEnd()).toBe("alpha !**bold** omega");
+    await settleMarkdownListener();
+  });
+
+  it.each([
+    {
+      clientX: 147,
+      expectedMarkText: "boldx",
+      expectedSource: "**boldx** after",
+      label: "strong inside",
+      reportsSurroundingTarget: false,
+      selector: ".markra-live-mark-strong",
+      source: "**bold** after"
+    },
+    {
+      clientX: 149,
+      expectedMarkText: "bold",
+      expectedSource: "**bold**x after",
+      label: "strong outside",
+      reportsSurroundingTarget: false,
+      selector: ".markra-live-mark-strong",
+      source: "**bold** after"
+    },
+    {
+      clientX: 148,
+      expectedMarkText: "bold italicx",
+      expectedSource: "***bold italicx*** after",
+      label: "strong emphasis inside with a surrounding WebView target",
+      reportsSurroundingTarget: true,
+      selector: ".markra-live-mark-strong.markra-live-mark-emphasis",
+      source: "***bold italic*** after"
+    },
+    {
+      clientX: 149,
+      expectedMarkText: "bold italic",
+      expectedSource: "***bold italic***x after",
+      label: "strong emphasis outside with a surrounding WebView target",
+      reportsSurroundingTarget: true,
+      selector: ".markra-live-mark-strong.markra-live-mark-emphasis",
+      source: "***bold italic*** after"
+    }
+  ])("keeps typed $label on the clicked side of live Markdown", async ({
+    clientX,
+    expectedMarkText,
+    expectedSource,
+    reportsSurroundingTarget,
+    selector,
+    source
+  }) => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, source);
+
+    const liveMark = container.querySelector<HTMLElement>(`.ProseMirror ${selector}`);
+    expect(liveMark).toBeInTheDocument();
+    mockInlineElementRect(liveMark!, {
+      bottom: 32,
+      left: 100,
+      right: 148,
+      top: 12
+    });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", {
+      configurable: true,
+      value: reportsSurroundingTarget ? container.querySelector(".ProseMirror p") : liveMark
+    });
+    const handled = view.someProp(
+      "handleDOMEvents",
+      (handlers) => handlers.mousedown?.(view, edgeClick)
+    );
+
+    expect(handled).toBe(true);
+    typeText(view, "x");
+
+    expect(container.querySelector(`.ProseMirror ${selector}`)).toHaveTextContent(expectedMarkText);
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe(expectedSource);
+    await settleMarkdownListener();
+  });
+
+  it.each([
+    {
+      expected: "**boldx** and ***bold italic*** and ~~strike~~",
+      label: "strong",
+      selector: ".markra-live-mark-strong:not(.markra-live-mark-emphasis)",
+      text: "bold"
+    },
+    {
+      expected: "**bold** and ***bold italicx*** and ~~strike~~",
+      label: "strong emphasis",
+      selector: ".markra-live-mark-strong.markra-live-mark-emphasis",
+      text: "bold italic"
+    },
+    {
+      expected: "**bold** and ***bold italic*** and ~~strikex~~",
+      label: "strikethrough",
+      selector: ".markra-live-mark-strikethrough",
+      text: "strike"
+    }
+  ])("keeps $label inside when the WebView reports its closing delimiter at the content edge", async ({
+    expected,
+    selector,
+    text
+  }) => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**bold** and ***bold italic*** and ~~strike~~");
+    moveCursor(view, findTextPosition(view, text, 1));
+
+    const liveMark = container.querySelector<HTMLElement>(`.ProseMirror ${selector}`);
+    const delimiters = Array.from(
+      container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-delimiter:not(.markra-md-virtual-delimiter)")
+    );
+    expect(liveMark).toBeInTheDocument();
+    expect(delimiters).toHaveLength(2);
+    const closingDelimiter = delimiters[1];
+    mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
+    mockInlineElementRect(closingDelimiter!, { bottom: 32, left: 148, right: 164, top: 12 });
+
+    const contentEdgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 148,
+      clientY: 22
+    });
+    Object.defineProperty(contentEdgeClick, "target", {
+      configurable: true,
+      value: closingDelimiter
+    });
+    const handled = view.someProp(
+      "handleDOMEvents",
+      (handlers) => handlers.mousedown?.(view, contentEdgeClick)
+    );
+
+    expect(handled).toBe(true);
+    typeText(view, "x");
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe(expected);
     await settleMarkdownListener();
   });
 
@@ -8186,7 +8405,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("snaps finalized formatting edge clicks when the WebView reports a surrounding target", async () => {
+  it("keeps finalized formatting edge clicks on their visual side when the WebView reports a surrounding target", async () => {
     const { container, editor, view } = await renderEditor("alpha **bold** omega");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
@@ -8220,7 +8439,8 @@ describe("MarkdownPaper editing", () => {
 
     typeText(view, "!");
 
-    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold!");
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold!** omega");
     await settleMarkdownListener();
   });
 
@@ -8294,6 +8514,39 @@ describe("MarkdownPaper editing", () => {
     moveCursor(view, 3);
     expect(pressArrowLeft(view)).toBe(true);
     expect(view.state.selection.from).toBe(1);
+    await settleMarkdownListener();
+  });
+
+  it.each([
+    { expected: "**bold input** after", label: "strong", markdown: "**bold** after", text: "bold" },
+    {
+      expected: "***bold italic input*** after",
+      label: "strong emphasis",
+      markdown: "***bold italic*** after",
+      text: "bold italic"
+    },
+    { expected: "~~strike input~~ after", label: "strikethrough", markdown: "~~strike~~ after", text: "strike" }
+  ])("restores explicit stored marks when native keyboard movement lands inside finalized $label", async ({
+    expected,
+    markdown,
+    text
+  }) => {
+    const { editor, view } = await renderEditor(markdown);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    const contentEnd = findTextPosition(view, text, text.length);
+    moveCursor(view, findLastTextBlockEndCursor(view));
+    // ProseMirror receives this selection after the WebView performs an unhandled ArrowLeft movement.
+    moveCursor(view, contentEnd);
+    const insideMarkTypes = (view.state.selection.$from.nodeBefore?.marks ?? []).map((mark) => mark.type.name);
+    expect(insideMarkTypes.length).toBeGreaterThan(0);
+
+    const keyup = new KeyboardEvent("keyup", { bubbles: true, key: "ArrowLeft" });
+    view.someProp("handleDOMEvents", (handlers) => handlers.keyup?.(view, keyup));
+
+    expect(view.state.storedMarks?.map((mark) => mark.type.name)).toEqual(insideMarkTypes);
+    insertTextThroughInputHandler(view, " input");
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8569,6 +8569,64 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("leaves intermediate IME composition text under native control at a finalized boundary", async () => {
+    const { container, editor, unmount, view } = await renderEditor("**bold** after");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+    mockInlineElementRect(strong!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", { configurable: true, value: strong });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
+    ).toBe(true);
+
+    view.dom.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+
+    try {
+      expect(view.composing).toBe(true);
+      const { from, to } = view.state.selection;
+      const insertText = () => view.state.tr.insertText("s", from, to).scrollIntoView();
+      const handled = view.someProp(
+        "handleTextInput",
+        (handler) => handler(view, from, to, "s", insertText)
+      );
+
+      expect(handled).toBeUndefined();
+      view.dispatch(insertText());
+      expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**bolds** after");
+
+      const compositionMarks = view.state.doc.resolve(from + 1).nodeBefore?.marks ?? [];
+      const replaceCompositionText = (text: string, to: number) =>
+        view.state.tr.replaceWith(from, to, view.state.schema.text(text, compositionMarks)).scrollIntoView();
+      view.dispatch(replaceCompositionText("sd", from + 1));
+      expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**boldsd** after");
+
+      view.dom.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true, data: "confirmed" }));
+      expect(view.composing).toBe(false);
+
+      const finalInsert = () => replaceCompositionText("confirmed", from + 2);
+      const finalHandled = view.someProp(
+        "handleTextInput",
+        (handler) => handler(view, from, from + 2, "confirmed", finalInsert)
+      );
+      expect(finalHandled).toBeUndefined();
+      view.dispatch(finalInsert());
+      expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**boldconfirmed** after");
+    } finally {
+      if (view.composing) {
+        view.dom.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+      }
+      unmount();
+    }
+  });
+
   it("keeps consecutive beforeinput characters inside live Markdown", async () => {
     const { container, view } = await renderEditor();
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8232,6 +8232,86 @@ describe("MarkdownPaper editing", () => {
   });
 
   it.each([
+    { commit: "text input", input: "mouse", placement: "inside" },
+    { commit: "text input", input: "mouse", placement: "outside" },
+    { commit: "text input", input: "keyboard", placement: "inside" },
+    { commit: "text input", input: "keyboard", placement: "outside" },
+    { commit: "beforeinput", input: "mouse", placement: "inside" },
+    { commit: "beforeinput", input: "mouse", placement: "outside" }
+  ] as const)(
+    "preserves finalized $placement affinity for $commit after $input input",
+    async ({ commit, input, placement }) => {
+      const { container, editor, view } = await renderEditor("**bold** after");
+      const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+      const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
+      const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+      const contentEnd = findTextPosition(view, "bold", "bold".length);
+      const insideMarks = view.state.doc.resolve(contentEnd).nodeBefore?.marks ?? [];
+
+      expect(strong).toHaveTextContent("bold");
+
+      if (input === "mouse") {
+        mockInlineElementRect(strong!, { bottom: 32, left: 100, right: 148, top: 12 });
+        const edgeClick = new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+          clientX: placement === "inside" ? 147 : 149,
+          clientY: 22
+        });
+        Object.defineProperty(edgeClick, "target", {
+          configurable: true,
+          value: placement === "inside" ? strong : paragraph
+        });
+
+        const handled = view.someProp(
+          "handleDOMEvents",
+          (handlers) => handlers.mousedown?.(view, edgeClick)
+        );
+        expect(handled).toBe(true);
+      } else {
+        moveCursor(view, contentEnd);
+        if (placement === "inside") {
+          moveCursor(view, findLastTextBlockEndCursor(view));
+          moveCursor(view, contentEnd);
+          const keyup = new KeyboardEvent("keyup", { bubbles: true, key: "ArrowLeft" });
+          view.someProp("handleDOMEvents", (handlers) => handlers.keyup?.(view, keyup));
+        } else {
+          expect(pressArrowRight(view)).toBe(true);
+        }
+      }
+
+      // WebViews can restore their native boundary selection after the editor has assigned mark affinity.
+      view.dispatch(
+        view.state.tr
+          .setSelection(TextSelection.create(view.state.doc, contentEnd))
+          .setStoredMarks(placement === "inside" ? null : insideMarks)
+      );
+      if (commit === "beforeinput") {
+        const beforeInput = new InputEvent("beforeinput", {
+          bubbles: true,
+          cancelable: true,
+          data: "x",
+          inputType: "insertText"
+        });
+        const handled = view.someProp(
+          "handleDOMEvents",
+          (handlers) => handlers.beforeinput?.(view, beforeInput)
+        );
+        expect(handled).toBe(true);
+        expect(beforeInput.defaultPrevented).toBe(true);
+      } else {
+        insertTextThroughInputHandler(view, "x");
+      }
+
+      expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(
+        placement === "inside" ? "**boldx** after" : "**bold**x after"
+      );
+      await settleMarkdownListener();
+    }
+  );
+
+  it.each([
     {
       clientX: 147,
       expectedMarkText: "boldx",
@@ -8310,6 +8390,269 @@ describe("MarkdownPaper editing", () => {
 
     expect(container.querySelector(`.ProseMirror ${selector}`)).toHaveTextContent(expectedMarkText);
     expect(container.querySelector(".ProseMirror p")?.textContent).toBe(expectedSource);
+    await settleMarkdownListener();
+  });
+
+  it.each([
+    { commit: "text input", placement: "inside" },
+    { commit: "text input", placement: "outside" },
+    { commit: "beforeinput", placement: "inside" },
+    { commit: "beforeinput", placement: "outside" }
+  ] as const)(
+    "preserves live Markdown $placement intent for $commit after a WebView selection overwrite",
+    async ({ commit, placement }) => {
+      const { container, view } = await renderEditor();
+
+      typeText(view, "**bold** after");
+      const liveMark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+      const contentEnd = findTextPosition(view, "bold", "bold".length);
+      const outsidePosition = findTextPosition(view, " after");
+      mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+      const edgeClick = new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        clientX: placement === "inside" ? 147 : 149,
+        clientY: 22
+      });
+      Object.defineProperty(edgeClick, "target", {
+        configurable: true,
+        value: placement === "inside" ? liveMark : container.querySelector(".ProseMirror p")
+      });
+      const handled = view.someProp(
+        "handleDOMEvents",
+        (handlers) => handlers.mousedown?.(view, edgeClick)
+      );
+      expect(handled).toBe(true);
+
+      view.dispatch(
+        view.state.tr
+          .setSelection(
+            TextSelection.create(view.state.doc, placement === "inside" ? outsidePosition : contentEnd)
+          )
+          .setStoredMarks(null)
+      );
+      if (commit === "beforeinput") {
+        const beforeInput = new InputEvent("beforeinput", {
+          bubbles: true,
+          cancelable: true,
+          data: "x",
+          inputType: "insertText"
+        });
+        const handled = view.someProp(
+          "handleDOMEvents",
+          (handlers) => handlers.beforeinput?.(view, beforeInput)
+        );
+        expect(handled).toBe(true);
+        expect(beforeInput.defaultPrevented).toBe(true);
+      } else {
+        insertTextThroughInputHandler(view, "x");
+      }
+
+      expect(container.querySelector(".ProseMirror p")?.textContent).toBe(
+        placement === "inside" ? "**boldx** after" : "**bold**x after"
+      );
+      await settleMarkdownListener();
+    }
+  );
+
+  it.each([
+    { direction: "right", expected: "**bold**x after", placement: "inside" },
+    { direction: "left", expected: "**boldx** after", placement: "outside" }
+  ] as const)(
+    "replaces live Markdown $placement intent after the $direction arrow crosses the delimiter",
+    async ({ direction, expected, placement }) => {
+      const { container, view } = await renderEditor();
+
+      typeText(view, "**bold** after");
+      const liveMark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+      mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+      const edgeClick = new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        clientX: placement === "inside" ? 147 : 149,
+        clientY: 22
+      });
+      Object.defineProperty(edgeClick, "target", {
+        configurable: true,
+        value: placement === "inside" ? liveMark : container.querySelector(".ProseMirror p")
+      });
+      const handled = view.someProp(
+        "handleDOMEvents",
+        (handlers) => handlers.mousedown?.(view, edgeClick)
+      );
+      expect(handled).toBe(true);
+
+      expect(direction === "right" ? pressArrowRight(view) : pressArrowLeft(view)).toBe(true);
+      insertTextThroughInputHandler(view, "x");
+
+      expect(container.querySelector(".ProseMirror p")?.textContent).toBe(expected);
+      await settleMarkdownListener();
+    }
+  );
+
+  it("does not pre-insert text for a non-cancelable boundary beforeinput event", async () => {
+    const { container, editor, view } = await renderEditor("**bold** after");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+    mockInlineElementRect(strong!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", { configurable: true, value: strong });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
+    ).toBe(true);
+
+    const beforeInput = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: false,
+      data: "x",
+      inputType: "insertText"
+    });
+    const handled = view.someProp(
+      "handleDOMEvents",
+      (handlers) => handlers.beforeinput?.(view, beforeInput)
+    );
+
+    expect(handled).toBeUndefined();
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**bold** after");
+    await settleMarkdownListener();
+  });
+
+  it("keeps consecutive beforeinput characters inside a finalized mark", async () => {
+    const { container, editor, view } = await renderEditor("**bold** after");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
+    mockInlineElementRect(strong!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", { configurable: true, value: strong });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
+    ).toBe(true);
+
+    for (const character of "xyz") {
+      const cursor = view.state.selection.from;
+      view.dispatch(
+        view.state.tr
+          .setSelection(TextSelection.create(view.state.doc, cursor))
+          .setStoredMarks(null)
+      );
+      const beforeInput = new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: character,
+        inputType: "insertText"
+      });
+
+      expect(
+        view.someProp("handleDOMEvents", (handlers) => handlers.beforeinput?.(view, beforeInput))
+      ).toBe(true);
+    }
+
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**boldxyz** after");
+    await settleMarkdownListener();
+  });
+
+  it("keeps consecutive beforeinput characters inside live Markdown", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**bold** after");
+    const liveMark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+    mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", { configurable: true, value: liveMark });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
+    ).toBe(true);
+
+    for (const character of "xyz") {
+      const outsidePosition = findTextPosition(view, " after");
+      view.dispatch(
+        view.state.tr
+          .setSelection(TextSelection.create(view.state.doc, outsidePosition))
+          .setStoredMarks(null)
+      );
+      const beforeInput = new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        data: character,
+        inputType: "insertText"
+      });
+
+      expect(
+        view.someProp("handleDOMEvents", (handlers) => handlers.beforeinput?.(view, beforeInput))
+      ).toBe(true);
+    }
+
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("**boldxyz** after");
+    await settleMarkdownListener();
+  });
+
+  it("ends a live Markdown typing session when inserted text invalidates the range", async () => {
+    const { container, view } = await renderEditor();
+
+    typeText(view, "**bold** after");
+    const liveMark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+    mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", { configurable: true, value: liveMark });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
+    ).toBe(true);
+
+    const spaceInput = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      data: " ",
+      inputType: "insertText"
+    });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.beforeinput?.(view, spaceInput))
+    ).toBe(true);
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("**bold ** after");
+
+    moveCursor(view, view.state.selection.from + 1);
+    const nextInput = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      data: "x",
+      inputType: "insertText"
+    });
+
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.beforeinput?.(view, nextInput))
+    ).toBeUndefined();
+    expect(container.querySelector(".ProseMirror p")?.textContent).toBe("**bold ** after");
     await settleMarkdownListener();
   });
 
@@ -8547,6 +8890,86 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.storedMarks?.map((mark) => mark.type.name)).toEqual(insideMarkTypes);
     insertTextThroughInputHandler(view, " input");
     expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
+    await settleMarkdownListener();
+  });
+
+  it.each([
+    {
+      expected: "**boldx** and ***bold italic*** and ~~strike~~ after",
+      markdown: "**bold** and ***bold italic*** and ~~strike~~ after",
+      text: "bold"
+    },
+    {
+      expected: "**bold** and ***bold italicx*** and ~~strike~~ after",
+      markdown: "**bold** and ***bold italic*** and ~~strike~~ after",
+      text: "bold italic"
+    },
+    {
+      expected: "**bold** and ***bold italic*** and ~~strikex~~ after",
+      markdown: "**bold** and ***bold italic*** and ~~strike~~ after",
+      text: "strike"
+    },
+    {
+      expected: "`codex` and **bold** after",
+      markdown: "`code` and **bold** after",
+      text: "code"
+    }
+  ])("moves into finalized $text on keydown before the WebView selection update", async ({
+    expected,
+    markdown,
+    text
+  }) => {
+    const { editor, view } = await renderEditor(markdown);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const contentEnd = findTextPosition(view, text, text.length);
+
+    moveCursor(view, contentEnd + 1);
+
+    expect(pressArrowLeft(view)).toBe(true);
+    expect(view.state.selection.from).toBe(contentEnd);
+
+    insertTextThroughInputHandler(view, "x");
+
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
+    await settleMarkdownListener();
+  });
+
+  it("moves into the start of a finalized mark on right keydown", async () => {
+    const { editor, view } = await renderEditor("before **bold** after");
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const contentStart = findTextPosition(view, "bold");
+
+    moveCursor(view, contentStart - 1);
+
+    expect(pressArrowRight(view)).toBe(true);
+    expect(view.state.selection.from).toBe(contentStart);
+
+    insertTextThroughInputHandler(view, "x");
+
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("before **xbold** after");
+    await settleMarkdownListener();
+  });
+
+  it("leaves right-to-left finalized mark navigation to the WebView", async () => {
+    const { view } = await renderEditor("**bold** after");
+    const contentEnd = findTextPosition(view, "bold", "bold".length);
+    view.dom.style.direction = "rtl";
+
+    moveCursor(view, contentEnd + 1);
+
+    expect(pressArrowLeft(view)).toBeUndefined();
+    expect(view.state.selection.from).toBe(contentEnd + 1);
+    await settleMarkdownListener();
+  });
+
+  it("leaves bidirectional-control finalized mark navigation to the WebView", async () => {
+    const { view } = await renderEditor("**bold** \u2067after\u2069");
+    const contentEnd = findTextPosition(view, "bold", "bold".length);
+
+    moveCursor(view, contentEnd + 1);
+
+    expect(pressArrowLeft(view)).toBeUndefined();
+    expect(view.state.selection.from).toBe(contentEnd + 1);
     await settleMarkdownListener();
   });
 

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8587,10 +8587,19 @@ describe("MarkdownPaper editing", () => {
       view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
     ).toBe(true);
 
+    const contentEnd = findTextPosition(view, "bold", "bold".length);
+    view.dispatch(
+      view.state.tr
+        .setSelection(TextSelection.create(view.state.doc, contentEnd))
+        .setStoredMarks(null)
+    );
+    expect(view.state.storedMarks).toBeNull();
+
     view.dom.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
 
     try {
       expect(view.composing).toBe(true);
+      expect(view.state.storedMarks?.map((mark) => mark.type.name)).toContain("strong");
       const { from, to } = view.state.selection;
       const insertText = () => view.state.tr.insertText("s", from, to).scrollIntoView();
       const handled = view.someProp(
@@ -8619,6 +8628,50 @@ describe("MarkdownPaper editing", () => {
       expect(finalHandled).toBeUndefined();
       view.dispatch(finalInsert());
       expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("**boldconfirmed** after");
+    } finally {
+      if (view.composing) {
+        view.dom.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+      }
+      unmount();
+    }
+  });
+
+  it("restores the inside live Markdown position before native IME composition", async () => {
+    const { container, unmount, view } = await renderEditor();
+
+    typeText(view, "**bold** after");
+    const liveMark = container.querySelector<HTMLElement>(".ProseMirror .markra-live-mark-strong");
+    const contentEnd = findTextPosition(view, "bold", "bold".length);
+    const outsidePosition = findTextPosition(view, " after");
+    mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
+
+    const edgeClick = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      clientX: 147,
+      clientY: 22
+    });
+    Object.defineProperty(edgeClick, "target", { configurable: true, value: liveMark });
+    expect(
+      view.someProp("handleDOMEvents", (handlers) => handlers.mousedown?.(view, edgeClick))
+    ).toBe(true);
+
+    view.dispatch(
+      view.state.tr
+        .setSelection(TextSelection.create(view.state.doc, outsidePosition))
+        .setStoredMarks(null)
+    );
+    expect(view.state.selection.from).toBe(outsidePosition);
+
+    view.dom.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+
+    try {
+      expect(view.composing).toBe(true);
+      expect(view.state.selection.from).toBe(contentEnd);
+
+      insertTextDirectly(view, "confirmed");
+      expect(container.querySelector(".ProseMirror p")?.textContent).toBe("**boldconfirmed** after");
     } finally {
       if (view.composing) {
         view.dom.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -72,16 +72,28 @@ type LiveMarkdownPluginState = {
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
 const liveMarkdownDelimiterSelector = ".markra-md-delimiter[data-markra-live-delimiter-position]";
-const formattedMarkEdgeSelector = "strong, em, del, code";
+const liveMarkdownMarkSelector =
+  ".markra-live-mark[data-markra-live-mark-from][data-markra-live-mark-to]" +
+  "[data-markra-live-mark-content-from][data-markra-live-mark-content-to]";
+const formattedMarkEdgeSelector = `${liveMarkdownMarkSelector}, strong, em, del, code`;
 const formattedMarkEdgeSnapPixels = 6;
 const formattedMarkEdgeVerticalTolerancePixels = 4;
 
 type FormattedMarkEdge = "start" | "end";
+type FormattedMarkEdgePlacement = "inside" | "outside";
 
 type FormattedMarkEdgeHit = {
   distance: number;
   edge: FormattedMarkEdge;
   element: HTMLElement;
+  placement: FormattedMarkEdgePlacement;
+};
+
+type LiveMarkdownMarkPositions = {
+  contentFrom: number;
+  contentTo: number;
+  from: number;
+  to: number;
 };
 
 function getLiveMarkdownKinds(spec: LiveMarkdownSpec) {
@@ -446,6 +458,7 @@ function insertMulticharTextWithoutStaleManagedMarks(
 function moveCursorPastFoldedMarkdownDelimiter(
   view: EditorView,
   specs: LiveMarkdownSpec[],
+  markTypes: MarkType[],
   direction: "left" | "right"
 ) {
   const { selection } = view.state;
@@ -460,9 +473,11 @@ function moveCursorPastFoldedMarkdownDelimiter(
     const foldedRange =
       pluginState?.activeFoldedRange ?? getFoldedMarkdownRangeAtCursor(view.state.doc, selection.from, specs);
     if (!foldedRange || selection.from !== foldedRange.to) return false;
+    const outsideMarks = selection.$from.marks().filter((mark) => !markTypes.includes(mark.type));
 
     view.dispatch(
       view.state.tr
+        .setStoredMarks(outsideMarks)
         .setMeta(liveMarkdownKey, { exitedFoldedRange: { ...foldedRange, cursor: selection.from } })
         .scrollIntoView()
     );
@@ -471,13 +486,41 @@ function moveCursorPastFoldedMarkdownDelimiter(
 
   const exitedRange = pluginState?.exitedFoldedRange ?? null;
   if (!exitedRange || selection.from !== exitedRange.cursor) return false;
+  const insideMarks = selection.$from.nodeBefore?.marks ?? [];
 
   view.dispatch(
     view.state.tr
+      .setStoredMarks(insideMarks)
       .setMeta(liveMarkdownKey, { activeFoldedRange: exitedRange, exitedFoldedRange: null })
       .scrollIntoView()
   );
   return true;
+}
+
+function marksAtFormattedEdge(view: EditorView, position: number, edge: FormattedMarkEdge) {
+  const $position = view.state.doc.resolve(position);
+  return edge === "start" ? ($position.nodeAfter?.marks ?? []) : ($position.nodeBefore?.marks ?? []);
+}
+
+function restoreFoldedMarkdownMarksAfterNativeArrow(view: EditorView, event: Event) {
+  if (!(event instanceof KeyboardEvent)) return false;
+  if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return false;
+  if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
+  const range = pluginState?.activeFoldedRange ?? null;
+  if (!range || pluginState?.exitedFoldedRange) return false;
+
+  const edge = selection.from === range.from ? "start" : selection.from === range.to ? "end" : null;
+  const marks = edge ? marksAtFormattedEdge(view, selection.from, edge) : [];
+  if (marks.length === 0) return false;
+
+  // An unhandled native arrow move can land at a virtual marker without carrying ProseMirror's mark affinity.
+  view.dispatch(view.state.tr.setStoredMarks(marks));
+  return false;
 }
 
 function deleteTextAfterLiveMarkdownRange(
@@ -585,6 +628,23 @@ function liveMarkdownDelimiterAttrs(className: string, position: number | null) 
   };
 }
 
+function liveMarkdownMarkAttrs(
+  className: string,
+  from: number,
+  to: number,
+  contentFrom: number,
+  contentTo: number
+) {
+  // WebViews disagree on DOM hit-testing beside hidden markers, so retain both source and visible-content edges.
+  return {
+    class: className,
+    "data-markra-live-mark-from": String(from),
+    "data-markra-live-mark-to": String(to),
+    "data-markra-live-mark-content-from": String(contentFrom),
+    "data-markra-live-mark-content-to": String(contentTo)
+  };
+}
+
 function liveMarkdownDelimiterTarget(target: EventTarget | null) {
   const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
   return element?.closest<HTMLElement>(liveMarkdownDelimiterSelector) ?? null;
@@ -655,6 +715,15 @@ function horizontalEdgeDistance(event: MouseEvent, rect: DOMRect, edge: "left" |
   return distance <= tolerance ? distance : null;
 }
 
+function formattedMarkEdgePlacement(
+  event: MouseEvent,
+  rect: DOMRect,
+  edge: FormattedMarkEdge
+): FormattedMarkEdgePlacement {
+  if (edge === "start") return event.clientX >= rect.left ? "inside" : "outside";
+  return event.clientX <= rect.right ? "inside" : "outside";
+}
+
 function formattedMarkEdgeHitFromElement(event: MouseEvent, element: HTMLElement): FormattedMarkEdgeHit | null {
   const rects = visibleClientRects(element);
   const firstRect = rects[0];
@@ -664,10 +733,20 @@ function formattedMarkEdgeHitFromElement(event: MouseEvent, element: HTMLElement
 
   if (startDistance === null && endDistance === null) return null;
   if (endDistance !== null && (startDistance === null || endDistance < startDistance)) {
-    return { distance: endDistance, edge: "end", element };
+    return {
+      distance: endDistance,
+      edge: "end",
+      element,
+      placement: formattedMarkEdgePlacement(event, lastRect!, "end")
+    };
   }
 
-  return { distance: startDistance ?? 0, edge: "start", element };
+  return {
+    distance: startDistance ?? 0,
+    edge: "start",
+    element,
+    placement: formattedMarkEdgePlacement(event, firstRect!, "start")
+  };
 }
 
 function directFormattedMarkEdgeHit(view: EditorView, event: MouseEvent) {
@@ -702,6 +781,37 @@ function formattedMarkEdgePosition(view: EditorView, element: HTMLElement, edge:
   }
 }
 
+function liveMarkdownMarkPositions(element: HTMLElement): LiveMarkdownMarkPositions | null {
+  const from = Number(element.dataset.markraLiveMarkFrom);
+  const to = Number(element.dataset.markraLiveMarkTo);
+  const contentFrom = Number(element.dataset.markraLiveMarkContentFrom);
+  const contentTo = Number(element.dataset.markraLiveMarkContentTo);
+
+  if (![from, to, contentFrom, contentTo].every(Number.isInteger)) return null;
+  if (from < 0 || from > contentFrom || contentFrom > contentTo || contentTo > to) return null;
+
+  return { contentFrom, contentTo, from, to };
+}
+
+function liveMarkdownMarkEdgePosition(
+  positions: LiveMarkdownMarkPositions,
+  edge: FormattedMarkEdge,
+  placement: FormattedMarkEdgePlacement
+) {
+  if (placement === "inside") return edge === "start" ? positions.contentFrom : positions.contentTo;
+  return edge === "start" ? positions.from : positions.to;
+}
+
+function formattedMarkEdgeMarks(
+  view: EditorView,
+  position: number,
+  edge: FormattedMarkEdge,
+  placement: FormattedMarkEdgePlacement
+) {
+  if (placement === "outside") return null;
+  return marksAtFormattedEdge(view, position, edge);
+}
+
 function selectFormattedMarkEdge(view: EditorView, event: Event) {
   if (!(event instanceof MouseEvent)) return false;
   if (event.button !== 0) return false;
@@ -709,17 +819,22 @@ function selectFormattedMarkEdge(view: EditorView, event: Event) {
   const hit = directFormattedMarkEdgeHit(view, event) ?? nearbyFormattedMarkEdgeHit(view, event);
   if (!hit) return false;
 
-  const position = formattedMarkEdgePosition(view, hit.element, hit.edge);
+  const livePositions = liveMarkdownMarkPositions(hit.element);
+  const position = livePositions
+    ? liveMarkdownMarkEdgePosition(livePositions, hit.edge, hit.placement)
+    : formattedMarkEdgePosition(view, hit.element, hit.edge);
   if (position === null) return false;
+  if (position > view.state.doc.content.size) return false;
+  const marks = livePositions ? null : formattedMarkEdgeMarks(view, position, hit.edge, hit.placement);
 
   event.preventDefault();
   event.stopPropagation();
-  view.dispatch(
-    view.state.tr
-      .setSelection(TextSelection.create(view.state.doc, position))
-      .scrollIntoView()
-  );
+  // Focusing can restore the previous DOM selection, so apply inside-edge marks only after focus settles.
   view.focus();
+  const transaction = view.state.tr
+    .setSelection(TextSelection.create(view.state.doc, position))
+    .scrollIntoView();
+  view.dispatch(marks ? transaction.setStoredMarks(marks) : transaction);
   return true;
 }
 
@@ -761,10 +876,9 @@ function buildLiveMarkdownDecorations(
       );
 
       if (range.contentFrom < range.contentTo) {
+        const markClass = ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ");
         decorations.push(
-          Decoration.inline(contentFrom, contentTo, {
-            class: ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ")
-          })
+          Decoration.inline(contentFrom, contentTo, liveMarkdownMarkAttrs(markClass, from, to, contentFrom, contentTo))
         );
       }
     }
@@ -1387,7 +1501,9 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
     props: {
       handleDOMEvents: {
         mousedown: (view, event) =>
-          selectLiveMarkdownDelimiterEdge(view, event) || selectFormattedMarkEdge(view, event)
+          // Resolve the visible content edge before trusting the WebView's unstable wrapper target.
+          selectFormattedMarkEdge(view, event) || selectLiveMarkdownDelimiterEdge(view, event),
+        keyup: restoreFoldedMarkdownMarksAfterNativeArrow
       },
       decorations: (state) => {
         const pluginState = liveMarkdownKey.getState(state) as LiveMarkdownPluginState | undefined;
@@ -1430,7 +1546,12 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           );
           const handledFoldedRange =
             handledLiveRange ||
-            moveCursorPastFoldedMarkdownDelimiter(view, specs, event.key === "ArrowLeft" ? "left" : "right");
+            moveCursorPastFoldedMarkdownDelimiter(
+              view,
+              specs,
+              managedMarkTypes,
+              event.key === "ArrowLeft" ? "left" : "right"
+            );
 
           if (handledFoldedRange) {
             event.preventDefault();

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -62,9 +62,22 @@ type ExitedFoldedMarkdownRange = FoldedMarkdownRange & {
   cursor: number;
 };
 
+type FormattedMarkEdge = "start" | "end";
+type FormattedMarkEdgePlacement = "inside" | "outside";
+
+type FormattedBoundaryInputIntent = {
+  edge: FormattedMarkEdge;
+  finalized: boolean;
+  placement: FormattedMarkEdgePlacement;
+  position: number;
+  selectionFrom: number;
+  selectionTo: number;
+};
+
 type LiveMarkdownPluginState = {
   suppressActiveAt: number | null;
   activeFoldedRange: FoldedMarkdownRange | null;
+  boundaryInputIntent: FormattedBoundaryInputIntent | null;
   exitedFoldedRange: ExitedFoldedMarkdownRange | null;
   suppressedLiveRange: SuppressedLiveMarkdownRange | null;
   suppressedLiteralRanges: SuppressedLiteralMarkdownRange[];
@@ -78,9 +91,11 @@ const liveMarkdownMarkSelector =
 const formattedMarkEdgeSelector = `${liveMarkdownMarkSelector}, strong, em, del, code`;
 const formattedMarkEdgeSnapPixels = 6;
 const formattedMarkEdgeVerticalTolerancePixels = 4;
-
-type FormattedMarkEdge = "start" | "end";
-type FormattedMarkEdgePlacement = "inside" | "outside";
+const graphemeSegmenter = typeof Intl.Segmenter === "function"
+  ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+  : null;
+const bidirectionalTextPattern =
+  /[\u0590-\u08ff\u200e-\u200f\u202a-\u202e\u2066-\u2069\ufb1d-\ufdff\ufe70-\ufeff\u{10800}-\u{10fff}\u{1e800}-\u{1efff}]/u;
 
 type FormattedMarkEdgeHit = {
   distance: number;
@@ -413,6 +428,116 @@ function clearManagedStoredMarks(state: EditorState, markTypes: MarkType[]) {
   return state.tr.setStoredMarks(nextMarks);
 }
 
+function marksForBoundaryInputIntent(
+  view: EditorView,
+  intent: FormattedBoundaryInputIntent,
+  markTypes: MarkType[]
+) {
+  if (intent.finalized && intent.placement === "inside") {
+    return marksAtFormattedEdge(view, intent.position, intent.edge);
+  }
+
+  return view.state.doc.resolve(intent.position).marks().filter((mark) => !markTypes.includes(mark.type));
+}
+
+function boundaryInputIntentAfterInsert(
+  intent: FormattedBoundaryInputIntent,
+  cursor: number,
+  insertedSize: number,
+  doc: ProseNode,
+  specs: LiveMarkdownSpec[]
+) {
+  // End-edge typing recreates the same ambiguous DOM boundary after every character; start-edge typing moves inward.
+  if (intent.edge !== "end" || intent.placement !== "inside") return null;
+
+  if (intent.finalized) {
+    return {
+      ...intent,
+      position: cursor,
+      selectionFrom: cursor,
+      selectionTo: cursor
+    };
+  }
+
+  const nextIntent = {
+    ...intent,
+    position: cursor,
+    selectionFrom: intent.selectionFrom + insertedSize,
+    selectionTo: intent.selectionTo + insertedSize
+  };
+  const $cursor = doc.resolve(cursor);
+  if (!$cursor.parent.isTextblock) return null;
+
+  const blockStart = $cursor.start();
+  const rangeStillExists = getLiveMarkdownRangesInTextblock($cursor.parent, specs).some((range) =>
+    blockStart + range.contentTo === nextIntent.selectionFrom
+    && blockStart + range.to === nextIntent.selectionTo
+  );
+
+  return rangeStillExists ? nextIntent : null;
+}
+
+function insertTextAtFormattedBoundaryIntent(
+  view: EditorView,
+  from: number,
+  to: number,
+  text: string,
+  markTypes: MarkType[],
+  specs: LiveMarkdownSpec[]
+) {
+  if (text.length === 0) return false;
+  if (from !== to) return false;
+
+  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
+  const intent = pluginState?.boundaryInputIntent ?? null;
+  if (!intent) return false;
+  if (from < intent.selectionFrom || from > intent.selectionTo) return false;
+  if (intent.position < 0 || intent.position > view.state.doc.content.size) return false;
+
+  // WebViews may overwrite the DOM selection after pointer or key events, so honor the captured visual side here.
+  const marks = marksForBoundaryInputIntent(view, intent, markTypes);
+  const insertedText = view.state.schema.text(text, marks);
+  const transaction = view.state.tr.replaceWith(intent.position, intent.position, insertedText);
+  const cursor = intent.position + insertedText.nodeSize;
+  const nextIntent = boundaryInputIntentAfterInsert(
+    intent,
+    cursor,
+    insertedText.nodeSize,
+    transaction.doc,
+    specs
+  );
+
+  view.dispatch(
+    transaction
+      .setSelection(TextSelection.create(transaction.doc, cursor))
+      .setStoredMarks(marks)
+      .setMeta(liveMarkdownKey, { boundaryInputIntent: nextIntent })
+      .scrollIntoView()
+  );
+  return true;
+}
+
+function handleFormattedBoundaryBeforeInput(
+  view: EditorView,
+  event: Event,
+  markTypes: MarkType[],
+  specs: LiveMarkdownSpec[]
+) {
+  if (!(event instanceof InputEvent)) return false;
+  if (!event.cancelable) return false;
+
+  if (!event.isComposing && event.inputType === "insertText" && event.data) {
+    const { from, to } = view.state.selection;
+    if (insertTextAtFormattedBoundaryIntent(view, from, to, event.data, markTypes, specs)) {
+      // A native WebView insertion can ignore ProseMirror's stored-mark affinity at an identical DOM offset.
+      event.preventDefault();
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function insertTextAfterExitedFoldedMarkdown(
   view: EditorView,
   text: string,
@@ -478,7 +603,10 @@ function moveCursorPastFoldedMarkdownDelimiter(
     view.dispatch(
       view.state.tr
         .setStoredMarks(outsideMarks)
-        .setMeta(liveMarkdownKey, { exitedFoldedRange: { ...foldedRange, cursor: selection.from } })
+        .setMeta(liveMarkdownKey, {
+          boundaryInputIntent: formattedBoundaryInputIntent(null, selection.from, "end", "outside"),
+          exitedFoldedRange: { ...foldedRange, cursor: selection.from }
+        })
         .scrollIntoView()
     );
     return true;
@@ -491,7 +619,11 @@ function moveCursorPastFoldedMarkdownDelimiter(
   view.dispatch(
     view.state.tr
       .setStoredMarks(insideMarks)
-      .setMeta(liveMarkdownKey, { activeFoldedRange: exitedRange, exitedFoldedRange: null })
+      .setMeta(liveMarkdownKey, {
+        activeFoldedRange: exitedRange,
+        boundaryInputIntent: formattedBoundaryInputIntent(null, selection.from, "end", "inside"),
+        exitedFoldedRange: null
+      })
       .scrollIntoView()
   );
   return true;
@@ -515,12 +647,80 @@ function restoreFoldedMarkdownMarksAfterNativeArrow(view: EditorView, event: Eve
   if (!range || pluginState?.exitedFoldedRange) return false;
 
   const edge = selection.from === range.from ? "start" : selection.from === range.to ? "end" : null;
-  const marks = edge ? marksAtFormattedEdge(view, selection.from, edge) : [];
+  if (!edge) return false;
+  const marks = marksAtFormattedEdge(view, selection.from, edge);
   if (marks.length === 0) return false;
 
   // An unhandled native arrow move can land at a virtual marker without carrying ProseMirror's mark affinity.
-  view.dispatch(view.state.tr.setStoredMarks(marks));
+  view.dispatch(
+    view.state.tr
+      .setStoredMarks(marks)
+      .setMeta(liveMarkdownKey, {
+        boundaryInputIntent: formattedBoundaryInputIntent(null, selection.from, edge, "inside")
+      })
+  );
   return false;
+}
+
+function singleGraphemeLength(text: string) {
+  const segments = graphemeSegmenter
+    ? graphemeSegmenter.segment(text)[Symbol.iterator]()
+    : text[Symbol.iterator]();
+  const first = segments.next();
+  if (first.done || !segments.next().done) return 0;
+
+  return typeof first.value === "string" ? first.value.length : first.value.segment.length;
+}
+
+function sameMarks(left: readonly Mark[], right: readonly Mark[]) {
+  return left.length === right.length && left.every((mark, index) => mark.eq(right[index]!));
+}
+
+function moveCursorIntoAdjacentFormattedBoundary(
+  view: EditorView,
+  markTypes: MarkType[],
+  direction: "left" | "right"
+) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
+  if (pluginState?.exitedFoldedRange) return false;
+  const computedDirection = view.dom.ownerDocument.defaultView?.getComputedStyle(view.dom).direction;
+  // Native arrows follow visual order for RTL and mixed-bidi text, which does not map to position +/- one.
+  if (computedDirection === "rtl" || bidirectionalTextPattern.test(selection.$from.parent.textContent)) return false;
+
+  const adjacentText = direction === "left" ? selection.$from.nodeBefore?.text : selection.$from.nodeAfter?.text;
+  if (!adjacentText) return false;
+
+  const distance = singleGraphemeLength(adjacentText);
+  if (distance === 0) return false;
+
+  const position = selection.from + (direction === "left" ? -distance : distance);
+  const $position = view.state.doc.resolve(position);
+  const leftMarks = $position.nodeBefore?.marks ?? [];
+  const rightMarks = $position.nodeAfter?.marks ?? [];
+  const leftManagedMarks = leftMarks.filter((mark) => markTypes.includes(mark.type));
+  const rightManagedMarks = rightMarks.filter((mark) => markTypes.includes(mark.type));
+  if (sameMarks(leftManagedMarks, rightManagedMarks)) return false;
+
+  // Prefer the marks on the character crossed by the arrow; when that side is plain, enter the formatted side.
+  const crossedMarks = direction === "left" ? rightManagedMarks : leftManagedMarks;
+  const crossedEdge = direction === "left" ? "start" : "end";
+  const oppositeEdge = direction === "left" ? "end" : "start";
+  const edge: FormattedMarkEdge = crossedMarks.length > 0 ? crossedEdge : oppositeEdge;
+  const marks = edge === "start" ? rightMarks : leftMarks;
+  if (!hasManagedMark(marks, markTypes)) return false;
+
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, position))
+      .setStoredMarks(marks)
+      .setMeta(liveMarkdownKey, {
+        boundaryInputIntent: formattedBoundaryInputIntent(null, position, edge, "inside")
+      })
+      .scrollIntoView()
+  );
+  return true;
 }
 
 function deleteTextAfterLiveMarkdownRange(
@@ -670,6 +870,7 @@ function selectLiveMarkdownDelimiterEdge(view: EditorView, event: Event) {
   view.dispatch(
     view.state.tr
       .setSelection(TextSelection.create(view.state.doc, position))
+      .setMeta(liveMarkdownKey, { boundaryInputIntent: null })
       .scrollIntoView()
   );
   view.focus();
@@ -802,6 +1003,33 @@ function liveMarkdownMarkEdgePosition(
   return edge === "start" ? positions.from : positions.to;
 }
 
+function formattedBoundaryInputIntent(
+  livePositions: LiveMarkdownMarkPositions | null,
+  position: number,
+  edge: FormattedMarkEdge,
+  placement: FormattedMarkEdgePlacement
+): FormattedBoundaryInputIntent {
+  if (!livePositions) {
+    return {
+      edge,
+      finalized: true,
+      placement,
+      position,
+      selectionFrom: position,
+      selectionTo: position
+    };
+  }
+
+  return {
+    edge,
+    finalized: false,
+    placement,
+    position,
+    selectionFrom: edge === "start" ? livePositions.from : livePositions.contentTo,
+    selectionTo: edge === "start" ? livePositions.contentFrom : livePositions.to
+  };
+}
+
 function formattedMarkEdgeMarks(
   view: EditorView,
   position: number,
@@ -833,6 +1061,9 @@ function selectFormattedMarkEdge(view: EditorView, event: Event) {
   view.focus();
   const transaction = view.state.tr
     .setSelection(TextSelection.create(view.state.doc, position))
+    .setMeta(liveMarkdownKey, {
+      boundaryInputIntent: formattedBoundaryInputIntent(livePositions, position, hit.edge, hit.placement)
+    })
     .scrollIntoView();
   view.dispatch(marks ? transaction.setStoredMarks(marks) : transaction);
   return true;
@@ -1209,6 +1440,20 @@ export function setLiveMarkdownSourceContext(
   } satisfies Partial<LiveMarkdownPluginState>);
 }
 
+function nextBoundaryInputIntent(
+  current: FormattedBoundaryInputIntent | null,
+  meta: Partial<LiveMarkdownPluginState> | undefined,
+  transaction: Transaction,
+  selection: TextSelection | null
+) {
+  if (meta && "boundaryInputIntent" in meta) return meta.boundaryInputIntent ?? null;
+  if (transaction.docChanged) return null;
+  if (!transaction.selectionSet) return current;
+  if (!selection?.empty || !current) return null;
+
+  return selection.from >= current.selectionFrom && selection.from <= current.selectionTo ? current : null;
+}
+
 function moveCursorOverLiveMarkdownDelimiter(
   view: EditorView,
   specs: LiveMarkdownSpec[],
@@ -1277,7 +1522,10 @@ function moveCursorOverLiveMarkdownDelimiter(
   view.dispatch(
     view.state.tr
       .setSelection(TextSelection.create(view.state.doc, target))
-      .setMeta(liveMarkdownKey, suppressedLiveRange ? { suppressedLiveRange } : {})
+      .setMeta(liveMarkdownKey, {
+        boundaryInputIntent: null,
+        ...(suppressedLiveRange ? { suppressedLiveRange } : {})
+      })
       .scrollIntoView()
   );
   return true;
@@ -1425,6 +1673,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
       init: (_config, state): LiveMarkdownPluginState => ({
         suppressActiveAt: null,
         activeFoldedRange: null,
+        boundaryInputIntent: null,
         exitedFoldedRange: null,
         suppressedLiveRange: null,
         suppressedLiteralRanges: findSuppressedLiteralRanges(state.doc, specs, options.initialMarkdown)
@@ -1435,10 +1684,13 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           meta && "suppressedLiteralRanges" in meta
             ? meta.suppressedLiteralRanges ?? []
             : mapSuppressedLiteralRanges(value.suppressedLiteralRanges, tr);
+        const textSelection = newState.selection instanceof TextSelection ? newState.selection : null;
+        const boundaryInputIntent = nextBoundaryInputIntent(value.boundaryInputIntent, meta, tr, textSelection);
         if (meta && "exitedFoldedRange" in meta) {
           return {
             suppressActiveAt: null,
             activeFoldedRange: meta.activeFoldedRange ?? null,
+            boundaryInputIntent,
             exitedFoldedRange: meta.exitedFoldedRange ?? null,
             suppressedLiveRange: null,
             suppressedLiteralRanges
@@ -1450,6 +1702,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           return {
             suppressActiveAt: null,
             activeFoldedRange: null,
+            boundaryInputIntent,
             exitedFoldedRange: null,
             suppressedLiveRange: meta.suppressedLiveRange,
             suppressedLiteralRanges
@@ -1460,6 +1713,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           return {
             suppressActiveAt: meta.suppressActiveAt,
             activeFoldedRange: null,
+            boundaryInputIntent,
             exitedFoldedRange: null,
             suppressedLiveRange: null,
             suppressedLiteralRanges
@@ -1467,20 +1721,20 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
         }
 
         if (tr.selectionSet) {
-          const selection = newState.selection instanceof TextSelection ? newState.selection : null;
           const exitedFoldedRange =
-            selection?.from === value.exitedFoldedRange?.cursor ? value.exitedFoldedRange : null;
+            textSelection?.from === value.exitedFoldedRange?.cursor ? value.exitedFoldedRange : null;
           const activeFoldedRange =
-            selection?.empty && selection.from !== value.suppressActiveAt && !exitedFoldedRange
-              ? getFoldedMarkdownRangeAtCursor(newState.doc, selection.from, specs)
+            textSelection?.empty && textSelection.from !== value.suppressActiveAt && !exitedFoldedRange
+              ? getFoldedMarkdownRangeAtCursor(newState.doc, textSelection.from, specs)
               : null;
 
           return {
-            suppressActiveAt: selection?.from === value.suppressActiveAt ? value.suppressActiveAt : null,
+            suppressActiveAt: textSelection?.from === value.suppressActiveAt ? value.suppressActiveAt : null,
             activeFoldedRange,
+            boundaryInputIntent,
             exitedFoldedRange,
             suppressedLiveRange:
-              selection?.from === value.suppressedLiveRange?.cursor ? value.suppressedLiveRange : null,
+              textSelection?.from === value.suppressedLiveRange?.cursor ? value.suppressedLiveRange : null,
             suppressedLiteralRanges
           };
         }
@@ -1489,17 +1743,27 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           return {
             suppressActiveAt: null,
             activeFoldedRange: null,
+            boundaryInputIntent,
             exitedFoldedRange: null,
             suppressedLiveRange: null,
             suppressedLiteralRanges
           };
         }
 
-        return suppressedLiteralRanges === value.suppressedLiteralRanges ? value : { ...value, suppressedLiteralRanges };
+        return suppressedLiteralRanges === value.suppressedLiteralRanges
+          && boundaryInputIntent === value.boundaryInputIntent
+          ? value
+          : { ...value, boundaryInputIntent, suppressedLiteralRanges };
       }
     },
     props: {
       handleDOMEvents: {
+        beforeinput: (view, event) => handleFormattedBoundaryBeforeInput(
+          view,
+          event,
+          managedMarkTypes,
+          specs
+        ),
         mousedown: (view, event) =>
           // Resolve the visible content edge before trusting the WebView's unstable wrapper target.
           selectFormattedMarkEdge(view, event) || selectLiveMarkdownDelimiterEdge(view, event),
@@ -1524,7 +1788,8 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           pluginState?.suppressedLiteralRanges ?? []
         );
       },
-      handleTextInput: (view, _from, _to, text) =>
+      handleTextInput: (view, from, to, text) =>
+        insertTextAtFormattedBoundaryIntent(view, from, to, text, managedMarkTypes, specs) ||
         insertMulticharTextWithoutStaleManagedMarks(view, text, managedMarkTypes) ||
         insertTextAfterExitedFoldedMarkdown(view, text, managedMarkTypes),
       handleKeyDown: (view, event) => {
@@ -1549,6 +1814,11 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
             moveCursorPastFoldedMarkdownDelimiter(
               view,
               specs,
+              managedMarkTypes,
+              event.key === "ArrowLeft" ? "left" : "right"
+            ) ||
+            moveCursorIntoAdjacentFormattedBoundary(
+              view,
               managedMarkTypes,
               event.key === "ArrowLeft" ? "left" : "right"
             );

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -519,6 +519,29 @@ function insertTextAtFormattedBoundaryIntent(
   return true;
 }
 
+function prepareFormattedBoundaryComposition(
+  view: EditorView,
+  markTypes: MarkType[]
+) {
+  const { selection } = view.state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+
+  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
+  const intent = pluginState?.boundaryInputIntent ?? null;
+  if (!intent) return false;
+  if (selection.from < intent.selectionFrom || selection.from > intent.selectionTo) return false;
+  if (intent.position < 0 || intent.position > view.state.doc.content.size) return false;
+
+  const marks = marksForBoundaryInputIntent(view, intent, markTypes);
+  // ProseMirror must see the corrected selection and marks before it creates its native IME mark cursor.
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, intent.position))
+      .setStoredMarks(marks)
+  );
+  return false;
+}
+
 function handleFormattedBoundaryBeforeInput(
   view: EditorView,
   event: Event,
@@ -1766,6 +1789,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           managedMarkTypes,
           specs
         ),
+        compositionstart: (view) => prepareFormattedBoundaryComposition(view, managedMarkTypes),
         mousedown: (view, event) =>
           // Resolve the visible content edge before trusting the WebView's unstable wrapper target.
           selectFormattedMarkEdge(view, event) || selectLiveMarkdownDelimiterEdge(view, event),

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -487,6 +487,8 @@ function insertTextAtFormattedBoundaryIntent(
 ) {
   if (text.length === 0) return false;
   if (from !== to) return false;
+  // Intermediate IME text must stay in the native composition DOM until the final commit arrives.
+  if (view.composing) return false;
 
   const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
   const intent = pluginState?.boundaryInputIntent ?? null;


### PR DESCRIPTION
## Summary

- retain explicit inside/outside affinity when desktop WebViews overwrite the ProseMirror boundary selection
- preserve inside affinity across consecutive characters while remapping and revalidating live Markdown ranges
- restore the captured selection and stored marks before native IME composition starts
- leave intermediate IME composition text under native ProseMirror/WebView control and apply only the final commit
- clear stale affinity when arrows cross delimiters or live syntax becomes invalid
- take over only cancelable, non-composing `insertText` events and keep native RTL/bidi navigation
- cover finalized and live `**`, `***`, `~~`, inline-code, and IME boundary cases with English synthetic tests

## Why

This is a follow-up to #419 and #510. Real macOS WebKit and Windows WebView2 can restore a DOM selection after ProseMirror has assigned mark affinity, causing boundary input to intermittently move outside the wrapper, change sides after the first character, or start native IME composition on the wrong side. Handling intermediate composition text directly can also duplicate phonetic input and lose the caret.

## Validation

- `pnpm --filter @markra/app test` — 116 files and 1807 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- `git diff --check` — passed

## Risk

- Only composition that starts with a captured formatted-boundary intent receives the corrected selection and marks; intermediate IME text remains native.
- Non-cancelable input and RTL/bidi arrow navigation intentionally fall back to native ProseMirror/WebView behavior.
- Manual macOS and Windows WebView QA is still required because jsdom cannot reproduce native candidate UI, DOM mutation timing, caret restoration, or every selection event ordering.

Refs #419