### PR TITLE
fix(ai): include client version in ACP initialization

### DIFF
--- a/packages/ai/src/acp/client.ts
+++ b/packages/ai/src/acp/client.ts
@@ -64,7 +64,7 @@ export type AcpContentBlock =
 export type AcpClientInfo = {
   name: string;
   title?: string;
-  version?: string;
+  version: string;
 };
 
 export type AcpClientTransport = {

--- a/packages/app/src/lib/acp-agent.test.ts
+++ b/packages/app/src/lib/acp-agent.test.ts
@@ -1,5 +1,6 @@
 import { configureAppRuntime, createDefaultAppRuntime, resetAppRuntimeForTests, type AppAcpAgentMessageEvent } from "../runtime";
 import { parseAcpAgentArgs, resolveAcpAgentCwd, runAcpDocumentAgent, runAcpInlineAiAgent } from "./acp-agent";
+import { appVersion } from "./app-version";
 
 describe("ACP agent helpers", () => {
   afterEach(() => {
@@ -40,6 +41,78 @@ describe("ACP agent helpers", () => {
       "/mock-workspace/notes/current.md",
       "/mock-workspace/notes/current.md"
     )).toBe("/mock-workspace/notes");
+  });
+
+  it("identifies the Markra version when initializing an ACP agent", async () => {
+    let handleAgentMessage: ((event: AppAcpAgentMessageEvent) => unknown) | null = null;
+    let initializeParams: unknown;
+    const runtime = createDefaultAppRuntime();
+
+    configureAppRuntime({
+      ...runtime,
+      acp: {
+        listenAgentMessages: vi.fn(async (handler) => {
+          handleAgentMessage = handler;
+
+          return () => {
+            handleAgentMessage = null;
+          };
+        }),
+        startAgent: vi.fn(async () => ({ connectionId: "acp-1" })),
+        stopAgent: vi.fn(async () => undefined),
+        writeAgentMessage: vi.fn(async (_connectionId, message) => {
+          if (!(message && typeof message === "object" && "method" in message && "id" in message)) return;
+
+          if (message.method === "initialize") {
+            initializeParams = "params" in message ? message.params : undefined;
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: {} }),
+              type: "message"
+            });
+            return;
+          }
+          if (message.method === "session/new") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { sessionId: "session-1" } }),
+              type: "message"
+            });
+            return;
+          }
+          if (message.method === "session/prompt") {
+            handleAgentMessage?.({
+              connectionId: "acp-1",
+              message: JSON.stringify({ id: message.id, jsonrpc: "2.0", result: { stopReason: "end_turn" } }),
+              type: "message"
+            });
+          }
+        })
+      }
+    });
+
+    await runAcpDocumentAgent({
+      documentContent: "# Synthetic note",
+      documentPath: "/mock-workspace/current.md",
+      history: [],
+      onTextDelta: vi.fn(),
+      prompt: "Hello",
+      settings: {
+        args: "",
+        command: "synthetic-acp-agent",
+        cwd: "",
+        enabled: true
+      },
+      workspaceKey: "/mock-workspace"
+    });
+
+    expect(initializeParams).toMatchObject({
+      clientInfo: {
+        name: "markra",
+        title: "Markra",
+        version: appVersion
+      }
+    });
   });
 
   it("embeds current and historical chat images as ACP resources in turn order", async () => {

--- a/packages/app/src/lib/acp-agent.ts
+++ b/packages/app/src/lib/acp-agent.ts
@@ -24,7 +24,15 @@ import {
 } from "@markra/ai";
 import type { AgentEvent } from "@earendil-works/pi-agent-core";
 import { getAppRuntime, type RuntimeCleanup } from "../runtime";
+import { appVersion } from "./app-version";
 import type { AcpAgentSettings } from "./settings/app-settings";
+
+const markraAcpClientInfo = {
+  name: "markra",
+  title: "Markra",
+  // ACP 0.23 agents reject clientInfo when its required version is missing.
+  version: appVersion
+};
 
 export type AcpDocumentAgentRunOptions = {
   documentContent: string;
@@ -221,7 +229,7 @@ export async function runAcpDocumentAgent({
   }
 
   try {
-    const initializeResponse = await agentFailure.race(client.initialize({ name: "markra", title: "Markra" }));
+    const initializeResponse = await agentFailure.race(client.initialize(markraAcpClientInfo));
     const session = await createAcpSession({
       agentFailure,
       client,
@@ -314,7 +322,7 @@ export async function runAcpInlineAiAgent({
   }
 
   try {
-    const initializeResponse = await agentFailure.race(client.initialize({ name: "markra", title: "Markra" }));
+    const initializeResponse = await agentFailure.race(client.initialize(markraAcpClientInfo));
     const session = await createAcpSession({
       agentFailure,
       client,


### PR DESCRIPTION
## Summary

- require ACP client metadata to include a version
- send the Markra app version for document and inline ACP sessions
- add a regression test for the initialization payload

## Why

Kimi Code 0.26.0 uses ACP SDK 0.23.0, which requires `clientInfo.version`. Markra omitted that field, so Kimi rejected the first `initialize` request with `-32602 Invalid params`.

## Validation

- `pnpm --filter @markra/app exec vitest run src/lib/acp-agent.test.ts` — 18 passed
- `pnpm --filter @markra/ai test` — 245 passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/ai build` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification

## Known test issue

- `pnpm --filter @markra/app test` completed 1,836 of 1,837 tests successfully. The existing `App.ai.test.tsx` visible-editor test failed and was reproduced in the unmodified original worktree, so it is unrelated to this change.

Fixes #544