### PR TITLE
fix(app): stabilize quick open keyboard navigation

### DIFF
--- a/packages/app/src/components/QuickOpenPanel.test.tsx
+++ b/packages/app/src/components/QuickOpenPanel.test.tsx
@@ -15,6 +15,16 @@ const files = [
   }
 ] satisfies NativeMarkdownFolderFile[];
 
+const manyFiles = Array.from({ length: 12 }, (_, index) => {
+  const sequence = String(index + 1).padStart(2, "0");
+
+  return {
+    name: `note-${sequence}.md`,
+    path: `/mock-vault/note-${sequence}.md`,
+    relativePath: `note-${sequence}.md`
+  };
+}) satisfies NativeMarkdownFolderFile[];
+
 describe("QuickOpenPanel", () => {
   it("opens the keyboard-selected file", () => {
     const openFile = vi.fn();
@@ -36,5 +46,74 @@ describe("QuickOpenPanel", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(openFile).toHaveBeenCalledWith(files[1], { toSide: false });
+  });
+
+  it("scrolls the keyboard-selected file into view", () => {
+    render(
+      <QuickOpenPanel
+        files={files}
+        language="en"
+        onClose={() => {}}
+        onOpenFile={() => {}}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Quick open" });
+    const input = within(dialog).getByRole("searchbox", { name: "Quick open" });
+    const options = within(dialog).getAllByRole("option");
+    const scrollIntoView = vi.fn();
+    options[1].scrollIntoView = scrollIntoView;
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("keeps keyboard selection when scrolling emits mouse movement under a stationary pointer", () => {
+    const openFile = vi.fn();
+
+    render(
+      <QuickOpenPanel
+        files={manyFiles}
+        language="en"
+        onClose={() => {}}
+        onOpenFile={openFile}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Quick open" });
+    const input = within(dialog).getByRole("searchbox", { name: "Quick open" });
+    const options = within(dialog).getAllByRole("option");
+
+    for (let index = 1; index < manyFiles.length; index += 1) {
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+    }
+    fireEvent.mouseMove(options[manyFiles.length - 3]);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(openFile).toHaveBeenCalledWith(manyFiles.at(-1), { toSide: false });
+  });
+
+  it("opens a clicked result independently from keyboard selection", () => {
+    const openFile = vi.fn();
+
+    render(
+      <QuickOpenPanel
+        files={files}
+        language="en"
+        onClose={() => {}}
+        onOpenFile={openFile}
+      />
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Quick open" });
+    const input = within(dialog).getByRole("searchbox", { name: "Quick open" });
+    const options = within(dialog).getAllByRole("option");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.mouseMove(options[0]);
+    fireEvent.click(within(options[0]).getAllByRole("button")[0]);
+
+    expect(openFile).toHaveBeenCalledWith(files[0], { toSide: false });
   });
 });

--- a/packages/app/src/components/QuickOpenPanel.tsx
+++ b/packages/app/src/components/QuickOpenPanel.tsx
@@ -59,6 +59,7 @@ export function QuickOpenPanel({
   const quickOpenLabel = (key: I18nKey, values: Record<string, string>) =>
     formatQuickOpenMessage(label(key), values);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const selectedResultRef = useRef<HTMLDivElement | null>(null);
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const results = useMemo(
@@ -82,6 +83,10 @@ export function QuickOpenPanel({
   useEffect(() => {
     setSelectedIndex((current) => Math.min(current, Math.max(0, results.length - 1)));
   }, [results.length]);
+
+  useEffect(() => {
+    selectedResultRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [selectedIndex]);
 
   const openResult = (result: QuickOpenResult | undefined, toSide: boolean) => {
     if (!result) return;
@@ -165,6 +170,7 @@ export function QuickOpenPanel({
               const selected = index === selectedIndex;
 
               return (
+                // Keep pointer hover visual-only because WebKit may emit movement events while scrolling.
                 <div
                   className={`group grid min-h-11 w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-sm px-1.5 py-1.5 transition-colors duration-150 ${
                     selected ? "bg-(--bg-active)" : "hover:bg-(--bg-hover)"
@@ -173,8 +179,8 @@ export function QuickOpenPanel({
                   aria-label={quickOpenLabel("app.quickOpen.openFile", { path: result.file.relativePath })}
                   aria-selected={selected}
                   key={result.file.path}
+                  ref={selected ? selectedResultRef : undefined}
                   role="option"
-                  onMouseEnter={() => setSelectedIndex(index)}
                 >
                   <FileText aria-hidden="true" className="text-(--text-secondary)" size={15} />
                   <button


### PR DESCRIPTION
## Summary
- keep the keyboard-selected quick open result visible with nearest scrolling
- keep pointer hover visual-only so WebKit scroll events cannot overwrite keyboard selection
- cover long-list scrolling and pointer click behavior with regression tests

## Validation
- `pnpm --dir packages/app test` — 122 test files and 1830 tests passed
- `pnpm --dir packages/app build` — passed
- `git diff --check` — passed

## Risk
- Pointer hover no longer changes the keyboard-selected result; clicking a hovered result still opens it.
- Packaged Tauri WebView QA was not run locally.

## Related Issues
Fixes #541