### PR TITLE
fix(app): stabilize titlebar popovers across platforms

### DIFF
--- a/packages/app/src/App.document-history.test.tsx
+++ b/packages/app/src/App.document-history.test.tsx
@@ -7,6 +7,7 @@ import {
   mockedConsumeWelcomeDocumentState,
   mockedListNativeMarkdownFileHistory,
   mockedReadNativeMarkdownFileHistory,
+  mockedResolveDesktopPlatform,
   mockedSaveNativeMarkdownFile,
   renderApp
 } from "./test/app-harness";
@@ -124,6 +125,53 @@ describe("Markra document history restore", () => {
     debugSpy.mockRestore();
   });
 
+  it("closes history before opening another titlebar menu", async () => {
+    mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
+    mockOpenMarkdownFile({
+      content: "# Current\n\nSynthetic body.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    expect(await screen.findByText("Current")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show history" }));
+    expect(await screen.findByRole("region", { name: "History versions" })).toBeInTheDocument();
+
+    const viewModeButton = screen.getByRole("button", { name: "View mode: Daily" });
+    fireEvent.pointerDown(viewModeButton);
+    fireEvent.click(viewModeButton);
+
+    expect(screen.queryByRole("region", { name: "History versions" })).not.toBeInTheDocument();
+    expect(screen.getByRole("menu", { name: "View mode" })).toBeInTheDocument();
+  });
+
+  it("positions history below the self-drawn Windows titlebar", async () => {
+    mockedResolveDesktopPlatform.mockReturnValue("windows");
+    mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
+    mockOpenMarkdownFile({
+      content: "# Current\n\nSynthetic body.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    renderApp();
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: "o" });
+    expect(await screen.findByText("Current")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show history" }));
+
+    expect(await screen.findByRole("region", { name: "History versions" })).toHaveStyle({
+      top: "88px"
+    });
+  });
+
   it("writes restored history contents into the active visual editor", async () => {
     mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
     mockOpenMarkdownFile({
@@ -221,6 +269,7 @@ describe("Markra document history restore", () => {
     fireEvent.click(historyButton);
     expect(await screen.findByRole("region", { name: "History versions" })).toBeInTheDocument();
 
+    fireEvent.pointerDown(historyButton);
     fireEvent.click(historyButton);
     expect(screen.queryByRole("region", { name: "History versions" })).not.toBeInTheDocument();
   });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4301,6 +4301,7 @@ function WorkspaceApp() {
             onClose={() => setDocumentHistoryOpen(false)}
             onRestore={handleDocumentHistoryRestore}
             refreshKey={documentHistoryRefreshKey}
+            windowsSelfDrawnChrome={windowsSelfDrawnChromeEnabled}
           />
         ) : null}
 

--- a/packages/app/src/components/DocumentHistoryDialog.test.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.test.tsx
@@ -87,10 +87,53 @@ describe("DocumentHistoryDialog", () => {
       />
     );
 
-    expect(await screen.findByRole("region", { name: "History versions" })).toHaveClass(
+    const panel = await screen.findByRole("region", { name: "History versions" });
+
+    expect(panel).toHaveClass(
       "animate-[markra-history-panel-in_140ms_cubic-bezier(0.2,0,0,1)_both]",
       "motion-reduce:animate-none"
     );
+    expect(panel).toHaveStyle({ top: "48px" });
+  });
+
+  it("dismisses on an outside pointer press without dismissing interactions inside the panel", async () => {
+    const onClose = vi.fn();
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    render(
+      <DocumentHistoryDialog
+        documentPath="/mock-files/guide.md"
+        language="en"
+        onClose={onClose}
+        onRestore={() => {}}
+      />
+    );
+
+    const panel = await screen.findByRole("region", { name: "History versions" });
+
+    fireEvent.pointerDown(panel);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("sits below both rows of the self-drawn Windows titlebar", async () => {
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    render(
+      <DocumentHistoryDialog
+        documentPath="/mock-files/guide.md"
+        language="en"
+        onClose={() => {}}
+        onRestore={() => {}}
+        windowsSelfDrawnChrome
+      />
+    );
+
+    expect(await screen.findByRole("region", { name: "History versions" })).toHaveStyle({
+      top: "88px"
+    });
   });
 
   it("restores the selected version after StrictMode remount checks", async () => {

--- a/packages/app/src/components/DocumentHistoryDialog.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.tsx
@@ -14,7 +14,11 @@ export type DocumentHistoryDialogProps = {
   onClose: () => unknown;
   onRestore: (contents: string, historyId: string) => unknown;
   refreshKey?: number;
+  windowsSelfDrawnChrome?: boolean;
 };
+
+const documentHistoryPanelGapPx = 8;
+const titlebarRowHeightPx = 40;
 
 function formatHistoryDate(language: AppLanguage, timestamp: number) {
   return new Intl.DateTimeFormat(language, {
@@ -34,7 +38,8 @@ export function DocumentHistoryDialog({
   language = "en",
   onClose,
   onRestore,
-  refreshKey = 0
+  refreshKey = 0,
+  windowsSelfDrawnChrome = false
 }: DocumentHistoryDialogProps) {
   const label = (key: string) => t(language, key);
   const [entries, setEntries] = useState<NativeMarkdownFileHistoryEntry[]>([]);
@@ -43,8 +48,10 @@ export function DocumentHistoryDialog({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [restorePendingId, setRestorePendingId] = useState<string | null>(null);
   const [restoreError, setRestoreError] = useState(false);
+  const panelRef = useRef<HTMLElement | null>(null);
   const loadedDocumentPathRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
+  const panelTopPx = titlebarRowHeightPx * (windowsSelfDrawnChrome ? 2 : 1) + documentHistoryPanelGapPx;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -55,15 +62,26 @@ export function DocumentHistoryDialog({
   }, []);
 
   useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || panelRef.current?.contains(target)) return;
+
+      // The trigger owns the toggle; dismissing on pointerdown would let its following click reopen the panel.
+      if (target instanceof Element && target.closest("[data-document-history-trigger]")) return;
+
+      onClose();
+    };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
 
       onClose();
     };
 
+    window.addEventListener("pointerdown", handlePointerDown);
     window.addEventListener("keydown", handleKeyDown);
 
     return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [onClose]);
@@ -172,8 +190,13 @@ export function DocumentHistoryDialog({
   return (
     <section
       aria-label={label("app.documentHistory")}
-      className="fixed right-3 top-12 z-40 grid w-[min(22rem,calc(100vw-1rem))] max-h-[min(420px,calc(100vh-56px))] animate-[markra-history-panel-in_140ms_cubic-bezier(0.2,0,0,1)_both] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-xl motion-reduce:animate-none"
+      className="fixed right-3 z-40 grid w-[min(22rem,calc(100vw-1rem))] animate-[markra-history-panel-in_140ms_cubic-bezier(0.2,0,0,1)_both] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-xl motion-reduce:animate-none"
+      ref={panelRef}
       role="region"
+      style={{
+        maxHeight: `min(420px, calc(100vh - ${panelTopPx + documentHistoryPanelGapPx}px))`,
+        top: panelTopPx
+      }}
     >
       <div className="flex items-center justify-between gap-3 border-b border-(--border-default) px-3 py-2">
         <h4 className="m-0 truncate text-[12px] leading-5 font-bold text-(--text-heading)">

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -54,9 +54,10 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector("[data-titlebar-action='open']")).not.toBeInTheDocument();
     expect(within(container.querySelector(".document-actions") as HTMLElement).queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
     expect(titlebar).toHaveClass("grid-cols-[164px_minmax(0,1fr)_164px]");
-    expect(titlebar).toHaveClass("h-10");
+    expect(titlebar).toHaveClass("h-10", "z-30");
     expect(container.querySelector(".windows-titlebar-corner-mask")).not.toBeInTheDocument();
     expect(container.querySelector(".document-actions")).toHaveClass("h-10");
+    expect(container.querySelector(".document-actions")).toHaveClass("opacity-40");
     expect(container.querySelector("[data-titlebar-action='aiAgent']")).toHaveClass("transition-transform");
   });
 
@@ -988,6 +989,7 @@ describe("NativeTitleBar", () => {
     const menu = screen.getByRole("menu", { name: "View mode" });
 
     expect(menu).toBeInTheDocument();
+    expect(menu.closest(".native-titlebar")).toHaveClass("z-30");
     expect(menu.closest(".native-titlebar.overflow-hidden")).toBeNull();
   });
 

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -520,6 +520,7 @@ export function NativeTitleBar({
       return (
         <IconButton
           className={mergeClassNames("disabled:opacity-35", sortable.actionClassName)}
+          data-document-history-trigger="true"
           disabled={historyDisabled || !onShowDocumentHistory}
           label={label("app.showDocumentHistory")}
           onClick={(event) => {
@@ -585,7 +586,7 @@ export function NativeTitleBar({
     </div>
   );
 
-  const documentActionsClassName = `document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-10 group-hover/titlebar:opacity-100 focus-within:opacity-100 motion-reduce:transition-none ${
+  const documentActionsClassName = `document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 group-hover/titlebar:opacity-100 focus-within:opacity-100 motion-reduce:transition-none ${
     aiAgentResizing
       ? "transition-none"
       : "transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]"
@@ -706,7 +707,7 @@ export function NativeTitleBar({
 
   return (
     <header
-      className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-8 grid h-10 grid-cols-[164px_minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
+      className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-30 grid h-10 grid-cols-[164px_minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
       style={titlebarGridStyle}
       aria-label={label("app.windowDragRegion")}
       data-tauri-drag-region={nativeWindowChrome && !titleContent ? true : undefined}

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -415,7 +415,7 @@ export function WindowsNativeTitleBar({
         {renderWindowsAppChrome()}
         {renderWindowsTitlebarCornerMask()}
         <header
-          className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-10 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
+          className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-30 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
           style={windowsTitlebarStyle}
           aria-label={label("app.windowDragRegion")}
           onMouseDownCapture={handleWindowsTitlebarMouseDownCapture}
@@ -454,7 +454,7 @@ export function WindowsNativeTitleBar({
       {renderWindowsAppChrome()}
       {renderWindowsTitlebarCornerMask()}
       <header
-        className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-10 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
+        className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-30 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
         style={windowsTitlebarStyle}
         aria-label={label("app.windowDragRegion")}
         data-tauri-drag-region={nativeWindowChrome ? true : undefined}


### PR DESCRIPTION
## Summary
- dismiss the history panel on outside pointer presses while preserving its trigger toggle
- position history below single-row and Windows double-row titlebars
- raise titlebar popovers above editor split resize borders
- align inactive titlebar action opacity across platforms

## Why
- the history panel stayed open and could cover other titlebar popovers
- its fixed 48px top offset overlapped the Windows action row
- popovers could not escape the titlebar stacking context below editor resize handles
- Linux titlebar actions faded to 10% opacity while Windows used 40%

## Validation
- `pnpm test` passed: 2,392 tests
- `pnpm build` passed for all workspace projects, including desktop vendor chunk verification

## Risk
- Manual visual QA on Debian 13 MiniOS and Windows WebView was not available locally; the platform branches and interaction sequence are covered by component and app integration tests.