### PR TITLE
fix(editor): center table controls and use Lucide icons

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -5475,14 +5475,22 @@ describe("MarkdownPaper editing", () => {
     expect(cellCountInFirstRow()).toBe(2);
     expect(rowCount()).toBe(2);
 
-    fireEvent.mouseDown(screen.getByRole("button", { name: "Add column to the right" }));
+    const addColumnButton = screen.getByRole("button", { name: "Add column to the right" });
+    const addRowButton = screen.getByRole("button", { name: "Add row below" });
+
+    expect(addColumnButton.querySelector("svg.markra-lucide-icon.markra-table-control-icon")).toBeInTheDocument();
+    expect(addColumnButton).not.toHaveTextContent("+");
+    expect(addRowButton.querySelector("svg.markra-lucide-icon.markra-table-control-icon")).toBeInTheDocument();
+    expect(addRowButton).not.toHaveTextContent("+");
+
+    fireEvent.mouseDown(addColumnButton);
 
     await waitFor(() => expect(cellCountInFirstRow()).toBe(3));
     expect(container.querySelector(".ProseMirror .selectedCell")).not.toBeInTheDocument();
     typeText(view, "New column");
     await waitFor(() => expect(firstRowCells()).toEqual(["Field", "Value", "New column"]));
 
-    fireEvent.mouseDown(screen.getByRole("button", { name: "Add row below" }));
+    fireEvent.mouseDown(addRowButton);
 
     await waitFor(() => expect(rowCount()).toBe(3));
     expect(container.querySelector(".ProseMirror .selectedCell")).not.toBeInTheDocument();
@@ -5501,14 +5509,18 @@ describe("MarkdownPaper editing", () => {
     fireEvent.mouseMove(screen.getByRole("cell", { name: "5" }));
 
     expect(screen.queryByRole("button", { name: "Delete column" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Delete row" })).toBeInTheDocument();
+    const firstDeleteRowButton = screen.getByRole("button", { name: "Delete row" });
+    expect(firstDeleteRowButton.querySelector("svg.markra-lucide-icon.markra-table-control-icon")).toBeInTheDocument();
+    expect(firstDeleteRowButton).not.toHaveTextContent("-");
 
     fireEvent.mouseMove(screen.getByRole("columnheader", { name: "B" }));
 
-    expect(screen.getByRole("button", { name: "Delete column" })).toBeInTheDocument();
+    const deleteColumnButton = screen.getByRole("button", { name: "Delete column" });
+    expect(deleteColumnButton.querySelector("svg.markra-lucide-icon.markra-table-control-icon")).toBeInTheDocument();
+    expect(deleteColumnButton).not.toHaveTextContent("-");
     expect(screen.queryByRole("button", { name: "Delete row" })).not.toBeInTheDocument();
 
-    fireEvent.mouseDown(screen.getByRole("button", { name: "Delete column" }));
+    fireEvent.mouseDown(deleteColumnButton);
 
     await waitFor(() =>
       expect(tableRows()).toEqual([
@@ -5522,9 +5534,11 @@ describe("MarkdownPaper editing", () => {
     fireEvent.mouseMove(screen.getByRole("cell", { name: "4" }));
 
     expect(screen.queryByRole("button", { name: "Delete column" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Delete row" })).toBeInTheDocument();
+    const deleteRowButton = screen.getByRole("button", { name: "Delete row" });
+    expect(deleteRowButton.querySelector("svg.markra-lucide-icon.markra-table-control-icon")).toBeInTheDocument();
+    expect(deleteRowButton).not.toHaveTextContent("-");
 
-    fireEvent.mouseDown(screen.getByRole("button", { name: "Delete row" }));
+    fireEvent.mouseDown(deleteRowButton);
 
     await waitFor(() =>
       expect(tableRows()).toEqual([
@@ -5538,10 +5552,12 @@ describe("MarkdownPaper editing", () => {
   it("deletes a whole table from the visual controls", async () => {
     const initialTable = ["| Field | Value |", "| --- | --- |", "| Name | Markra |"].join("\n");
     const { container, editor, view } = await renderEditor(initialTable);
+    const deleteTableButton = screen.getByRole("button", { name: "Delete table" });
 
     expect(container.querySelector(".ProseMirror table")).toBeInTheDocument();
+    expect(deleteTableButton.querySelector("svg.markra-lucide-icon.markra-table-control-icon")).toBeInTheDocument();
 
-    fireEvent.mouseDown(screen.getByRole("button", { name: "Delete table" }));
+    fireEvent.mouseDown(deleteTableButton);
 
     await waitFor(() => expect(container.querySelector(".ProseMirror table")).not.toBeInTheDocument());
     typeText(view, "After table");

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1988,6 +1988,9 @@
   }
 
   .markdown-paper .markra-table-controls-wrapper {
+    /* Center add controls against the table viewport, excluding the asymmetric control gutters. */
+    --markra-table-control-inline-center-offset: -1.125rem;
+    --markra-table-control-block-center-offset: -0.25rem;
     @apply relative overflow-visible pt-7 pr-9 pb-9;
   }
 
@@ -2029,6 +2032,8 @@
 
   .markdown-paper[data-editor-theme="github"] .markra-table-controls-wrapper,
   .markdown-paper[data-editor-theme="github-dark"] .markra-table-controls-wrapper {
+    --markra-table-control-inline-center-offset: 0rem;
+    --markra-table-control-block-center-offset: 0rem;
     padding: 0;
   }
 
@@ -2399,10 +2404,6 @@
     color: oklch(57.7% 0.245 27.325);
   }
 
-  .markdown-paper .markra-table-delete-table-icon {
-    @apply size-3.5;
-  }
-
   .markdown-paper .markra-table-align-icon {
     @apply flex w-3.5 flex-col gap-0.75;
   }
@@ -2436,11 +2437,21 @@
   }
 
   .markdown-paper .markra-table-add-column {
-    @apply right-1.5 top-1/2 -translate-y-1/2;
+    @apply right-1.5 -translate-y-1/2;
+    top: calc(50% + var(--markra-table-control-block-center-offset));
   }
 
   .markdown-paper .markra-table-add-row {
-    @apply bottom-1.5 left-1/2 -translate-x-1/2;
+    @apply bottom-1.5 -translate-x-1/2;
+    left: calc(50% + var(--markra-table-control-inline-center-offset));
+  }
+
+  .markdown-paper .markra-lucide-icon {
+    pointer-events: none;
+  }
+
+  .markdown-paper .markra-table-control-icon {
+    @apply size-3.5 shrink-0;
   }
 
   .markdown-paper a {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -25,6 +25,7 @@
     "cspell-trie-lib": "10.0.1",
     "katex": "0.16.45",
     "lowlight": "3.3.0",
+    "lucide": "1.14.0",
     "mermaid": "11.15.0",
     "prosemirror-tables": "1.8.5",
     "remark-frontmatter": "5.0.0",

--- a/packages/editor/src/table-controls.ts
+++ b/packages/editor/src/table-controls.ts
@@ -2,7 +2,8 @@ import { $prose } from "@milkdown/kit/utils";
 import type { Node as ProseNode } from "@milkdown/kit/prose/model";
 import { Plugin, TextSelection, type Transaction } from "@milkdown/kit/prose/state";
 import type { EditorView, ViewMutationRecord } from "@milkdown/kit/prose/view";
-import { popoverPosition } from "@markra/shared";
+import { createLucideIcon, popoverPosition } from "@markra/shared";
+import { Minus, Plus, Trash2 } from "lucide";
 import { addColumnAfter, addRowAfter, deleteColumn, deleteRow, TableMap } from "prosemirror-tables";
 
 type TableControlLabels = {
@@ -124,13 +125,11 @@ function createTableControlButton(
   ownerDocument: Document,
   className: string,
   label: string,
-  text: string,
   onMouseDown: (event: MouseEvent) => unknown
 ) {
   const button = ownerDocument.createElement("button");
   button.type = "button";
   button.className = `markra-table-control ${className}`;
-  button.textContent = text;
   button.title = label;
   button.ariaLabel = label;
   button.contentEditable = "false";
@@ -187,26 +186,6 @@ function createTableWidthIcon(ownerDocument: Document) {
     part.className = className;
     if (className === "markra-table-width-letter") part.textContent = "A";
     icon.append(part);
-  }
-
-  return icon;
-}
-
-function createDeleteTableIcon(ownerDocument: Document) {
-  const icon = ownerDocument.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("class", "markra-table-delete-table-icon");
-  icon.setAttribute("aria-hidden", "true");
-  icon.setAttribute("viewBox", "0 0 24 24");
-  icon.setAttribute("fill", "none");
-  icon.setAttribute("stroke", "currentColor");
-  icon.setAttribute("stroke-width", "2");
-  icon.setAttribute("stroke-linecap", "round");
-  icon.setAttribute("stroke-linejoin", "round");
-
-  for (const pathData of ["M3 6h18", "M8 6V4h8v2", "M19 6l-1 14H6L5 6", "M10 11v6", "M14 11v6"]) {
-    const path = ownerDocument.createElementNS("http://www.w3.org/2000/svg", "path");
-    path.setAttribute("d", pathData);
-    icon.append(path);
   }
 
   return icon;
@@ -272,7 +251,6 @@ class MarkraTableNodeView {
       view.dom.ownerDocument,
       "markra-table-size-button",
       labels.adjustTable,
-      "",
       this.handleSizeButtonMouseDown
     );
     this.sizeButton.ariaExpanded = "false";
@@ -287,7 +265,6 @@ class MarkraTableNodeView {
         view.dom.ownerDocument,
         `markra-table-align-button markra-table-align-${alignment}`,
         label,
-        "",
         this.handleAlignMouseDown
       );
       button.dataset.alignment = alignment;
@@ -298,7 +275,6 @@ class MarkraTableNodeView {
       view.dom.ownerDocument,
       "markra-table-width-button",
       labels.autoWidth,
-      "",
       this.handleWidthModeMouseDown
     );
     this.widthModeButton.addEventListener("keydown", this.handleWidthModeKeyDown);
@@ -307,38 +283,37 @@ class MarkraTableNodeView {
       view.dom.ownerDocument,
       "markra-table-add-column",
       labels.addColumnRight,
-      "+",
       this.handleAddColumnMouseDown
     );
+    this.addColumnButton.append(createLucideIcon(view.dom.ownerDocument, Plus, "markra-table-control-icon"));
     this.addRowButton = createTableControlButton(
       view.dom.ownerDocument,
       "markra-table-add-row",
       labels.addRowBelow,
-      "+",
       this.handleAddRowMouseDown
     );
+    this.addRowButton.append(createLucideIcon(view.dom.ownerDocument, Plus, "markra-table-control-icon"));
     this.deleteColumnButton = createTableControlButton(
       view.dom.ownerDocument,
       "markra-table-delete-control markra-table-delete-column",
       labels.deleteColumn,
-      "-",
       this.handleDeleteColumnMouseDown
     );
+    this.deleteColumnButton.append(createLucideIcon(view.dom.ownerDocument, Minus, "markra-table-control-icon"));
     this.deleteRowButton = createTableControlButton(
       view.dom.ownerDocument,
       "markra-table-delete-control markra-table-delete-row",
       labels.deleteRow,
-      "-",
       this.handleDeleteRowMouseDown
     );
+    this.deleteRowButton.append(createLucideIcon(view.dom.ownerDocument, Minus, "markra-table-control-icon"));
     this.deleteTableButton = createTableControlButton(
       view.dom.ownerDocument,
       "markra-table-delete-table",
       labels.deleteTable,
-      "",
       this.handleDeleteTableMouseDown
     );
-    this.deleteTableButton.append(createDeleteTableIcon(view.dom.ownerDocument));
+    this.deleteTableButton.append(createLucideIcon(view.dom.ownerDocument, Trash2, "markra-table-control-icon"));
 
     this.dom.className = "tableWrapper markra-table-controls-wrapper";
     this.tableScroll.className = "markra-table-scroll";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,9 @@
     "test": "vitest run --environment jsdom --globals",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
+  "dependencies": {
+    "lucide": "1.14.0"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "6.9.1",
     "@types/node": "24.10.0",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./debug.ts";
 export * from "./diagnostics.ts";
 export * from "./i18n/index.ts";
 export * from "./keyboard-shortcuts.ts";
+export * from "./lucide.ts";
 export * from "./markdown-callout.ts";
 export * from "./markdown-image-drag.ts";
 export * from "./number.ts";

--- a/packages/shared/src/lucide.ts
+++ b/packages/shared/src/lucide.ts
@@ -1,0 +1,14 @@
+import { createElement as createLucideElement } from "lucide";
+
+type LucideIconNode = Parameters<typeof createLucideElement>[0];
+
+export function createLucideIcon(ownerDocument: Document, iconNode: LucideIconNode, className: string) {
+  const icon = createLucideElement(iconNode, {
+    "aria-hidden": "true",
+    class: `markra-lucide-icon ${className}`,
+    focusable: "false"
+  });
+
+  // Lucide creates the SVG in the global document; preserve the caller's document for embedded surfaces.
+  return icon.ownerDocument === ownerDocument ? icon : ownerDocument.importNode(icon, true);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       lowlight:
         specifier: 3.3.0
         version: 3.3.0
+      lucide:
+        specifier: 1.14.0
+        version: 1.14.0
       mermaid:
         specifier: 11.15.0
         version: 11.15.0
@@ -486,6 +489,10 @@ importers:
         version: 24.10.0
 
   packages/shared:
+    dependencies:
+      lucide:
+        specifier: 1.14.0
+        version: 1.14.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 6.9.1
@@ -2542,6 +2549,9 @@ packages:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lucide@1.14.0:
+    resolution: {integrity: sha512-IoRC3lHwemJWvsXKcHK90hkgY4h1HGztBL63w2XwFtIu8gFDPp4/kiuqVtlN3vaM9bxsLQ4ZUBJfGsbKFaB2IA==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -5857,6 +5867,8 @@ snapshots:
   lucide-react@1.14.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  lucide@1.14.0: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary
- center the add-row and add-column controls against the visible table viewport
- replace character and hand-built table action icons with Lucide icons
- expose a reusable createLucideIcon helper from @markra/shared and remove obsolete icon code
- cover add, delete-row, delete-column, and delete-table icons with regression tests

## Validation
- pnpm --filter @markra/shared build
- pnpm --filter @markra/shared test (47 tests passed)
- pnpm --filter @markra/editor build
- pnpm --filter @markra/app exec vitest run src/components/MarkdownPaper.test.tsx (502 tests passed)
- pnpm --filter @markra/app exec vitest run src/styles.test.ts (43 tests passed)
- pnpm --filter @markra/desktop build (production build and 15 vendor chunk imports passed)

## Risk
- Low; changes are limited to table control rendering, positioning, shared icon creation, and focused tests.