### PR TITLE
fix(app): preserve local links when moving notes

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -115,7 +115,10 @@ import {
 } from "./lib/workspace-operation-animation";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
-import { moveMarkdownTreeFileWithLinks } from "./lib/markdown-tree-move";
+import {
+  moveMarkdownTreeFileWithLinks,
+  type MarkdownTreeMoveDocumentUpdate
+} from "./lib/markdown-tree-move";
 import { replaceMovedPath, sameNativePath } from "./lib/path-move";
 import { createAppSpellcheckerForLanguage } from "./lib/spellcheck";
 import { editorContentWidthPixels, shouldShowEditorWidthResizer } from "./lib/editor-width";
@@ -749,6 +752,7 @@ function WorkspaceApp() {
     tabs: documentTabs,
     activeTabId,
     closeMarkdownTab,
+    getDirtyMarkdownFileContent,
     handleDroppedMarkdownPath,
     handleMarkdownChange,
     handleMarkdownTabChange,
@@ -1120,7 +1124,7 @@ function WorkspaceApp() {
   const applyMovedTreeFile = useCallback((
     previousFile: NativeMarkdownFolderFile,
     movedFile: NativeMarkdownFolderFile,
-    content?: string
+    documentUpdate?: MarkdownTreeMoveDocumentUpdate
   ) => {
     const moveFolderFile = (file: NativeMarkdownFolderFile): NativeMarkdownFolderFile => {
       const nextPath = replaceMovedPath(file.path, previousFile.path, movedFile.path);
@@ -1134,7 +1138,7 @@ function WorkspaceApp() {
       };
     };
 
-    replaceMovedOpenDocumentFile(previousFile.path, movedFile, content);
+    replaceMovedOpenDocumentFile(previousFile.path, movedFile, documentUpdate);
     persistSideDocumentGroupPathUpdate({
       nextPath: movedFile.path,
       previousPath: previousFile.path
@@ -1149,16 +1153,16 @@ function WorkspaceApp() {
     file: NativeMarkdownFolderFile,
     targetParentPath: string | null
   ) => {
-    await saveDirtyMarkdownFiles();
     const result = await moveMarkdownTreeFileWithLinks(file, targetParentPath, {
+      dirtyContent: file.kind ? null : getDirtyMarkdownFileContent(file.path),
       moveFile: moveMarkdownTreeFile,
       readFile: readNativeMarkdownFile,
       saveFile: saveNativeMarkdownFile
     });
-    if (result) applyMovedTreeFile(file, result.file, result.content);
+    if (result) applyMovedTreeFile(file, result.file, result.document);
 
     return result?.file ?? null;
-  }, [applyMovedTreeFile, moveMarkdownTreeFile, saveDirtyMarkdownFiles]);
+  }, [applyMovedTreeFile, getDirtyMarkdownFileContent, moveMarkdownTreeFile]);
   const getAiDocumentContent = useCallback(
     () => (document.open ? readCurrentMarkdownForDocument(document.content) : document.content),
     [document.content, document.open, readCurrentMarkdownForDocument]

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -115,6 +115,7 @@ import {
 } from "./lib/workspace-operation-animation";
 import { shouldBlockLargeMarkdownVisual } from "./lib/large-markdown";
 import { markAppPerformance } from "./lib/performance-marks";
+import { moveMarkdownTreeFileWithLinks } from "./lib/markdown-tree-move";
 import { replaceMovedPath, sameNativePath } from "./lib/path-move";
 import { createAppSpellcheckerForLanguage } from "./lib/spellcheck";
 import { editorContentWidthPixels, shouldShowEditorWidthResizer } from "./lib/editor-width";
@@ -1118,7 +1119,8 @@ function WorkspaceApp() {
   }, [persistSideDocumentGroupPathUpdate, replaceOpenDocumentFile]);
   const applyMovedTreeFile = useCallback((
     previousFile: NativeMarkdownFolderFile,
-    movedFile: NativeMarkdownFolderFile
+    movedFile: NativeMarkdownFolderFile,
+    content?: string
   ) => {
     const moveFolderFile = (file: NativeMarkdownFolderFile): NativeMarkdownFolderFile => {
       const nextPath = replaceMovedPath(file.path, previousFile.path, movedFile.path);
@@ -1132,7 +1134,7 @@ function WorkspaceApp() {
       };
     };
 
-    replaceMovedOpenDocumentFile(previousFile.path, movedFile);
+    replaceMovedOpenDocumentFile(previousFile.path, movedFile, content);
     persistSideDocumentGroupPathUpdate({
       nextPath: movedFile.path,
       previousPath: previousFile.path
@@ -1143,6 +1145,20 @@ function WorkspaceApp() {
     }));
     setActiveImageFile((currentFile) => currentFile ? moveFolderFile(currentFile) : currentFile);
   }, [persistSideDocumentGroupPathUpdate, replaceMovedOpenDocumentFile]);
+  const moveTreeFileWithLinks = useCallback(async (
+    file: NativeMarkdownFolderFile,
+    targetParentPath: string | null
+  ) => {
+    await saveDirtyMarkdownFiles();
+    const result = await moveMarkdownTreeFileWithLinks(file, targetParentPath, {
+      moveFile: moveMarkdownTreeFile,
+      readFile: readNativeMarkdownFile,
+      saveFile: saveNativeMarkdownFile
+    });
+    if (result) applyMovedTreeFile(file, result.file, result.content);
+
+    return result?.file ?? null;
+  }, [applyMovedTreeFile, moveMarkdownTreeFile, saveDirtyMarkdownFiles]);
   const getAiDocumentContent = useCallback(
     () => (document.open ? readCurrentMarkdownForDocument(document.content) : document.content),
     [document.content, document.open, readCurrentMarkdownForDocument]
@@ -1175,12 +1191,7 @@ function WorkspaceApp() {
       operations: createWorkspaceChangePlanOperations({
         createFile: createMarkdownTreeFile,
         createFolder: createMarkdownTreeFolder,
-        moveFile: async (file, targetParentPath) => {
-          const movedFile = await moveMarkdownTreeFile(file, targetParentPath);
-          if (movedFile) applyMovedTreeFile(file, movedFile);
-
-          return movedFile;
-        },
+        moveFile: moveTreeFileWithLinks,
         readFile: readAiWorkspaceFile,
         renameFile: async (file, fileName) => {
           const renamedFile = await renameMarkdownTreeFile(file, fileName);
@@ -1206,14 +1217,13 @@ function WorkspaceApp() {
     await refreshMarkdownFileTree(document.path);
     return result;
   }, [
-    applyMovedTreeFile,
     applyRenamedTreeFile,
     createMarkdownTreeFile,
     createMarkdownTreeFolder,
     document.path,
     fileTreeFiles,
     fileTreeSourcePath,
-    moveMarkdownTreeFile,
+    moveTreeFileWithLinks,
     readAiWorkspaceFile,
     refreshMarkdownFileTree,
     renameMarkdownTreeFile,
@@ -2376,12 +2386,11 @@ function WorkspaceApp() {
     targetParentPath: string | null
   ) => {
     try {
-      const movedFile = await moveMarkdownTreeFile(file, targetParentPath);
-      if (movedFile) applyMovedTreeFile(file, movedFile);
+      await moveTreeFileWithLinks(file, targetParentPath);
     } catch {
       // Keep the existing tree state if the native move fails.
     }
-  }, [applyMovedTreeFile, moveMarkdownTreeFile]);
+  }, [moveTreeFileWithLinks]);
   const handleDeleteMarkdownTreeFile = useCallback(async (
     file: NativeMarkdownFolderFile,
     context?: { files: readonly NativeMarkdownFolderFile[] }

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -2530,7 +2530,10 @@ describe("useMarkdownDocument", () => {
         name: "daily.md",
         path: "/mock-files/archive/daily.md",
         relativePath: "archive/daily.md"
-      }, "![Diagram](../notes/assets/diagram.png)")).toBe(true);
+      }, {
+        content: "![Diagram](../notes/assets/diagram.png)",
+        dirty: false
+      })).toBe(true);
     });
 
     expect(result.current.document).toMatchObject({
@@ -2542,6 +2545,90 @@ describe("useMarkdownDocument", () => {
     expect(result.current.tabs[0]).toMatchObject({
       content: "![Diagram](../notes/assets/diagram.png)",
       dirty: false,
+      path: "/mock-files/archive/daily.md"
+    });
+  });
+
+  it("returns dirty content for the requested document without mixing dirty tabs", async () => {
+    mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
+      content: path.endsWith("daily.md") ? "# Daily" : "# Other",
+      name: path.endsWith("daily.md") ? "daily.md" : "other.md",
+      path
+    }));
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "daily.md",
+        path: "/mock-files/notes/daily.md",
+        relativePath: "notes/daily.md"
+      });
+      await result.current.openTreeMarkdownFileInBackground({
+        name: "other.md",
+        path: "/mock-files/notes/other.md",
+        relativePath: "notes/other.md"
+      });
+    });
+    act(() => {
+      result.current.handleMarkdownChange("# Daily\n\nDraft");
+      const otherTab = result.current.tabs.find((tab) => tab.path === "/mock-files/notes/other.md");
+      expect(otherTab).toBeTruthy();
+      result.current.handleMarkdownTabChange(otherTab!.id, "# Other\n\nDraft");
+    });
+
+    expect(result.current.getDirtyMarkdownFileContent("/mock-files/notes/daily.md")).toBe("# Daily\n\nDraft");
+    expect(result.current.getDirtyMarkdownFileContent("/mock-files/notes/other.md")).toBe("# Other\n\nDraft");
+    expect(result.current.getDirtyMarkdownFileContent("/mock-files/notes/missing.md")).toBeNull();
+  });
+
+  it("keeps rebased moved content dirty when it came from an unsaved document", async () => {
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "![Diagram](assets/diagram.png)",
+      name: "daily.md",
+      path: "/mock-files/notes/daily.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "daily.md",
+        path: "/mock-files/notes/daily.md",
+        relativePath: "notes/daily.md"
+      });
+    });
+
+    act(() => {
+      expect(result.current.replaceMovedOpenDocumentFile("/mock-files/notes/daily.md", {
+        name: "daily.md",
+        path: "/mock-files/archive/daily.md",
+        relativePath: "archive/daily.md"
+      }, {
+        content: "![Diagram](../notes/assets/diagram.png)\n\nDraft",
+        dirty: true
+      })).toBe(true);
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "![Diagram](../notes/assets/diagram.png)\n\nDraft",
+      dirty: true,
       path: "/mock-files/archive/daily.md"
     });
   });

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -2499,6 +2499,53 @@ describe("useMarkdownDocument", () => {
     ]);
   });
 
+  it("updates open document content when a moved file has rebased links", async () => {
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "![Diagram](assets/diagram.png)",
+      name: "daily.md",
+      path: "/mock-files/notes/daily.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "daily.md",
+        path: "/mock-files/notes/daily.md",
+        relativePath: "notes/daily.md"
+      });
+    });
+    const previousRevision = result.current.document.revision;
+
+    act(() => {
+      expect(result.current.replaceMovedOpenDocumentFile("/mock-files/notes/daily.md", {
+        name: "daily.md",
+        path: "/mock-files/archive/daily.md",
+        relativePath: "archive/daily.md"
+      }, "![Diagram](../notes/assets/diagram.png)")).toBe(true);
+    });
+
+    expect(result.current.document).toMatchObject({
+      content: "![Diagram](../notes/assets/diagram.png)",
+      dirty: false,
+      path: "/mock-files/archive/daily.md",
+      revision: previousRevision + 1
+    });
+    expect(result.current.tabs[0]).toMatchObject({
+      content: "![Diagram](../notes/assets/diagram.png)",
+      dirty: false,
+      path: "/mock-files/archive/daily.md"
+    });
+  });
+
   it("skips a restored folder workspace when the folder no longer opens", async () => {
     const onTreeRootFromFolderPath = vi.fn(async () => null);
     mockedGetStoredWorkspaceState.mockResolvedValue({

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -101,6 +101,11 @@ type ApplySavedCurrentDocumentOptions = {
   targetTabId?: string | null;
 };
 
+type MovedMarkdownDocumentUpdate = {
+  content: string;
+  dirty: boolean;
+};
+
 export type ActiveDiskFileContentChange = {
   content: string;
   path: string;
@@ -546,6 +551,13 @@ export function useMarkdownDocument({
   const persistActiveDocumentDraftSnapshot = useCallback(() => {
     const snapshot = syncActiveDocumentDraftSnapshot();
     return persistWorkspaceState(draftWorkspacePatchFromTabs(snapshot.tabs, snapshot.activeTabId));
+  }, [syncActiveDocumentDraftSnapshot]);
+
+  const getDirtyMarkdownFileContent = useCallback((path: string) => {
+    const snapshot = syncActiveDocumentDraftSnapshot();
+    const tab = snapshot.tabs.find((candidate) => sameNativePath(candidate.path, path));
+
+    return tab?.dirty ? tab.content : null;
   }, [syncActiveDocumentDraftSnapshot]);
 
   const persistNativeEditorWindowRestoreSnapshot = useCallback(async () => {
@@ -1251,7 +1263,7 @@ export function useMarkdownDocument({
   const replaceMovedOpenDocumentFile = useCallback((
     previousPath: string,
     file: NativeMarkdownFolderFile,
-    content?: string
+    documentUpdate?: MovedMarkdownDocumentUpdate
   ) => {
     const movedPathFor = (path: string | null) => (path ? replaceMovedPath(path, previousPath, file.path) : path);
     const affected =
@@ -1263,10 +1275,16 @@ export function useMarkdownDocument({
     if (current.path !== null) {
       const nextPath = movedPathFor(current.path);
       if (nextPath !== current.path) {
-        const contentRebased = content !== undefined && sameNativePath(current.path, previousPath);
+        const contentRebased = documentUpdate !== undefined && sameNativePath(current.path, previousPath);
         setActiveDocument({
           ...current,
-          ...(contentRebased ? { content, dirty: false, revision: current.revision + 1 } : {}),
+          ...(contentRebased
+            ? {
+                content: documentUpdate.content,
+                dirty: documentUpdate.dirty,
+                revision: current.revision + 1
+              }
+            : {}),
           deleted: false,
           name: current.path === previousPath ? file.name : current.name,
           path: nextPath
@@ -1278,11 +1296,17 @@ export function useMarkdownDocument({
       const nextPath = movedPathFor(tab.path);
       if (nextPath === tab.path) return tab;
 
-      const contentRebased = content !== undefined && sameNativePath(tab.path, previousPath);
+      const contentRebased = documentUpdate !== undefined && sameNativePath(tab.path, previousPath);
       if (contentRebased) editorSyncState.clearCleanVisualMarkdownBaseline(tab.id);
       return {
         ...tab,
-        ...(contentRebased ? { content, dirty: false, revision: tab.revision + 1 } : {}),
+        ...(contentRebased
+          ? {
+              content: documentUpdate.content,
+              dirty: documentUpdate.dirty,
+              revision: tab.revision + 1
+            }
+          : {}),
         deleted: false,
         name: tab.path === previousPath ? file.name : tab.name,
         path: nextPath
@@ -2278,6 +2302,7 @@ export function useMarkdownDocument({
     tabs,
     activeTabId,
     handleDroppedMarkdownPath,
+    getDirtyMarkdownFileContent,
     handleMarkdownChange,
     handleMarkdownTabChange,
     handleSaveClick,

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -1248,7 +1248,11 @@ export function useMarkdownDocument({
     return true;
   }, [registerWindowRestoreState, setActiveDocument]);
 
-  const replaceMovedOpenDocumentFile = useCallback((previousPath: string, file: NativeMarkdownFolderFile) => {
+  const replaceMovedOpenDocumentFile = useCallback((
+    previousPath: string,
+    file: NativeMarkdownFolderFile,
+    content?: string
+  ) => {
     const movedPathFor = (path: string | null) => (path ? replaceMovedPath(path, previousPath, file.path) : path);
     const affected =
       tabsRef.current.some((tab) => tab.path !== null && movedPathFor(tab.path) !== tab.path) ||
@@ -1259,8 +1263,10 @@ export function useMarkdownDocument({
     if (current.path !== null) {
       const nextPath = movedPathFor(current.path);
       if (nextPath !== current.path) {
+        const contentRebased = content !== undefined && sameNativePath(current.path, previousPath);
         setActiveDocument({
           ...current,
+          ...(contentRebased ? { content, dirty: false, revision: current.revision + 1 } : {}),
           deleted: false,
           name: current.path === previousPath ? file.name : current.name,
           path: nextPath
@@ -1272,8 +1278,11 @@ export function useMarkdownDocument({
       const nextPath = movedPathFor(tab.path);
       if (nextPath === tab.path) return tab;
 
+      const contentRebased = content !== undefined && sameNativePath(tab.path, previousPath);
+      if (contentRebased) editorSyncState.clearCleanVisualMarkdownBaseline(tab.id);
       return {
         ...tab,
+        ...(contentRebased ? { content, dirty: false, revision: tab.revision + 1 } : {}),
         deleted: false,
         name: tab.path === previousPath ? file.name : tab.name,
         path: nextPath
@@ -1288,7 +1297,7 @@ export function useMarkdownDocument({
       openFilePaths: openFilePathsFromTabs(nextTabs)
     });
     return true;
-  }, [registerWindowRestoreState, setActiveDocument]);
+  }, [editorSyncState, registerWindowRestoreState, setActiveDocument]);
 
   const detachDeletedDocumentFile = useCallback((path: string) => {
     const currentTabs = tabsRef.current;

--- a/packages/app/src/lib/markdown-tree-move.test.ts
+++ b/packages/app/src/lib/markdown-tree-move.test.ts
@@ -29,12 +29,15 @@ describe("Markdown tree moves", () => {
       readFile,
       saveFile
     })).resolves.toEqual({
-      content: "![Diagram](../notes/assets/diagram.png)",
+      document: {
+        content: "![Diagram](../notes/assets/diagram.png)",
+        dirty: false
+      },
       file: movedFile
     });
 
-    expect(readFile).toHaveBeenCalledWith(sourceFile.path);
     expect(moveFile).toHaveBeenCalledWith(sourceFile, "/mock-vault/archive");
+    expect(readFile).toHaveBeenCalledWith(movedFile.path);
     expect(saveFile).toHaveBeenCalledWith({
       contents: "![Diagram](../notes/assets/diagram.png)",
       path: movedFile.path,
@@ -68,6 +71,68 @@ describe("Markdown tree moves", () => {
     expect(saveFile).not.toHaveBeenCalled();
   });
 
+  it("rebases the latest disk content after the move completes", async () => {
+    let diskContent = "![Original](assets/original.png)";
+    const moveFile = vi.fn().mockImplementation(async () => {
+      diskContent = "![External](assets/external.png)";
+      return movedFile;
+    });
+    const readFile = vi.fn().mockImplementation(async () => ({
+      ...movedFile,
+      content: diskContent
+    }));
+    const saveFile = vi.fn().mockResolvedValue({
+      ...movedFile,
+      content: "![External](../notes/assets/external.png)"
+    });
+
+    await expect(moveMarkdownTreeFileWithLinks(sourceFile, "/mock-vault/archive", {
+      moveFile,
+      readFile,
+      saveFile
+    })).resolves.toEqual({
+      document: {
+        content: "![External](../notes/assets/external.png)",
+        dirty: false
+      },
+      file: movedFile
+    });
+
+    expect(saveFile).toHaveBeenCalledWith(expect.objectContaining({
+      contents: "![External](../notes/assets/external.png)"
+    }));
+  });
+
+  it("rebases a dirty open document without saving its unsaved content", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      ...movedFile,
+      content: "![Saved](assets/saved.png)"
+    });
+    const moveFile = vi.fn().mockResolvedValue(movedFile);
+    const saveFile = vi.fn().mockResolvedValue({
+      ...movedFile,
+      content: "![Saved](../notes/assets/saved.png)"
+    });
+
+    await expect(moveMarkdownTreeFileWithLinks(sourceFile, "/mock-vault/archive", {
+      dirtyContent: "![Draft](assets/draft.png)",
+      moveFile,
+      readFile,
+      saveFile
+    })).resolves.toEqual({
+      document: {
+        content: "![Draft](../notes/assets/draft.png)",
+        dirty: true
+      },
+      file: movedFile
+    });
+
+    expect(saveFile).toHaveBeenCalledOnce();
+    expect(saveFile).toHaveBeenCalledWith(expect.objectContaining({
+      contents: "![Saved](../notes/assets/saved.png)"
+    }));
+  });
+
   it("restores the original location when rewritten content cannot be saved", async () => {
     const readFile = vi.fn().mockResolvedValue({
       ...sourceFile,
@@ -85,5 +150,22 @@ describe("Markdown tree moves", () => {
     })).rejects.toThrow("Synthetic save failure");
 
     expect(moveFile).toHaveBeenNthCalledWith(2, movedFile, "/mock-vault/notes");
+  });
+
+  it("restores the original location when moved content cannot be read", async () => {
+    const readFile = vi.fn().mockRejectedValue(new Error("Synthetic read failure"));
+    const moveFile = vi.fn()
+      .mockResolvedValueOnce(movedFile)
+      .mockResolvedValueOnce(sourceFile);
+    const saveFile = vi.fn();
+
+    await expect(moveMarkdownTreeFileWithLinks(sourceFile, "/mock-vault/archive", {
+      moveFile,
+      readFile,
+      saveFile
+    })).rejects.toThrow("Synthetic read failure");
+
+    expect(moveFile).toHaveBeenNthCalledWith(2, movedFile, "/mock-vault/notes");
+    expect(saveFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/lib/markdown-tree-move.test.ts
+++ b/packages/app/src/lib/markdown-tree-move.test.ts
@@ -1,0 +1,89 @@
+import { moveMarkdownTreeFileWithLinks } from "./markdown-tree-move";
+
+const sourceFile = {
+  name: "daily.md",
+  path: "/mock-vault/notes/daily.md",
+  relativePath: "notes/daily.md"
+};
+
+const movedFile = {
+  name: "daily.md",
+  path: "/mock-vault/archive/daily.md",
+  relativePath: "archive/daily.md"
+};
+
+describe("Markdown tree moves", () => {
+  it("rewrites local links after moving a Markdown file", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      ...sourceFile,
+      content: "![Diagram](assets/diagram.png)"
+    });
+    const moveFile = vi.fn().mockResolvedValue(movedFile);
+    const saveFile = vi.fn().mockResolvedValue({
+      ...movedFile,
+      content: "![Diagram](../notes/assets/diagram.png)"
+    });
+
+    await expect(moveMarkdownTreeFileWithLinks(sourceFile, "/mock-vault/archive", {
+      moveFile,
+      readFile,
+      saveFile
+    })).resolves.toEqual({
+      content: "![Diagram](../notes/assets/diagram.png)",
+      file: movedFile
+    });
+
+    expect(readFile).toHaveBeenCalledWith(sourceFile.path);
+    expect(moveFile).toHaveBeenCalledWith(sourceFile, "/mock-vault/archive");
+    expect(saveFile).toHaveBeenCalledWith({
+      contents: "![Diagram](../notes/assets/diagram.png)",
+      path: movedFile.path,
+      suggestedName: movedFile.name
+    });
+  });
+
+  it("moves folders without reading or rewriting their contents", async () => {
+    const folder = {
+      kind: "folder" as const,
+      name: "notes",
+      path: "/mock-vault/notes",
+      relativePath: "notes"
+    };
+    const movedFolder = {
+      ...folder,
+      path: "/mock-vault/archive/notes",
+      relativePath: "archive/notes"
+    };
+    const readFile = vi.fn();
+    const moveFile = vi.fn().mockResolvedValue(movedFolder);
+    const saveFile = vi.fn();
+
+    await expect(moveMarkdownTreeFileWithLinks(folder, "/mock-vault/archive", {
+      moveFile,
+      readFile,
+      saveFile
+    })).resolves.toEqual({ file: movedFolder });
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("restores the original location when rewritten content cannot be saved", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      ...sourceFile,
+      content: "![Diagram](assets/diagram.png)"
+    });
+    const moveFile = vi.fn()
+      .mockResolvedValueOnce(movedFile)
+      .mockResolvedValueOnce(sourceFile);
+    const saveFile = vi.fn().mockRejectedValue(new Error("Synthetic save failure"));
+
+    await expect(moveMarkdownTreeFileWithLinks(sourceFile, "/mock-vault/archive", {
+      moveFile,
+      readFile,
+      saveFile
+    })).rejects.toThrow("Synthetic save failure");
+
+    expect(moveFile).toHaveBeenNthCalledWith(2, movedFile, "/mock-vault/notes");
+  });
+});

--- a/packages/app/src/lib/markdown-tree-move.ts
+++ b/packages/app/src/lib/markdown-tree-move.ts
@@ -1,0 +1,67 @@
+import { rebaseMarkdownLocalLinks } from "@markra/markdown";
+import { parentPathFromPath } from "@markra/shared";
+import type {
+  NativeMarkdownFile,
+  NativeMarkdownFolderFile,
+  SaveNativeMarkdownFileInput,
+  SavedNativeMarkdownFile
+} from "./tauri/file";
+
+type MarkdownTreeMoveOperations = {
+  moveFile: (
+    file: NativeMarkdownFolderFile,
+    targetParentPath: string | null
+  ) => Promise<NativeMarkdownFolderFile | null>;
+  readFile: (path: string) => Promise<NativeMarkdownFile>;
+  saveFile: (input: SaveNativeMarkdownFileInput) => Promise<SavedNativeMarkdownFile | null>;
+};
+
+export type MarkdownTreeMoveResult = {
+  content?: string;
+  file: NativeMarkdownFolderFile;
+};
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function moveMarkdownTreeFileWithLinks(
+  file: NativeMarkdownFolderFile,
+  targetParentPath: string | null,
+  operations: MarkdownTreeMoveOperations
+): Promise<MarkdownTreeMoveResult | null> {
+  if (file.kind) {
+    const movedFile = await operations.moveFile(file, targetParentPath);
+    return movedFile ? { file: movedFile } : null;
+  }
+
+  const source = await operations.readFile(file.path);
+  const movedFile = await operations.moveFile(file, targetParentPath);
+  if (!movedFile) return null;
+
+  const content = rebaseMarkdownLocalLinks(source.content, file.relativePath, movedFile.relativePath);
+  if (content === source.content) return { file: movedFile };
+
+  try {
+    const savedFile = await operations.saveFile({
+      contents: content,
+      path: movedFile.path,
+      suggestedName: movedFile.name
+    });
+    if (!savedFile) throw new Error(`Could not update links in "${movedFile.relativePath}".`);
+  } catch (saveError) {
+    // A moved note with an unwritten rebase is broken, so put the original file back whenever possible.
+    try {
+      const restoredFile = await operations.moveFile(movedFile, parentPathFromPath(file.path));
+      if (!restoredFile) throw new Error("The original file location could not be restored.");
+    } catch (rollbackError) {
+      throw new Error(
+        `${errorMessage(saveError)} The move also could not be rolled back: ${errorMessage(rollbackError)}`,
+        { cause: saveError }
+      );
+    }
+    throw saveError;
+  }
+
+  return { content, file: movedFile };
+}

--- a/packages/app/src/lib/markdown-tree-move.ts
+++ b/packages/app/src/lib/markdown-tree-move.ts
@@ -8,6 +8,7 @@ import type {
 } from "./tauri/file";
 
 type MarkdownTreeMoveOperations = {
+  dirtyContent?: string | null;
   moveFile: (
     file: NativeMarkdownFolderFile,
     targetParentPath: string | null
@@ -16,8 +17,13 @@ type MarkdownTreeMoveOperations = {
   saveFile: (input: SaveNativeMarkdownFileInput) => Promise<SavedNativeMarkdownFile | null>;
 };
 
+export type MarkdownTreeMoveDocumentUpdate = {
+  content: string;
+  dirty: boolean;
+};
+
 export type MarkdownTreeMoveResult = {
-  content?: string;
+  document?: MarkdownTreeMoveDocumentUpdate;
   file: NativeMarkdownFolderFile;
 };
 
@@ -35,33 +41,62 @@ export async function moveMarkdownTreeFileWithLinks(
     return movedFile ? { file: movedFile } : null;
   }
 
-  const source = await operations.readFile(file.path);
   const movedFile = await operations.moveFile(file, targetParentPath);
   if (!movedFile) return null;
 
-  const content = rebaseMarkdownLocalLinks(source.content, file.relativePath, movedFile.relativePath);
-  if (content === source.content) return { file: movedFile };
-
   try {
-    const savedFile = await operations.saveFile({
-      contents: content,
-      path: movedFile.path,
-      suggestedName: movedFile.name
-    });
-    if (!savedFile) throw new Error(`Could not update links in "${movedFile.relativePath}".`);
-  } catch (saveError) {
+    const sourceDirtyContent = operations.dirtyContent;
+    let dirtyDocumentUpdate: MarkdownTreeMoveDocumentUpdate | undefined;
+    if (sourceDirtyContent !== null && sourceDirtyContent !== undefined) {
+      const rebasedDirtyContent = rebaseMarkdownLocalLinks(
+        sourceDirtyContent,
+        file.relativePath,
+        movedFile.relativePath
+      );
+      if (rebasedDirtyContent !== sourceDirtyContent) {
+        dirtyDocumentUpdate = { content: rebasedDirtyContent, dirty: true };
+      }
+    }
+    const movedDiskFile = await operations.readFile(movedFile.path);
+    const savedContent = rebaseMarkdownLocalLinks(
+      movedDiskFile.content,
+      file.relativePath,
+      movedFile.relativePath
+    );
+    if (savedContent !== movedDiskFile.content) {
+      const savedFile = await operations.saveFile({
+        contents: savedContent,
+        path: movedFile.path,
+        suggestedName: movedFile.name
+      });
+      if (!savedFile) throw new Error(`Could not update links in "${movedFile.relativePath}".`);
+    }
+
+    if (sourceDirtyContent !== null && sourceDirtyContent !== undefined) {
+      // Keep the editor draft separate from the saved file so moving a note never implicitly saves it.
+      return {
+        ...(dirtyDocumentUpdate ? { document: dirtyDocumentUpdate } : {}),
+        file: movedFile
+      };
+    }
+
+    return {
+      ...(savedContent !== movedDiskFile.content
+        ? { document: { content: savedContent, dirty: false } }
+        : {}),
+      file: movedFile
+    };
+  } catch (updateError) {
     // A moved note with an unwritten rebase is broken, so put the original file back whenever possible.
     try {
       const restoredFile = await operations.moveFile(movedFile, parentPathFromPath(file.path));
       if (!restoredFile) throw new Error("The original file location could not be restored.");
     } catch (rollbackError) {
       throw new Error(
-        `${errorMessage(saveError)} The move also could not be rolled back: ${errorMessage(rollbackError)}`,
-        { cause: saveError }
+        `${errorMessage(updateError)} The move also could not be rolled back: ${errorMessage(rollbackError)}`,
+        { cause: updateError }
       );
     }
-    throw saveError;
+    throw updateError;
   }
-
-  return { content, file: movedFile };
 }

--- a/packages/markdown/src/links.test.ts
+++ b/packages/markdown/src/links.test.ts
@@ -91,6 +91,31 @@ describe("markdown links", () => {
     expect(rebaseMarkdownLocalLinks(markdown, "notes/daily.md", "notes/renamed.md")).toBe(markdown);
   });
 
+  it("keeps self references and query-only links attached to the moved document", () => {
+    const markdown = [
+      "[Self](daily.md#section)",
+      "[Dot self](./daily.md)",
+      "[Query](?preview=1)"
+    ].join("\n");
+
+    expect(rebaseMarkdownLocalLinks(markdown, "notes/daily.md", "archive/daily.md")).toBe(markdown);
+  });
+
+  it("rebases many local links without repeatedly copying the whole document", () => {
+    const markdown = Array.from(
+      { length: 15_000 },
+      (_, index) => `![Asset ${index}](assets/asset-${index}.png)`
+    ).join("\n");
+    const startedAt = performance.now();
+
+    const rebased = rebaseMarkdownLocalLinks(markdown, "notes/daily.md", "archive/daily.md");
+    const elapsed = performance.now() - startedAt;
+
+    expect(rebased).toContain("![Asset 0](../notes/assets/asset-0.png)");
+    expect(rebased).toContain("![Asset 14999](../notes/assets/asset-14999.png)");
+    expect(elapsed).toBeLessThan(1_500);
+  }, 15_000);
+
   it("finds unlinked mentions outside existing links and code", () => {
     const markdown = [
       "# Mock note",

--- a/packages/markdown/src/links.test.ts
+++ b/packages/markdown/src/links.test.ts
@@ -113,7 +113,7 @@ describe("markdown links", () => {
 
     expect(rebased).toContain("![Asset 0](../notes/assets/asset-0.png)");
     expect(rebased).toContain("![Asset 14999](../notes/assets/asset-14999.png)");
-    expect(elapsed).toBeLessThan(1_500);
+    expect(elapsed).toBeLessThan(5_000);
   }, 15_000);
 
   it("finds unlinked mentions outside existing links and code", () => {

--- a/packages/markdown/src/links.test.ts
+++ b/packages/markdown/src/links.test.ts
@@ -1,7 +1,8 @@
 import {
   findMarkdownUnlinkedMentions,
   parseMarkdownLinkReferences,
-  parseMarkdownMentionRanges
+  parseMarkdownMentionRanges,
+  rebaseMarkdownLocalLinks
 } from "./links";
 
 describe("markdown links", () => {
@@ -34,6 +35,60 @@ describe("markdown links", () => {
         text: "Gamma label"
       }
     ]);
+  });
+
+  it("rebases local image and attachment links when a document moves", () => {
+    const markdown = [
+      "![Diagram](assets/diagram.png)",
+      "[Reference](assets/Reference%20Doc.pdf)",
+      "[Nested](../shared/data.csv?download=1#latest)"
+    ].join("\n");
+
+    expect(rebaseMarkdownLocalLinks(markdown, "notes/daily.md", "archive/daily.md")).toBe([
+      "![Diagram](../notes/assets/diagram.png)",
+      "[Reference](../notes/assets/Reference%20Doc.pdf)",
+      "[Nested](../shared/data.csv?download=1#latest)"
+    ].join("\n"));
+  });
+
+  it("rebases reference definitions while preserving local-only boundaries", () => {
+    const markdown = [
+      "![Diagram][diagram]",
+      "[Reference][reference]",
+      "",
+      "[diagram]: <assets/diagram (wide).png> \"Wide diagram\"",
+      "[reference]: assets/reference.pdf 'Reference'",
+      "",
+      "[Remote](https://example.test/file.pdf)",
+      "[Anchor](#section)",
+      "[Root](/assets/root.png)",
+      "",
+      "```md",
+      "![Code](assets/code.png)",
+      "```"
+    ].join("\n");
+
+    expect(rebaseMarkdownLocalLinks(markdown, "notes/daily.md", "archive/daily.md")).toBe([
+      "![Diagram][diagram]",
+      "[Reference][reference]",
+      "",
+      "[diagram]: <../notes/assets/diagram%20%28wide%29.png> \"Wide diagram\"",
+      "[reference]: ../notes/assets/reference.pdf 'Reference'",
+      "",
+      "[Remote](https://example.test/file.pdf)",
+      "[Anchor](#section)",
+      "[Root](/assets/root.png)",
+      "",
+      "```md",
+      "![Code](assets/code.png)",
+      "```"
+    ].join("\n"));
+  });
+
+  it("returns the original markdown when the document directory does not change", () => {
+    const markdown = "![Diagram](assets/diagram.png)";
+
+    expect(rebaseMarkdownLocalLinks(markdown, "notes/daily.md", "notes/renamed.md")).toBe(markdown);
   });
 
   it("finds unlinked mentions outside existing links and code", () => {

--- a/packages/markdown/src/links.ts
+++ b/packages/markdown/src/links.ts
@@ -300,6 +300,8 @@ function rebasedMarkdownHref(href: string, fromDocumentPath: string, toDocumentP
   const suffixStart = trimmed.search(/[?#]/u);
   const rawPath = suffixStart >= 0 ? trimmed.slice(0, suffixStart) : trimmed;
   const suffix = suffixStart >= 0 ? trimmed.slice(suffixStart) : "";
+  if (!rawPath) return null;
+
   let decodedPath: string;
   try {
     decodedPath = decodeURI(rawPath);
@@ -313,6 +315,8 @@ function rebasedMarkdownHref(href: string, fromDocumentPath: string, toDocumentP
 
   const targetParts = normalizedRelativePathParts([...fromDirectory, decodedPath].join("/"));
   if (!targetParts) return null;
+  const fromDocumentParts = normalizedRelativePathParts(fromDocumentPath);
+  if (fromDocumentParts?.join("/") === targetParts.join("/")) return null;
 
   let shared = 0;
   while (
@@ -330,6 +334,20 @@ function rebasedMarkdownHref(href: string, fromDocumentPath: string, toDocumentP
   if (!rebasedPath) return null;
 
   return `${encodedMarkdownHrefPath(rebasedPath)}${suffix}`;
+}
+
+function applyMarkdownEdits(markdown: string, edits: MarkdownEdit[]) {
+  if (!edits.length) return markdown;
+
+  const contentParts: string[] = [];
+  let cursor = 0;
+  for (const edit of edits.sort((left, right) => left.from - right.from)) {
+    contentParts.push(markdown.slice(cursor, edit.from), edit.text);
+    cursor = edit.to;
+  }
+  contentParts.push(markdown.slice(cursor));
+
+  return contentParts.join("");
 }
 
 function decodeMarkdownHref(href: string) {
@@ -556,9 +574,7 @@ export function rebaseMarkdownLocalLinks(
     edits.push({ ...range, text: href });
   });
 
-  return edits
-    .sort((left, right) => right.from - left.from)
-    .reduce((content, edit) => `${content.slice(0, edit.from)}${edit.text}${content.slice(edit.to)}`, markdown);
+  return applyMarkdownEdits(markdown, edits);
 }
 
 export function parseMarkdownMentionRanges(markdown: string): MarkdownMentionRange[] {

--- a/packages/markdown/src/links.ts
+++ b/packages/markdown/src/links.ts
@@ -28,6 +28,12 @@ type ProtectedRange = {
   to: number;
 };
 
+type MarkdownEdit = {
+  from: number;
+  text: string;
+  to: number;
+};
+
 export type MarkdownLinkReference = {
   columnNumber: number;
   from: number;
@@ -68,6 +74,7 @@ const localUrlSchemePattern = /^[a-z][a-z\d+.-]*:/iu;
 const wikiLinkPattern = /!?\[\[([^\]\n]+)\]\]/gu;
 const wordCharacterPattern = /[\p{L}\p{N}_-]/u;
 const boundarySensitiveTitlePattern = /[\p{Script=Latin}\p{N}_-]/u;
+const unsafeMarkdownHrefCharactersPattern = /%(?![a-f\d]{2})|[\s()<>#]/giu;
 
 function parseMarkdown(markdown: string) {
   return markdownLinkParser.parse(markdown) as MarkdownNode;
@@ -157,6 +164,172 @@ function traverseMarkdownNode(node: MarkdownNode, visit: (node: MarkdownNode, pa
   };
 
   walk(node, []);
+}
+
+function markdownLabelEnd(source: string, start: number) {
+  let depth = 0;
+
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (character === "[") {
+      depth += 1;
+      continue;
+    }
+    if (character !== "]") continue;
+
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+
+  return -1;
+}
+
+function skipMarkdownWhitespace(source: string, start: number) {
+  let index = start;
+  while (index < source.length && /[\t\n\r ]/u.test(source[index] ?? "")) index += 1;
+  return index;
+}
+
+function markdownDestinationEnd(source: string, start: number, inline: boolean) {
+  if (source[start] === "<") {
+    for (let index = start + 1; index < source.length; index += 1) {
+      if (source[index] === "\\") {
+        index += 1;
+        continue;
+      }
+      if (source[index] === ">") return index;
+    }
+    return -1;
+  }
+
+  let nestedParentheses = 0;
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index] ?? "";
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (inline && character === "(") {
+      nestedParentheses += 1;
+      continue;
+    }
+    if (inline && character === ")") {
+      if (nestedParentheses === 0) return index;
+      nestedParentheses -= 1;
+      continue;
+    }
+    if (/\s/u.test(character) && nestedParentheses === 0) return index;
+  }
+
+  return source.length;
+}
+
+function markdownDestinationRange(markdown: string, node: MarkdownNode): ProtectedRange | null {
+  const nodeStart = markdownNodeStart(node);
+  const nodeEnd = markdownNodeEnd(node);
+  if (typeof nodeStart !== "number" || typeof nodeEnd !== "number") return null;
+
+  const source = markdown.slice(nodeStart, nodeEnd);
+  const labelStart = source.startsWith("![") ? 1 : 0;
+  if (source[labelStart] !== "[") return null;
+
+  const labelEnd = markdownLabelEnd(source, labelStart);
+  if (labelEnd < 0) return null;
+
+  const definition = node.type === "definition";
+  const delimiter = definition ? ":" : "(";
+  if (source[labelEnd + 1] !== delimiter) return null;
+
+  let destinationStart = skipMarkdownWhitespace(source, labelEnd + 2);
+  const wrapped = source[destinationStart] === "<";
+  const destinationEnd = markdownDestinationEnd(source, destinationStart, !definition);
+  if (destinationEnd < 0) return null;
+  if (wrapped) destinationStart += 1;
+
+  return {
+    from: nodeStart + destinationStart,
+    to: nodeStart + destinationEnd
+  };
+}
+
+function normalizedRelativePathParts(path: string) {
+  const parts: string[] = [];
+
+  for (const part of path.replace(/\\/gu, "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (!parts.length) return null;
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+
+  return parts;
+}
+
+function markdownDocumentDirectoryParts(path: string) {
+  const parts = normalizedRelativePathParts(path);
+  if (!parts) return null;
+
+  return parts.slice(0, -1);
+}
+
+function encodedMarkdownHrefPath(path: string) {
+  return path.replace(unsafeMarkdownHrefCharactersPattern, (character) =>
+    `%${character.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`
+  );
+}
+
+function rebasedMarkdownHref(href: string, fromDocumentPath: string, toDocumentPath: string) {
+  const trimmed = href.trim();
+  if (
+    !trimmed ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("\\") ||
+    localUrlSchemePattern.test(trimmed)
+  ) {
+    return null;
+  }
+
+  const suffixStart = trimmed.search(/[?#]/u);
+  const rawPath = suffixStart >= 0 ? trimmed.slice(0, suffixStart) : trimmed;
+  const suffix = suffixStart >= 0 ? trimmed.slice(suffixStart) : "";
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURI(rawPath);
+  } catch {
+    return null;
+  }
+
+  const fromDirectory = markdownDocumentDirectoryParts(fromDocumentPath);
+  const toDirectory = markdownDocumentDirectoryParts(toDocumentPath);
+  if (!fromDirectory || !toDirectory) return null;
+
+  const targetParts = normalizedRelativePathParts([...fromDirectory, decodedPath].join("/"));
+  if (!targetParts) return null;
+
+  let shared = 0;
+  while (
+    shared < toDirectory.length &&
+    shared < targetParts.length &&
+    toDirectory[shared] === targetParts[shared]
+  ) {
+    shared += 1;
+  }
+
+  const rebasedPath = [
+    ...toDirectory.slice(shared).map(() => ".."),
+    ...targetParts.slice(shared)
+  ].join("/");
+  if (!rebasedPath) return null;
+
+  return `${encodedMarkdownHrefPath(rebasedPath)}${suffix}`;
 }
 
 function decodeMarkdownHref(href: string) {
@@ -355,6 +528,37 @@ export function parseMarkdownLinkReferences(markdown: string): MarkdownLinkRefer
   });
 
   return links.sort((left, right) => left.from - right.from);
+}
+
+export function rebaseMarkdownLocalLinks(
+  markdown: string,
+  fromDocumentPath: string,
+  toDocumentPath: string
+) {
+  const fromDirectory = markdownDocumentDirectoryParts(fromDocumentPath);
+  const toDirectory = markdownDocumentDirectoryParts(toDocumentPath);
+  if (!fromDirectory || !toDirectory || fromDirectory.join("/") === toDirectory.join("/")) return markdown;
+
+  const edits: MarkdownEdit[] = [];
+  traverseMarkdownNode(parseMarkdown(markdown), (node) => {
+    if (
+      (node.type !== "link" && node.type !== "image" && node.type !== "definition") ||
+      typeof node.url !== "string"
+    ) {
+      return;
+    }
+
+    const href = rebasedMarkdownHref(node.url, fromDocumentPath, toDocumentPath);
+    if (!href || href === node.url) return;
+
+    const range = markdownDestinationRange(markdown, node);
+    if (!range) return;
+    edits.push({ ...range, text: href });
+  });
+
+  return edits
+    .sort((left, right) => right.from - left.from)
+    .reduce((content, edit) => `${content.slice(0, edit.from)}${edit.text}${content.slice(edit.to)}`, markdown);
 }
 
 export function parseMarkdownMentionRanges(markdown: string): MarkdownMentionRange[] {


### PR DESCRIPTION
## Summary
- preserve relative image, attachment, and document link targets when a Markdown file moves between folders
- rebase the latest moved file from disk, while keeping an open unsaved draft isolated and dirty
- preserve self references and query-only links, and apply link edits in one linear pass for large notes
- restore the original file location when moved content cannot be read or rewritten

## Validation
- `pnpm test` — 2,437 tests passed across the workspace
- `pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/markdown typecheck:test` — passed
- `pnpm build` — workspace, desktop, and web builds passed

## Risk
- moving a whole folder keeps its existing behavior because internal relative paths move with the folder; this PR only rebases individually moved Markdown files
- remote URLs, anchors, root paths, fenced code, self references, and query-only links are left unchanged
- ordinary tree moves no longer save unrelated dirty tabs; AI workspace plans retain their existing explicit pre-save behavior

## Related Issues
Closes #556