### PR TITLE
fix(ai): preserve reasoning metadata across tool calls

### DIFF
--- a/packages/ai/src/agent/chat-adapters.test.ts
+++ b/packages/ai/src/agent/chat-adapters.test.ts
@@ -5,6 +5,7 @@ import {
 import { buildInlineAiMessages } from "./inline-prompt";
 import type { AiProviderConfig } from "@markra/providers";
 import type { Tool } from "@earendil-works/pi-ai";
+import { encodeOpenRouterReasoningDetails } from "./reasoning-metadata";
 
 function provider(overrides: Partial<AiProviderConfig>): AiProviderConfig {
   return {
@@ -935,6 +936,52 @@ describe("AI chat adapters", () => {
         choices: [{ delta: { content: "Final answer" }, finish_reason: "stop" }]
       })
     ).toEqual({ contentDelta: "Final answer", finishReason: "stop" });
+  });
+
+  it("parses and replays OpenRouter reasoning_details around tool calls", () => {
+    const adapter = getChatAdapter("openrouter");
+    const reasoningDetails = [
+      { format: "anthropic-claude-v1", index: 0, text: "Inspect first", type: "reasoning.text" },
+      { data: "encrypted", id: "call_read", index: 1, type: "reasoning.encrypted" }
+    ];
+
+    expect(
+      adapter.parseStreamEvent({
+        choices: [{ delta: { reasoning_details: reasoningDetails } }]
+      })
+    ).toEqual({ reasoningDetails });
+
+    const request = adapter.buildRequest(
+      provider({ baseUrl: "https://openrouter.ai/api/v1", id: "openrouter", type: "openrouter" }),
+      "anthropic/claude-sonnet-4.5",
+      [
+        { content: "Inspect.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          toolCalls: [{
+            arguments: {},
+            id: "call_read",
+            name: "read_document",
+            thoughtSignature: encodeOpenRouterReasoningDetails(reasoningDetails)
+          }]
+        },
+        {
+          content: "Tool result from read_document:\nDraft",
+          role: "user",
+          toolResult: { outputText: "Draft", toolCallId: "call_read", toolName: "read_document" }
+        }
+      ],
+      { stream: true }
+    );
+
+    expect(request.body).toMatchObject({
+      messages: [
+        { content: "Inspect.", role: "user" },
+        { reasoning_details: reasoningDetails, role: "assistant" },
+        { content: "Draft", role: "tool", tool_call_id: "call_read" }
+      ]
+    });
   });
 
   it("parses OpenAI-compatible stream events that carry final message content", () => {

--- a/packages/ai/src/agent/chat-adapters.ts
+++ b/packages/ai/src/agent/chat-adapters.ts
@@ -26,6 +26,7 @@ import { buildResponsesRequestBody } from "./requests/responses";
 import { mergeRequestBody } from "./requests/shared";
 import { buildAnthropicTools } from "./tool-builders/anthropic";
 import { buildGoogleTools } from "./tool-builders/google";
+import { decodeOpenRouterReasoningDetails, encodeOpenRouterReasoningDetails } from "./reasoning-metadata";
 
 export type * from "./chat/types";
 
@@ -78,7 +79,9 @@ const openAiCompatibleAdapter: ChatAdapter = {
     const requestParts = buildOpenAiCompatibleRequestParts(config, model, options);
     const body = buildChatCompletionsRequestBody({
       extraBody: requestParts.extraBody,
-      messages: messages.map(openAiCompatibleMessage),
+      messages: messages.map((message) =>
+        openAiCompatibleMessage(message, config.type === "openrouter" || config.id === "openrouter")
+      ),
       model,
       nativeTools: requestParts.nativeTools,
       stream: options.stream,
@@ -104,11 +107,20 @@ const openAiCompatibleAdapter: ChatAdapter = {
     const message = isRecord(firstChoice.message) ? firstChoice.message : {};
     const content = readOpenAiCompatibleContentDeltas(message.content).contentDelta ?? "";
     const toolCalls = readOpenAiCompatibleToolCalls(message);
+    const reasoningDetails = readOpenRouterReasoningDetails(message.reasoning_details);
+    const reasoningSignature = encodeOpenRouterReasoningDetails(reasoningDetails);
 
     return {
       content,
       finishReason: normalizeFinishReason(typeof firstChoice.finish_reason === "string" ? firstChoice.finish_reason : undefined),
-      ...(toolCalls.length ? { toolCalls } : {})
+      ...(toolCalls.length
+        ? {
+            toolCalls: toolCalls.map((toolCall, index) => ({
+              ...toolCall,
+              ...(index === 0 && reasoningSignature ? { thoughtSignature: reasoningSignature } : {})
+            }))
+          }
+        : {})
     };
   },
   parseStreamEvent(body) {
@@ -339,7 +351,7 @@ const azureAdapter: ChatAdapter = {
 
     const body = buildChatCompletionsRequestBody({
       extraBody: buildOpenAiCompatibleRequestParts(config, model, options).extraBody,
-      messages: messages.map(openAiCompatibleMessage),
+      messages: messages.map((message) => openAiCompatibleMessage(message)),
       stream: options.stream,
       tools: options.tools
     });
@@ -477,6 +489,8 @@ export function getChatAdapter(apiStyle: AiProviderApiStyle | AiProviderRequestS
 }
 
 export function getChatAdapterForProvider(provider: AiProviderConfig): ChatAdapter {
+  // Catalog entries expose DeepSeek's compatible wire style, but its tool loop still requires provider-specific reasoning replay.
+  if (provider.type === "deepseek") return deepseekAdapter;
   return provider.apiStyle ? getChatAdapter(provider.apiStyle) : getChatAdapter(provider.type);
 }
 
@@ -484,7 +498,7 @@ function isRequestStyleAdapterKey(apiStyle: AiProviderApiStyle | AiProviderReque
   return Object.hasOwn(adapterByRequestStyle, apiStyle);
 }
 
-function openAiCompatibleMessage(message: ChatMessage) {
+function openAiCompatibleMessage(message: ChatMessage, replayOpenRouterReasoning = false) {
   if (message.toolResult && !message.images?.length) {
     return {
       content: message.toolResult.outputText,
@@ -495,8 +509,13 @@ function openAiCompatibleMessage(message: ChatMessage) {
   }
 
   if (message.role === "assistant" && message.toolCalls?.length) {
+    const reasoningDetails = replayOpenRouterReasoning
+      ? message.toolCalls.map((toolCall) => decodeOpenRouterReasoningDetails(toolCall.thoughtSignature)).find(Boolean)
+      : undefined;
+
     return {
       content: message.content,
+      ...(reasoningDetails ? { reasoning_details: reasoningDetails } : {}),
       role: message.role,
       tool_calls: message.toolCalls.map((toolCall) => ({
         function: {
@@ -705,13 +724,21 @@ function parseOpenAiCompatibleStreamEvent(body: unknown): ChatStreamEventResult 
   const contentDeltas = readOpenAiCompatibleContentDeltas(delta.content ?? message.content);
   const thinkingDelta = readOpenAiCompatibleThinkingDelta(delta) ?? contentDeltas.thinkingDelta;
   const toolCallDeltas = readOpenAiCompatibleToolCallDeltas(delta);
+  const reasoningDetails = readOpenRouterReasoningDetails(delta.reasoning_details ?? message.reasoning_details);
 
   if (contentDeltas.contentDelta) result.contentDelta = contentDeltas.contentDelta;
   if (thinkingDelta) result.thinkingDelta = thinkingDelta;
+  if (reasoningDetails.length > 0) result.reasoningDetails = reasoningDetails;
   if (toolCallDeltas.length > 0) result.toolCallDeltas = toolCallDeltas;
   if (typeof firstChoice.finish_reason === "string") result.finishReason = normalizeFinishReason(firstChoice.finish_reason);
 
   return result;
+}
+
+function readOpenRouterReasoningDetails(value: unknown) {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter(isRecord);
 }
 
 function readOpenAiCompatibleThinkingDelta(delta: Record<string, unknown>) {

--- a/packages/ai/src/agent/chat-completion.test.ts
+++ b/packages/ai/src/agent/chat-completion.test.ts
@@ -1,5 +1,6 @@
 import { chatCompletion, chatCompletionStream } from "./chat-completion";
 import type { AiProviderConfig } from "@markra/providers";
+import { decodeOpenRouterReasoningDetails, decodeProviderMetadata } from "./reasoning-metadata";
 
 function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
   return {
@@ -386,44 +387,47 @@ describe("chatCompletion", () => {
       return { status: 200 };
     });
 
-    await expect(
-      chatCompletionStream(
-        provider({
-          apiStyle: "openai-responses"
-        }),
-        "gpt-5.5",
-        [{ content: "Read the document.", role: "user" }],
-        {
-          fallbackTransport: vi.fn(),
-          onToolCallDelta,
-          streamTransport,
-          tools: [
-            {
-              description: "Read the current document.",
-              name: "read_document",
-              parameters: {
-                additionalProperties: false,
-                properties: {
-                  path: { type: "string" }
-                },
-                required: ["path"],
-                type: "object"
-              }
+    const response = await chatCompletionStream(
+      provider({
+        apiStyle: "openai-responses"
+      }),
+      "gpt-5.5",
+      [{ content: "Read the document.", role: "user" }],
+      {
+        fallbackTransport: vi.fn(),
+        onToolCallDelta,
+        streamTransport,
+        tools: [
+          {
+            description: "Read the current document.",
+            name: "read_document",
+            parameters: {
+              additionalProperties: false,
+              properties: {
+                path: { type: "string" }
+              },
+              required: ["path"],
+              type: "object"
             }
-          ],
-          useVercelAiSdk: true
-        }
-      )
-    ).resolves.toEqual({
+          }
+        ],
+        useVercelAiSdk: true
+      }
+    );
+    expect(response).toEqual({
       content: "",
       finishReason: "tool-calls",
       toolCalls: [
         {
           arguments: { path: "README.md" },
           id: "call_read",
-          name: "read_document"
+          name: "read_document",
+          thoughtSignature: expect.any(String)
         }
       ]
+    });
+    expect(decodeProviderMetadata(response.toolCalls?.[0]?.thoughtSignature)).toEqual({
+      openai: { itemId: "fc_1" }
     });
 
     expect(onToolCallDelta).toHaveBeenCalledWith({
@@ -441,7 +445,75 @@ describe("chatCompletion", () => {
     });
   });
 
-  it("falls back when the Vercel AI SDK Responses stream hits malformed JSON before text", async () => {
+  it("captures and replays OpenAI Responses reasoning items", async () => {
+    const onThinkingMetadata = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.created","response":{"id":"resp_reasoning","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
+      onChunk('data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"in_progress","summary":[],"encrypted_content":"encrypted-reasoning"}}\n\n');
+      onChunk('data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"completed","summary":[],"encrypted_content":"encrypted-reasoning"}}\n\n');
+      onChunk('data: {"type":"response.completed","response":{"id":"resp_reasoning","created_at":0,"model":"gpt-5.5","object":"response","status":"completed","output":[{"id":"rs_1","type":"reasoning","status":"completed","summary":[],"encrypted_content":"encrypted-reasoning"}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":1}}}}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+    const openAiResponsesProvider = provider({ apiStyle: "openai-responses" });
+
+    await chatCompletionStream(openAiResponsesProvider, "gpt-5.5", [{ content: "Inspect.", role: "user" }], {
+      fallbackTransport: vi.fn(),
+      onThinkingMetadata,
+      streamTransport,
+      thinkingEnabled: true,
+      useVercelAiSdk: true
+    });
+
+    const signature = onThinkingMetadata.mock.calls
+      .map(([metadata]) => metadata.signature as string | undefined)
+      .find((value) => decodeProviderMetadata(value)?.openai !== undefined);
+    expect(decodeProviderMetadata(signature)).toEqual({
+      openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-reasoning" }
+    });
+
+    const replayStreamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"response.created","response":{"id":"resp_done","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
+      onChunk('data: {"type":"response.completed","response":{"id":"resp_done","created_at":0,"model":"gpt-5.5","object":"response","status":"completed","output":[{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Done","annotations":[]}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+    await chatCompletionStream(
+      openAiResponsesProvider,
+      "gpt-5.5",
+      [
+        { content: "Inspect.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          thinking: "",
+          thinkingSignature: signature,
+          toolCalls: [{ arguments: {}, id: "call_read", name: "read_document" }]
+        },
+        {
+          content: "Tool result from read_document:\nDraft",
+          role: "user",
+          toolResult: { outputText: "Draft", toolCallId: "call_read", toolName: "read_document" }
+        }
+      ],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport: replayStreamTransport,
+        thinkingEnabled: true,
+        tools: [{ description: "Read.", name: "read_document", parameters: { properties: {}, type: "object" } }],
+        useVercelAiSdk: true
+      }
+    );
+
+    const replayBody = JSON.parse(replayStreamTransport.mock.calls[0]?.[0].body ?? "{}") as {
+      input?: Array<Record<string, unknown>>;
+    };
+    expect(replayBody.input).toContainEqual({ id: "rs_1", type: "item_reference" });
+  });
+
+  it("does not fall back after the Vercel AI SDK has emitted tool-call state", async () => {
     const onToolCallDelta = vi.fn();
     const streamTransport = vi.fn(async (_request, onChunk) => {
       onChunk('data: {"type":"response.created","response":{"id":"resp_tool","created_at":0,"model":"gpt-5.5","object":"response","status":"in_progress"}}\n\n');
@@ -495,24 +567,14 @@ describe("chatCompletion", () => {
           useVercelAiSdk: true
         }
       )
-    ).resolves.toEqual({
-      content: "",
-      finishReason: "completed",
-      toolCalls: [
-        {
-          arguments: { path: "README.md" },
-          id: "call_read",
-          name: "read_document"
-        }
-      ]
-    });
+    ).rejects.toThrow();
 
     expect(onToolCallDelta).toHaveBeenCalledWith({
       id: "call_read",
       index: 0,
       nameDelta: "read_document"
     });
-    expect(fallbackTransport).toHaveBeenCalledOnce();
+    expect(fallbackTransport).not.toHaveBeenCalled();
   });
 
   it("uses the Vercel AI SDK stream path for Anthropic when enabled", async () => {
@@ -689,6 +751,106 @@ describe("chatCompletion", () => {
     });
   });
 
+  it("captures and replays Anthropic thinking signatures through the Vercel AI SDK", async () => {
+    const onThinkingMetadata = vi.fn();
+    const signatureStreamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n');
+      onChunk('data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Inspect first"}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"anthropic-signature"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":0}\n\n');
+      onChunk('data: {"type":"content_block_start","index":1,"content_block":{"type":"redacted_thinking","data":"anthropic-redacted-data"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":1}\n\n');
+      onChunk('data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}\n\n');
+      onChunk('data: {"type":"message_stop"}\n\n');
+
+      return { status: 200 };
+    });
+    const anthropicProvider = provider({
+      apiStyle: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      id: "anthropic",
+      name: "Anthropic",
+      type: "anthropic"
+    });
+
+    await chatCompletionStream(anthropicProvider, "claude-sonnet-4-5", [{ content: "Inspect.", role: "user" }], {
+      fallbackTransport: vi.fn(),
+      onThinkingMetadata,
+      streamTransport: signatureStreamTransport,
+      thinkingEnabled: true,
+      useVercelAiSdk: true
+    });
+
+    const signature = onThinkingMetadata.mock.calls
+      .map(([metadata]) => metadata.signature as string | undefined)
+      .find((value) => decodeProviderMetadata(value)?.anthropic !== undefined);
+    expect(decodeProviderMetadata(signature)).toEqual({
+      anthropic: { signature: "anthropic-signature" }
+    });
+    const redactedSignature = onThinkingMetadata.mock.calls
+      .map(([metadata]) => metadata.signature as string | undefined)
+      .find((value) => decodeProviderMetadata(value)?.anthropic?.redactedData !== undefined);
+    expect(decodeProviderMetadata(redactedSignature)).toEqual({
+      anthropic: { redactedData: "anthropic-redacted-data" }
+    });
+
+    const replayStreamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"type":"message_start","message":{"id":"msg_2","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n');
+      onChunk('data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n');
+      onChunk('data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done"}}\n\n');
+      onChunk('data: {"type":"content_block_stop","index":0}\n\n');
+      onChunk('data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}\n\n');
+      onChunk('data: {"type":"message_stop"}\n\n');
+
+      return { status: 200 };
+    });
+
+    await chatCompletionStream(
+      anthropicProvider,
+      "claude-sonnet-4-5",
+      [
+        { content: "Inspect.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          thinking: "Inspect first",
+          thinkingBlocks: [
+            { thinking: "Inspect first", thinkingSignature: signature },
+            { redacted: true, thinking: "", thinkingSignature: redactedSignature }
+          ],
+          thinkingSignature: signature,
+          toolCalls: [{ arguments: {}, id: "call_read", name: "read_document" }]
+        },
+        {
+          content: "Tool result from read_document:\nDraft",
+          role: "user",
+          toolResult: { outputText: "Draft", toolCallId: "call_read", toolName: "read_document" }
+        }
+      ],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport: replayStreamTransport,
+        thinkingEnabled: true,
+        tools: [{ description: "Read.", name: "read_document", parameters: { properties: {}, type: "object" } }],
+        useVercelAiSdk: true
+      }
+    );
+
+    const replayBody = JSON.parse(replayStreamTransport.mock.calls[0]?.[0].body ?? "{}") as {
+      messages?: Array<{ content?: Array<Record<string, unknown>>; role?: string }>;
+    };
+    expect(replayBody.messages?.find((message) => message.role === "assistant")?.content).toContainEqual({
+      signature: "anthropic-signature",
+      thinking: "Inspect first",
+      type: "thinking"
+    });
+    expect(replayBody.messages?.find((message) => message.role === "assistant")?.content).toContainEqual({
+      data: "anthropic-redacted-data",
+      type: "redacted_thinking"
+    });
+  });
+
   it("uses the Vercel AI SDK stream path for Google when enabled", async () => {
     const onDelta = vi.fn();
     const streamTransport = vi.fn(async (_request, onChunk) => {
@@ -780,6 +942,75 @@ describe("chatCompletion", () => {
     }));
     expect(body.tools).toContainEqual({ googleSearch: {} });
     expect(onThinkingDelta).toHaveBeenCalledWith("Grounding ");
+  });
+
+  it("captures and replays Gemini thought signatures on tool calls", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_document","args":{}},"thoughtSignature":"gemini-signature"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}\n\n');
+
+      return { status: 200 };
+    });
+    const googleProvider = provider({
+      apiStyle: "google",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      id: "google",
+      name: "Google",
+      type: "google"
+    });
+    const firstResponse = await chatCompletionStream(
+      googleProvider,
+      "gemini-3.1-pro-preview",
+      [{ content: "Read.", role: "user" }],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport,
+        thinkingEnabled: true,
+        tools: [{ description: "Read.", name: "read_document", parameters: { properties: {}, type: "object" } }],
+        useVercelAiSdk: true
+      }
+    );
+    const thoughtSignature = firstResponse.toolCalls?.[0]?.thoughtSignature;
+    expect(decodeProviderMetadata(thoughtSignature)).toEqual({
+      google: { thoughtSignature: "gemini-signature" }
+    });
+
+    const replayStreamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Done"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}\n\n');
+
+      return { status: 200 };
+    });
+    await chatCompletionStream(
+      googleProvider,
+      "gemini-3.1-pro-preview",
+      [
+        { content: "Read.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          toolCalls: [{ arguments: {}, id: "call_read", name: "read_document", thoughtSignature }]
+        },
+        {
+          content: "Tool result from read_document:\nDraft",
+          role: "user",
+          toolResult: { outputText: "Draft", toolCallId: "call_read", toolName: "read_document" }
+        }
+      ],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport: replayStreamTransport,
+        thinkingEnabled: true,
+        tools: [{ description: "Read.", name: "read_document", parameters: { properties: {}, type: "object" } }],
+        useVercelAiSdk: true
+      }
+    );
+
+    const replayBody = JSON.parse(replayStreamTransport.mock.calls[0]?.[0].body ?? "{}") as {
+      contents?: Array<{ parts?: Array<Record<string, unknown>>; role?: string }>;
+    };
+    expect(replayBody.contents?.find((message) => message.role === "model")?.parts).toContainEqual(expect.objectContaining({
+      functionCall: { args: {}, id: "call_read", name: "read_document" },
+      thoughtSignature: "gemini-signature"
+    }));
   });
 
   it.each([
@@ -952,6 +1183,88 @@ describe("chatCompletion", () => {
       reasoning_content: "I need to inspect the document before answering.",
       role: "assistant"
     }));
+  });
+
+  it("replays DeepSeek V4 reasoning content on the native fallback path", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"choices":[{"delta":{"content":"Done"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+      return { status: 200 };
+    });
+
+    await chatCompletionStream(
+      provider({
+        apiStyle: "openai-compatible",
+        baseUrl: "https://api.deepseek.com",
+        id: "deepseek",
+        name: "DeepSeek",
+        type: "deepseek"
+      }),
+      "deepseek-v4-pro",
+      [
+        { content: "Inspect.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          thinking: "Need the document first.",
+          toolCalls: [{ arguments: {}, id: "call_read", name: "read_document" }]
+        },
+        {
+          content: "Tool result from read_document:\nDraft",
+          role: "user",
+          toolResult: { outputText: "Draft", toolCallId: "call_read", toolName: "read_document" }
+        }
+      ],
+      { streamTransport, thinkingEnabled: true }
+    );
+
+    const body = JSON.parse(streamTransport.mock.calls[0]?.[0].body ?? "{}") as {
+      messages?: Array<Record<string, unknown>>;
+    };
+    expect(body.messages).toContainEqual(expect.objectContaining({
+      reasoning_content: "Need the document first.",
+      role: "assistant"
+    }));
+  });
+
+  it.each([
+    { baseUrl: "https://api.mistral.ai/v1", id: "mistral", model: "mistral-large-latest", name: "Mistral", type: "mistral" },
+    { baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1", id: "aliyun-bailian", model: "qwen3.6-plus", name: "Qwen", type: "openai-compatible" }
+  ] as const)("does not replay unsigned reasoning content through the $name SDK", async ({ baseUrl, id, model, name, type }) => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"test","choices":[{"index":0,"delta":{"content":"Done"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await chatCompletionStream(
+      provider({ apiStyle: "openai-compatible", baseUrl, id, name, type }),
+      model,
+      [
+        { content: "Inspect.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          thinking: "Unsigned private reasoning",
+          toolCalls: [{ arguments: {}, id: "call_read", name: "read_document" }]
+        },
+        {
+          content: "Tool result from read_document:\nDraft",
+          role: "user",
+          toolResult: { outputText: "Draft", toolCallId: "call_read", toolName: "read_document" }
+        }
+      ],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport,
+        thinkingEnabled: true,
+        tools: [{ description: "Read.", name: "read_document", parameters: { properties: {}, type: "object" } }],
+        useVercelAiSdk: true
+      }
+    );
+
+    expect(streamTransport.mock.calls[0]?.[0].body).not.toContain("Unsigned private reasoning");
   });
 
   it("uses the Azure OpenAI Vercel AI SDK package with deployment URLs", async () => {
@@ -1207,6 +1520,43 @@ describe("chatCompletion", () => {
     expect(onThinkingDelta).toHaveBeenCalledWith("Thinking");
     expect(onDelta).toHaveBeenNthCalledWith(1, "Better ");
     expect(onDelta).toHaveBeenNthCalledWith(2, "text");
+  });
+
+  it("merges OpenRouter reasoning_details and replays them after a streamed tool call", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","index":0,"text":"Inspect "}]}}]}\n\n');
+      onChunk('data: {"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","index":0,"text":"first"},{"type":"reasoning.encrypted","index":1,"id":"call_read","data":"encrypted"}],"tool_calls":[{"index":0,"id":"call_read","function":{"name":"read_document","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    const response = await chatCompletionStream(
+      provider({
+        baseUrl: "https://openrouter.ai/api/v1",
+        id: "openrouter",
+        name: "OpenRouter",
+        type: "openrouter"
+      }),
+      "anthropic/claude-sonnet-4.5",
+      [{ content: "Inspect.", role: "user" }],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport,
+        tools: [{ description: "Read.", name: "read_document", parameters: { properties: {}, type: "object" } }],
+        useVercelAiSdk: true
+      }
+    );
+
+    expect(response).toMatchObject({
+      finishReason: "toolUse",
+      toolCalls: [{ arguments: {}, id: "call_read", name: "read_document", thoughtSignature: expect.any(String) }]
+    });
+    expect(decodeOpenRouterReasoningDetails(response.toolCalls?.[0]?.thoughtSignature)).toEqual([
+      { index: 0, text: "Inspect first", type: "reasoning.text" },
+      { data: "encrypted", id: "call_read", index: 1, type: "reasoning.encrypted" }
+    ]);
+    expect(streamTransport.mock.calls[0]?.[0].headers["user-agent"]).toBeUndefined();
   });
 
   it("falls back to a final provider body when streaming chunks contain no text", async () => {

--- a/packages/ai/src/agent/chat-completion.test.ts
+++ b/packages/ai/src/agent/chat-completion.test.ts
@@ -884,6 +884,76 @@ describe("chatCompletion", () => {
     expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
   });
 
+  it("replays DeepSeek V4 reasoning content through the Vercel AI SDK after a tool call", async () => {
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"Done"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await chatCompletionStream(
+      provider({
+        apiStyle: "openai-compatible",
+        baseUrl: "https://api.deepseek.com",
+        id: "deepseek",
+        name: "DeepSeek",
+        type: "deepseek"
+      }),
+      "deepseek-v4-pro",
+      [
+        { content: "Read the current document.", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          thinking: "I need to inspect the document before answering.",
+          toolCalls: [
+            {
+              arguments: {},
+              id: "call_read_document",
+              name: "read_document"
+            }
+          ]
+        },
+        {
+          content: "Tool result from read_document:\n# Draft",
+          role: "user",
+          toolResult: {
+            outputText: "# Draft",
+            toolCallId: "call_read_document",
+            toolName: "read_document"
+          }
+        }
+      ],
+      {
+        fallbackTransport: vi.fn(),
+        streamTransport,
+        thinkingEnabled: true,
+        tools: [
+          {
+            description: "Read the current document.",
+            name: "read_document",
+            parameters: {
+              additionalProperties: false,
+              properties: {},
+              type: "object"
+            }
+          }
+        ],
+        useVercelAiSdk: true
+      }
+    );
+
+    const request = streamTransport.mock.calls[0]?.[0];
+    const body = JSON.parse(request?.body ?? "{}") as {
+      messages?: Array<Record<string, unknown>>;
+    };
+    expect(body.messages).toContainEqual(expect.objectContaining({
+      reasoning_content: "I need to inspect the document before answering.",
+      role: "assistant"
+    }));
+  });
+
   it("uses the Azure OpenAI Vercel AI SDK package with deployment URLs", async () => {
     const onDelta = vi.fn();
     const streamTransport = vi.fn(async (_request, onChunk) => {

--- a/packages/ai/src/agent/chat-completion.ts
+++ b/packages/ai/src/agent/chat-completion.ts
@@ -4,7 +4,8 @@ import {
   getChatAdapter,
   getChatAdapterForProvider
 } from "./chat-adapters";
-import type { ChatMessage, ChatResponse, ChatToolCallDelta } from "./chat/types";
+import type { ChatMessage, ChatResponse, ChatThinkingMetadata, ChatToolCallDelta } from "./chat/types";
+import { encodeOpenRouterReasoningDetails, mergeOpenRouterReasoningDetails } from "./reasoning-metadata";
 
 export type NativeAiChatRequest = {
   body: string;
@@ -32,6 +33,7 @@ export type ChatCompletionStreamOptions = {
   fallbackTransport?: ChatCompletionTransport;
   onDelta?: (delta: string) => unknown;
   onThinkingDelta?: (delta: string) => unknown;
+  onThinkingMetadata?: (metadata: ChatThinkingMetadata) => unknown;
   onToolCallDelta?: (delta: ChatToolCallDelta) => unknown;
   streamTransport?: ChatCompletionStreamTransport;
   thinkingEnabled?: boolean;
@@ -73,6 +75,7 @@ export async function chatCompletionStream(
     fallbackTransport,
     onDelta,
     onThinkingDelta,
+    onThinkingMetadata,
     onToolCallDelta,
     streamTransport = missingChatCompletionStreamTransport,
     thinkingEnabled,
@@ -96,7 +99,8 @@ export async function chatCompletionStream(
   };
   let content = "";
   let finishReason: string | undefined;
-  const toolCalls = new Map<number, { argumentsText: string; id: string; name: string }>();
+  const toolCalls = new Map<number, { argumentsText: string; id: string; name: string; thoughtSignature?: string }>();
+  let reasoningDetails: Record<string, unknown>[] = [];
   const parser = createServerSentEventParser();
   const inlineThinkingExtractor = thinkingEnabled ? createInlineThinkingExtractor() : null;
   let streamErrorMessage: string | undefined;
@@ -132,6 +136,9 @@ export async function chatCompletionStream(
     }
 
     if (parsed.thinkingDelta) emitThinkingDelta(parsed.thinkingDelta);
+    if (parsed.reasoningDetails?.length) {
+      reasoningDetails = mergeOpenRouterReasoningDetails(reasoningDetails, parsed.reasoningDetails);
+    }
     if (parsed.toolCallDeltas?.length) {
       for (const delta of parsed.toolCallDeltas) {
         const currentToolCall = toolCalls.get(delta.index) ?? { argumentsText: "", id: "", name: "" };
@@ -158,23 +165,34 @@ export async function chatCompletionStream(
       toolCalls.set(index, {
         argumentsText: JSON.stringify(toolCall.arguments),
         id: toolCall.id,
-        name: toolCall.name
+        name: toolCall.name,
+        ...(toolCall.thoughtSignature ? { thoughtSignature: toolCall.thoughtSignature } : {})
       });
     }
   };
-  const buildResponse = (): ChatResponse => ({
-    content,
-    finishReason,
-    ...(toolCalls.size > 0
-      ? {
-          toolCalls: [...toolCalls.entries()].map(([, toolCall]) => ({
-            arguments: parseToolArguments(toolCall.argumentsText),
-            id: toolCall.id,
-            name: toolCall.name
-          }))
-        }
-      : {})
-  });
+  const buildResponse = (): ChatResponse => {
+    // OpenRouter details belong to the assistant turn; the first tool call is pi-ai's opaque transport field for them.
+    const reasoningSignature = encodeOpenRouterReasoningDetails(reasoningDetails);
+
+    return {
+      content,
+      finishReason,
+      ...(toolCalls.size > 0
+        ? {
+            toolCalls: [...toolCalls.entries()].map(([, toolCall], index) => ({
+              arguments: parseToolArguments(toolCall.argumentsText),
+              id: toolCall.id,
+              name: toolCall.name,
+              ...(toolCall.thoughtSignature
+                ? { thoughtSignature: toolCall.thoughtSignature }
+                : index === 0 && reasoningSignature
+                  ? { thoughtSignature: reasoningSignature }
+                  : {})
+            }))
+          }
+        : {})
+    };
+  };
   const flushInlineThinking = () => {
     const finalInlineThinkingDelta = inlineThinkingExtractor?.finish();
     if (finalInlineThinkingDelta?.thinkingDelta) emitThinkingDelta(finalInlineThinkingDelta.thinkingDelta);
@@ -246,18 +264,28 @@ export async function chatCompletionStream(
       useVercelAiSdk,
       webSearchEnabled
     })) {
-      let sdkContentEmitted = false;
+      let sdkOutputEmitted = false;
       try {
         return await chatCompletionStreamWithVercelAiSdk({
           fallbackTransport,
           messages,
           model,
           onDelta: (delta) => {
-            sdkContentEmitted = true;
+            sdkOutputEmitted = true;
             onDelta?.(delta);
           },
-          onThinkingDelta,
-          onToolCallDelta,
+          onThinkingDelta: (delta) => {
+            sdkOutputEmitted = true;
+            onThinkingDelta?.(delta);
+          },
+          onThinkingMetadata: (metadata) => {
+            sdkOutputEmitted = true;
+            onThinkingMetadata?.(metadata);
+          },
+          onToolCallDelta: (delta) => {
+            sdkOutputEmitted = true;
+            onToolCallDelta?.(delta);
+          },
           provider,
           streamTransport,
           thinkingEnabled,
@@ -265,7 +293,7 @@ export async function chatCompletionStream(
           webSearchEnabled
         });
       } catch (error) {
-        if (sdkContentEmitted) throw error;
+        if (sdkOutputEmitted) throw error;
         if (canFallbackToNonStream()) return runNonStreamFallback();
       }
     }

--- a/packages/ai/src/agent/chat/types.ts
+++ b/packages/ai/src/agent/chat/types.ts
@@ -6,12 +6,21 @@ export type ChatMessage = {
   images?: ChatImageAttachment[];
   role: "assistant" | "system" | "user";
   thinking?: string;
+  thinkingBlocks?: ChatThinkingBlock[];
+  thinkingRedacted?: boolean;
+  thinkingSignature?: string;
   toolCalls?: ChatToolCall[];
   toolResult?: {
     outputText: string;
     toolCallId: string;
     toolName: string;
   };
+};
+
+export type ChatThinkingBlock = {
+  redacted?: boolean;
+  thinking: string;
+  thinkingSignature?: string;
 };
 
 export type ChatImageAttachment = {
@@ -36,6 +45,14 @@ export type ChatToolCall = {
   arguments: Record<string, unknown>;
   id: string;
   name: string;
+  thoughtSignature?: string;
+};
+
+export type ChatThinkingMetadata = {
+  blockId?: string;
+  phase?: "end" | "start" | "update";
+  redacted?: boolean;
+  signature?: string;
 };
 
 export type ChatToolCallDelta = {
@@ -57,6 +74,7 @@ export type ChatStreamEventResult = {
   contentDelta?: string;
   done?: boolean;
   finishReason?: string;
+  reasoningDetails?: Record<string, unknown>[];
   thinkingDelta?: string;
   toolCallDeltas?: ChatToolCallDelta[];
 };

--- a/packages/ai/src/agent/reasoning-metadata.test.ts
+++ b/packages/ai/src/agent/reasoning-metadata.test.ts
@@ -1,0 +1,74 @@
+import {
+  decodeOpenRouterReasoningDetails,
+  decodeProviderMetadata,
+  encodeOpenRouterReasoningDetails,
+  encodeProviderMetadata,
+  mergeOpenRouterReasoningDetails
+} from "./reasoning-metadata";
+
+describe("reasoning metadata", () => {
+  it("round-trips AI SDK provider metadata through an opaque signature", () => {
+    const metadata = {
+      anthropic: {
+        signature: "anthropic-signature"
+      }
+    };
+
+    expect(decodeProviderMetadata(encodeProviderMetadata(metadata))).toEqual(metadata);
+  });
+
+  it("round-trips OpenRouter reasoning details through an opaque signature", () => {
+    const details = [
+      {
+        format: "anthropic-claude-v1",
+        index: 0,
+        signature: "detail-signature",
+        text: "Need context",
+        type: "reasoning.text"
+      }
+    ];
+
+    expect(decodeOpenRouterReasoningDetails(encodeOpenRouterReasoningDetails(details))).toEqual(details);
+  });
+
+  it("ignores malformed, unknown, and mismatched signatures", () => {
+    const unknownVersion = JSON.stringify({
+      kind: "provider-metadata",
+      value: { anthropic: { signature: "signature" } },
+      version: 2
+    });
+
+    expect(decodeProviderMetadata("not-json")).toBeUndefined();
+    expect(decodeProviderMetadata(unknownVersion)).toBeUndefined();
+    expect(decodeOpenRouterReasoningDetails(encodeProviderMetadata({ openai: { itemId: "rs_123" } }))).toBeUndefined();
+  });
+
+  it("merges incremental and cumulative OpenRouter reasoning detail chunks in order", () => {
+    const merged = mergeOpenRouterReasoningDetails(
+      [
+        { format: "anthropic-claude-v1", index: 0, text: "Need", type: "reasoning.text" },
+        { data: "encrypted", id: "call_read", index: 1, type: "reasoning.encrypted" }
+      ],
+      [
+        { index: 0, text: " context", type: "reasoning.text" },
+        { data: "encrypted-final", id: "call_read", index: 1, type: "reasoning.encrypted" },
+        { index: 2, summary: "Ready", type: "reasoning.summary" }
+      ]
+    );
+
+    expect(merged).toEqual([
+      { format: "anthropic-claude-v1", index: 0, text: "Need context", type: "reasoning.text" },
+      { data: "encrypted-final", id: "call_read", index: 1, type: "reasoning.encrypted" },
+      { index: 2, summary: "Ready", type: "reasoning.summary" }
+    ]);
+
+    expect(mergeOpenRouterReasoningDetails(merged, [
+      { index: 0, text: "Need context for tools", type: "reasoning.text" }
+    ])[0]).toEqual({
+      format: "anthropic-claude-v1",
+      index: 0,
+      text: "Need context for tools",
+      type: "reasoning.text"
+    });
+  });
+});

--- a/packages/ai/src/agent/reasoning-metadata.ts
+++ b/packages/ai/src/agent/reasoning-metadata.ts
@@ -1,0 +1,134 @@
+import type { ProviderMetadata } from "ai";
+
+import { isRecord } from "@markra/shared";
+
+type ReasoningMetadataEnvelope =
+  | {
+      kind: "openrouter-reasoning-details";
+      value: Record<string, unknown>[];
+      version: 1;
+    }
+  | {
+      kind: "provider-metadata";
+      value: ProviderMetadata;
+      version: 1;
+    };
+
+export function encodeProviderMetadata(metadata: ProviderMetadata | undefined) {
+  if (!metadata || Object.keys(metadata).length === 0) return undefined;
+
+  return encodeEnvelope({
+    kind: "provider-metadata",
+    value: metadata,
+    version: 1
+  });
+}
+
+export function decodeProviderMetadata(signature: string | undefined): ProviderMetadata | undefined {
+  const envelope = decodeEnvelope(signature);
+  if (!envelope || envelope.kind !== "provider-metadata" || !isProviderMetadata(envelope.value)) return undefined;
+
+  return envelope.value;
+}
+
+export function encodeOpenRouterReasoningDetails(details: Record<string, unknown>[]) {
+  if (details.length === 0) return undefined;
+
+  return encodeEnvelope({
+    kind: "openrouter-reasoning-details",
+    value: details,
+    version: 1
+  });
+}
+
+export function decodeOpenRouterReasoningDetails(signature: string | undefined) {
+  const envelope = decodeEnvelope(signature);
+  if (
+    !envelope ||
+    envelope.kind !== "openrouter-reasoning-details" ||
+    !Array.isArray(envelope.value) ||
+    !envelope.value.every(isRecord)
+  ) {
+    return undefined;
+  }
+
+  return envelope.value;
+}
+
+export function mergeOpenRouterReasoningDetails(
+  current: Record<string, unknown>[],
+  incoming: Record<string, unknown>[]
+) {
+  const merged = current.map((detail) => ({ ...detail }));
+
+  for (const [incomingIndex, incomingDetail] of incoming.entries()) {
+    const detailIndex = merged.findIndex((detail, index) => {
+      return reasoningDetailKey(detail, index) === reasoningDetailKey(incomingDetail, incomingIndex);
+    });
+    if (detailIndex < 0) {
+      merged.push({ ...incomingDetail });
+      continue;
+    }
+
+    const previousDetail = merged[detailIndex]!;
+    merged[detailIndex] = {
+      ...previousDetail,
+      ...incomingDetail,
+      ...mergedTextFields(previousDetail, incomingDetail)
+    };
+  }
+
+  return merged;
+}
+
+function encodeEnvelope(envelope: ReasoningMetadataEnvelope) {
+  try {
+    return JSON.stringify(envelope);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeEnvelope(signature: string | undefined): ReasoningMetadataEnvelope | undefined {
+  if (!signature?.trim()) return undefined;
+
+  try {
+    const value = JSON.parse(signature) as unknown;
+    if (!isRecord(value) || value.version !== 1) return undefined;
+    if (value.kind !== "provider-metadata" && value.kind !== "openrouter-reasoning-details") return undefined;
+
+    return value as ReasoningMetadataEnvelope;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProviderMetadata(value: unknown): value is ProviderMetadata {
+  return isRecord(value) && Object.values(value).every(isRecord);
+}
+
+function reasoningDetailKey(detail: Record<string, unknown>, fallbackIndex: number) {
+  if (typeof detail.index === "number") return `index:${detail.index}`;
+  if (typeof detail.id === "string" && detail.id) return `id:${detail.id}`;
+
+  return `position:${fallbackIndex}`;
+}
+
+function mergedTextFields(previous: Record<string, unknown>, incoming: Record<string, unknown>) {
+  return Object.fromEntries(
+    ["summary", "text"].flatMap((field) => {
+      const previousText = previous[field];
+      const incomingText = incoming[field];
+      if (typeof previousText !== "string" || typeof incomingText !== "string") return [];
+
+      return [[field, mergeReasoningText(previousText, incomingText)]];
+    })
+  );
+}
+
+function mergeReasoningText(previous: string, incoming: string) {
+  if (incoming.startsWith(previous)) return incoming;
+  if (previous.endsWith(incoming)) return previous;
+
+  return `${previous}${incoming}`;
+}

--- a/packages/ai/src/agent/runtime.test.ts
+++ b/packages/ai/src/agent/runtime.test.ts
@@ -1,6 +1,7 @@
 import { runInlineAiAgent } from "./runtime";
 import { messagesFromPiContext } from "./runtime/messages";
 import type { AiProviderConfig } from "@markra/providers";
+import type { ThinkingContent } from "@earendil-works/pi-ai";
 import type { ChatMessage } from "./chat/types";
 
 function provider(overrides: Partial<AiProviderConfig> = {}): AiProviderConfig {
@@ -183,13 +184,119 @@ describe("inline AI agent runtime", () => {
     expect(deltas).toEqual(["Better ", "body"]);
   });
 
+  it("preserves metadata-only redacted thinking blocks from streaming completions", async () => {
+    let finalThinkingBlock: ThinkingContent | undefined;
+    const complete = vi.fn(async (_provider, _model, _messages, options) => {
+      options?.onThinkingMetadata?.({
+        redacted: true,
+        signature: "provider-metadata-envelope"
+      });
+      options?.onDelta?.("Better body");
+
+      return { content: "Better body", finishReason: "stop" };
+    });
+
+    await runInlineAiAgent({
+      complete,
+      documentContent: "# Draft\n\nOriginal body",
+      documentPath: "/vault/README.md",
+      model: "gpt-5.5",
+      onEvent: (event) => {
+        if (event.type !== "message_end" || event.message.role !== "assistant") return;
+        finalThinkingBlock = event.message.content.find((part) => part.type === "thinking");
+      },
+      prompt: "make it clearer",
+      provider: provider(),
+      target: {
+        from: 9,
+        original: "Original body",
+        promptText: "Original body",
+        to: 22,
+        type: "replace"
+      }
+    });
+
+    expect(finalThinkingBlock).toEqual({
+      redacted: true,
+      thinking: "",
+      thinkingSignature: "provider-metadata-envelope",
+      type: "thinking"
+    });
+  });
+
+  it("preserves ordered signed and redacted thinking blocks from streaming completions", async () => {
+    let finalThinkingBlocks: ThinkingContent[] = [];
+    const complete = vi.fn(async (_provider, _model, _messages, options) => {
+      options?.onThinkingMetadata?.({ blockId: "thinking-0", phase: "start" });
+      options?.onThinkingDelta?.("Inspect first");
+      options?.onThinkingMetadata?.({
+        blockId: "thinking-0",
+        phase: "update",
+        signature: "thinking-envelope"
+      });
+      options?.onThinkingMetadata?.({ blockId: "thinking-0", phase: "end" });
+      options?.onThinkingMetadata?.({
+        blockId: "thinking-1",
+        phase: "start",
+        redacted: true,
+        signature: "redacted-envelope"
+      });
+      options?.onThinkingMetadata?.({ blockId: "thinking-1", phase: "end" });
+      options?.onDelta?.("Better body");
+
+      return { content: "Better body", finishReason: "stop" };
+    });
+
+    await runInlineAiAgent({
+      complete,
+      documentContent: "# Draft\n\nOriginal body",
+      documentPath: "/vault/README.md",
+      model: "gpt-5.5",
+      onEvent: (event) => {
+        if (event.type !== "message_end" || event.message.role !== "assistant") return;
+        finalThinkingBlocks = event.message.content.filter((part): part is ThinkingContent => part.type === "thinking");
+      },
+      prompt: "make it clearer",
+      provider: provider(),
+      target: {
+        from: 9,
+        original: "Original body",
+        promptText: "Original body",
+        to: 22,
+        type: "replace"
+      }
+    });
+
+    expect(finalThinkingBlocks).toEqual([
+      { thinking: "Inspect first", thinkingSignature: "thinking-envelope", type: "thinking" },
+      { redacted: true, thinking: "", thinkingSignature: "redacted-envelope", type: "thinking" }
+    ]);
+  });
+
   it("preserves assistant thinking blocks when replaying tool-calling context", () => {
     expect(messagesFromPiContext({
       messages: [
         {
           content: [
-            { thinking: "Need to inspect the document first.", type: "thinking" },
-            { arguments: {}, id: "call_read_document", name: "read_document", type: "toolCall" }
+            {
+              redacted: false,
+              thinking: "Need to inspect the document first.",
+              thinkingSignature: "thinking-envelope",
+              type: "thinking"
+            },
+            {
+              redacted: true,
+              thinking: "",
+              thinkingSignature: "redacted-envelope",
+              type: "thinking"
+            },
+            {
+              arguments: {},
+              id: "call_read_document",
+              name: "read_document",
+              thoughtSignature: "tool-envelope",
+              type: "toolCall"
+            }
           ],
           role: "assistant"
         }
@@ -200,11 +307,26 @@ describe("inline AI agent runtime", () => {
         content: "",
         role: "assistant",
         thinking: "Need to inspect the document first.",
+        thinkingBlocks: [
+          {
+            redacted: false,
+            thinking: "Need to inspect the document first.",
+            thinkingSignature: "thinking-envelope"
+          },
+          {
+            redacted: true,
+            thinking: "",
+            thinkingSignature: "redacted-envelope"
+          }
+        ],
+        thinkingRedacted: true,
+        thinkingSignature: "thinking-envelope",
         toolCalls: [
           {
             arguments: {},
             id: "call_read_document",
-            name: "read_document"
+            name: "read_document",
+            thoughtSignature: "tool-envelope"
           }
         ]
       }

--- a/packages/ai/src/agent/runtime/messages.ts
+++ b/packages/ai/src/agent/runtime/messages.ts
@@ -6,6 +6,7 @@ import type {
   Model,
   StopReason,
   TextContent,
+  ThinkingContent,
   ToolCall
 } from "@earendil-works/pi-ai";
 
@@ -25,19 +26,33 @@ function chatMessageFromPiMessage(message: Message): ChatMessage[] {
   }
 
   if (message.role === "assistant") {
-    const thinking = assistantThinkingContent(message);
+    const thinkingBlocks = message.content.filter((part): part is ThinkingContent => part.type === "thinking");
+    const thinking = thinkingBlocks.map((part) => part.thinking).join("");
+    const thinkingSignature = thinkingBlocks.find((part) => part.thinkingSignature)?.thinkingSignature;
     const toolCalls = message.content
       .filter((part): part is ToolCall => part.type === "toolCall")
       .map((toolCall) => ({
         arguments: structuredClone(toolCall.arguments),
         id: toolCall.id,
-        name: toolCall.name
+        name: toolCall.name,
+        ...(toolCall.thoughtSignature ? { thoughtSignature: toolCall.thoughtSignature } : {})
       }));
 
     return [{
       content: assistantTextContent(message),
       role: "assistant",
       ...(thinking ? { thinking } : {}),
+      ...(thinkingBlocks.length
+        ? {
+            thinkingBlocks: thinkingBlocks.map((part) => ({
+              ...(part.redacted !== undefined ? { redacted: part.redacted } : {}),
+              thinking: part.thinking,
+              ...(part.thinkingSignature ? { thinkingSignature: part.thinkingSignature } : {})
+            }))
+          }
+        : {}),
+      ...(thinkingBlocks.length ? { thinkingRedacted: thinkingBlocks.some((part) => part.redacted === true) } : {}),
+      ...(thinkingSignature ? { thinkingSignature } : {}),
       ...(toolCalls.length ? { toolCalls } : {})
     }];
   }
@@ -92,10 +107,6 @@ function imageDataUrlFromPiImage(image: ImageContent) {
 
 export function assistantTextContent(message: AssistantMessage) {
   return message.content.map((part) => (part.type === "text" ? part.text : "")).join("");
-}
-
-function assistantThinkingContent(message: AssistantMessage) {
-  return message.content.map((part) => (part.type === "thinking" ? part.thinking : "")).join("");
 }
 
 export function createAssistantMessage(

--- a/packages/ai/src/agent/runtime/stream.ts
+++ b/packages/ai/src/agent/runtime/stream.ts
@@ -66,6 +66,7 @@ async function streamNativeChatCompletion({
   }
 
   const contentBlocks: AssistantContentBlock[] = [];
+  const thinkingBlocksById = new Map<string, ThinkingContent>();
   const toolCallBlocks = new Map<number, ToolCall>();
   const toolCallArgumentBuffers = new Map<number, string>();
   const ignoredToolCallIndexes = new Set<number>();
@@ -116,13 +117,23 @@ async function streamNativeChatCompletion({
 
     return block;
   };
-  const ensureThinkingBlock = () => {
-    if (currentBlock?.type === "thinking") return currentBlock;
+  const ensureThinkingBlock = (blockId?: string) => {
+    const existingBlock = blockId ? thinkingBlocksById.get(blockId) : undefined;
+    if (existingBlock) {
+      if (currentBlock !== existingBlock) {
+        finishCurrentBlock();
+        currentBlock = existingBlock;
+      }
+
+      return existingBlock;
+    }
+    if (!blockId && currentBlock?.type === "thinking") return currentBlock;
 
     finishCurrentBlock();
     const block: ThinkingContent = { thinking: "", type: "thinking" };
     currentBlock = block;
     contentBlocks.push(block);
+    if (blockId) thinkingBlocksById.set(blockId, block);
     stream.push({
       contentIndex: contentBlocks.length - 1,
       partial: createAssistantMessage(model, contentBlocks),
@@ -204,6 +215,12 @@ async function streamNativeChatCompletion({
         type: "thinking_delta"
       });
     },
+    onThinkingMetadata: (metadata) => {
+      const thinkingBlock = ensureThinkingBlock(metadata.blockId);
+      if (metadata.signature) thinkingBlock.thinkingSignature = metadata.signature;
+      if (metadata.redacted !== undefined) thinkingBlock.redacted = metadata.redacted;
+      if (metadata.phase === "end" && currentBlock === thinkingBlock) finishCurrentBlock();
+    },
     onToolCallDelta: (delta) => {
       if (ignoredToolCallIndexes.has(delta.index)) return;
 
@@ -256,6 +273,7 @@ async function streamNativeChatCompletion({
       block.id = combineToolCallIds(toolCall.id, localToolCallIdFromCombined(block.id));
       block.name = toolCall.name;
       block.arguments = structuredClone(toolCall.arguments);
+      if (toolCall.thoughtSignature) block.thoughtSignature = toolCall.thoughtSignature;
       toolCallArgumentBuffers.set(index, JSON.stringify(toolCall.arguments));
     }
   }

--- a/packages/ai/src/agent/sdk/chat-completion.ts
+++ b/packages/ai/src/agent/sdk/chat-completion.ts
@@ -28,6 +28,7 @@ import {
   type JSONValue,
   type LanguageModel,
   type ModelMessage,
+  type ProviderMetadata,
   type ToolModelMessage,
   type ToolSet,
   type UserModelMessage
@@ -36,7 +37,14 @@ import type {
   ChatCompletionStreamTransport,
   ChatCompletionTransport
 } from "../chat-completion";
-import type { ChatImageAttachment, ChatMessage, ChatResponse, ChatToolCallDelta } from "../chat/types";
+import type {
+  ChatImageAttachment,
+  ChatMessage,
+  ChatResponse,
+  ChatThinkingMetadata,
+  ChatToolCallDelta
+} from "../chat/types";
+import { decodeProviderMetadata, encodeProviderMetadata } from "../reasoning-metadata";
 import { createNativeAiSdkFetch, type AiSdkFetch } from "./native-fetch";
 
 type AiSdkChatCompletionOptions = {
@@ -45,6 +53,7 @@ type AiSdkChatCompletionOptions = {
   model: string;
   onDelta?: (delta: string) => unknown;
   onThinkingDelta?: (delta: string) => unknown;
+  onThinkingMetadata?: (metadata: ChatThinkingMetadata) => unknown;
   onToolCallDelta?: (delta: ChatToolCallDelta) => unknown;
   provider: AiProviderConfig;
   streamTransport?: ChatCompletionStreamTransport;
@@ -60,6 +69,7 @@ type SdkToolCallState = {
   id: string;
   index: number;
   name: string;
+  thoughtSignature?: string;
 };
 
 type AiSdkProviderOptions = Record<string, Record<string, JSONValue>>;
@@ -125,6 +135,9 @@ export function canUseVercelAiSdkChatCompletion({
 
   return (
     useVercelAiSdk === true &&
+    // The generic compatible SDK drops reasoning_details, so OpenRouter tool loops stay on the native adapter.
+    provider.type !== "openrouter" &&
+    provider.id !== "openrouter" &&
     providerKind !== null &&
     streamTransport !== undefined &&
     fallbackTransport !== undefined &&
@@ -140,6 +153,7 @@ export async function chatCompletionStreamWithVercelAiSdk({
   model,
   onDelta,
   onThinkingDelta,
+  onThinkingMetadata,
   onToolCallDelta,
   provider,
   streamTransport,
@@ -149,9 +163,11 @@ export async function chatCompletionStreamWithVercelAiSdk({
 }: AiSdkChatCompletionOptions): Promise<ChatResponse> {
   if (!streamTransport) throw new Error("AI chat stream transport is not configured.");
   const nativeFetch = createNativeAiSdkFetch({ streamTransport, transport: fallbackTransport });
+  const providerKind = resolveAiSdkProviderKind(provider);
+  if (!providerKind) throw new Error("AI SDK does not support this provider API style.");
   const result = streamText({
     maxRetries: 0,
-    messages: buildAiSdkMessages(messages),
+    messages: buildAiSdkMessages(messages, providerKind),
     model: createAiSdkLanguageModel(provider, model, nativeFetch),
     providerOptions: buildAiSdkProviderOptions(provider, model, { thinkingEnabled, tools, webSearchEnabled }),
     tools: buildAiSdkTools(provider, model, { tools, webSearchEnabled })
@@ -162,17 +178,32 @@ export async function chatCompletionStreamWithVercelAiSdk({
   const toolCallsByIndex = new Map<number, SdkToolCallState>();
   const toolCallIndexById = new Map<string, number>();
 
-  const ensureToolCall = (id: string, name = "") => {
+  const emitThinkingMetadata = (
+    providerMetadata: ProviderMetadata | undefined,
+    blockId: string,
+    phase: ChatThinkingMetadata["phase"]
+  ) => {
+    onThinkingMetadata?.({
+      blockId,
+      ...(hasAnthropicRedactedThinking(providerMetadata) ? { redacted: true } : {}),
+      phase,
+      ...(providerMetadata ? { signature: encodeProviderMetadata(providerMetadata) } : {})
+    });
+  };
+
+  const ensureToolCall = (id: string, name = "", providerMetadata?: ProviderMetadata) => {
+    const thoughtSignature = providerMetadata ? encodeProviderMetadata(providerMetadata) : undefined;
     const existingIndex = toolCallIndexById.get(id);
     if (existingIndex !== undefined) {
       const existingToolCall = toolCallsByIndex.get(existingIndex);
       if (existingToolCall && name && !existingToolCall.name) existingToolCall.name = name;
+      if (existingToolCall && thoughtSignature) existingToolCall.thoughtSignature = thoughtSignature;
 
       return existingToolCall;
     }
 
     const index = toolCallsByIndex.size;
-    const toolCall = { arguments: {}, argumentsText: "", id, index, name };
+    const toolCall = { arguments: {}, argumentsText: "", id, index, name, ...(thoughtSignature ? { thoughtSignature } : {}) };
     toolCallIndexById.set(id, index);
     toolCallsByIndex.set(index, toolCall);
 
@@ -186,13 +217,19 @@ export async function chatCompletionStreamWithVercelAiSdk({
       continue;
     }
 
+    if (part.type === "reasoning-start" || part.type === "reasoning-end") {
+      emitThinkingMetadata(part.providerMetadata, part.id, part.type === "reasoning-start" ? "start" : "end");
+      continue;
+    }
+
     if (part.type === "reasoning-delta") {
       onThinkingDelta?.(part.text);
+      if (part.providerMetadata) emitThinkingMetadata(part.providerMetadata, part.id, "update");
       continue;
     }
 
     if (part.type === "tool-input-start") {
-      const toolCall = ensureToolCall(part.id, part.toolName);
+      const toolCall = ensureToolCall(part.id, part.toolName, part.providerMetadata);
       if (!toolCall) continue;
 
       onToolCallDelta?.({
@@ -217,7 +254,7 @@ export async function chatCompletionStreamWithVercelAiSdk({
     }
 
     if (part.type === "tool-call") {
-      const toolCall = ensureToolCall(part.toolCallId, part.toolName);
+      const toolCall = ensureToolCall(part.toolCallId, part.toolName, part.providerMetadata);
       if (!toolCall) continue;
 
       toolCall.arguments = isRecord(part.input) ? part.input : {};
@@ -252,7 +289,8 @@ export async function chatCompletionStreamWithVercelAiSdk({
           toolCalls: [...toolCallsByIndex.values()].map((toolCall) => ({
             arguments: toolCall.argumentsText ? parseToolArguments(toolCall.argumentsText) : toolCall.arguments,
             id: toolCall.id,
-            name: toolCall.name
+            name: toolCall.name,
+            ...(toolCall.thoughtSignature ? { thoughtSignature: toolCall.thoughtSignature } : {})
           }))
         }
       : {})
@@ -697,10 +735,10 @@ function mergeAiSdkProviderOptions(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-function buildAiSdkMessages(messages: ChatMessage[]): ModelMessage[] {
+function buildAiSdkMessages(messages: ChatMessage[], providerKind: AiSdkProviderKind): ModelMessage[] {
   return messages.map((message) => {
     if (message.toolResult) return buildAiSdkToolMessage(message);
-    if (message.role === "assistant") return buildAiSdkAssistantMessage(message);
+    if (message.role === "assistant") return buildAiSdkAssistantMessage(message, providerKind);
     if (message.role === "system") {
       return {
         content: message.content,
@@ -712,7 +750,7 @@ function buildAiSdkMessages(messages: ChatMessage[]): ModelMessage[] {
   });
 }
 
-function buildAiSdkAssistantMessage(message: ChatMessage): AssistantModelMessage {
+function buildAiSdkAssistantMessage(message: ChatMessage, providerKind: AiSdkProviderKind): AssistantModelMessage {
   if (!message.toolCalls?.length) {
     return {
       content: message.content,
@@ -720,20 +758,76 @@ function buildAiSdkAssistantMessage(message: ChatMessage): AssistantModelMessage
     };
   }
 
+  const reasoningBlocks = message.thinkingBlocks?.length
+    ? message.thinkingBlocks
+    : [{
+        ...(message.thinkingRedacted !== undefined ? { redacted: message.thinkingRedacted } : {}),
+        thinking: message.thinking ?? "",
+        ...(message.thinkingSignature ? { thinkingSignature: message.thinkingSignature } : {})
+      }];
+
   return {
     content: [
-      // DeepSeek V4 rejects follow-up tool requests unless the full reasoning content is replayed.
-      ...(message.thinking?.trim() ? [{ text: message.thinking, type: "reasoning" as const }] : []),
+      // Signatures authenticate one exact reasoning block, so never flatten adjacent signed or redacted blocks here.
+      ...reasoningBlocks.flatMap((reasoningBlock) => {
+        const providerOptions = decodeProviderMetadata(reasoningBlock.thinkingSignature);
+        if (
+          !shouldReplayAiSdkReasoning(providerKind, providerOptions) ||
+          (!reasoningBlock.thinking.trim() && reasoningBlock.redacted !== true && !providerOptions)
+        ) {
+          return [];
+        }
+
+        return [{
+          ...(providerOptions ? { providerOptions } : {}),
+          text: reasoningBlock.thinking,
+          type: "reasoning" as const
+        }];
+      }),
       ...(message.content.trim() ? [{ text: message.content, type: "text" as const }] : []),
-      ...message.toolCalls.map((toolCall) => ({
-        input: toolCall.arguments,
-        toolCallId: toolCall.id,
-        toolName: toolCall.name,
-        type: "tool-call" as const
-      }))
+      ...message.toolCalls.map((toolCall) => {
+        const providerOptions = decodeProviderMetadata(toolCall.thoughtSignature);
+
+        return {
+          input: toolCall.arguments,
+          ...(providerOptions && hasAiSdkProviderMetadata(providerKind, providerOptions) ? { providerOptions } : {}),
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          type: "tool-call" as const
+        };
+      })
     ],
     role: "assistant"
   };
+}
+
+function shouldReplayAiSdkReasoning(
+  providerKind: AiSdkProviderKind,
+  providerMetadata: ProviderMetadata | undefined
+) {
+  // Signed providers need original metadata; these compatible families replay the plain reasoning text they emitted.
+  if (
+    providerKind === "deepseek" ||
+    providerKind === "groq" ||
+    providerKind === "openai-compatible" ||
+    providerKind === "together"
+  ) {
+    return true;
+  }
+
+  return providerMetadata !== undefined && hasAiSdkProviderMetadata(providerKind, providerMetadata);
+}
+
+function hasAiSdkProviderMetadata(providerKind: AiSdkProviderKind, providerMetadata: ProviderMetadata) {
+  if (providerKind === "anthropic") return providerMetadata.anthropic !== undefined;
+  if (providerKind === "google") return providerMetadata.google !== undefined;
+  if (providerKind === "openai-responses") return providerMetadata.openai !== undefined;
+
+  return false;
+}
+
+function hasAnthropicRedactedThinking(providerMetadata: ProviderMetadata | undefined) {
+  return typeof providerMetadata?.anthropic?.redactedData === "string";
 }
 
 function buildAiSdkUserMessage(message: ChatMessage): UserModelMessage {

--- a/packages/ai/src/agent/sdk/chat-completion.ts
+++ b/packages/ai/src/agent/sdk/chat-completion.ts
@@ -722,6 +722,8 @@ function buildAiSdkAssistantMessage(message: ChatMessage): AssistantModelMessage
 
   return {
     content: [
+      // DeepSeek V4 rejects follow-up tool requests unless the full reasoning content is replayed.
+      ...(message.thinking?.trim() ? [{ text: message.thinking, type: "reasoning" as const }] : []),
       ...(message.content.trim() ? [{ text: message.content, type: "text" as const }] : []),
       ...message.toolCalls.map((toolCall) => ({
         input: toolCall.arguments,


### PR DESCRIPTION
## Summary
- preserve opaque reasoning metadata across local tool-call rounds through the existing pi-ai thinking and tool signature fields
- replay provider-native artifacts for DeepSeek, Anthropic, Gemini, OpenAI Responses, and OpenRouter without flattening signed or redacted blocks
- keep unsigned reasoning replay provider-aware so Qwen, Mistral, xAI, and Azure do not receive unsupported assistant reasoning
- add synthetic two-request regressions for metadata capture, tool execution, and follow-up request reconstruction

## Why
Reasoning providers attach protocol state to assistant turns and function calls. Markra previously reduced those responses to visible thinking text and basic tool-call fields, so follow-up requests could omit required signatures, encrypted content, item IDs, or structured reasoning details. DeepSeek surfaced this as an HTTP 400; other providers could fail similarly or lose reasoning continuity.

## Validation
- `pnpm test` — passed; AI package 245/245 and all workspace tests passed
- `pnpm build` — passed, including desktop/web production builds and vendor chunk verification
- `pnpm typecheck:test` — passed across the workspace
- `git diff --check` — passed

## Risk
- Moderate and isolated to AI tool-call history conversion. Provider metadata remains opaque and malformed envelopes are ignored.
- OpenRouter local tool loops now intentionally use the native compatible adapter because the generic SDK drops `reasoning_details`.
- SDK streams no longer retry through a fallback after emitting reasoning or tool-call state, preventing mixed state from two provider responses.