### PR TITLE
fix(editor): render paired inline HTML tags

### DIFF
--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -10159,6 +10159,52 @@ describe("MarkdownPaper editing", () => {
     expect(serializeMarkdown(view.state.doc)).toContain('<img src="https://example.test/badges/version.svg" />');
   });
 
+  it("renders balanced inline HTML without swallowing nested Markdown", async () => {
+    const source = "Power<sup>**2**</sup> tail";
+    const { container, editor, view } = await renderEditor(source);
+
+    const renderedSup = container.querySelector<HTMLElement>(".ProseMirror sup.markra-inline-html");
+    const renderedStrong = container.querySelector<HTMLElement>(".ProseMirror strong");
+    const boundaries = container.querySelectorAll<HTMLElement>(".ProseMirror .markra-inline-html-boundary");
+
+    expect(renderedSup).toBeInTheDocument();
+    expect(renderedSup).toHaveTextContent("2");
+    expect(renderedStrong).toHaveTextContent("2");
+    expect(boundaries).toHaveLength(2);
+    expect(Array.from(boundaries).every((boundary) => boundary.style.display === "none")).toBe(true);
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    const parseMarkdown = editor.action((ctx) => ctx.get(parserCtx));
+    const serialized = serializeMarkdown(view.state.doc);
+    const reloaded = parseMarkdown(serialized);
+    const reloadedHtmlValues: string[] = [];
+
+    reloaded.descendants((node) => {
+      if (node.type.name === "html" && typeof node.attrs.value === "string") {
+        reloadedHtmlValues.push(node.attrs.value);
+      }
+    });
+
+    expect(serialized).toBe(`${source}\n`);
+    expect(reloadedHtmlValues).toEqual(["<sup>", "</sup>"]);
+  });
+
+  it("sanitizes attributes on paired inline HTML without changing its source", async () => {
+    const source = '<a href="javascript:alert(1)" onclick="alert(2)" data-example="safe">Synthetic link</a>';
+    const { container, editor, view } = await renderEditor(source);
+
+    const renderedLink = container.querySelector<HTMLAnchorElement>(".ProseMirror a.markra-inline-html");
+
+    expect(renderedLink).toBeInTheDocument();
+    expect(renderedLink).not.toHaveAttribute("href");
+    expect(renderedLink).not.toHaveAttribute("onclick");
+    expect(renderedLink).toHaveAttribute("data-example", "safe");
+    expect(renderedLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+  });
+
   it("keeps GitHub README HTML badge rows together", async () => {
     const source = [
       '<p align="center">',

--- a/packages/app/src/components/MarkdownPaper.test.tsx
+++ b/packages/app/src/components/MarkdownPaper.test.tsx
@@ -10189,6 +10189,25 @@ describe("MarkdownPaper editing", () => {
     expect(reloadedHtmlValues).toEqual(["<sup>", "</sup>"]);
   });
 
+  it("preserves soft line breaks before paired inline HTML", async () => {
+    const source = [
+      "Mock<sub>2</sub> line",
+      "<sup>**2**</sup>",
+      "<mark>Highlighted</mark>",
+      "<kbd>Ctrl</kbd>"
+    ].join("\n");
+    const onMarkdownChange = vi.fn();
+    const { editor, view } = await renderEditor(source, { onMarkdownChange });
+    const serializeMarkdown = editor.action((ctx) => ctx.get(serializerCtx));
+
+    expect(serializeMarkdown(view.state.doc)).toBe(`${source}\n`);
+
+    view.dispatch(view.state.tr.setSelection(TextSelection.atEnd(view.state.doc)));
+    typeText(view, "!");
+
+    await waitFor(() => expect(onMarkdownChange).toHaveBeenLastCalledWith(`${source}!\n`));
+  });
+
   it("sanitizes attributes on paired inline HTML without changing its source", async () => {
     const source = '<a href="javascript:alert(1)" onclick="alert(2)" data-example="safe">Synthetic link</a>';
     const { container, editor, view } = await renderEditor(source);

--- a/packages/app/src/components/MarkdownPaperSurface.tsx
+++ b/packages/app/src/components/MarkdownPaperSurface.tsx
@@ -76,6 +76,7 @@ import {
   markraCommonmark,
   markraExternalLinkClickPlugin,
   markraGfm,
+  readInlineHtmlMarkdownText,
   markraTextSelectionObserverPlugin,
   serializeMarkdownClipboardText
 } from "./markdown-paper-plugins";
@@ -443,10 +444,25 @@ function MilkdownEditorSurface({
         .config((ctx) => {
           ctx.set(rootCtx, root);
           ctx.set(defaultValueCtx, initialContentRef.current);
-          ctx.update(remarkStringifyOptionsCtx, (options) => ({
-            ...options,
-            bullet: "-" as const
-          }));
+          ctx.update(remarkStringifyOptionsCtx, (options) => {
+            const textHandler = options.handlers?.text;
+            if (!textHandler) {
+              return {
+                ...options,
+                bullet: "-" as const
+              };
+            }
+
+            return {
+              ...options,
+              bullet: "-" as const,
+              handlers: {
+                ...options.handlers,
+                text: (node, parent, state, info) =>
+                  readInlineHtmlMarkdownText(node) ?? textHandler(node, parent, state, info)
+              }
+            };
+          });
           ctx.update(editorViewOptionsCtx, (options) => ({
             ...options,
             attributes: {

--- a/packages/app/src/components/markdown-paper-plugins.ts
+++ b/packages/app/src/components/markdown-paper-plugins.ts
@@ -3,6 +3,7 @@ import {
   emphasisSchema,
   hardbreakAttr,
   hardbreakSchema,
+  htmlSchema,
   hrSchema,
   imageSchema,
   inlineNodesCursorPlugin,
@@ -156,6 +157,45 @@ const markraHardbreakSchema = hardbreakSchema.extendSchema((previous) => (ctx) =
     }
   };
 });
+
+const inlineHtmlTextDataKey = "markraInlineHtml";
+
+function isInlineHtmlSource(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !/[\r\n]/u.test(value);
+}
+
+const markraHtmlSchema = htmlSchema.extendSchema((previous) => (ctx) => {
+  const baseSchema = previous(ctx);
+
+  return {
+    ...baseSchema,
+    toMarkdown: {
+      ...baseSchema.toMarkdown,
+      runner: (state, node) => {
+        const source = node.attrs.value;
+        if (!isInlineHtmlSource(source)) {
+          baseSchema.toMarkdown.runner(state, node);
+          return;
+        }
+
+        // mdast-util-to-markdown replaces a soft break before an `html` node with a space.
+        // A marked text node keeps the source token raw without triggering that normalization.
+        state.addNode("text", undefined, source, {
+          data: {
+            [inlineHtmlTextDataKey]: true
+          }
+        });
+      }
+    }
+  };
+});
+
+export function readInlineHtmlMarkdownText(node: { data?: unknown; value?: unknown }) {
+  const data = node.data;
+  if (!data || typeof data !== "object" || !(inlineHtmlTextDataKey in data)) return null;
+
+  return typeof node.value === "string" ? node.value : null;
+}
 
 function lineNumber(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -387,6 +427,7 @@ export const markraCommonmark = [
   markraStrongSchema,
   markraBlockImageSchema,
   markraHardbreakSchema,
+  markraHtmlSchema,
   markraCommonmarkInputRules,
   commonmarkCommands,
   commonmarkKeymap,

--- a/packages/editor/src/inline-html.test.ts
+++ b/packages/editor/src/inline-html.test.ts
@@ -1,0 +1,43 @@
+import { pairInlineHtmlBoundaries, type InlineHtmlBoundaryNode } from "./inline-html";
+
+function boundaries(sources: string[]) {
+  let position = 1;
+
+  return sources.map((source) => {
+    const boundary = {
+      from: position,
+      source,
+      to: position + 1
+    } satisfies InlineHtmlBoundaryNode;
+    position += 2;
+    return boundary;
+  });
+}
+
+describe("inline HTML pairing", () => {
+  it("pairs nested inline tags while preserving opening source", () => {
+    const ranges = pairInlineHtmlBoundaries(boundaries([
+      '<span title="a > b">',
+      "<sup>",
+      "</sup>",
+      "</span>"
+    ]));
+
+    expect(ranges).toMatchObject([
+      { openSource: "<sup>", tagName: "sup" },
+      { openSource: '<span title="a > b">', tagName: "span" }
+    ]);
+  });
+
+  it("leaves mismatched inline HTML boundaries unpaired", () => {
+    const ranges = pairInlineHtmlBoundaries(boundaries(["<sup>", "<em>", "</sup>", "</em>"]));
+
+    expect(ranges).toEqual([]);
+  });
+
+  it("ignores void tags inside a balanced inline pair", () => {
+    const ranges = pairInlineHtmlBoundaries(boundaries(["<span>", "<br>", "</span>"]));
+
+    expect(ranges).toMatchObject([{ tagName: "span" }]);
+  });
+});

--- a/packages/editor/src/inline-html.ts
+++ b/packages/editor/src/inline-html.ts
@@ -1,0 +1,139 @@
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+
+type HtmlBoundary = {
+  kind: "close" | "open" | "void";
+  tagName: string;
+};
+
+export type InlineHtmlBoundaryNode = {
+  from: number;
+  source: string;
+  to: number;
+};
+
+export type InlineHtmlRange = {
+  closeFrom: number;
+  closeTo: number;
+  from: number;
+  openFrom: number;
+  openSource: string;
+  openTo: number;
+  tagName: string;
+  to: number;
+};
+
+const pairedInlineHtmlTags = new Set([
+  "a",
+  "abbr",
+  "b",
+  "code",
+  "del",
+  "em",
+  "i",
+  "kbd",
+  "mark",
+  "s",
+  "small",
+  "span",
+  "strong",
+  "sub",
+  "sup",
+  "u"
+]);
+
+const voidHtmlTags = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr"
+]);
+
+function htmlBoundaryFromSource(source: string): HtmlBoundary | null {
+  const trimmed = source.trim();
+  const match = /^<\s*(\/?)\s*([A-Za-z][\w:.-]*)(?=[\s/>])[^<]*>$/u.exec(trimmed);
+  const tagName = match?.[2]?.toLowerCase();
+  if (!tagName) return null;
+
+  if (match?.[1] === "/") {
+    return { kind: "close", tagName };
+  }
+
+  if (/\/\s*>$/u.test(trimmed) || voidHtmlTags.has(tagName)) {
+    return { kind: "void", tagName };
+  }
+
+  return { kind: "open", tagName };
+}
+
+export function pairInlineHtmlBoundaries(boundaries: InlineHtmlBoundaryNode[]) {
+  const ranges: InlineHtmlRange[] = [];
+  const stack: Array<InlineHtmlBoundaryNode & { tagName: string }> = [];
+
+  boundaries.forEach((boundaryNode) => {
+    const boundary = htmlBoundaryFromSource(boundaryNode.source);
+    if (!boundary || boundary.kind === "void") return;
+
+    if (boundary.kind === "open") {
+      stack.push({ ...boundaryNode, tagName: boundary.tagName });
+      return;
+    }
+
+    const opening = stack.at(-1);
+    if (!opening || opening.tagName !== boundary.tagName) {
+      // A mismatched pair must not hide or restyle neighboring source nodes as if the HTML were valid.
+      stack.length = 0;
+      return;
+    }
+
+    stack.pop();
+    if (!pairedInlineHtmlTags.has(opening.tagName)) return;
+
+    ranges.push({
+      closeFrom: boundaryNode.from,
+      closeTo: boundaryNode.to,
+      from: opening.to,
+      openFrom: opening.from,
+      openSource: opening.source,
+      openTo: opening.to,
+      tagName: opening.tagName,
+      to: boundaryNode.from
+    });
+  });
+
+  return ranges;
+}
+
+export function findInlineHtmlRanges(doc: ProseNode) {
+  const ranges: InlineHtmlRange[] = [];
+
+  doc.descendants((node, position) => {
+    if (!node.isTextblock) return true;
+
+    const boundaries: InlineHtmlBoundaryNode[] = [];
+    node.forEach((child, offset) => {
+      if (child.type.name !== "html" || typeof child.attrs.value !== "string") return;
+
+      const from = position + 1 + offset;
+      boundaries.push({
+        from,
+        source: child.attrs.value,
+        to: from + child.nodeSize
+      });
+    });
+    ranges.push(...pairInlineHtmlBoundaries(boundaries));
+
+    return false;
+  });
+
+  return ranges;
+}

--- a/packages/editor/src/raw-html.ts
+++ b/packages/editor/src/raw-html.ts
@@ -1,7 +1,8 @@
 import type { Node as ProseNode } from "@milkdown/kit/prose/model";
 import { Plugin } from "@milkdown/kit/prose/state";
-import type { EditorView, NodeView } from "@milkdown/kit/prose/view";
+import { Decoration, DecorationSet, type EditorView, type NodeView } from "@milkdown/kit/prose/view";
 import { $prose } from "@milkdown/kit/utils";
+import { findInlineHtmlRanges, type InlineHtmlRange } from "./inline-html";
 
 export type ResolveRawHtmlSrc = (src: string) => string;
 
@@ -233,6 +234,54 @@ function sanitizeRawHtmlNode(
 
   element.append(...sanitizedChildren);
   return [element];
+}
+
+function inlineHtmlDecorationAttributes(
+  range: InlineHtmlRange,
+  ownerDocument: Document,
+  options: RawHtmlRenderOptions
+) {
+  const template = ownerDocument.createElement("template");
+  template.innerHTML = range.openSource;
+  const sourceElement = Array.from(template.content.childNodes).find((node) => node instanceof HTMLElement);
+  if (!(sourceElement instanceof HTMLElement)) return null;
+
+  const sanitizedElement = sanitizeRawHtmlNode(sourceElement, ownerDocument, options)
+    .find((node) => node instanceof HTMLElement);
+  if (!(sanitizedElement instanceof HTMLElement) || sanitizedElement.tagName.toLowerCase() !== range.tagName) return null;
+
+  const attributes: Record<string, string> = {
+    class: "markra-inline-html",
+    nodeName: range.tagName
+  };
+  for (const attribute of Array.from(sanitizedElement.attributes)) {
+    attributes[attribute.name] = attribute.value;
+  }
+
+  return attributes;
+}
+
+function inlineHtmlDecorations(doc: ProseNode, ownerDocument: Document, options: RawHtmlRenderOptions) {
+  const decorations: Decoration[] = [];
+
+  findInlineHtmlRanges(doc).forEach((range) => {
+    const attributes = inlineHtmlDecorationAttributes(range, ownerDocument, options);
+    if (!attributes) return;
+
+    // Keep the HTML boundary atoms in the document so nested Markdown stays editable and serializes unchanged.
+    if (range.from < range.to) {
+      decorations.push(Decoration.inline(range.from, range.to, attributes));
+    }
+
+    const boundaryAttributes = {
+      class: "markra-inline-html-boundary",
+      style: "display: none"
+    };
+    decorations.push(Decoration.node(range.openFrom, range.openTo, boundaryAttributes));
+    decorations.push(Decoration.node(range.closeFrom, range.closeTo, boundaryAttributes));
+  });
+
+  return decorations.length > 0 ? DecorationSet.create(doc, decorations) : DecorationSet.empty;
 }
 
 function createRawHtmlFallback(rawHtml: string, ownerDocument: Document) {
@@ -608,6 +657,11 @@ export function markraRawHtmlPlugin(options: RawHtmlRenderOptions = {}) {
   return $prose(() => {
     return new Plugin({
       props: {
+        decorations(state) {
+          if (typeof document === "undefined") return DecorationSet.empty;
+
+          return inlineHtmlDecorations(state.doc, document, options);
+        },
         nodeViews: {
           html: (node, view, getPos) => new MarkraRawHtmlNodeView(node, view, getPos as GetNodePosition, options)
         }


### PR DESCRIPTION
## Summary
- render balanced source-authored inline HTML pairs such as `<sup>...</sup>` as real inline elements in the visual editor
- preserve the underlying HTML boundary nodes so nested Markdown remains editable and serialization/reload stay unchanged
- preserve soft line breaks before inline HTML when the visual editor serializes back into the source pane
- reuse the existing raw HTML sanitizer for URLs and attributes, while leaving malformed and block-level boundaries on their current path

## Why
Milkdown represents inline raw HTML as separate opening and closing atoms. Rendering each atom independently made opening tags disappear and closing tags fall back to visible source.

The Markdown stringifier also normalizes a soft break immediately before an HTML node into a space. In split mode, the deferred visual update then wrote that normalized line back to the source pane. This PR marks single-line HTML tokens only while stringifying so their original line breaks survive without changing the ProseMirror document.

## Validation
- `pnpm test` passed: 2,412 tests
- `pnpm build` passed, including desktop vendor chunk verification
- `pnpm --filter @markra/app typecheck:test` passed
- focused inline HTML, raw HTML, and line-break integration tests passed: 7 tests

## Risk
- paired rendering is limited to a strict inline-tag allowlist
- rendered attributes pass through the existing sanitizer; unsafe URLs and event attributes remain removed
- the serializer marker is limited to non-empty, single-line HTML source; multiline block HTML keeps the existing serialization path

## Note
`&#x20;` is the Markdown serializer preserving a trailing space and reproduces without HTML. This PR does not strip it because doing so would make source round-trips lossy.

Closes #543