### PR TITLE
feat(editor): add table fragment merge action

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -30,6 +30,7 @@ vi.mock("mermaid", () => ({
 import type { Editor } from "@milkdown/kit/core";
 import { editorViewCtx, parserCtx, serializerCtx } from "@milkdown/kit/core";
 import { Fragment, Slice, type Node as ProseNode } from "@milkdown/kit/prose/model";
+import { undo } from "@milkdown/kit/prose/history";
 import { AllSelection, NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { MarkdownPaper } from "./MarkdownPaper";
@@ -5330,6 +5331,130 @@ describe("MarkdownPaper editing", () => {
     expect(view.state.doc.child(0).type.name).toBe("bullet_list");
     expect(view.state.doc.child(2).type.name).toBe("bullet_list");
     restoreLayout();
+  });
+
+  it("merges a compatible table fragment from the contextual control", async () => {
+    const initialMarkdown = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "| Beta | 2 |"
+    ].join("\n");
+    const onMarkdownChange = vi.fn();
+    const { container, editor, view } = await renderEditor(initialMarkdown, { onMarkdownChange });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdownBeforeMerge = serializeMarkdown(view.state.doc);
+
+    const mergeButton = screen.getByRole("button", { name: "Merge into table above" });
+    expect(mergeButton).toHaveClass("markra-table-fragment-merge-button");
+    expect(mergeButton.querySelector(".markra-table-fragment-merge-label")).toHaveTextContent(
+      "Merge into table above"
+    );
+
+    fireEvent.click(mergeButton);
+
+    const mergedMarkdown = serializeMarkdown(view.state.doc);
+    expect(container.querySelectorAll(".ProseMirror table tr")).toHaveLength(3);
+    expect(view.state.doc.childCount).toBe(1);
+    expect(mergedMarkdown).not.toContain("\n\n| Beta");
+    expect(view.state.selection.$from.parent.textContent).toBe("Beta");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenLastCalledWith(mergedMarkdown));
+
+    expect(undo(view.state, (transaction) => view.dispatch(transaction))).toBe(true);
+    expect(serializeMarkdown(view.state.doc)).toBe(markdownBeforeMerge);
+  });
+
+  it("merges every row in a compatible multi-line table fragment", async () => {
+    const initialMarkdown = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "| Beta | 2 |",
+      "| Gamma | 3 |"
+    ].join("\n");
+    const { container } = await renderEditor(initialMarkdown);
+
+    fireEvent.click(screen.getByRole("button", { name: "Merge into table above" }));
+
+    expect(container.querySelectorAll(".ProseMirror table tr")).toHaveLength(4);
+    expect(screen.getByRole("cell", { name: "Beta" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Gamma" })).toBeInTheDocument();
+  });
+
+  it("activates table fragment merging with Enter and Space", async () => {
+    const initialMarkdown = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "| Beta | 2 |"
+    ].join("\n");
+    const { container, view } = await renderEditor(initialMarkdown);
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Merge into table above" }), { key: "Enter" });
+    expect(container.querySelectorAll(".ProseMirror table tr")).toHaveLength(3);
+
+    expect(undo(view.state, (transaction) => view.dispatch(transaction))).toBe(true);
+    fireEvent.keyDown(screen.getByRole("button", { name: "Merge into table above" }), { key: " " });
+    expect(container.querySelectorAll(".ProseMirror table tr")).toHaveLength(3);
+  });
+
+  it("ignores context-style clicks on the table fragment control", async () => {
+    const initialMarkdown = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "| Beta | 2 |"
+    ].join("\n");
+    const { editor, view } = await renderEditor(initialMarkdown);
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const markdownBeforeClick = serializeMarkdown(view.state.doc);
+    const mergeButton = screen.getByRole("button", { name: "Merge into table above" });
+
+    fireEvent.mouseDown(mergeButton, { button: 2 });
+    fireEvent.click(mergeButton, { button: 2 });
+    expect(serializeMarkdown(view.state.doc)).toBe(markdownBeforeClick);
+
+    fireEvent.mouseDown(mergeButton, { button: 0, ctrlKey: true });
+    fireEvent.click(mergeButton, { button: 0, ctrlKey: true });
+    expect(serializeMarkdown(view.state.doc)).toBe(markdownBeforeClick);
+  });
+
+  it("hides table fragment merging while read-only", async () => {
+    const initialMarkdown = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "| Beta | 2 |"
+    ].join("\n");
+
+    await renderEditor(initialMarkdown, { readOnly: true });
+
+    expect(screen.queryByRole("button", { name: "Merge into table above" })).not.toBeInTheDocument();
+  });
+
+  it("hides table fragment merging for incompatible content and complete tables", async () => {
+    const table = ["| Name | Value |", "| --- | --- |", "| Alpha | 1 |"].join("\n");
+
+    const mismatch = await renderEditor(`${table}\n\n| Beta |`);
+    expect(screen.queryByRole("button", { name: "Merge into table above" })).not.toBeInTheDocument();
+    mismatch.unmount();
+
+    const partial = await renderEditor(`${table}\n\n| Beta | 2 |\n| Gamma |`);
+    expect(screen.queryByRole("button", { name: "Merge into table above" })).not.toBeInTheDocument();
+    partial.unmount();
+
+    const prose = await renderEditor(`${table}\n\nordinary | prose`);
+    expect(screen.queryByRole("button", { name: "Merge into table above" })).not.toBeInTheDocument();
+    prose.unmount();
+
+    const secondTable = await renderEditor(`${table}\n\n${table}`);
+    expect(screen.queryByRole("button", { name: "Merge into table above" })).not.toBeInTheDocument();
+    secondTable.unmount();
   });
 
   it("adds table rows and columns from the hover controls", async () => {

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5348,6 +5348,7 @@ describe("MarkdownPaper editing", () => {
 
     const mergeButton = screen.getByRole("button", { name: "Merge into table above" });
     expect(mergeButton).toHaveClass("markra-table-fragment-merge-button");
+    expect(mergeButton).not.toHaveAttribute("title");
     expect(mergeButton.querySelector(".markra-table-fragment-merge-label")).toHaveTextContent(
       "Merge into table above"
     );

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -49,6 +49,7 @@ import {
   markraSlashCommands,
   markraSpellcheckPlugin,
   markraTableControlsPlugin,
+  markraTableFragmentMergePlugin,
   markraTaskListPlugin,
   markraTrailingParagraphPlugin,
   markraTaskListSchema,
@@ -281,6 +282,7 @@ function MilkdownEditorSurface({
     tableColumns: t(language, "editor.table.columns"),
     tableRows: t(language, "editor.table.rows")
   };
+  const tableFragmentMergeLabel = t(language, "editor.table.mergeFragment");
   const blockDragLabels = {
     addBlock: t(language, "editor.blockAdd"),
     dragBlock: t(language, "editor.blockDrag")
@@ -556,6 +558,7 @@ function MilkdownEditorSurface({
             }
           )
         )
+        .use(markraTableFragmentMergePlugin(tableFragmentMergeLabel))
         .use(markraTableControlsPlugin(tableControlLabels, {
           getDefaultWidthMode: () => tableColumnWidthModeRef.current,
           getDocumentKey: () => documentPathRef.current

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2123,29 +2123,42 @@
   }
 
   .markdown-paper .markra-table-fragment-merge {
-    @apply relative z-20 flex h-0 w-full items-center gap-2 overflow-visible;
+    @apply relative z-20 h-0 w-full overflow-visible;
     color: var(--editor-text-secondary);
     pointer-events: none;
   }
 
-  .markdown-paper .markra-table-fragment-merge::before,
-  .markdown-paper .markra-table-fragment-merge::after {
-    height: 1px;
-    min-width: 1.5rem;
-    flex: 1;
-    background: color-mix(in srgb, var(--editor-border) 72%, transparent);
+  .markdown-paper .markra-table-fragment-merge-button {
+    @apply absolute top-0 left-0 inline-flex size-6 cursor-pointer items-center justify-center overflow-visible rounded-[7px] border p-0 text-xs font-semibold whitespace-nowrap focus-visible:outline-none;
+    border-color: color-mix(in srgb, var(--editor-border-strong) 78%, transparent);
+    background: color-mix(in srgb, var(--editor-paper-bg) 94%, var(--editor-bg-secondary));
+    box-shadow: 0 2px 7px rgba(0, 0, 0, 0.08);
+    color: var(--editor-text-secondary);
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-1.5rem, 0.125rem) scale(0.92);
+    transition:
+      color 120ms ease-out,
+      background-color 120ms ease-out,
+      border-color 120ms ease-out,
+      box-shadow 120ms ease-out,
+      opacity 120ms ease-out,
+      transform 120ms ease-out;
+  }
+
+  .markdown-paper .markra-table-fragment-merge-button::before {
+    position: absolute;
+    inset: -0.25rem 0 -0.25rem -0.25rem;
     content: "";
   }
 
-  .markdown-paper .markra-table-fragment-merge-button {
-    @apply inline-flex h-7 min-w-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border px-1.5 text-xs font-semibold whitespace-nowrap transition-[color,background-color,border-color,box-shadow,padding] duration-150 ease-out focus-visible:outline-none;
-    border-color: color-mix(in srgb, var(--editor-border-strong) 78%, transparent);
-    background: color-mix(in srgb, var(--editor-paper-bg) 94%, var(--editor-bg-secondary));
-    box-shadow:
-      0 6px 18px rgba(0, 0, 0, 0.08),
-      0 1px 2px rgba(0, 0, 0, 0.06);
-    color: var(--editor-text-secondary);
+  .markdown-paper .markra-table-fragment-merge:has(+ p:hover) .markra-table-fragment-merge-button,
+  .markdown-paper .markra-table-fragment-merge:focus-within .markra-table-fragment-merge-button,
+  .markdown-paper .markra-table-fragment-merge-button:hover,
+  .markdown-paper .markra-table-fragment-merge-button:focus-visible {
+    opacity: 1;
     pointer-events: auto;
+    transform: translate(-1.5rem, 0.125rem) scale(1);
   }
 
   .markdown-paper .markra-table-fragment-merge-button:hover,
@@ -2153,10 +2166,9 @@
     border-color: var(--editor-border-strong);
     background: var(--editor-bg-secondary);
     box-shadow:
-      0 9px 24px rgba(0, 0, 0, 0.1),
-      0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent);
+      0 3px 9px rgba(0, 0, 0, 0.09),
+      0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
     color: var(--editor-text-heading);
-    padding-inline: 0.55rem;
   }
 
   .markdown-paper .markra-table-fragment-merge-icon {
@@ -2165,21 +2177,36 @@
   }
 
   .markdown-paper .markra-table-fragment-merge-label {
-    max-width: 0;
-    overflow: hidden;
+    @apply absolute left-1 rounded-[7px] px-2 py-1 text-[11px] leading-tight font-medium;
+    bottom: calc(100% + 0.5rem);
+    background: var(--editor-text-heading);
+    box-shadow: 0 5px 14px rgba(0, 0, 0, 0.16);
+    color: var(--editor-paper-bg);
     opacity: 0;
     pointer-events: none;
+    transform: translateY(0.125rem);
     transition:
-      max-width 180ms ease,
-      margin-left 150ms ease,
-      opacity 120ms ease;
+      opacity 120ms ease-out,
+      transform 120ms ease-out,
+      visibility 0ms linear 120ms;
+    visibility: hidden;
+  }
+
+  .markdown-paper .markra-table-fragment-merge-label::after {
+    position: absolute;
+    top: 100%;
+    left: 0.625rem;
+    border: 0.25rem solid transparent;
+    border-top-color: var(--editor-text-heading);
+    content: "";
   }
 
   .markdown-paper .markra-table-fragment-merge-button:hover .markra-table-fragment-merge-label,
   .markdown-paper .markra-table-fragment-merge-button:focus-visible .markra-table-fragment-merge-label {
-    max-width: 14rem;
-    margin-left: 0.3rem;
     opacity: 1;
+    transform: translateY(0);
+    transition-delay: 0ms;
+    visibility: visible;
   }
 
   .markdown-paper .ProseMirror[contenteditable="false"] .markra-table-fragment-merge {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2122,6 +2122,70 @@
       0 0 0 3px color-mix(in srgb, var(--text-secondary) 14%, transparent);
   }
 
+  .markdown-paper .markra-table-fragment-merge {
+    @apply relative z-20 flex h-0 w-full items-center gap-2 overflow-visible;
+    color: var(--editor-text-secondary);
+    pointer-events: none;
+  }
+
+  .markdown-paper .markra-table-fragment-merge::before,
+  .markdown-paper .markra-table-fragment-merge::after {
+    height: 1px;
+    min-width: 1.5rem;
+    flex: 1;
+    background: color-mix(in srgb, var(--editor-border) 72%, transparent);
+    content: "";
+  }
+
+  .markdown-paper .markra-table-fragment-merge-button {
+    @apply inline-flex h-7 min-w-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border px-1.5 text-xs font-semibold whitespace-nowrap transition-[color,background-color,border-color,box-shadow,padding] duration-150 ease-out focus-visible:outline-none;
+    border-color: color-mix(in srgb, var(--editor-border-strong) 78%, transparent);
+    background: color-mix(in srgb, var(--editor-paper-bg) 94%, var(--editor-bg-secondary));
+    box-shadow:
+      0 6px 18px rgba(0, 0, 0, 0.08),
+      0 1px 2px rgba(0, 0, 0, 0.06);
+    color: var(--editor-text-secondary);
+    pointer-events: auto;
+  }
+
+  .markdown-paper .markra-table-fragment-merge-button:hover,
+  .markdown-paper .markra-table-fragment-merge-button:focus-visible {
+    border-color: var(--editor-border-strong);
+    background: var(--editor-bg-secondary);
+    box-shadow:
+      0 9px 24px rgba(0, 0, 0, 0.1),
+      0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent);
+    color: var(--editor-text-heading);
+    padding-inline: 0.55rem;
+  }
+
+  .markdown-paper .markra-table-fragment-merge-icon {
+    @apply size-3.5 shrink-0;
+    pointer-events: none;
+  }
+
+  .markdown-paper .markra-table-fragment-merge-label {
+    max-width: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition:
+      max-width 180ms ease,
+      margin-left 150ms ease,
+      opacity 120ms ease;
+  }
+
+  .markdown-paper .markra-table-fragment-merge-button:hover .markra-table-fragment-merge-label,
+  .markdown-paper .markra-table-fragment-merge-button:focus-visible .markra-table-fragment-merge-label {
+    max-width: 14rem;
+    margin-left: 0.3rem;
+    opacity: 1;
+  }
+
+  .markdown-paper .ProseMirror[contenteditable="false"] .markra-table-fragment-merge {
+    display: none;
+  }
+
   .markdown-paper .markra-table-delete-control {
     @apply hover:border-red-400/70 hover:bg-red-500/10 hover:text-red-600 focus-visible:border-red-400/70 focus-visible:bg-red-500/10 focus-visible:text-red-600;
     transform: translate(-50%, -50%);

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@cspell/cspell-types": "10.0.1",
     "@markra/ai": "workspace:*",
+    "@markra/markdown": "workspace:*",
     "@markra/shared": "workspace:*",
     "@milkdown/kit": "^7.20.0",
     "cspell-trie-lib": "10.0.1",

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -23,5 +23,6 @@ export * from "./shortcuts.ts";
 export * from "./slash-commands.ts";
 export * from "./spellcheck.ts";
 export * from "./table-controls.ts";
+export * from "./table-fragment-merge.ts";
 export * from "./task-list.ts";
 export * from "./trailing-paragraph.ts";

--- a/packages/editor/src/table-fragment-merge.test.ts
+++ b/packages/editor/src/table-fragment-merge.test.ts
@@ -1,0 +1,164 @@
+import { Schema, type Node as ProseNode } from "@milkdown/kit/prose/model";
+import { EditorState, type Transaction } from "@milkdown/kit/prose/state";
+
+type MergeCandidate = {
+  fragment: ProseNode;
+  fragmentFrom: number;
+  fragmentTo: number;
+  rows: readonly ProseNode[];
+  tableFrom: number;
+};
+
+type MergeTransactionFactory = (
+  state: EditorState,
+  candidate: MergeCandidate
+) => Transaction | null;
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { content: "inline*", group: "block" },
+    text: { group: "inline" },
+    table: {
+      content: "table_header_row table_row*",
+      group: "block",
+      isolating: true,
+      tableRole: "table"
+    },
+    table_header_row: {
+      content: "table_header+",
+      tableRole: "row"
+    },
+    table_row: {
+      content: "table_cell+",
+      tableRole: "row"
+    },
+    table_header: {
+      attrs: {
+        colspan: { default: 1 },
+        colwidth: { default: null },
+        rowspan: { default: 1 }
+      },
+      content: "paragraph",
+      isolating: true,
+      tableRole: "header_cell"
+    },
+    table_cell: {
+      attrs: {
+        colspan: { default: 1 },
+        colwidth: { default: null },
+        rowspan: { default: 1 }
+      },
+      content: "paragraph",
+      isolating: true,
+      tableRole: "cell"
+    }
+  }
+});
+
+const paragraph = schema.nodes.paragraph;
+const table = schema.nodes.table;
+const tableHeader = schema.nodes.table_header;
+const tableHeaderRow = schema.nodes.table_header_row;
+const tableCell = schema.nodes.table_cell;
+const tableRow = schema.nodes.table_row;
+
+function textParagraph(text: string) {
+  return paragraph.create(null, text ? schema.text(text) : undefined);
+}
+
+function headerCell(text: string) {
+  return tableHeader.create(null, textParagraph(text));
+}
+
+function bodyCell(text: string) {
+  return tableCell.create(null, textParagraph(text));
+}
+
+function bodyRow(...values: string[]) {
+  return tableRow.create(null, values.map(bodyCell));
+}
+
+function sampleTable() {
+  return table.create(null, [
+    tableHeaderRow.create(null, [headerCell("Name"), headerCell("Value")]),
+    bodyRow("Alpha", "1")
+  ]);
+}
+
+function sampleState(fragmentText = "| Beta | 2 |") {
+  const currentTable = sampleTable();
+  const fragment = textParagraph(fragmentText);
+  const doc = schema.topNodeType.create(null, [currentTable, fragment]);
+
+  return {
+    candidate: {
+      fragment,
+      fragmentFrom: currentTable.nodeSize,
+      fragmentTo: currentTable.nodeSize + fragment.nodeSize,
+      rows: [bodyRow("Beta", "2"), bodyRow("Gamma", "3")],
+      tableFrom: 0
+    },
+    state: EditorState.create({ doc, schema })
+  };
+}
+
+async function loadMergeTransactionFactory() {
+  const editor = await import("./index.ts") as unknown as {
+    createTableFragmentMergeTransaction?: MergeTransactionFactory;
+  };
+
+  return editor.createTableFragmentMergeTransaction;
+}
+
+describe("createTableFragmentMergeTransaction", () => {
+  it("appends rows, removes the orphan paragraph, and selects the first new cell", async () => {
+    const createTableFragmentMergeTransaction = await loadMergeTransactionFactory();
+    const { candidate, state } = sampleState();
+
+    const transaction = createTableFragmentMergeTransaction?.(state, candidate);
+
+    expect(transaction).not.toBeNull();
+    expect(transaction?.doc.childCount).toBe(1);
+    expect(transaction?.doc.firstChild?.childCount).toBe(4);
+    expect(transaction?.selection.$from.parent.textContent).toBe("Beta");
+  });
+
+  it("rejects a candidate after its orphan paragraph changes", async () => {
+    const createTableFragmentMergeTransaction = await loadMergeTransactionFactory();
+    const original = sampleState();
+    const changed = sampleState("| Changed | 9 |");
+
+    expect(
+      createTableFragmentMergeTransaction?.(changed.state, original.candidate)
+    ).toBeNull();
+  });
+
+  it("rejects stale positions and non-adjacent fragments", async () => {
+    const createTableFragmentMergeTransaction = await loadMergeTransactionFactory();
+    const { candidate, state } = sampleState();
+
+    expect(
+      createTableFragmentMergeTransaction?.(state, { ...candidate, tableFrom: 1 })
+    ).toBeNull();
+    expect(
+      createTableFragmentMergeTransaction?.(state, {
+        ...candidate,
+        fragmentFrom: candidate.fragmentFrom + 1,
+        fragmentTo: candidate.fragmentTo + 1
+      })
+    ).toBeNull();
+  });
+
+  it("rejects rows whose effective width differs from the current table", async () => {
+    const createTableFragmentMergeTransaction = await loadMergeTransactionFactory();
+    const { candidate, state } = sampleState();
+
+    expect(
+      createTableFragmentMergeTransaction?.(state, {
+        ...candidate,
+        rows: [bodyRow("Only one cell")]
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/editor/src/table-fragment-merge.ts
+++ b/packages/editor/src/table-fragment-merge.ts
@@ -185,7 +185,13 @@ function mergeIcon(document: Document) {
   icon.setAttribute("stroke-width", "2");
   icon.setAttribute("viewBox", "0 0 24 24");
 
-  for (const pathData of ["M7 6l5 5 5-5", "M7 18l5-5 5 5"]) {
+  for (const pathData of [
+    "M5 3.5h14v7H5z",
+    "M5 7h14",
+    "M5 20h14",
+    "M12 20v-7",
+    "m9 16 3-3 3 3"
+  ]) {
     const path = document.createElementNS(svgNamespace, "path");
     path.setAttribute("d", pathData);
     icon.append(path);

--- a/packages/editor/src/table-fragment-merge.ts
+++ b/packages/editor/src/table-fragment-merge.ts
@@ -1,0 +1,310 @@
+import { ParserReady, SerializerReady, parserCtx, serializerCtx } from "@milkdown/kit/core";
+import { Fragment, type Node as ProseNode } from "@milkdown/kit/prose/model";
+import { Plugin, TextSelection, type EditorState, type Transaction } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet, type EditorView } from "@milkdown/kit/prose/view";
+import { $proseAsync } from "@milkdown/kit/utils";
+import { parseGfmTableFragment, type GfmTableAlignment } from "@markra/markdown";
+import { TableMap } from "prosemirror-tables";
+
+export type TableFragmentMergeCandidate = {
+  fragment: ProseNode;
+  fragmentFrom: number;
+  fragmentTo: number;
+  rows: readonly ProseNode[];
+  tableFrom: number;
+};
+
+type MarkdownParser = (markdown: string) => ProseNode;
+type MarkdownSerializer = (doc: ProseNode) => string;
+
+const defaultMergeLabel = "Merge into table above";
+const svgNamespace = "http://www.w3.org/2000/svg";
+
+function tableRowWidth(row: ProseNode) {
+  let width = 0;
+
+  row.forEach((cell) => {
+    width += Math.max(1, Number(cell.attrs.colspan ?? 1));
+  });
+
+  return width;
+}
+
+function rowsAreCompatible(table: ProseNode, rows: readonly ProseNode[]) {
+  if (rows.length === 0) return false;
+
+  const width = TableMap.get(table).width;
+  const rowType = table.type.schema.nodes.table_row;
+  if (!rowType) return false;
+
+  return rows.every((row) => row.type === rowType && tableRowWidth(row) === width);
+}
+
+export function createTableFragmentMergeTransaction(
+  state: EditorState,
+  candidate: TableFragmentMergeCandidate
+): Transaction | null {
+  const table = state.doc.nodeAt(candidate.tableFrom);
+  if (!table || table.type.name !== "table") return null;
+
+  const fragmentFrom = candidate.tableFrom + table.nodeSize;
+  if (candidate.fragmentFrom !== fragmentFrom) return null;
+
+  const fragment = state.doc.nodeAt(fragmentFrom);
+  if (!fragment || fragment.type.name !== "paragraph" || !fragment.eq(candidate.fragment)) return null;
+
+  const fragmentTo = fragmentFrom + fragment.nodeSize;
+  if (candidate.fragmentTo !== fragmentTo) return null;
+  if (!rowsAreCompatible(table, candidate.rows)) return null;
+
+  const rows = Fragment.fromArray([...candidate.rows]);
+  if (!table.canReplace(table.childCount, table.childCount, rows)) return null;
+
+  const mergedTable = table.copy(table.content.append(rows));
+  const firstNewRowFrom = candidate.tableFrom + 1 + table.content.size;
+  const transaction = state.tr.replaceWith(candidate.tableFrom, fragmentTo, mergedTable);
+  const selection = TextSelection.near(transaction.doc.resolve(firstNewRowFrom + 2), 1);
+
+  return transaction.setSelection(selection).scrollIntoView();
+}
+
+function tableAlignments(table: ProseNode) {
+  const map = TableMap.get(table);
+  const alignments: GfmTableAlignment[] = [];
+
+  for (let column = 0; column < map.width; column += 1) {
+    const cell = table.nodeAt(map.positionAt(0, column, table));
+    const alignment = cell?.attrs.alignment;
+
+    if (alignment === "center" || alignment === "left" || alignment === "right") {
+      alignments.push(alignment);
+    } else {
+      alignments.push(null);
+    }
+  }
+
+  return alignments;
+}
+
+function serializeFragment(doc: ProseNode, fragment: ProseNode, serializeMarkdown: MarkdownSerializer) {
+  try {
+    const fragmentDocument = doc.type.create(null, Fragment.from(fragment));
+    // A standalone paragraph serializer escapes its leading pipe to keep it prose. Restore only
+    // that boundary marker so GFM can validate the row while cell-internal escapes stay intact.
+    return serializeMarkdown(fragmentDocument)
+      .replace(/^(\s*)\\\|/gmu, "$1|")
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+function parsedBodyRows(markdown: string, rowCount: number, parseMarkdown: MarkdownParser) {
+  try {
+    const parsedDocument = parseMarkdown(markdown);
+    if (parsedDocument.childCount !== 1) return null;
+
+    const parsedTable = parsedDocument.firstChild;
+    if (!parsedTable || parsedTable.type.name !== "table" || parsedTable.childCount !== rowCount + 1) {
+      return null;
+    }
+
+    const rows: ProseNode[] = [];
+    for (let index = 1; index < parsedTable.childCount; index += 1) {
+      const row = parsedTable.child(index);
+      if (row.type.name !== "table_row") return null;
+      rows.push(row);
+    }
+
+    return rows;
+  } catch {
+    return null;
+  }
+}
+
+function tableFragmentCandidateAt(
+  doc: ProseNode,
+  tableFrom: number,
+  parseMarkdown: MarkdownParser,
+  serializeMarkdown: MarkdownSerializer
+): TableFragmentMergeCandidate | null {
+  const table = doc.nodeAt(tableFrom);
+  if (!table || table.type.name !== "table") return null;
+
+  const fragmentFrom = tableFrom + table.nodeSize;
+  const fragment = doc.nodeAt(fragmentFrom);
+  if (!fragment || fragment.type.name !== "paragraph") return null;
+
+  const source = serializeFragment(doc, fragment, serializeMarkdown);
+  if (!source) return null;
+
+  const map = TableMap.get(table);
+  const parsedFragment = parseGfmTableFragment(source, map.width, tableAlignments(table));
+  if (!parsedFragment) return null;
+
+  const rows = parsedBodyRows(parsedFragment.markdown, parsedFragment.rowCount, parseMarkdown);
+  if (!rows || !rowsAreCompatible(table, rows)) return null;
+
+  return {
+    fragment,
+    fragmentFrom,
+    fragmentTo: fragmentFrom + fragment.nodeSize,
+    rows,
+    tableFrom
+  };
+}
+
+function tableFragmentCandidates(
+  doc: ProseNode,
+  parseMarkdown: MarkdownParser,
+  serializeMarkdown: MarkdownSerializer
+) {
+  const candidates: TableFragmentMergeCandidate[] = [];
+  let position = 0;
+
+  for (let index = 0; index < doc.childCount; index += 1) {
+    const node = doc.child(index);
+    if (node.type.name === "table") {
+      const candidate = tableFragmentCandidateAt(doc, position, parseMarkdown, serializeMarkdown);
+      if (candidate) candidates.push(candidate);
+    }
+    position += node.nodeSize;
+  }
+
+  return candidates;
+}
+
+function mergeIcon(document: Document) {
+  const icon = document.createElementNS(svgNamespace, "svg");
+  icon.classList.add("markra-table-fragment-merge-icon");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("viewBox", "0 0 24 24");
+
+  for (const pathData of ["M7 6l5 5 5-5", "M7 18l5-5 5 5"]) {
+    const path = document.createElementNS(svgNamespace, "path");
+    path.setAttribute("d", pathData);
+    icon.append(path);
+  }
+
+  return icon;
+}
+
+function emptyMergeWidget(document: Document) {
+  const placeholder = document.createElement("span");
+  placeholder.hidden = true;
+  placeholder.setAttribute("aria-hidden", "true");
+  return placeholder;
+}
+
+function createMergeWidget(
+  view: EditorView,
+  candidate: TableFragmentMergeCandidate,
+  label: string,
+  parseMarkdown: MarkdownParser,
+  serializeMarkdown: MarkdownSerializer
+) {
+  if (!view.editable) return emptyMergeWidget(view.dom.ownerDocument);
+
+  const document = view.dom.ownerDocument;
+  const wrapper = document.createElement("div");
+  const button = document.createElement("button");
+  const text = document.createElement("span");
+
+  wrapper.className = "markra-table-fragment-merge";
+  wrapper.contentEditable = "false";
+  wrapper.dataset.tableFrom = String(candidate.tableFrom);
+
+  button.type = "button";
+  button.className = "markra-table-fragment-merge-button";
+  button.ariaLabel = label;
+  button.title = label;
+  button.contentEditable = "false";
+  button.draggable = false;
+
+  text.className = "markra-table-fragment-merge-label";
+  text.textContent = label;
+  button.append(mergeIcon(document), text);
+  wrapper.append(button);
+
+  button.addEventListener("mousedown", (event) => {
+    if (event.button !== 0 || event.ctrlKey) return;
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  button.addEventListener("click", (event) => {
+    if (!view.editable || event.button !== 0 || event.ctrlKey) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const currentCandidate = tableFragmentCandidateAt(
+      view.state.doc,
+      candidate.tableFrom,
+      parseMarkdown,
+      serializeMarkdown
+    );
+    if (!currentCandidate) return;
+
+    const transaction = createTableFragmentMergeTransaction(view.state, currentCandidate);
+    if (!transaction) return;
+
+    view.dispatch(transaction);
+    view.focus();
+  });
+
+  button.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    event.stopPropagation();
+    button.click();
+  });
+
+  return wrapper;
+}
+
+function eventTargetsMergeWidget(event: Event) {
+  const element = event.target instanceof Element
+    ? event.target
+    : event.target instanceof Node
+      ? event.target.parentElement
+      : null;
+
+  return Boolean(element?.closest(".markra-table-fragment-merge"));
+}
+
+export function markraTableFragmentMergePlugin(label = defaultMergeLabel) {
+  return $proseAsync(async (ctx) => {
+    await Promise.all([ctx.wait(ParserReady), ctx.wait(SerializerReady)]);
+    const parseMarkdown = ctx.get(parserCtx);
+    const serializeMarkdown = ctx.get(serializerCtx);
+
+    return new Plugin({
+      props: {
+        decorations(state) {
+          const candidates = tableFragmentCandidates(state.doc, parseMarkdown, serializeMarkdown);
+          if (candidates.length === 0) return DecorationSet.empty;
+
+          return DecorationSet.create(
+            state.doc,
+            candidates.map((candidate) =>
+              Decoration.widget(
+                candidate.fragmentFrom,
+                (view) => createMergeWidget(view, candidate, label, parseMarkdown, serializeMarkdown),
+                {
+                  key: `markra-table-fragment-merge:${candidate.tableFrom}:${candidate.fragmentFrom}`,
+                  side: -1,
+                  stopEvent: eventTargetsMergeWidget
+                }
+              )
+            )
+          );
+        }
+      }
+    });
+  });
+}

--- a/packages/editor/src/table-fragment-merge.ts
+++ b/packages/editor/src/table-fragment-merge.ts
@@ -185,17 +185,9 @@ function mergeIcon(document: Document) {
   icon.setAttribute("stroke-width", "2");
   icon.setAttribute("viewBox", "0 0 24 24");
 
-  for (const pathData of [
-    "M5 3.5h14v7H5z",
-    "M5 7h14",
-    "M5 20h14",
-    "M12 20v-7",
-    "m9 16 3-3 3 3"
-  ]) {
-    const path = document.createElementNS(svgNamespace, "path");
-    path.setAttribute("d", pathData);
-    icon.append(path);
-  }
+  const path = document.createElementNS(svgNamespace, "path");
+  path.setAttribute("d", "M5 4h14M12 20V8m-5 5 5-5 5 5");
+  icon.append(path);
 
   return icon;
 }
@@ -228,7 +220,6 @@ function createMergeWidget(
   button.type = "button";
   button.className = "markra-table-fragment-merge-button";
   button.ariaLabel = label;
-  button.title = label;
   button.contentEditable = "false";
   button.draggable = false;
 

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./local-images.ts";
 export * from "./links.ts";
 export * from "./markdown.ts";
+export * from "./table-fragment.ts";

--- a/packages/markdown/src/table-fragment.test.ts
+++ b/packages/markdown/src/table-fragment.test.ts
@@ -1,0 +1,93 @@
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+type Alignment = "center" | "left" | "right" | null;
+type TableFragment = { markdown: string; rowCount: number };
+type TableFragmentParser = (
+  source: string,
+  columnCount: number,
+  alignments?: readonly Alignment[]
+) => TableFragment | null;
+
+type MarkdownNode = {
+  children?: MarkdownNode[];
+  type: string;
+};
+
+const parser = unified().use(remarkParse).use(remarkGfm);
+
+async function loadTableFragmentParser() {
+  const markdown = await import("./index.ts") as unknown as {
+    parseGfmTableFragment?: TableFragmentParser;
+  };
+
+  return markdown.parseGfmTableFragment;
+}
+
+function parseMarkdown(markdown: string) {
+  return parser.runSync(parser.parse(markdown)) as MarkdownNode;
+}
+
+describe("parseGfmTableFragment", () => {
+  it("builds a synthetic GFM table for one compatible row", async () => {
+    const parseGfmTableFragment = await loadTableFragmentParser();
+
+    const result = parseGfmTableFragment?.("| Beta | 2 |", 2, [null, null]);
+
+    expect(result).toMatchObject({ rowCount: 1 });
+    const tree = parseMarkdown(result?.markdown ?? "");
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children?.[0]?.type).toBe("table");
+    expect(tree.children?.[0]?.children).toHaveLength(2);
+  });
+
+  it("preserves multiple compatible rows and requested alignments", async () => {
+    const parseGfmTableFragment = await loadTableFragmentParser();
+
+    const result = parseGfmTableFragment?.(
+      "| Beta | 2 |\n| Gamma | 3 |",
+      2,
+      ["left", "right"]
+    );
+
+    expect(result).toMatchObject({ rowCount: 2 });
+    expect(result?.markdown).toContain("| :--- | ---: |");
+    expect(parseMarkdown(result?.markdown ?? "").children?.[0]?.children).toHaveLength(3);
+  });
+
+  it("rejects rows whose cell count differs from the table", async () => {
+    const parseGfmTableFragment = await loadTableFragmentParser();
+
+    expect(parseGfmTableFragment?.("| Beta |", 2, [null, null])).toBeNull();
+    expect(parseGfmTableFragment?.("| Beta | 2 | extra |", 2, [null, null])).toBeNull();
+  });
+
+  it("rejects prose that merely contains a pipe", async () => {
+    const parseGfmTableFragment = await loadTableFragmentParser();
+
+    expect(parseGfmTableFragment?.("ordinary | prose", 2, [null, null])).toBeNull();
+  });
+
+  it("rejects a multi-line fragment when any row is incompatible", async () => {
+    const parseGfmTableFragment = await loadTableFragmentParser();
+
+    expect(
+      parseGfmTableFragment?.("| Beta | 2 |\n| Gamma |", 2, [null, null])
+    ).toBeNull();
+  });
+
+  it("accepts escaped pipes and inline formatting through GFM parsing", async () => {
+    const parseGfmTableFragment = await loadTableFragmentParser();
+
+    const result = parseGfmTableFragment?.(
+      "| `a\\|b` | **bold** and [link](https://example.test) |",
+      2,
+      [null, null]
+    );
+
+    expect(result).toMatchObject({ rowCount: 1 });
+    expect(result?.markdown).toContain("`a\\|b`");
+    expect(result?.markdown).toContain("**bold**");
+  });
+});

--- a/packages/markdown/src/table-fragment.ts
+++ b/packages/markdown/src/table-fragment.ts
@@ -1,0 +1,83 @@
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+export type GfmTableAlignment = "center" | "left" | "right" | null;
+
+export type GfmTableFragment = {
+  markdown: string;
+  rowCount: number;
+};
+
+type MarkdownNode = {
+  children?: MarkdownNode[];
+  type: string;
+};
+
+const gfmTableParser = unified().use(remarkParse).use(remarkGfm);
+const pipeDelimitedRowPattern = /^\s*\|.*\|\s*$/u;
+
+function tableDelimiter(alignment: GfmTableAlignment) {
+  if (alignment === "left") return ":---";
+  if (alignment === "center") return ":---:";
+  if (alignment === "right") return "---:";
+  return "---";
+}
+
+function syntheticTableMarkdown(
+  rows: readonly string[],
+  columnCount: number,
+  alignments: readonly GfmTableAlignment[]
+) {
+  const headers = Array.from({ length: columnCount }, (_, index) => `markra-${index + 1}`);
+  const delimiters = Array.from(
+    { length: columnCount },
+    (_, index) => tableDelimiter(alignments[index] ?? null)
+  );
+
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${delimiters.join(" | ")} |`,
+    ...rows
+  ].join("\n");
+}
+
+function parsedTable(markdown: string) {
+  try {
+    const tree = gfmTableParser.runSync(gfmTableParser.parse(markdown)) as MarkdownNode;
+    if (tree.children?.length !== 1) return null;
+
+    const table = tree.children[0];
+    return table?.type === "table" ? table : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseGfmTableFragment(
+  source: string,
+  columnCount: number,
+  alignments: readonly GfmTableAlignment[] = []
+): GfmTableFragment | null {
+  if (!Number.isInteger(columnCount) || columnCount < 1) return null;
+
+  const normalizedSource = source.replace(/\r\n?/gu, "\n").trim();
+  if (!normalizedSource) return null;
+
+  const rows = normalizedSource.split("\n");
+  if (rows.some((row) => !pipeDelimitedRowPattern.test(row))) return null;
+
+  const markdown = syntheticTableMarkdown(rows, columnCount, alignments);
+  const table = parsedTable(markdown);
+  if (!table?.children || table.children.length !== rows.length + 1) return null;
+
+  const bodyRows = table.children.slice(1);
+  if (bodyRows.some((row) => row.type !== "tableRow" || row.children?.length !== columnCount)) {
+    return null;
+  }
+
+  return {
+    markdown,
+    rowCount: bodyRows.length
+  };
+}

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "Spalte löschen",
   "editor.table.deleteRow": "Zeile löschen",
   "editor.table.deleteTable": "Tabelle löschen",
+  "editor.table.mergeFragment": "Mit der obigen Tabelle zusammenführen",
   "editor.table.adjustTable": "Tabelle anpassen",
   "editor.table.resizeTableTo": "Tabelle auf {columns} Spalten x {rows} Zeilen anpassen",
   "editor.table.columns": "Tabellenspalten",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -727,6 +727,7 @@ const messages: BaseLocaleMessages = {
   "editor.table.deleteColumn": "Delete column",
   "editor.table.deleteRow": "Delete row",
   "editor.table.deleteTable": "Delete table",
+  "editor.table.mergeFragment": "Merge into table above",
   "editor.table.adjustTable": "Adjust table",
   "editor.table.resizeTableTo": "Resize table to {columns} columns by {rows} rows",
   "editor.table.columns": "Table columns",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "Eliminar columna",
   "editor.table.deleteRow": "Eliminar fila",
   "editor.table.deleteTable": "Eliminar tabla",
+  "editor.table.mergeFragment": "Combinar con la tabla de arriba",
   "editor.table.adjustTable": "Ajustar tabla",
   "editor.table.resizeTableTo": "Cambiar tabla a {columns} columnas x {rows} filas",
   "editor.table.columns": "Columnas de la tabla",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "Supprimer la colonne",
   "editor.table.deleteRow": "Supprimer la ligne",
   "editor.table.deleteTable": "Supprimer le tableau",
+  "editor.table.mergeFragment": "Fusionner avec le tableau ci-dessus",
   "editor.table.adjustTable": "Ajuster le tableau",
   "editor.table.resizeTableTo": "Redimensionner le tableau en {columns} colonnes x {rows} lignes",
   "editor.table.columns": "Colonnes du tableau",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "Elimina colonna",
   "editor.table.deleteRow": "Elimina riga",
   "editor.table.deleteTable": "Elimina tabella",
+  "editor.table.mergeFragment": "Unisci alla tabella sopra",
   "editor.table.adjustTable": "Regola tabella",
   "editor.table.resizeTableTo": "Ridimensiona tabella a {columns} colonne x {rows} righe",
   "editor.table.columns": "Colonne tabella",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -439,6 +439,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "列を削除",
   "editor.table.deleteRow": "行を削除",
   "editor.table.deleteTable": "表を削除",
+  "editor.table.mergeFragment": "上の表に結合",
   "editor.table.adjustTable": "表を調整",
   "editor.table.resizeTableTo": "{columns} 列 x {rows} 行に変更",
   "editor.table.columns": "表の列数",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "열 삭제",
   "editor.table.deleteRow": "행 삭제",
   "editor.table.deleteTable": "표 삭제",
+  "editor.table.mergeFragment": "위 표에 병합",
   "editor.table.adjustTable": "표 조정",
   "editor.table.resizeTableTo": "표를 {columns}열 x {rows}행으로 변경",
   "editor.table.columns": "표 열 수",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "Excluir coluna",
   "editor.table.deleteRow": "Excluir linha",
   "editor.table.deleteTable": "Excluir tabela",
+  "editor.table.mergeFragment": "Mesclar com a tabela acima",
   "editor.table.adjustTable": "Ajustar tabela",
   "editor.table.resizeTableTo": "Redimensionar tabela para {columns} colunas x {rows} linhas",
   "editor.table.columns": "Colunas da tabela",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -431,6 +431,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "Удалить столбец",
   "editor.table.deleteRow": "Удалить строку",
   "editor.table.deleteTable": "Удалить таблицу",
+  "editor.table.mergeFragment": "Объединить с таблицей выше",
   "editor.table.adjustTable": "Настроить таблицу",
   "editor.table.resizeTableTo": "Изменить таблицу до {columns} столбцов x {rows} строк",
   "editor.table.columns": "Столбцы таблицы",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -738,6 +738,7 @@ export type I18nKey =
   | "editor.table.deleteColumn"
   | "editor.table.deleteRow"
   | "editor.table.deleteTable"
+  | "editor.table.mergeFragment"
   | "editor.table.adjustTable"
   | "editor.table.resizeTableTo"
   | "editor.table.columns"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -727,6 +727,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "删除列",
   "editor.table.deleteRow": "删除行",
   "editor.table.deleteTable": "删除表格",
+  "editor.table.mergeFragment": "合并到上方表格",
   "editor.table.adjustTable": "调整表格",
   "editor.table.resizeTableTo": "调整为 {columns} 列 x {rows} 行",
   "editor.table.columns": "表格列数",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -439,6 +439,7 @@ const messages: LocaleMessages = {
   "editor.table.deleteColumn": "刪除欄",
   "editor.table.deleteRow": "刪除列",
   "editor.table.deleteTable": "刪除表格",
+  "editor.table.mergeFragment": "合併到上方表格",
   "editor.table.adjustTable": "調整表格",
   "editor.table.resizeTableTo": "調整為 {columns} 欄 x {rows} 列",
   "editor.table.columns": "表格欄數",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@markra/ai':
         specifier: workspace:*
         version: link:../ai
+      '@markra/markdown':
+        specifier: workspace:*
+        version: link:../markdown
       '@markra/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary
- detect compatible GFM table-row fragments immediately following a table
- keep the editor quiet at rest, then reveal a compact left-gutter merge action when the fragment is hovered or the action is focused
- use a simple upward-to-line icon and a hover/focus tooltip without a duplicate native title
- merge compatible rows in one undoable transaction while hiding the action for incompatible or read-only content

## Why
A blank line inside a Markdown table splits the trailing rows into a separate block. Preview mode has no editable object for that separator, so repairing it currently requires switching to Source mode. The action stays out of the reading flow until it is relevant.

## Validation
- `pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx -t "table fragment"` passed (6 tests)
- `pnpm --filter @markra/editor exec vitest run --environment jsdom --globals src/table-fragment-merge.test.ts` passed (4 tests)
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- browser QA passed for the quiet default state, focus disclosure and tooltip, keyboard merge, and single-step undo

## Risk
- recognition is intentionally limited to outer-pipe GFM row fragments with the same effective column count
- complete second tables, incompatible rows, ordinary prose, and read-only editors remain unchanged
- merging is always an explicit user action and remains undoable

## Related Issues
Closes #509