### PR TITLE
fix(editor): align caret during IME composition

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -1067,6 +1067,131 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
+  it("keeps the custom caret aligned with the DOM selection while IME text is composing", async () => {
+    const { view } = await renderEditor("Alpha");
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 42,
+      left: 24,
+      right: 25,
+      top: 10
+    });
+
+    focusEditor(view);
+    moveCursor(view, findTextPosition(view, "Alpha", 2));
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+    const textNode = view.dom.querySelector("p")?.firstChild;
+    const nativeSelection = view.dom.ownerDocument.getSelection();
+    const nativeRange = view.dom.ownerDocument.createRange();
+
+    expect(textNode).toBeInstanceOf(Text);
+    expect(nativeSelection).not.toBeNull();
+
+    const originalText = textNode!.textContent ?? "";
+    const rangeRectSpy = vi.spyOn(Range.prototype, "getBoundingClientRect").mockImplementation(function (this: Range) {
+      const preeditOffset = this.startContainer === textNode ? this.startOffset - originalText.length : 0;
+      const left = 48 + preeditOffset * 12;
+      return testRect({ bottom: 48, left, right: left, top: 16 });
+    });
+
+    try {
+      fireEvent.compositionStart(view.dom);
+
+      textNode!.textContent = `${originalText}s'd's`;
+      nativeRange.setStart(textNode!, originalText.length + 1);
+      nativeRange.collapse(true);
+      nativeSelection!.removeAllRanges();
+      nativeSelection!.addRange(nativeRange);
+      fireEvent.input(view.dom);
+
+      expect(caret?.style.display).toBe("block");
+      expect(caret?.style.left).toBe("60px");
+      expect(caret?.style.top).toBe("23px");
+      expect(caret?.style.height).toBe("18px");
+
+      nativeSelection!.collapse(textNode!, originalText.length + 2);
+      view.dom.ownerDocument.dispatchEvent(new Event("selectionchange"));
+
+      expect(caret?.style.left).toBe("72px");
+
+      nativeSelection!.collapse(textNode!, originalText.length + 3);
+      fireEvent.input(view.dom);
+
+      expect(caret?.style.left).toBe("84px");
+
+      textNode!.textContent = originalText;
+      fireEvent.compositionEnd(view.dom);
+
+      expect(caret?.style.display).toBe("block");
+      expect(caret?.style.left).toBe("24px");
+    } finally {
+      textNode!.textContent = originalText;
+      fireEvent.compositionEnd(view.dom);
+      nativeSelection?.removeAllRanges();
+      rangeRectSpy.mockRestore();
+      coordsSpy.mockRestore();
+      await settleMarkdownListener();
+    }
+  });
+
+  it("uses the adjacent text edge when an IME caret range has empty geometry", async () => {
+    const { view } = await renderEditor("Alpha");
+    const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({
+      bottom: 42,
+      left: 24,
+      right: 25,
+      top: 10
+    });
+
+    focusEditor(view);
+    moveCursor(view, findTextPosition(view, "Alpha", 2));
+
+    const caret = view.dom.ownerDocument.querySelector<HTMLElement>(".markra-prosemirror-caret");
+    const textNode = view.dom.querySelector("p")?.firstChild;
+    const nativeSelection = view.dom.ownerDocument.getSelection();
+    const nativeRange = view.dom.ownerDocument.createRange();
+    const emptyRect = testRect({ bottom: 0, left: 0, right: 0, top: 0 });
+    const adjacentRect = testRect({ bottom: 48, left: 96, right: 108, top: 16 });
+
+    expect(textNode).toBeInstanceOf(Text);
+    expect(nativeSelection).not.toBeNull();
+
+    const originalText = textNode!.textContent ?? "";
+    const boundingRectSpy = vi.spyOn(Range.prototype, "getBoundingClientRect").mockReturnValue(emptyRect);
+    const clientRectsSpy = vi.spyOn(Range.prototype, "getClientRects").mockImplementation(function (this: Range) {
+      const measuresLastPreeditCharacter =
+        !this.collapsed &&
+        this.startContainer === textNode &&
+        this.startOffset === originalText.length + 4 &&
+        this.endOffset === originalText.length + 5;
+      return (measuresLastPreeditCharacter ? [adjacentRect] : [emptyRect]) as unknown as DOMRectList;
+    });
+
+    try {
+      fireEvent.compositionStart(view.dom);
+
+      textNode!.textContent = `${originalText}s'd's`;
+      nativeRange.setStart(textNode!, originalText.length + 5);
+      nativeRange.collapse(true);
+      nativeSelection!.removeAllRanges();
+      nativeSelection!.addRange(nativeRange);
+      fireEvent.input(view.dom);
+
+      expect(caret?.style.display).toBe("block");
+      expect(caret?.style.left).toBe("108px");
+      expect(caret?.style.top).toBe("23px");
+      expect(caret?.style.height).toBe("18px");
+    } finally {
+      textNode!.textContent = originalText;
+      fireEvent.compositionEnd(view.dom);
+      nativeSelection?.removeAllRanges();
+      clientRectsSpy.mockRestore();
+      boundingRectSpy.mockRestore();
+      coordsSpy.mockRestore();
+      await settleMarkdownListener();
+    }
+  });
+
   it("hides the custom caret for non-collapsed ProseMirror selections", async () => {
     const { view } = await renderEditor("Alpha");
     const coordsSpy = vi.spyOn(view, "coordsAtPos").mockReturnValue({

--- a/packages/editor/src/caret.ts
+++ b/packages/editor/src/caret.ts
@@ -24,6 +24,76 @@ function hideCaret(caret: HTMLElement) {
   caret.style.display = "none";
 }
 
+function usableRangeRect(range: Range) {
+  const usable = (rect: DOMRect) =>
+    [rect.bottom, rect.left, rect.right, rect.top].every(Number.isFinite) &&
+    (rect.bottom > rect.top || rect.right > rect.left);
+  const clientRect = Array.from(range.getClientRects()).find(usable);
+  if (clientRect) return clientRect;
+
+  const boundingRect = range.getBoundingClientRect();
+  return usable(boundingRect) ? boundingRect : null;
+}
+
+function adjacentTextCaretCoords(view: EditorView, text: Text, offset: number, range: Range) {
+  const useNextCharacter = offset < text.data.length;
+  if (!useNextCharacter && offset === 0) return null;
+
+  if (useNextCharacter) {
+    range.setStart(text, offset);
+    range.setEnd(text, offset + 1);
+  } else {
+    range.setStart(text, offset - 1);
+    range.setEnd(text, offset);
+  }
+
+  const rect = usableRangeRect(range);
+  if (!rect) return null;
+
+  const direction = text.parentElement
+    ? view.dom.ownerDocument.defaultView?.getComputedStyle(text.parentElement).direction
+    : "ltr";
+  const rtl = direction === "rtl";
+  const leadingEdge = rtl ? rect.right : rect.left;
+  const trailingEdge = rtl ? rect.left : rect.right;
+  const left = useNextCharacter ? leadingEdge : trailingEdge;
+
+  return {
+    bottom: rect.bottom,
+    left,
+    right: left,
+    top: rect.top
+  };
+}
+
+function compositionCaretCoords(view: EditorView) {
+  const selection = view.dom.ownerDocument.getSelection();
+  const focusNode = selection?.focusNode;
+  if (!selection || !focusNode || !view.dom.contains(focusNode)) return null;
+
+  try {
+    // ProseMirror positions exclude uncommitted IME text, but the DOM selection tracks its internal caret.
+    const range = view.dom.ownerDocument.createRange();
+    range.setStart(focusNode, selection.focusOffset);
+    range.collapse(true);
+    const rect = usableRangeRect(range);
+    if (rect) {
+      return {
+        bottom: rect.bottom,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top
+      };
+    }
+
+    return focusNode.nodeType === Node.TEXT_NODE
+      ? adjacentTextCaretCoords(view, focusNode as Text, selection.focusOffset, range)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 class VisualCaretView {
   private readonly caret: HTMLElement;
   private composing = false;
@@ -51,12 +121,16 @@ class VisualCaretView {
 
   private readonly handleCompositionStart = () => {
     this.composing = true;
-    hideCaret(this.caret);
+    this.update(this.view);
   };
 
   private readonly handleCompositionEnd = () => {
     this.composing = false;
     this.update(this.view);
+  };
+
+  private readonly handleInput = () => {
+    if (this.composing) this.update(this.view);
   };
 
   private readonly handleViewportChange = () => {
@@ -69,6 +143,7 @@ class VisualCaretView {
     this.view.dom.addEventListener("blur", this.handleBlur);
     this.view.dom.addEventListener("compositionstart", this.handleCompositionStart);
     this.view.dom.addEventListener("compositionend", this.handleCompositionEnd);
+    this.view.dom.addEventListener("input", this.handleInput);
     this.view.dom.ownerDocument.addEventListener("selectionchange", this.handleViewportChange);
     window?.addEventListener("resize", this.handleViewportChange);
     window?.addEventListener("scroll", this.handleViewportChange, true);
@@ -79,7 +154,6 @@ class VisualCaretView {
 
     const { selection } = view.state;
     if (
-      this.composing ||
       !view.editable ||
       !focused(view) ||
       !(selection instanceof TextSelection) ||
@@ -95,6 +169,19 @@ class VisualCaretView {
     } catch {
       hideCaret(this.caret);
       return;
+    }
+
+    if (this.composing) {
+      const compositionCoords = compositionCaretCoords(view);
+      if (compositionCoords) {
+        const hasCompositionLineHeight = compositionCoords.bottom > compositionCoords.top;
+        coords = {
+          bottom: hasCompositionLineHeight ? compositionCoords.bottom : coords.bottom,
+          left: compositionCoords.left,
+          right: compositionCoords.right,
+          top: hasCompositionLineHeight ? compositionCoords.top : coords.top
+        };
+      }
     }
 
     const lineHeight = coords.bottom - coords.top;
@@ -114,6 +201,7 @@ class VisualCaretView {
     this.view.dom.removeEventListener("blur", this.handleBlur);
     this.view.dom.removeEventListener("compositionstart", this.handleCompositionStart);
     this.view.dom.removeEventListener("compositionend", this.handleCompositionEnd);
+    this.view.dom.removeEventListener("input", this.handleInput);
     this.view.dom.ownerDocument.removeEventListener("selectionchange", this.handleViewportChange);
     window?.removeEventListener("resize", this.handleViewportChange);
     window?.removeEventListener("scroll", this.handleViewportChange, true);


### PR DESCRIPTION
## Summary
- keep the Markra custom caret visible during IME composition
- measure the DOM selection focus point so the caret follows uncommitted preedit text
- fall back to the adjacent text edge when WebKit reports empty collapsed-range geometry
- cover composition input, selection movement, and empty-range fallback behavior

## Why
The visual editor hides the browser caret while the Markra caret is active. The previous composition path also hid the custom caret, making the cursor invisible during pinyin input. Temporarily restoring the native caret fixed visibility but introduced a different height and width, so this keeps one consistently styled caret throughout composition.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx src/styles.test.ts` — 549 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `git diff --check` — passed

## Risk
- automated coverage simulates uncommitted composition DOM and WebKit range fallbacks
- real macOS/WebKit IME QA is still recommended for wrapped lines, composition cancellation, and mixed-direction or complex Unicode input

Closes #515
