### PR TITLE
fix(app): repair titlebar and AI panel layering

### DIFF
--- a/packages/app/src/App.ai.test.tsx
+++ b/packages/app/src/App.ai.test.tsx
@@ -102,6 +102,8 @@ describe("Markra AI workspace", () => {
     expect(screen.getByRole("button", { name: "Toggle Markra AI" })).toHaveAttribute("aria-pressed", "true");
     const agentPanel = await screen.findByRole("complementary", { name: "Markra AI" });
     expect(agentPanel).toBeInTheDocument();
+    expect(container.querySelector(".native-titlebar")).toHaveClass("z-8");
+    expect(agentPanel.closest(".ai-agent-panel-slot")).toHaveClass("z-20");
     expect(within(agentPanel).getAllByText("OpenAI · GPT-5.5")[0]).toBeInTheDocument();
     expect(within(agentPanel).getByRole("combobox", { name: "AI model" })).toHaveTextContent("OpenAI · GPT-5.5");
     expect(within(agentPanel).getByRole("button", { name: "Attach images" })).toBeEnabled();

--- a/packages/app/src/App.document-history.test.tsx
+++ b/packages/app/src/App.document-history.test.tsx
@@ -172,6 +172,32 @@ describe("Markra document history restore", () => {
     });
   });
 
+  it("keeps history to the left of the open AI panel", async () => {
+    mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
+    mockOpenMarkdownFile({
+      content: "# Current\n\nSynthetic body.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    expect(await screen.findByText("Current")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Markra AI" }));
+    expect(await screen.findByRole("complementary", { name: "Markra AI" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show history" }));
+
+    expect(await screen.findByRole("region", { name: "History versions" })).toHaveStyle({
+      maxWidth: "22rem",
+      right: "396px",
+      width: "calc(100vw - 400px)"
+    });
+  });
+
   it("writes restored history contents into the active visual editor", async () => {
     mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
     mockOpenMarkdownFile({

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4301,6 +4301,7 @@ function WorkspaceApp() {
             onClose={() => setDocumentHistoryOpen(false)}
             onRestore={handleDocumentHistoryRestore}
             refreshKey={documentHistoryRefreshKey}
+            rightInsetPx={visibleAiAgentOpen ? aiAgentPanelWidth : 0}
             windowsSelfDrawnChrome={windowsSelfDrawnChromeEnabled}
           />
         ) : null}

--- a/packages/app/src/components/DocumentHistoryDialog.test.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.test.tsx
@@ -136,6 +136,51 @@ describe("DocumentHistoryDialog", () => {
     });
   });
 
+  it("stays inside the editor area when a right-side panel is open", async () => {
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    render(
+      <DocumentHistoryDialog
+        documentPath="/mock-files/guide.md"
+        language="en"
+        onClose={() => {}}
+        onRestore={() => {}}
+        rightInsetPx={384}
+      />
+    );
+
+    expect(await screen.findByRole("region", { name: "History versions" })).toHaveStyle({
+      maxWidth: "22rem",
+      right: "396px",
+      width: "calc(100vw - 400px)"
+    });
+  });
+
+  it("stays visible when the window is too narrow to fully avoid the right-side panel", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 360 });
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([]);
+
+    try {
+      render(
+        <DocumentHistoryDialog
+          documentPath="/mock-files/guide.md"
+          language="en"
+          onClose={() => {}}
+          onRestore={() => {}}
+          rightInsetPx={320}
+        />
+      );
+
+      expect(await screen.findByRole("region", { name: "History versions" })).toHaveStyle({
+        right: "164px",
+        width: "calc(100vw - 168px)"
+      });
+    } finally {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
+    }
+  });
+
   it("restores the selected version after StrictMode remount checks", async () => {
     const onRestore = vi.fn();
     mockedListNativeMarkdownFileHistory.mockResolvedValue([

--- a/packages/app/src/components/DocumentHistoryDialog.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.tsx
@@ -14,10 +14,14 @@ export type DocumentHistoryDialogProps = {
   onClose: () => unknown;
   onRestore: (contents: string, historyId: string) => unknown;
   refreshKey?: number;
+  rightInsetPx?: number;
   windowsSelfDrawnChrome?: boolean;
 };
 
+const documentHistoryPanelHorizontalGapPx = 12;
 const documentHistoryPanelGapPx = 8;
+const documentHistoryPanelMinimumWidthPx = 192;
+const documentHistoryPanelViewportMarginPx = 4;
 const titlebarRowHeightPx = 40;
 
 function formatHistoryDate(language: AppLanguage, timestamp: number) {
@@ -39,6 +43,7 @@ export function DocumentHistoryDialog({
   onClose,
   onRestore,
   refreshKey = 0,
+  rightInsetPx = 0,
   windowsSelfDrawnChrome = false
 }: DocumentHistoryDialogProps) {
   const label = (key: string) => t(language, key);
@@ -51,7 +56,17 @@ export function DocumentHistoryDialog({
   const panelRef = useRef<HTMLElement | null>(null);
   const loadedDocumentPathRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
+  const normalizedRightInsetPx = Math.max(0, rightInsetPx);
   const panelTopPx = titlebarRowHeightPx * (windowsSelfDrawnChrome ? 2 : 1) + documentHistoryPanelGapPx;
+  const viewportWidthPx = typeof window === "undefined" ? Number.POSITIVE_INFINITY : window.innerWidth;
+  const requestedPanelRightPx = normalizedRightInsetPx + documentHistoryPanelHorizontalGapPx;
+  // Preserve a usable panel on narrow windows even when fully avoiding the AI sidebar is impossible.
+  const maximumPanelRightPx = Math.max(
+    documentHistoryPanelHorizontalGapPx,
+    viewportWidthPx - documentHistoryPanelMinimumWidthPx - documentHistoryPanelViewportMarginPx
+  );
+  const panelRightPx = Math.min(requestedPanelRightPx, maximumPanelRightPx);
+  const panelWidthInsetPx = panelRightPx + documentHistoryPanelViewportMarginPx;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -190,12 +205,15 @@ export function DocumentHistoryDialog({
   return (
     <section
       aria-label={label("app.documentHistory")}
-      className="fixed right-3 z-40 grid w-[min(22rem,calc(100vw-1rem))] animate-[markra-history-panel-in_140ms_cubic-bezier(0.2,0,0,1)_both] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-xl motion-reduce:animate-none"
+      className="fixed z-40 grid animate-[markra-history-panel-in_140ms_cubic-bezier(0.2,0,0,1)_both] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-xl motion-reduce:animate-none"
       ref={panelRef}
       role="region"
       style={{
         maxHeight: `min(420px, calc(100vh - ${panelTopPx + documentHistoryPanelGapPx}px))`,
-        top: panelTopPx
+        maxWidth: "22rem",
+        right: panelRightPx,
+        top: panelTopPx,
+        width: `calc(100vw - ${panelWidthInsetPx}px)`
       }}
     >
       <div className="flex items-center justify-between gap-3 border-b border-(--border-default) px-3 py-2">

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -54,7 +54,7 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector("[data-titlebar-action='open']")).not.toBeInTheDocument();
     expect(within(container.querySelector(".document-actions") as HTMLElement).queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
     expect(titlebar).toHaveClass("grid-cols-[164px_minmax(0,1fr)_164px]");
-    expect(titlebar).toHaveClass("h-10", "z-30");
+    expect(titlebar).toHaveClass("h-10", "z-8");
     expect(container.querySelector(".windows-titlebar-corner-mask")).not.toBeInTheDocument();
     expect(container.querySelector(".document-actions")).toHaveClass("h-10");
     expect(container.querySelector(".document-actions")).toHaveClass("opacity-40");
@@ -943,10 +943,15 @@ describe("NativeTitleBar", () => {
     const viewModeButton = screen.getByRole("button", { name: "View mode: Focus" });
 
     expect(viewModeButton).toContainElement(container.querySelector(".lucide-focus"));
+    expect(container.querySelector(".native-titlebar")).toHaveClass("z-8");
 
     fireEvent.click(viewModeButton);
 
-    expect(screen.getByRole("menu", { name: "View mode" })).toBeInTheDocument();
+    const menu = screen.getByRole("menu", { name: "View mode" });
+
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveClass("fixed", "z-40");
+    expect(menu.closest(".native-titlebar")).toBeNull();
     expect(screen.getByRole("menuitemradio", { name: "Focus" })).toHaveAttribute("aria-checked", "true");
 
     fireEvent.click(screen.getByRole("menuitemradio", { name: "Immersive" }));
@@ -957,7 +962,7 @@ describe("NativeTitleBar", () => {
 
   it("keeps the Windows workspace view mode menu outside clipped titlebar overflow", () => {
     const selectViewMode = vi.fn();
-    render(
+    const { container } = render(
       <NativeTitleBar
         aiAgentOpen={false}
         dirty={false}
@@ -984,12 +989,15 @@ describe("NativeTitleBar", () => {
       />
     );
 
+    expect(container.querySelector(".native-titlebar")).toHaveClass("z-10");
+
     fireEvent.click(screen.getByRole("button", { name: "View mode: Focus" }));
 
     const menu = screen.getByRole("menu", { name: "View mode" });
 
     expect(menu).toBeInTheDocument();
-    expect(menu.closest(".native-titlebar")).toHaveClass("z-30");
+    expect(menu).toHaveClass("fixed", "z-40");
+    expect(menu.closest(".native-titlebar")).toBeNull();
     expect(menu.closest(".native-titlebar.overflow-hidden")).toBeNull();
   });
 
@@ -1420,7 +1428,7 @@ describe("NativeTitleBar", () => {
     const titlebar = container.querySelector(".native-titlebar");
 
     expect(screen.getAllByLabelText("Window drag region")).toHaveLength(2);
-    expect(titlebar).toHaveClass("fixed", "inset-x-0", "grid");
+    expect(titlebar).toHaveClass("fixed", "inset-x-0", "grid", "z-10");
     expect(titlebar).not.toHaveClass("right-3.5", "w-auto");
     expect(titlebar).not.toHaveClass("grid-cols-[240px_minmax(0,1fr)_240px]");
     expect(container.querySelector(".mac-window-controls")).not.toBeInTheDocument();

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -24,6 +25,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode
 } from "react";
+import { createPortal } from "react-dom";
 import {
   closestCenter,
   DndContext,
@@ -44,6 +46,7 @@ import {
   type TitlebarActionPreference
 } from "../lib/settings/app-settings";
 import { viewModeOptions, type ViewMode } from "../lib/view-mode";
+import { anchoredPopoverStyle } from "../lib/anchored-popover";
 import type { NativeMenuHandlers } from "../lib/tauri/menu";
 import { resolveDesktopPlatform, type DesktopPlatform } from "../lib/platform";
 import { t, type AppLanguage } from "@markra/shared";
@@ -161,10 +164,12 @@ export function NativeTitleBar({
 }: NativeTitleBarProps) {
   const openMenuRef = useRef<HTMLDivElement | null>(null);
   const viewModeMenuRef = useRef<HTMLDivElement | null>(null);
+  const viewModeMenuSurfaceRef = useRef<HTMLDivElement | null>(null);
   const draggingActionIdRef = useRef<TitlebarActionId | null>(null);
   const suppressActionClickIdsRef = useRef(new Set<TitlebarActionId>());
   const [openMenuVisible, setOpenMenuVisible] = useState(false);
   const [viewModeMenuVisible, setViewModeMenuVisible] = useState(false);
+  const [viewModeMenuStyle, setViewModeMenuStyle] = useState<CSSProperties | null>(null);
   const label = (key: Parameters<typeof t>[1]) => t(language, key);
   const themeActionLabel = theme === "dark" ? label("app.switchToLightTheme") : label("app.switchToDarkTheme");
   const editorViewMode = splitMode ? "split" : sourceMode ? "source" : "visual";
@@ -185,6 +190,19 @@ export function NativeTitleBar({
       distance: titlebarActionDragThresholdPx
     }
   }));
+  const positionViewModeMenu = (anchor: Element) => {
+    setViewModeMenuStyle(
+      anchoredPopoverStyle(anchor, viewModeMenuSurfaceRef.current, {
+        align: "end",
+        fallbackSize: {
+          height: viewModeOptions.length * 32 + 8,
+          width: 176
+        },
+        gap: 6,
+        placement: "bottom"
+      })
+    );
+  };
 
   useEffect(() => {
     if (!openMarkdownButtonVisible) setOpenMenuVisible(false);
@@ -200,7 +218,13 @@ export function NativeTitleBar({
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node;
       if (openMenuVisible && !openMenuRef.current?.contains(target)) setOpenMenuVisible(false);
-      if (viewModeMenuVisible && !viewModeMenuRef.current?.contains(target)) setViewModeMenuVisible(false);
+      if (
+        viewModeMenuVisible &&
+        !viewModeMenuRef.current?.contains(target) &&
+        !viewModeMenuSurfaceRef.current?.contains(target)
+      ) {
+        setViewModeMenuVisible(false);
+      }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -208,15 +232,30 @@ export function NativeTitleBar({
         setViewModeMenuVisible(false);
       }
     };
+    const handleLayoutChange = () => {
+      const trigger = viewModeMenuRef.current?.querySelector("button");
+      if (viewModeMenuVisible && trigger) positionViewModeMenu(trigger);
+    };
 
     window.addEventListener("pointerdown", handlePointerDown);
     window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", handleLayoutChange);
+    window.addEventListener("scroll", handleLayoutChange, true);
 
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", handleLayoutChange);
+      window.removeEventListener("scroll", handleLayoutChange, true);
     };
   }, [openMenuVisible, viewModeMenuVisible]);
+
+  useLayoutEffect(() => {
+    if (!viewModeMenuVisible) return;
+
+    const trigger = viewModeMenuRef.current?.querySelector("button");
+    if (trigger) positionViewModeMenu(trigger);
+  }, [viewModeMenuVisible]);
 
   const runOpenAction = (action: () => unknown) => {
     setOpenMenuVisible(false);
@@ -430,7 +469,13 @@ export function NativeTitleBar({
                 }
 
                 setOpenMenuVisible(false);
-                setViewModeMenuVisible((current) => !current);
+                if (viewModeMenuVisible) {
+                  setViewModeMenuVisible(false);
+                  return;
+                }
+
+                positionViewModeMenu(event.currentTarget);
+                setViewModeMenuVisible(true);
               });
             }}
             {...sortable.actionAttributes}
@@ -438,33 +483,39 @@ export function NativeTitleBar({
           >
             <Focus aria-hidden="true" size={15} />
           </IconButton>
-          {onSelectViewMode && viewModeMenuVisible ? (
-            <PopoverSurface
-              className="absolute top-[calc(100%+6px)] right-0 z-40 w-44 overflow-hidden rounded-lg p-1"
-              open
-              role="menu"
-              aria-label={label("settings.editor.viewMode")}
-            >
-              {viewModeOptions.map((mode) => {
-                const selected = mode === viewMode;
-                const optionLabel = label(`settings.editor.viewMode.${mode}` as Parameters<typeof t>[1]);
+          {onSelectViewMode && viewModeMenuVisible && viewModeMenuStyle && typeof document !== "undefined"
+            ? createPortal(
+                // Escape the titlebar stacking context without lifting its full-width surface above the AI panel.
+                <PopoverSurface
+                  ref={viewModeMenuSurfaceRef}
+                  className="fixed z-40 w-44 overflow-hidden rounded-lg p-1"
+                  style={viewModeMenuStyle}
+                  open
+                  role="menu"
+                  aria-label={label("settings.editor.viewMode")}
+                >
+                  {viewModeOptions.map((mode) => {
+                    const selected = mode === viewMode;
+                    const optionLabel = label(`settings.editor.viewMode.${mode}` as Parameters<typeof t>[1]);
 
-                return (
-                  <button
-                    key={mode}
-                    className="flex h-8 w-full cursor-pointer items-center justify-between gap-3 rounded-md border-0 bg-transparent px-2.5 text-left text-[12px] leading-5 font-[560] text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-checked:text-(--text-heading)"
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={selected}
-                    onClick={() => runViewModeAction(mode)}
-                  >
-                    <span className="truncate">{optionLabel}</span>
-                    {selected ? <Check aria-hidden="true" className="shrink-0 text-(--accent)" size={14} /> : null}
-                  </button>
-                );
-              })}
-            </PopoverSurface>
-          ) : null}
+                    return (
+                      <button
+                        key={mode}
+                        className="flex h-8 w-full cursor-pointer items-center justify-between gap-3 rounded-md border-0 bg-transparent px-2.5 text-left text-[12px] leading-5 font-[560] text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none aria-checked:text-(--text-heading)"
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={selected}
+                        onClick={() => runViewModeAction(mode)}
+                      >
+                        <span className="truncate">{optionLabel}</span>
+                        {selected ? <Check aria-hidden="true" className="shrink-0 text-(--accent)" size={14} /> : null}
+                      </button>
+                    );
+                  })}
+                </PopoverSurface>,
+                document.body
+              )
+            : null}
         </div>
       );
     }
@@ -707,7 +758,7 @@ export function NativeTitleBar({
 
   return (
     <header
-      className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-30 grid h-10 grid-cols-[164px_minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
+      className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-8 grid h-10 grid-cols-[164px_minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
       style={titlebarGridStyle}
       aria-label={label("app.windowDragRegion")}
       data-tauri-drag-region={nativeWindowChrome && !titleContent ? true : undefined}

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -415,7 +415,7 @@ export function WindowsNativeTitleBar({
         {renderWindowsAppChrome()}
         {renderWindowsTitlebarCornerMask()}
         <header
-          className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-30 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
+          className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-10 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
           style={windowsTitlebarStyle}
           aria-label={label("app.windowDragRegion")}
           onMouseDownCapture={handleWindowsTitlebarMouseDownCapture}
@@ -454,7 +454,7 @@ export function WindowsNativeTitleBar({
       {renderWindowsAppChrome()}
       {renderWindowsTitlebarCornerMask()}
       <header
-        className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-30 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
+        className={`native-titlebar group/titlebar fixed inset-x-0 ${windowsTitlebarTopClassName} z-10 grid h-10 select-none items-center ${windowsTitlebarSurfaceClassName} ${windowsTitlebarEdgeClassName} ${windowsTitlebarPositionTransitionClassName} [-webkit-user-select:none]`}
         style={windowsTitlebarStyle}
         aria-label={label("app.windowDragRegion")}
         data-tauri-drag-region={nativeWindowChrome ? true : undefined}


### PR DESCRIPTION
## Summary
- restore the native titlebar base stacking level so it no longer covers the AI panel header
- render the view-mode menu through a portal so it stays above preview dividers without elevating the full titlebar
- position document history to the left of the AI panel when space permits, with a usable narrow-window fallback
- add focused titlebar, AI panel, and document-history regression coverage

## Why
The titlebar elevation introduced by #538 fixed mode-menu layering, but the full-width titlebar surface then covered the top of the AI panel. Document history also remained aligned to the viewport edge, causing it to overlap the open AI panel and become visually detached from its trigger.

## Validation
- `pnpm --filter @markra/app test` passed: 122 files, 1,824 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm build` passed, including desktop vendor chunk verification
- `git diff --check` passed

## Risk
- Not manually replayed on physical Windows or Debian-based MiniOS; platform-specific stacking and placement are covered by component and integration tests.