### PR TITLE
fix(editor): avoid Safari IME cursor widgets

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -3107,6 +3107,31 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).not.toContain("MockBefore\n\nMockAfter");
   });
 
+  it("does not add Chrome inline cursor widgets between consecutive HTML atoms on Safari", async () => {
+    const { container, view } = await renderEditor("MockBefore<br><br>MockAfter");
+    const paragraph = view.state.doc.child(0);
+    let childOffset = 0;
+    let betweenHtmlAtoms: number | null = null;
+
+    for (let index = 0; index < paragraph.childCount; index += 1) {
+      const child = paragraph.child(index);
+      const nextChild = paragraph.maybeChild(index + 1);
+      if (child.type.name === "html" && nextChild?.type.name === "html") {
+        betweenHtmlAtoms = 1 + childOffset + child.nodeSize;
+        break;
+      }
+      childOffset += child.nodeSize;
+    }
+
+    expect(container.querySelectorAll('.ProseMirror .markra-html-node[data-value="<br>"]')).toHaveLength(2);
+    expect(betweenHtmlAtoms).not.toBeNull();
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, betweenHtmlAtoms!)));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll(".ProseMirror p > span.ProseMirror-widget")).toHaveLength(0);
+    });
+  });
+
   it("keeps the native caret anchor when leaving display math source at the closing delimiter", async () => {
     const source = String.raw`$$ E = mc^2 $$`;
     const { container, view } = await renderEditor(source);

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -5,6 +5,7 @@ import {
   hardbreakSchema,
   hrSchema,
   imageSchema,
+  inlineNodesCursorPlugin,
   insertHrInputRule,
   inputRules as commonmarkInputRules,
   keymap as commonmarkKeymap,
@@ -366,6 +367,17 @@ const markraCommonmarkInputRules = commonmarkInputRules.map((plugin) =>
   plugin === insertHrInputRule ? markraInsertHrInputRule : plugin
 );
 
+const browserUsesSafariEngine =
+  typeof navigator !== "undefined" && /Apple Computer/iu.test(navigator.vendor);
+
+const markraCommonmarkPlugins = commonmarkPlugins.filter((plugin) =>
+  plugin !== remarkPreserveEmptyLinePlugin.plugin &&
+  plugin !== remarkPreserveEmptyLinePlugin.options &&
+  // Milkdown's dual editable widgets work around a Chrome 98 cursor bug, but WebKit
+  // directs IME preedit text into those widgets and never updates the document model.
+  (!browserUsesSafariEngine || plugin !== inlineNodesCursorPlugin)
+);
+
 export const markraCommonmark = [
   markraMarkdownStyleRemarkPlugin,
   markraBlankParagraphRemarkPlugin,
@@ -378,10 +390,7 @@ export const markraCommonmark = [
   markraCommonmarkInputRules,
   commonmarkCommands,
   commonmarkKeymap,
-  commonmarkPlugins.filter((plugin) =>
-    plugin !== remarkPreserveEmptyLinePlugin.plugin &&
-    plugin !== remarkPreserveEmptyLinePlugin.options
-  )
+  markraCommonmarkPlugins
 ].flat();
 
 export const markraGfm = [


### PR DESCRIPTION
## Summary

- skip Milkdown's Chrome 98 inline cursor workaround on Safari/WebKit
- keep the workaround enabled on non-Safari browsers
- cover consecutive raw HTML atoms with an editor regression test

## Why

Milkdown inserts two editable empty widgets when the cursor sits between adjacent inline atoms. In WebKit, IME preedit text can be directed into those widgets instead of the ProseMirror document, leaving the model selection frozen and causing repeated composition input.

## Validation

- `pnpm --filter @markra/app test` — 117 test files and 1,794 tests passed
- `pnpm --filter @markra/app build`
- `git diff --check`

## Risk

Safari/WebKit no longer receives the workaround for a Chrome 98 cursor bug. Chrome and other non-Safari browsers keep the existing plugin behavior.