### PR TITLE
chore: ignore local superpowers artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 
 .cargo-target/
 apps/desktop/src-tauri/gen/schemas/windows-schema.json
+.superpowers


### PR DESCRIPTION
## Summary
- ignore local `.superpowers` workflow and brainstorming artifacts
- keep generated local files out of repository status and accidental commits

## Validation
- `git diff --check origin/main...HEAD` passed
- `git check-ignore -v .superpowers` resolves to the new `.gitignore` entry
- Not run: tests, because this is an ignore-only configuration change

## Risk
- no runtime or product behavior changes