### PR TITLE
revert(editor): roll back inline mark boundary input changes

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -8080,7 +8080,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("keeps finalized formatting edge clicks on their visual side", async () => {
+  it("snaps finalized formatting edge clicks to the mark boundary", async () => {
     const { container, editor, unmount, view } = await renderEditor("alpha **bold** omega");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const strong = container.querySelector<HTMLElement>(".ProseMirror strong");
@@ -8114,8 +8114,8 @@ describe("MarkdownPaper editing", () => {
 
     typeText(view, "!");
 
-    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold!");
-    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold!** omega");
+    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
     unmount();
 
     const before = await renderEditor("alpha **bold** omega");
@@ -8150,227 +8150,8 @@ describe("MarkdownPaper editing", () => {
 
     typeText(before.view, "!");
 
-    expect(before.container.querySelector(".ProseMirror strong")).toHaveTextContent("!bold");
-    expect(beforeSerializer(before.view.state.doc).trimEnd()).toBe("alpha **!bold** omega");
-    await settleMarkdownListener();
-  });
-
-  it("keeps clicks just outside finalized formatting edges outside the mark", async () => {
-    const after = await renderEditor("alpha **bold** omega");
-    const afterSerializer = after.editor.action((ctx) => ctx.get(serializerCtx));
-    const afterParagraph = after.container.querySelector<HTMLElement>(".ProseMirror p");
-    const afterStrong = after.container.querySelector<HTMLElement>(".ProseMirror strong");
-
-    expect(afterParagraph).toBeInTheDocument();
-    expect(afterStrong).toHaveTextContent("bold");
-    mockInlineElementRect(afterStrong!, {
-      bottom: 32,
-      left: 100,
-      right: 148,
-      top: 12
-    });
-
-    const rightOutsideClick = new MouseEvent("mousedown", {
-      bubbles: true,
-      button: 0,
-      cancelable: true,
-      clientX: 149,
-      clientY: 22
-    });
-    Object.defineProperty(rightOutsideClick, "target", {
-      configurable: true,
-      value: afterParagraph
-    });
-    const rightHandled = after.view.someProp(
-      "handleDOMEvents",
-      (handlers) => handlers.mousedown?.(after.view, rightOutsideClick)
-    );
-
-    expect(rightHandled).toBe(true);
-    typeText(after.view, "!");
-
-    expect(after.container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
-    expect(afterSerializer(after.view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
-    after.unmount();
-
-    const before = await renderEditor("alpha **bold** omega");
-    const beforeSerializer = before.editor.action((ctx) => ctx.get(serializerCtx));
-    const beforeParagraph = before.container.querySelector<HTMLElement>(".ProseMirror p");
-    const beforeStrong = before.container.querySelector<HTMLElement>(".ProseMirror strong");
-
-    expect(beforeParagraph).toBeInTheDocument();
-    expect(beforeStrong).toHaveTextContent("bold");
-    mockInlineElementRect(beforeStrong!, {
-      bottom: 32,
-      left: 100,
-      right: 148,
-      top: 12
-    });
-
-    const leftOutsideClick = new MouseEvent("mousedown", {
-      bubbles: true,
-      button: 0,
-      cancelable: true,
-      clientX: 99,
-      clientY: 22
-    });
-    Object.defineProperty(leftOutsideClick, "target", {
-      configurable: true,
-      value: beforeParagraph
-    });
-    const leftHandled = before.view.someProp(
-      "handleDOMEvents",
-      (handlers) => handlers.mousedown?.(before.view, leftOutsideClick)
-    );
-
-    expect(leftHandled).toBe(true);
-    typeText(before.view, "!");
-
     expect(before.container.querySelector(".ProseMirror strong")).toHaveTextContent("bold");
     expect(beforeSerializer(before.view.state.doc).trimEnd()).toBe("alpha !**bold** omega");
-    await settleMarkdownListener();
-  });
-
-  it.each([
-    {
-      clientX: 147,
-      expectedMarkText: "boldx",
-      expectedSource: "**boldx** after",
-      label: "strong inside",
-      reportsSurroundingTarget: false,
-      selector: ".markra-live-mark-strong",
-      source: "**bold** after"
-    },
-    {
-      clientX: 149,
-      expectedMarkText: "bold",
-      expectedSource: "**bold**x after",
-      label: "strong outside",
-      reportsSurroundingTarget: false,
-      selector: ".markra-live-mark-strong",
-      source: "**bold** after"
-    },
-    {
-      clientX: 148,
-      expectedMarkText: "bold italicx",
-      expectedSource: "***bold italicx*** after",
-      label: "strong emphasis inside with a surrounding WebView target",
-      reportsSurroundingTarget: true,
-      selector: ".markra-live-mark-strong.markra-live-mark-emphasis",
-      source: "***bold italic*** after"
-    },
-    {
-      clientX: 149,
-      expectedMarkText: "bold italic",
-      expectedSource: "***bold italic***x after",
-      label: "strong emphasis outside with a surrounding WebView target",
-      reportsSurroundingTarget: true,
-      selector: ".markra-live-mark-strong.markra-live-mark-emphasis",
-      source: "***bold italic*** after"
-    }
-  ])("keeps typed $label on the clicked side of live Markdown", async ({
-    clientX,
-    expectedMarkText,
-    expectedSource,
-    reportsSurroundingTarget,
-    selector,
-    source
-  }) => {
-    const { container, view } = await renderEditor();
-
-    typeText(view, source);
-
-    const liveMark = container.querySelector<HTMLElement>(`.ProseMirror ${selector}`);
-    expect(liveMark).toBeInTheDocument();
-    mockInlineElementRect(liveMark!, {
-      bottom: 32,
-      left: 100,
-      right: 148,
-      top: 12
-    });
-
-    const edgeClick = new MouseEvent("mousedown", {
-      bubbles: true,
-      button: 0,
-      cancelable: true,
-      clientX,
-      clientY: 22
-    });
-    Object.defineProperty(edgeClick, "target", {
-      configurable: true,
-      value: reportsSurroundingTarget ? container.querySelector(".ProseMirror p") : liveMark
-    });
-    const handled = view.someProp(
-      "handleDOMEvents",
-      (handlers) => handlers.mousedown?.(view, edgeClick)
-    );
-
-    expect(handled).toBe(true);
-    typeText(view, "x");
-
-    expect(container.querySelector(`.ProseMirror ${selector}`)).toHaveTextContent(expectedMarkText);
-    expect(container.querySelector(".ProseMirror p")?.textContent).toBe(expectedSource);
-    await settleMarkdownListener();
-  });
-
-  it.each([
-    {
-      expected: "**boldx** and ***bold italic*** and ~~strike~~",
-      label: "strong",
-      selector: ".markra-live-mark-strong:not(.markra-live-mark-emphasis)",
-      text: "bold"
-    },
-    {
-      expected: "**bold** and ***bold italicx*** and ~~strike~~",
-      label: "strong emphasis",
-      selector: ".markra-live-mark-strong.markra-live-mark-emphasis",
-      text: "bold italic"
-    },
-    {
-      expected: "**bold** and ***bold italic*** and ~~strikex~~",
-      label: "strikethrough",
-      selector: ".markra-live-mark-strikethrough",
-      text: "strike"
-    }
-  ])("keeps $label inside when the WebView reports its closing delimiter at the content edge", async ({
-    expected,
-    selector,
-    text
-  }) => {
-    const { container, view } = await renderEditor();
-
-    typeText(view, "**bold** and ***bold italic*** and ~~strike~~");
-    moveCursor(view, findTextPosition(view, text, 1));
-
-    const liveMark = container.querySelector<HTMLElement>(`.ProseMirror ${selector}`);
-    const delimiters = Array.from(
-      container.querySelectorAll<HTMLElement>(".ProseMirror .markra-md-delimiter:not(.markra-md-virtual-delimiter)")
-    );
-    expect(liveMark).toBeInTheDocument();
-    expect(delimiters).toHaveLength(2);
-    const closingDelimiter = delimiters[1];
-    mockInlineElementRect(liveMark!, { bottom: 32, left: 100, right: 148, top: 12 });
-    mockInlineElementRect(closingDelimiter!, { bottom: 32, left: 148, right: 164, top: 12 });
-
-    const contentEdgeClick = new MouseEvent("mousedown", {
-      bubbles: true,
-      button: 0,
-      cancelable: true,
-      clientX: 148,
-      clientY: 22
-    });
-    Object.defineProperty(contentEdgeClick, "target", {
-      configurable: true,
-      value: closingDelimiter
-    });
-    const handled = view.someProp(
-      "handleDOMEvents",
-      (handlers) => handlers.mousedown?.(view, contentEdgeClick)
-    );
-
-    expect(handled).toBe(true);
-    typeText(view, "x");
-    expect(container.querySelector(".ProseMirror p")?.textContent).toBe(expected);
     await settleMarkdownListener();
   });
 
@@ -8405,7 +8186,7 @@ describe("MarkdownPaper editing", () => {
     await settleMarkdownListener();
   });
 
-  it("keeps finalized formatting edge clicks on their visual side when the WebView reports a surrounding target", async () => {
+  it("snaps finalized formatting edge clicks when the WebView reports a surrounding target", async () => {
     const { container, editor, view } = await renderEditor("alpha **bold** omega");
     const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
     const paragraph = container.querySelector<HTMLElement>(".ProseMirror p");
@@ -8439,8 +8220,7 @@ describe("MarkdownPaper editing", () => {
 
     typeText(view, "!");
 
-    expect(container.querySelector(".ProseMirror strong")).toHaveTextContent("bold!");
-    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold!** omega");
+    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe("alpha **bold**! omega");
     await settleMarkdownListener();
   });
 
@@ -8514,39 +8294,6 @@ describe("MarkdownPaper editing", () => {
     moveCursor(view, 3);
     expect(pressArrowLeft(view)).toBe(true);
     expect(view.state.selection.from).toBe(1);
-    await settleMarkdownListener();
-  });
-
-  it.each([
-    { expected: "**bold input** after", label: "strong", markdown: "**bold** after", text: "bold" },
-    {
-      expected: "***bold italic input*** after",
-      label: "strong emphasis",
-      markdown: "***bold italic*** after",
-      text: "bold italic"
-    },
-    { expected: "~~strike input~~ after", label: "strikethrough", markdown: "~~strike~~ after", text: "strike" }
-  ])("restores explicit stored marks when native keyboard movement lands inside finalized $label", async ({
-    expected,
-    markdown,
-    text
-  }) => {
-    const { editor, view } = await renderEditor(markdown);
-    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
-
-    const contentEnd = findTextPosition(view, text, text.length);
-    moveCursor(view, findLastTextBlockEndCursor(view));
-    // ProseMirror receives this selection after the WebView performs an unhandled ArrowLeft movement.
-    moveCursor(view, contentEnd);
-    const insideMarkTypes = (view.state.selection.$from.nodeBefore?.marks ?? []).map((mark) => mark.type.name);
-    expect(insideMarkTypes.length).toBeGreaterThan(0);
-
-    const keyup = new KeyboardEvent("keyup", { bubbles: true, key: "ArrowLeft" });
-    view.someProp("handleDOMEvents", (handlers) => handlers.keyup?.(view, keyup));
-
-    expect(view.state.storedMarks?.map((mark) => mark.type.name)).toEqual(insideMarkTypes);
-    insertTextThroughInputHandler(view, " input");
-    expect(serializeMarkdown(view.state.doc).trimEnd()).toBe(expected);
     await settleMarkdownListener();
   });
 

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -72,28 +72,16 @@ type LiveMarkdownPluginState = {
 
 const liveMarkdownKey = new PluginKey("markra-live-markdown");
 const liveMarkdownDelimiterSelector = ".markra-md-delimiter[data-markra-live-delimiter-position]";
-const liveMarkdownMarkSelector =
-  ".markra-live-mark[data-markra-live-mark-from][data-markra-live-mark-to]" +
-  "[data-markra-live-mark-content-from][data-markra-live-mark-content-to]";
-const formattedMarkEdgeSelector = `${liveMarkdownMarkSelector}, strong, em, del, code`;
+const formattedMarkEdgeSelector = "strong, em, del, code";
 const formattedMarkEdgeSnapPixels = 6;
 const formattedMarkEdgeVerticalTolerancePixels = 4;
 
 type FormattedMarkEdge = "start" | "end";
-type FormattedMarkEdgePlacement = "inside" | "outside";
 
 type FormattedMarkEdgeHit = {
   distance: number;
   edge: FormattedMarkEdge;
   element: HTMLElement;
-  placement: FormattedMarkEdgePlacement;
-};
-
-type LiveMarkdownMarkPositions = {
-  contentFrom: number;
-  contentTo: number;
-  from: number;
-  to: number;
 };
 
 function getLiveMarkdownKinds(spec: LiveMarkdownSpec) {
@@ -458,7 +446,6 @@ function insertMulticharTextWithoutStaleManagedMarks(
 function moveCursorPastFoldedMarkdownDelimiter(
   view: EditorView,
   specs: LiveMarkdownSpec[],
-  markTypes: MarkType[],
   direction: "left" | "right"
 ) {
   const { selection } = view.state;
@@ -473,11 +460,9 @@ function moveCursorPastFoldedMarkdownDelimiter(
     const foldedRange =
       pluginState?.activeFoldedRange ?? getFoldedMarkdownRangeAtCursor(view.state.doc, selection.from, specs);
     if (!foldedRange || selection.from !== foldedRange.to) return false;
-    const outsideMarks = selection.$from.marks().filter((mark) => !markTypes.includes(mark.type));
 
     view.dispatch(
       view.state.tr
-        .setStoredMarks(outsideMarks)
         .setMeta(liveMarkdownKey, { exitedFoldedRange: { ...foldedRange, cursor: selection.from } })
         .scrollIntoView()
     );
@@ -486,41 +471,13 @@ function moveCursorPastFoldedMarkdownDelimiter(
 
   const exitedRange = pluginState?.exitedFoldedRange ?? null;
   if (!exitedRange || selection.from !== exitedRange.cursor) return false;
-  const insideMarks = selection.$from.nodeBefore?.marks ?? [];
 
   view.dispatch(
     view.state.tr
-      .setStoredMarks(insideMarks)
       .setMeta(liveMarkdownKey, { activeFoldedRange: exitedRange, exitedFoldedRange: null })
       .scrollIntoView()
   );
   return true;
-}
-
-function marksAtFormattedEdge(view: EditorView, position: number, edge: FormattedMarkEdge) {
-  const $position = view.state.doc.resolve(position);
-  return edge === "start" ? ($position.nodeAfter?.marks ?? []) : ($position.nodeBefore?.marks ?? []);
-}
-
-function restoreFoldedMarkdownMarksAfterNativeArrow(view: EditorView, event: Event) {
-  if (!(event instanceof KeyboardEvent)) return false;
-  if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return false;
-  if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
-
-  const { selection } = view.state;
-  if (!(selection instanceof TextSelection) || !selection.empty) return false;
-
-  const pluginState = liveMarkdownKey.getState(view.state) as LiveMarkdownPluginState | undefined;
-  const range = pluginState?.activeFoldedRange ?? null;
-  if (!range || pluginState?.exitedFoldedRange) return false;
-
-  const edge = selection.from === range.from ? "start" : selection.from === range.to ? "end" : null;
-  const marks = edge ? marksAtFormattedEdge(view, selection.from, edge) : [];
-  if (marks.length === 0) return false;
-
-  // An unhandled native arrow move can land at a virtual marker without carrying ProseMirror's mark affinity.
-  view.dispatch(view.state.tr.setStoredMarks(marks));
-  return false;
 }
 
 function deleteTextAfterLiveMarkdownRange(
@@ -628,23 +585,6 @@ function liveMarkdownDelimiterAttrs(className: string, position: number | null) 
   };
 }
 
-function liveMarkdownMarkAttrs(
-  className: string,
-  from: number,
-  to: number,
-  contentFrom: number,
-  contentTo: number
-) {
-  // WebViews disagree on DOM hit-testing beside hidden markers, so retain both source and visible-content edges.
-  return {
-    class: className,
-    "data-markra-live-mark-from": String(from),
-    "data-markra-live-mark-to": String(to),
-    "data-markra-live-mark-content-from": String(contentFrom),
-    "data-markra-live-mark-content-to": String(contentTo)
-  };
-}
-
 function liveMarkdownDelimiterTarget(target: EventTarget | null) {
   const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
   return element?.closest<HTMLElement>(liveMarkdownDelimiterSelector) ?? null;
@@ -715,15 +655,6 @@ function horizontalEdgeDistance(event: MouseEvent, rect: DOMRect, edge: "left" |
   return distance <= tolerance ? distance : null;
 }
 
-function formattedMarkEdgePlacement(
-  event: MouseEvent,
-  rect: DOMRect,
-  edge: FormattedMarkEdge
-): FormattedMarkEdgePlacement {
-  if (edge === "start") return event.clientX >= rect.left ? "inside" : "outside";
-  return event.clientX <= rect.right ? "inside" : "outside";
-}
-
 function formattedMarkEdgeHitFromElement(event: MouseEvent, element: HTMLElement): FormattedMarkEdgeHit | null {
   const rects = visibleClientRects(element);
   const firstRect = rects[0];
@@ -733,20 +664,10 @@ function formattedMarkEdgeHitFromElement(event: MouseEvent, element: HTMLElement
 
   if (startDistance === null && endDistance === null) return null;
   if (endDistance !== null && (startDistance === null || endDistance < startDistance)) {
-    return {
-      distance: endDistance,
-      edge: "end",
-      element,
-      placement: formattedMarkEdgePlacement(event, lastRect!, "end")
-    };
+    return { distance: endDistance, edge: "end", element };
   }
 
-  return {
-    distance: startDistance ?? 0,
-    edge: "start",
-    element,
-    placement: formattedMarkEdgePlacement(event, firstRect!, "start")
-  };
+  return { distance: startDistance ?? 0, edge: "start", element };
 }
 
 function directFormattedMarkEdgeHit(view: EditorView, event: MouseEvent) {
@@ -781,37 +702,6 @@ function formattedMarkEdgePosition(view: EditorView, element: HTMLElement, edge:
   }
 }
 
-function liveMarkdownMarkPositions(element: HTMLElement): LiveMarkdownMarkPositions | null {
-  const from = Number(element.dataset.markraLiveMarkFrom);
-  const to = Number(element.dataset.markraLiveMarkTo);
-  const contentFrom = Number(element.dataset.markraLiveMarkContentFrom);
-  const contentTo = Number(element.dataset.markraLiveMarkContentTo);
-
-  if (![from, to, contentFrom, contentTo].every(Number.isInteger)) return null;
-  if (from < 0 || from > contentFrom || contentFrom > contentTo || contentTo > to) return null;
-
-  return { contentFrom, contentTo, from, to };
-}
-
-function liveMarkdownMarkEdgePosition(
-  positions: LiveMarkdownMarkPositions,
-  edge: FormattedMarkEdge,
-  placement: FormattedMarkEdgePlacement
-) {
-  if (placement === "inside") return edge === "start" ? positions.contentFrom : positions.contentTo;
-  return edge === "start" ? positions.from : positions.to;
-}
-
-function formattedMarkEdgeMarks(
-  view: EditorView,
-  position: number,
-  edge: FormattedMarkEdge,
-  placement: FormattedMarkEdgePlacement
-) {
-  if (placement === "outside") return null;
-  return marksAtFormattedEdge(view, position, edge);
-}
-
 function selectFormattedMarkEdge(view: EditorView, event: Event) {
   if (!(event instanceof MouseEvent)) return false;
   if (event.button !== 0) return false;
@@ -819,22 +709,17 @@ function selectFormattedMarkEdge(view: EditorView, event: Event) {
   const hit = directFormattedMarkEdgeHit(view, event) ?? nearbyFormattedMarkEdgeHit(view, event);
   if (!hit) return false;
 
-  const livePositions = liveMarkdownMarkPositions(hit.element);
-  const position = livePositions
-    ? liveMarkdownMarkEdgePosition(livePositions, hit.edge, hit.placement)
-    : formattedMarkEdgePosition(view, hit.element, hit.edge);
+  const position = formattedMarkEdgePosition(view, hit.element, hit.edge);
   if (position === null) return false;
-  if (position > view.state.doc.content.size) return false;
-  const marks = livePositions ? null : formattedMarkEdgeMarks(view, position, hit.edge, hit.placement);
 
   event.preventDefault();
   event.stopPropagation();
-  // Focusing can restore the previous DOM selection, so apply inside-edge marks only after focus settles.
+  view.dispatch(
+    view.state.tr
+      .setSelection(TextSelection.create(view.state.doc, position))
+      .scrollIntoView()
+  );
   view.focus();
-  const transaction = view.state.tr
-    .setSelection(TextSelection.create(view.state.doc, position))
-    .scrollIntoView();
-  view.dispatch(marks ? transaction.setStoredMarks(marks) : transaction);
   return true;
 }
 
@@ -876,9 +761,10 @@ function buildLiveMarkdownDecorations(
       );
 
       if (range.contentFrom < range.contentTo) {
-        const markClass = ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ");
         decorations.push(
-          Decoration.inline(contentFrom, contentTo, liveMarkdownMarkAttrs(markClass, from, to, contentFrom, contentTo))
+          Decoration.inline(contentFrom, contentTo, {
+            class: ["markra-live-mark", ...range.kinds.map((kind) => `markra-live-mark-${kind}`)].join(" ")
+          })
         );
       }
     }
@@ -1501,9 +1387,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
     props: {
       handleDOMEvents: {
         mousedown: (view, event) =>
-          // Resolve the visible content edge before trusting the WebView's unstable wrapper target.
-          selectFormattedMarkEdge(view, event) || selectLiveMarkdownDelimiterEdge(view, event),
-        keyup: restoreFoldedMarkdownMarksAfterNativeArrow
+          selectLiveMarkdownDelimiterEdge(view, event) || selectFormattedMarkEdge(view, event)
       },
       decorations: (state) => {
         const pluginState = liveMarkdownKey.getState(state) as LiveMarkdownPluginState | undefined;
@@ -1546,12 +1430,7 @@ export const markraLiveMarkdownPlugin = (options: MarkraLiveMarkdownOptions = {}
           );
           const handledFoldedRange =
             handledLiveRange ||
-            moveCursorPastFoldedMarkdownDelimiter(
-              view,
-              specs,
-              managedMarkTypes,
-              event.key === "ArrowLeft" ? "left" : "right"
-            );
+            moveCursorPastFoldedMarkdownDelimiter(view, specs, event.key === "ArrowLeft" ? "left" : "right");
 
           if (handledFoldedRange) {
             event.preventDefault();


### PR DESCRIPTION
## Summary

- revert the inline mark boundary input changes from #510
- restore the editor implementation and tests to their state immediately before #510

## Why

The WebView-specific boundary handling remains unreliable on real macOS and Windows devices. Chinese IME input can still be committed outside the intended formatted wrapper, so the merged change should be removed from `main` while the root cause is investigated separately.

## Validation

- verified the reverted files are byte-for-byte identical to the parent of #510
- `pnpm --filter @markra/app test` — 116 files and 1771 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- `git diff --check HEAD^ HEAD` — passed

## Risk

- this intentionally removes the boundary behavior introduced by #510, including its mouse and keyboard improvements
- issue #419 remains unresolved and requires a different approach validated in native macOS and Windows WebViews

Reverts #510
Refs #419