### PR TITLE
fix(ai): allow inline chat to reuse agent model

### DIFF
--- a/packages/app/src/hooks/useAiSettings.test.tsx
+++ b/packages/app/src/hooks/useAiSettings.test.tsx
@@ -201,6 +201,58 @@ describe("useAiSettings", () => {
     );
   });
 
+  it("lets inline AI select the model already selected by the agent panel", async () => {
+    mockedGetStoredAiSettings.mockResolvedValue({
+      agentDefaultModelId: "model-b",
+      agentDefaultProviderId: "provider-b",
+      defaultModelId: "model-a",
+      defaultProviderId: "provider-a",
+      inlineDefaultModelId: "model-a",
+      inlineDefaultProviderId: "provider-a",
+      providers: [
+        {
+          apiKey: "provider-a-key",
+          baseUrl: "https://provider-a.example.test/v1",
+          defaultModelId: "model-a",
+          enabled: true,
+          id: "provider-a",
+          models: [{ capabilities: ["text"], enabled: true, id: "model-a", name: "Model A" }],
+          name: "Provider A",
+          type: "openai-compatible"
+        },
+        {
+          apiKey: "provider-b-key",
+          baseUrl: "https://provider-b.example.test/v1",
+          defaultModelId: "model-b",
+          enabled: true,
+          id: "provider-b",
+          models: [{ capabilities: ["text"], enabled: true, id: "model-b", name: "Model B" }],
+          name: "Provider B",
+          type: "openai-compatible"
+        }
+      ]
+    });
+
+    const { result } = renderHook(() => useAiSettings());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectInlineModel("provider-b", "model-b");
+    });
+
+    expect(result.current.inlineProviderId).toBe("provider-b");
+    expect(result.current.inlineModelId).toBe("model-b");
+    expect(mockedSaveStoredAiSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDefaultModelId: "model-b",
+        agentDefaultProviderId: "provider-b",
+        inlineDefaultModelId: "model-b",
+        inlineDefaultProviderId: "provider-b"
+      })
+    );
+  });
+
   it("reacts to AI settings updates from another window", async () => {
     let handleAiSettingsChanged: ((settings: Parameters<typeof mockedNotifyAppAiSettingsChanged>[0]) => unknown) | null = null;
 

--- a/packages/app/src/hooks/useAiSettings.ts
+++ b/packages/app/src/hooks/useAiSettings.ts
@@ -68,7 +68,8 @@ export function useAiSettings() {
       const selectedModel = selectedProvider?.models.find((model) => isEnabledTextModel(model) && model.id === modelId);
 
       if (!selectedProvider || !selectedModel) return;
-      if (settings.agentDefaultProviderId === providerId && settings.agentDefaultModelId === modelId) return;
+      // Inline and agent selections are independent, even when both choose the same model.
+      if (settings.inlineDefaultProviderId === providerId && settings.inlineDefaultModelId === modelId) return;
 
       const nextSettings: AiProviderSettings = {
         ...settings,


### PR DESCRIPTION
## Summary
- fix inline AI model selection when the same model is already selected in the agent sidebar
- keep inline and agent model choices independent
- add regression coverage for selecting the agent model from inline chat

## Validation
- `pnpm --filter @markra/app test` — 122 files and 1840 tests passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed

## Risk
- Low: the change only corrects the inline selection no-op guard and adds focused coverage

Closes #549