### PR TITLE
feat(desktop): add adaptive macOS app icon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         include:
           - name: macOS (Apple Silicon)
             artifact_name: macOS-apple-silicon
-            os: macos-15
+            os: macos-26
             target: aarch64-apple-darwin
             asset_platform: macos
             asset_arch: arm64
@@ -48,7 +48,7 @@ jobs:
             args: --target aarch64-apple-darwin
           - name: macOS (Intel)
             artifact_name: macOS-intel
-            os: macos-15-intel
+            os: macos-26-intel
             target: x86_64-apple-darwin
             asset_platform: macos
             asset_arch: x64

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage/
 
 # Tauri and Rust
 apps/*/src-tauri/target/
+apps/desktop/src-tauri/icons/generated/
 target/
 **/*.rs.bk
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.app.json && vite build && pnpm verify:chunks",
+    "build:icon": "node scripts/icon.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit",

--- a/apps/desktop/scripts/icon.mjs
+++ b/apps/desktop/scripts/icon.mjs
@@ -1,0 +1,63 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+if (process.platform !== "darwin") process.exit(0);
+
+const desktopRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+// actool's app-icon name must match CFBundleIconName in Info.plist.
+const iconName = "Markra";
+const source = join(desktopRoot, "src-tauri", "icons", `${iconName}.icon`);
+const output = join(desktopRoot, "src-tauri", "icons", "generated");
+const catalog = join(output, "Assets.car");
+const partialPlist = join(output, "partial.plist");
+
+let versionOutput;
+try {
+  versionOutput = execFileSync("xcodebuild", ["-version"], { encoding: "utf8" });
+} catch {
+  throw new Error("Building the macOS adaptive icon requires Xcode 26 or later.");
+}
+
+const versionMatch = /^Xcode\s+(\d+)(?:\.(\d+))?/m.exec(versionOutput);
+const majorVersion = Number(versionMatch?.[1] ?? 0);
+if (majorVersion < 26) {
+  throw new Error(
+    `Building the macOS adaptive icon requires Xcode 26 or later; found ${versionOutput.trim()}.`
+  );
+}
+
+rmSync(output, { force: true, recursive: true });
+mkdirSync(output, { recursive: true });
+
+try {
+  execFileSync(
+    "xcrun",
+    [
+      "actool",
+      source,
+      "--compile",
+      output,
+      "--output-partial-info-plist",
+      partialPlist,
+      "--app-icon",
+      iconName,
+      "--enable-on-demand-resources",
+      "NO",
+      "--target-device",
+      "mac",
+      "--minimum-deployment-target",
+      "10.13",
+      "--platform",
+      "macosx"
+    ],
+    { stdio: "inherit" }
+  );
+} catch (error) {
+  throw new Error("Failed to compile the macOS adaptive icon with Xcode actool.", { cause: error });
+}
+
+if (!existsSync(catalog)) {
+  throw new Error(`actool did not produce the expected asset catalog at ${catalog}.`);
+}

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -6,6 +6,8 @@
   <true/>
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
+  <key>CFBundleIconName</key>
+  <string>Markra</string>
   <key>CFBundleLocalizations</key>
   <array>
     <string>en</string>

--- a/apps/desktop/src-tauri/icons/Markra.icon/Assets/mark.svg
+++ b/apps/desktop/src-tauri/icons/Markra.icon/Assets/mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <path d="M142 352V150h55l59 92 59-92h55v202h-48V225l-50 77h-32l-50-77v127h-48z" fill="#333333"/>
+</svg>

--- a/apps/desktop/src-tauri/icons/Markra.icon/Assets/underline.svg
+++ b/apps/desktop/src-tauri/icons/Markra.icon/Assets/underline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect x="128" y="374" width="256" height="20" rx="10" fill="#5b808d"/>
+</svg>

--- a/apps/desktop/src-tauri/icons/Markra.icon/icon.json
+++ b/apps/desktop/src-tauri/icons/Markra.icon/icon.json
@@ -1,0 +1,72 @@
+{
+  "color-space-for-untagged-svg-colors": "display-p3",
+  "fill": "system-light",
+  "groups": [
+    {
+      "layers": [
+        {
+          "fill-specializations": [
+            {
+              "value": {
+                "solid": "srgb:0.35686,0.50196,0.55294,1.00000"
+              }
+            },
+            {
+              "appearance": "dark",
+              "value": {
+                "solid": "srgb:0.49412,0.65882,0.71373,1.00000"
+              }
+            }
+          ],
+          "image-name": "underline.svg",
+          "name": "underline",
+          "position": {
+            "scale": 2,
+            "translation-in-points": [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "fill-specializations": [
+            {
+              "value": {
+                "solid": "srgb:0.20000,0.20000,0.20000,1.00000"
+              }
+            },
+            {
+              "appearance": "dark",
+              "value": {
+                "solid": "srgb:0.94118,0.95294,0.96078,1.00000"
+              }
+            }
+          ],
+          "image-name": "mark.svg",
+          "name": "mark",
+          "position": {
+            "scale": 2,
+            "translation-in-points": [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "shadow": {
+        "kind": "neutral",
+        "opacity": 0.25
+      },
+      "specular": false,
+      "translucency": {
+        "enabled": false,
+        "value": 0
+      }
+    }
+  ],
+  "supported-platforms": {
+    "squares": [
+      "macOS"
+    ]
+  }
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "pnpm dev --host 127.0.0.1 --port 1420 --strictPort",
     "devUrl": "http://127.0.0.1:1420",
-    "beforeBuildCommand": "pnpm build",
+    "beforeBuildCommand": "pnpm build && pnpm build:icon",
     "frontendDist": "../dist"
   },
   "app": {
@@ -60,6 +60,7 @@
     ],
     "macOS": {
       "files": {
+        "Resources/Assets.car": "icons/generated/Assets.car",
         "Resources/de.lproj": "macos-locales/de.lproj",
         "Resources/en.lproj": "macos-locales/en.lproj",
         "Resources/es.lproj": "macos-locales/es.lproj",


### PR DESCRIPTION
## Summary
- add an Icon Composer source with appearance-specific Markra foreground colors and a native system background
- compile and bundle `Assets.car` during macOS Tauri builds while retaining the legacy `.icns` fallback
- move Apple Silicon and Intel release jobs to macOS 26 runners with Xcode 26

## Why
macOS 26 can select the matching light or dark app icon for Finder, Dock, Launchpad, and desktop aliases even when Markra is not running. This uses the native icon asset system instead of runtime icon switching.

## Validation
- `pnpm test` passed (2,332 tests)
- `pnpm build` passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --locked` passed (234 tests)
- `pnpm tauri build --debug` produced the macOS app and DMG bundles
- `xcrun assetutil --validate-file` accepted the bundled asset catalog
- macOS IconServices rendered distinct default and dark outputs without launching Markra

## Risk
- macOS packaging now requires Xcode 26 or later; release jobs use the corresponding GitHub-hosted runners
- older macOS versions continue to use the existing `.icns` fallback
- non-macOS icon build invocations remain no-ops
