### PR TITLE
fix(export): improve numeral rendering in exported documents

### DIFF
--- a/packages/app/src/lib/document-export.test.ts
+++ b/packages/app/src/lib/document-export.test.ts
@@ -63,6 +63,19 @@ describe("document export helpers", () => {
     expect(exportRule).toContain("font-variant-numeric: lining-nums;");
   });
 
+  it("uses a unified CJK serif stack for Simplified Chinese exports", () => {
+    const html = buildMarkdownHtmlDocument({
+      bodyHtml: "<p>示例12345</p>",
+      language: "zh-CN",
+      title: "Mock CJK export"
+    });
+    const simplifiedChineseRule = html.match(/:root:lang\(zh-CN\),[\s\S]*?\{([^}]*)\}/u)?.[1] ?? "";
+
+    expect(simplifiedChineseRule).toMatch(
+      /font-family: "Noto Serif CJK SC",[\s\S]*"Songti SC",[\s\S]*ui-serif/u
+    );
+  });
+
   it("removes rendered pure LaTeX macro definition blocks from standalone documents", () => {
     const html = buildMarkdownHtmlDocument({
       bodyHtml: [

--- a/packages/app/src/lib/document-export.test.ts
+++ b/packages/app/src/lib/document-export.test.ts
@@ -53,6 +53,16 @@ describe("document export helpers", () => {
     expect(html).toContain(".markdown-export pre,\n  .markdown-export pre code {\n    white-space: pre-wrap;\n    overflow-wrap: anywhere;\n  }");
   });
 
+  it("uses lining figures so exported digits have a consistent height", () => {
+    const html = buildMarkdownHtmlDocument({
+      bodyHtml: "<p>Mock IDs A64, A064, A55, A054, A39, and A039.</p>",
+      title: "Mock numeric export"
+    });
+    const exportRule = html.match(/\.markdown-export \{([^}]*)\}/u)?.[1];
+
+    expect(exportRule).toContain("font-variant-numeric: lining-nums;");
+  });
+
   it("removes rendered pure LaTeX macro definition blocks from standalone documents", () => {
     const html = buildMarkdownHtmlDocument({
       bodyHtml: [

--- a/packages/app/src/lib/document-export.ts
+++ b/packages/app/src/lib/document-export.ts
@@ -76,6 +76,8 @@ body {
   padding: 48px 56px;
   font-size: 16px;
   line-height: 1.65;
+  /* Serif export fonts may default to old-style figures with uneven heights. */
+  font-variant-numeric: lining-nums;
 }
 
 .markdown-export h1,

--- a/packages/app/src/lib/document-export.ts
+++ b/packages/app/src/lib/document-export.ts
@@ -62,6 +62,13 @@ ${katexStyles}
   font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
 }
 
+/* Keep Han text and Latin numerals on one CJK-capable family when possible. */
+:root:lang(zh-CN),
+:root:lang(zh-SG),
+:root:lang(zh-Hans) {
+  font-family: "Noto Serif CJK SC", "Noto Serif SC", "Source Han Serif SC", "Source Han Serif CN", "Songti SC", STSong, SimSun, ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+}
+
 body {
   margin: 0;
   background: #fff;


### PR DESCRIPTION
## Summary
- Render exported document digits with lining figures so serif numerals share a consistent height.
- Prefer a CJK-capable serif family for Simplified Chinese exports so Han text and numerals use compatible glyph metrics.
- Add regression coverage for both export style rules.

## Why
PDF exports use browser-generated HTML. The previous font stack rendered Latin numerals with `ui-serif` or Georgia while Chinese text fell back to a separate CJK font, leaving mixed-script text visually inconsistent even after enabling lining figures.

## Validation
- `pnpm --filter @markra/app test` — 122 test files and 1832 tests passed.
- `pnpm --filter @markra/app build` — TypeScript build check passed.
- Generated an A4 PDF with headless Chrome and rendered it with `pdftoppm`; verified consistent date numerals and mixed Han/numeral text with no clipping or layout regression.

## Risk
Low. This is export-only CSS. Simplified Chinese exports now use the first available CJK serif family for Latin text and numerals as well as Han text; other language exports and the Pandoc path are unchanged.

Closes #551