### PR TITLE
fix(editor): stabilize visual markdown escaping

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -7329,6 +7329,30 @@ describe("MarkdownPaper editing", () => {
     expect(markdown).toBe(expected);
   });
 
+  it("preserves markdown punctuation inside typed live inline code", async () => {
+    const onMarkdownChange = vi.fn();
+    const { container, view } = await renderEditor("", { onMarkdownChange });
+
+    typeText(view, "`[mock]` tail");
+
+    expectLiveMark(container, "inlineCode", "[mock]");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe("`[mock]` tail");
+  });
+
+  it("serializes html-looking text typed in the visual editor as literal text", async () => {
+    const onMarkdownChange = vi.fn();
+    const { view } = await renderEditor("", { onMarkdownChange });
+
+    typeText(view, "mock<sup>2</sup> tail");
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).toBe(String.raw`mock\<sup>2\</sup> tail`);
+  });
+
   it.each(["*", "_", "~", "`", "="])("serializes a typed %s delimiter without escaping it", async (delimiter) => {
     const onMarkdownChange = vi.fn();
     const { view } = await renderEditor("", { onMarkdownChange });
@@ -10756,6 +10780,26 @@ describe("MarkdownPaper editing", () => {
     expect(container.querySelectorAll(".ProseMirror .markra-live-link-source.markra-md-delimiter")).toHaveLength(2);
     expect(container.querySelector(".ProseMirror")?.textContent).toBe("[Markra](https://example.com)");
     await settleMarkdownListener();
+  });
+
+  it("treats escaped link-looking text typed in the visual editor as literal text", async () => {
+    const source = String.raw`[mock\]](docs/mock-target)`;
+    const onMarkdownChange = vi.fn();
+    const rendered = await renderEditor("", { onMarkdownChange });
+
+    typeText(rendered.view, source);
+    expect(rendered.container.querySelector(".markra-live-link-source-label")).not.toBeInTheDocument();
+    expect(rendered.container.querySelector(".ProseMirror a[href]")).not.toBeInTheDocument();
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenCalled());
+
+    const markdown = String(onMarkdownChange.mock.calls.at(-1)?.[0] ?? "").trimEnd();
+    expect(markdown).not.toBe(source);
+    expect(markdown).toBe(String.raw`[mock\\]]\(docs/mock-target)`);
+    rendered.unmount();
+
+    const reloaded = await renderEditor(markdown);
+    expect(reloaded.view.state.doc.textContent).toBe(source);
+    expect(reloaded.container.querySelector(".ProseMirror a[href]")).not.toBeInTheDocument();
   });
 
   it("turns pasted standalone URLs into finalized links", async () => {

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -56,7 +56,7 @@ import {
   getActiveSpellcheckMatch,
   normalizeMarkdownShortcuts,
   replaceSpellcheckMatch,
-  restoreEscapedLiveMarkdownSource,
+  restoreEscapedMarkdownSource,
   serializeLinkImageLiveMarkdown,
   updateSpellcheckOptions,
   type MarkdownShortcutMap,
@@ -480,10 +480,11 @@ function MilkdownEditorSurface({
               deferredMarkdownChange.schedule(() => {
                 try {
                   onMarkdownChangeRef.current(
-                    restoreEscapedLiveMarkdownSource(
+                    restoreEscapedMarkdownSource(
                       serializeLinkImageLiveMarkdown(markdownDocument, serializeMarkdown, link, image),
                       markdownState,
-                      liveMarkdownSpecs
+                      liveMarkdownSpecs,
+                      serializeMarkdown
                     )
                   );
                 } catch {

--- a/packages/app/src/hooks/useEditorController.ts
+++ b/packages/app/src/hooks/useEditorController.ts
@@ -16,7 +16,7 @@ import {
   markraLiveMarkdownSpecs,
   scrollAiEditorPreviewIntoView,
   scrollSearchMatchIntoView,
-  restoreEscapedLiveMarkdownSource,
+  restoreEscapedMarkdownSource,
   serializeLinkImageLiveMarkdown,
   setLiveMarkdownSourceContext,
   showAiEditorPreview,
@@ -109,10 +109,11 @@ function serializeCurrentEditorMarkdown(
   image: NodeType,
   liveMarkdownSpecs: ReturnType<typeof markraLiveMarkdownSpecs>
 ) {
-  return restoreEscapedLiveMarkdownSource(
+  return restoreEscapedMarkdownSource(
     serializeLinkImageLiveMarkdown(view.state.doc, serializeMarkdown, link, image),
     view.state,
-    liveMarkdownSpecs
+    liveMarkdownSpecs,
+    serializeMarkdown
   );
 }
 

--- a/packages/editor/src/input-rules.ts
+++ b/packages/editor/src/input-rules.ts
@@ -862,6 +862,7 @@ export function finalizeActiveLiveMarkdown(view: EditorView, specs: LiveMarkdown
 
 const hasRestorableLiveMarkdownDelimiterPattern = /\\[*_~`=]/u;
 const escapedIntrawordUnderscorePattern = /(?<=[\p{L}\p{N}])\\_(?=[\p{L}\p{N}])/gu;
+const escapedLabelLiteralPattern = /\[((?:\\.|[^\]\\\n])+)\]\(([^)\n]+)\)/g;
 const restorableLiveMarkdownDelimiterCharacters = new Set(["*", "_", "~", "`", "="]);
 const singleRestorableLiveMarkdownDelimiters = new Set(["*", "_", "~", "`", "="]);
 
@@ -869,6 +870,13 @@ type SerializedMarkdownOperation = {
   candidates: string[];
   from: number;
   replacement: string;
+  to: number;
+};
+
+type MarkdownSerializer = (doc: ProseNode) => string;
+
+type MarkdownTextRange = {
+  from: number;
   to: number;
 };
 
@@ -934,21 +942,72 @@ function singleDelimiterOperation(
 }
 
 function liveMarkdownOperation(
+  state: EditorState,
   node: ProseNode,
   blockStart: number,
-  range: LiveMarkdownRange
+  range: LiveMarkdownRange,
+  serializeMarkdown: MarkdownSerializer
 ): SerializedMarkdownOperation {
   const source = node.textContent.slice(range.from, range.to);
+  const serializedSource = serializedPlainText(source, state, serializeMarkdown);
 
   return {
-    candidates: serializedLiveMarkdownCandidates(source, range.marker),
+    candidates: [...new Set([
+      ...serializedLiveMarkdownCandidates(source, range.marker),
+      ...(serializedSource ? [serializedSource] : [])
+    ])],
     from: blockStart + range.from,
     replacement: source,
     to: blockStart + range.to
   };
 }
 
-function serializedMarkdownOperations(state: EditorState, specs: LiveMarkdownSpec[]) {
+function serializedPlainText(source: string, state: EditorState, serializeMarkdown: MarkdownSerializer) {
+  const paragraph = state.schema.nodes.paragraph;
+  if (!paragraph || source.length === 0) return "";
+
+  // Reuse the configured serializer so source restoration follows its exact escaping rules.
+  const text = state.schema.text(source);
+  const document = state.schema.topNodeType.create(null, paragraph.create(null, text));
+  return serializeMarkdown(document).trimEnd();
+}
+
+function escapedLabelLiteralRanges(text: string) {
+  escapedLabelLiteralPattern.lastIndex = 0;
+
+  return Array.from(text.matchAll(escapedLabelLiteralPattern))
+    .filter((match) => match[1]?.includes("\\"))
+    .map((match): MarkdownTextRange => ({
+      from: match.index,
+      to: match.index + match[0].length
+    }));
+}
+
+function escapedLabelLiteralOperation(
+  state: EditorState,
+  node: ProseNode,
+  blockStart: number,
+  range: MarkdownTextRange,
+  serializeMarkdown: MarkdownSerializer
+): SerializedMarkdownOperation | null {
+  const source = node.textContent.slice(range.from, range.to);
+  const serializedSource = serializedPlainText(source, state, serializeMarkdown);
+  if (!serializedSource.startsWith("\\[")) return null;
+
+  // Avoid `\[` here because Markra reserves it as a math delimiter; `\(` still keeps this text from becoming a link.
+  return {
+    candidates: [serializedSource],
+    from: blockStart + range.from,
+    replacement: serializedSource.slice(1),
+    to: blockStart + range.to
+  };
+}
+
+function serializedMarkdownOperations(
+  state: EditorState,
+  specs: LiveMarkdownSpec[],
+  serializeMarkdown: MarkdownSerializer
+) {
   const pluginState = liveMarkdownKey.getState(state) as LiveMarkdownPluginState | undefined;
   const suppressedLiteralRanges = pluginState?.suppressedLiteralRanges ?? [];
   const operations: SerializedMarkdownOperation[] = [];
@@ -965,12 +1024,29 @@ function serializedMarkdownOperations(state: EditorState, specs: LiveMarkdownSpe
     const singleOperation = singleDelimiterOperation(node, blockStart, specs);
     if (singleOperation) operations.push(singleOperation);
 
-    for (const range of getLiveMarkdownRangesInTextblock(node, specs)) {
+    const liveRanges = getLiveMarkdownRangesInTextblock(node, specs);
+    for (const range of liveRanges) {
       const from = blockStart + range.from;
       const to = blockStart + range.to;
       if (isSuppressedLiteralRange(suppressedLiteralRanges, from, to, range.marker)) continue;
 
-      operations.push(liveMarkdownOperation(node, blockStart, range));
+      operations.push(liveMarkdownOperation(state, node, blockStart, range, serializeMarkdown));
+    }
+
+    const inlineCodeMarkTypes = getMarkTypesForKind(specs, "inlineCode");
+    for (const range of escapedLabelLiteralRanges(node.textContent)) {
+      if (!textRangeAvoidsMarks(node, range.from, range.to, inlineCodeMarkTypes)) continue;
+      if (
+        liveRanges.some(
+          (liveRange) =>
+            liveRange.kinds.includes("inlineCode") && range.from < liveRange.to && range.to > liveRange.from
+        )
+      ) {
+        continue;
+      }
+
+      const operation = escapedLabelLiteralOperation(state, node, blockStart, range, serializeMarkdown);
+      if (operation) operations.push(operation);
     }
   });
 
@@ -1064,10 +1140,15 @@ function restoreIntrawordEscapedUnderscores(markdown: string) {
   return markdown.replace(escapedIntrawordUnderscorePattern, "_");
 }
 
-export function restoreEscapedLiveMarkdownSource(markdown: string, state: EditorState, specs: LiveMarkdownSpec[]) {
-  if (!hasRestorableLiveMarkdownDelimiterPattern.test(markdown)) return markdown;
+export function restoreEscapedMarkdownSource(
+  markdown: string,
+  state: EditorState,
+  specs: LiveMarkdownSpec[],
+  serializeMarkdown: MarkdownSerializer
+) {
+  if (!hasRestorableLiveMarkdownDelimiterPattern.test(markdown) && !markdown.includes("\\[")) return markdown;
 
-  const operations = serializedMarkdownOperations(state, specs);
+  const operations = serializedMarkdownOperations(state, specs, serializeMarkdown);
   const { protectedMarkdown, protectedSegments } = protectMarkdownCode(markdown);
   let restored = "";
   let markdownCursor = 0;


### PR DESCRIPTION
## Summary
- preserve live inline code Markdown when its content starts with punctuation that the configured serializer escapes
- keep HTML-looking and backslash-escaped link-looking text typed in the visual editor literal
- avoid emitting a leading `\[` for escaped link-looking literals because Markra reserves it as a math delimiter

## Why
Issue #542 exposed multiple cases where visual input intent and serialized Markdown diverged. Simple live Markdown should retain its source, while source-level HTML and backslash-escaped link syntax typed in the visual editor should remain literal text across save and reload.

## Validation
- `pnpm test` passed: 2,409 tests
- `pnpm build` passed
- desktop vendor chunk verification imported all 15 vendor chunks successfully
- focused visual editor regressions passed for inline code punctuation, HTML-looking literals, escaped link-looking literals, and ordinary live links

## Risk
- source restoration now asks the configured serializer for its exact escaping output before replacing live Markdown candidates
- escaped link-looking literal handling is excluded from inline code and fenced code ranges
- raw HTML parsing/rendering from source mode remains separate and is tracked by #543

## Related Issues
- Closes #542
- Follow-up: #543
