### PR TITLE
fix(editor): let live preview resolve link targets through the host app

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -545,6 +545,10 @@ describe("Markra workspace", () => {
 
   afterEach(() => {
     resetAppRuntimeForTests();
+    // jsdom shares one document selection across tests. A selection left on a
+    // destroyed editor makes the next CodeMirror view treat the mismatching
+    // DOM selection as user input and collapse its own selection.
+    document.getSelection()?.removeAllRanges();
   });
 
   it("syncs selection toolbar formatting after running the editor link command", () => {
@@ -7547,7 +7551,7 @@ describe("Markra workspace", () => {
     expect(container.querySelector(".cm-editor .markra-search-match-current")).not.toBeInTheDocument();
   });
 
-  it("clears finalized image source editing when document search opens", async () => {
+  it("keeps the image preview rendered while source editing and document search open", async () => {
     mockOpenMarkdownFile({
       content: "Intro\n\n![Screenshot](assets/pasted-image.png)\n\nContent",
       name: "native.md",
@@ -7567,15 +7571,14 @@ describe("Markra workspace", () => {
       view.dispatch({ selection: EditorSelection.cursor(imageFrom + 2) });
     });
     await waitFor(() => {
-      expect(container.querySelector('.cm-editor img[src="assets/pasted-image.png"]')).not.toBeInTheDocument();
+      expect(container.querySelector(".markra-image-node-selected")).toBeInTheDocument();
     });
+    expect(container.querySelector('.cm-editor img[src="assets/pasted-image.png"]')).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "f", metaKey: true });
 
     expect(screen.getByRole("searchbox", { name: "Find in document" })).toHaveFocus();
-    await waitFor(() => {
-      expect(container.querySelector('.cm-editor img[src="assets/pasted-image.png"]')).toBeInTheDocument();
-    });
+    expect(container.querySelector('.cm-editor img[src="assets/pasted-image.png"]')).toBeInTheDocument();
   });
 
   it("replaces the current source-mode document search match", async () => {

--- a/packages/app/src/components/CodeMirrorPaperSurface.tsx
+++ b/packages/app/src/components/CodeMirrorPaperSurface.tsx
@@ -178,6 +178,7 @@ function markdownExtension({
 
   return liveMarkdown({
     highlight: extendedSyntax?.highlight ?? true,
+    resolveLinkTarget: linkOptions?.resolveTarget,
     plugins: [
       blocksPlugin({
         callout: extendedSyntax?.githubAlerts ?? true,

--- a/packages/app/src/test/setup.ts
+++ b/packages/app/src/test/setup.ts
@@ -1,7 +1,9 @@
 import * as matchers from "@testing-library/jest-dom/matchers";
+import { configure } from "@testing-library/react";
 import { expect, vi } from "vitest";
 
 expect.extend(matchers);
+configure({ asyncUtilTimeout: 5000 });
 
 const testRect = {
   bottom: 0,

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig(({ mode }) => ({
     environment: "jsdom",
     globals: true,
     ...localTestWorkerConfig,
-    setupFiles: "./src/test/setup.ts"
+    setupFiles: "./src/test/setup.ts",
+    // waitFor polls for up to 5s (see src/test/setup.ts); leave headroom so a
+    // slow machine hits a waitFor diagnostic instead of a bare test timeout.
+    testTimeout: 15000
   }
 }));

--- a/packages/editor/src/codemirror/inline-markdown.ts
+++ b/packages/editor/src/codemirror/inline-markdown.ts
@@ -30,6 +30,33 @@ export interface InlineMarkdownRenderOptions {
   readonly resolveImageSource?: (
     details: InlineMarkdownImageDetails,
   ) => string | null;
+  readonly resolveLinkTarget?: (source: string) => string | null;
+}
+
+function resolveLinkHref(
+  linkSource: string,
+  autolink: boolean,
+  options: InlineMarkdownRenderOptions,
+) {
+  const resolveTarget = options.resolveLinkTarget;
+  if (!resolveTarget) {
+    return autolink
+      ? resolveAutolinkTarget(linkSource)
+      : resolveSafeLinkTarget(linkSource);
+  }
+
+  const candidate = autolink
+    ? resolveAutolinkTarget(linkSource)
+    : unescapeMarkdown(linkSource);
+  if (!candidate) return null;
+  let target: string | null;
+  try {
+    target = resolveTarget(candidate);
+  } catch {
+    return null;
+  }
+  const normalizedTarget = target?.trim();
+  return normalizedTarget ? normalizedTarget : null;
 }
 
 function appendText(
@@ -125,7 +152,11 @@ function renderLink(
     return;
   }
 
-  const href = resolveSafeLinkTarget(source.slice(url.from, url.to).trim());
+  const href = resolveLinkHref(
+    source.slice(url.from, url.to).trim(),
+    false,
+    options,
+  );
   const element = ownerDocument.createElement(href ? "a" : "span");
   element.dataset.markraLinkMarkdown = source.slice(node.from, node.to);
   element.dataset.markraLinkSource = source.slice(url.from, url.to).trim();
@@ -158,6 +189,7 @@ function renderAutolink(
   ownerDocument: Document,
   source: string,
   node: InlineNode,
+  options: InlineMarkdownRenderOptions,
 ) {
   const url = node.name === "URL"
     ? node
@@ -168,7 +200,7 @@ function renderAutolink(
   }
 
   const linkSource = unescapeMarkdown(source.slice(url.from, url.to).trim());
-  const href = resolveAutolinkTarget(linkSource);
+  const href = resolveLinkHref(linkSource, true, options);
   const element = ownerDocument.createElement(href ? "a" : "span");
   element.dataset.markraLinkMarkdown = source.slice(node.from, node.to);
   element.dataset.markraLinkSource = href ?? linkSource;
@@ -282,7 +314,7 @@ function renderNode(
       return;
     case "Autolink":
     case "URL":
-      renderAutolink(parent, ownerDocument, source, node);
+      renderAutolink(parent, ownerDocument, source, node, options);
       return;
     case "HardBreak":
       parent.appendChild(ownerDocument.createElement("br"));

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -200,6 +200,37 @@ describe("liveMarkdown", () => {
     expect(view.state.doc.toString()).toBe(doc);
   });
 
+  it("renders an anchor for a target allowed by a custom link resolver", () => {
+    const doc = "Read [doc](FILE:///attachments/Doc.pdf)\n\nEdit";
+    const view = createView({
+      doc,
+      extensions: [
+        liveMarkdown({
+          resolveLinkTarget: ({ source }) =>
+            source.startsWith("FILE:") ? source : null,
+        }),
+      ],
+    });
+    const rendered = view.dom.querySelector(".cm-markra-link");
+
+    expect(rendered?.textContent).toBe("doc");
+    expect(rendered?.tagName).toBe("A");
+    expect(rendered?.getAttribute("href")).toBe("FILE:///attachments/Doc.pdf");
+  });
+
+  it("renders a plain span when the custom link resolver rejects a target", () => {
+    const doc = "Read [site](https://example.test)\n\nEdit";
+    const view = createView({
+      doc,
+      extensions: [liveMarkdown({ resolveLinkTarget: () => null })],
+    });
+    const rendered = view.dom.querySelector(".cm-markra-link");
+
+    expect(rendered?.textContent).toBe("site");
+    expect(rendered?.tagName).not.toBe("A");
+    expect(rendered?.hasAttribute("href")).toBe(false);
+  });
+
   it("enables and renders GFM strikethrough by default", () => {
     const doc = "Keep ~~old~~ new\n\nEdit";
     const view = createView({ doc });

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAutolinkTarget,
   resolveSafeLinkTarget,
+  type MarkraLinkSourceContext,
 } from "./links.ts";
 import { unescapeMarkdown } from "./syntax.ts";
 import { createTaskDecoration } from "./tasks.ts";
@@ -155,8 +156,31 @@ function headingAriaLabel(source: string, setext: boolean) {
 }
 
 export interface LivePreviewConfig {
+  resolveLinkTarget?: (context: MarkraLinkSourceContext) => string | null;
   reveal?: RevealPolicy;
   taskCheckboxes?: boolean;
+}
+
+function resolveLinkHref(
+  nodeName: string,
+  source: string,
+  view: EditorView,
+  resolveTarget: LivePreviewConfig["resolveLinkTarget"],
+) {
+  const candidate = nodeName === "Link" ? source : resolveAutolinkTarget(source);
+  if (!candidate) return null;
+  if (!resolveTarget) {
+    return nodeName === "Link" ? resolveSafeLinkTarget(candidate) : candidate;
+  }
+
+  let target: string | null;
+  try {
+    target = resolveTarget({ source: candidate, state: view.state, view });
+  } catch {
+    return null;
+  }
+  const normalizedTarget = target?.trim();
+  return normalizedTarget ? normalizedTarget : null;
 }
 
 class LinkIconWidget extends WidgetType {
@@ -218,6 +242,7 @@ function buildDecorations(
   view: EditorView,
   reveal: RevealPolicy,
   taskCheckboxes: boolean,
+  resolveLinkTarget: LivePreviewConfig["resolveLinkTarget"],
 ) {
   const { state } = view;
   const ranges: Range<Decoration>[] = [];
@@ -382,9 +407,7 @@ function buildDecorations(
         ? unescapeMarkdown(state.sliceDoc(linkUrl.from, linkUrl.to).trim())
         : null;
       const linkHref = linkSource
-        ? node.name === "Link"
-          ? resolveSafeLinkTarget(linkSource)
-          : resolveAutolinkTarget(linkSource)
+        ? resolveLinkHref(node.name, linkSource, view, resolveLinkTarget)
         : null;
       const linkRevealed = linkLike && reveal({
         view,
@@ -586,6 +609,7 @@ function buildDecorations(
 function previewPlugin(config: LivePreviewConfig): Extension {
   const reveal = config.reveal ?? revealActiveLine;
   const taskCheckboxes = config.taskCheckboxes ?? true;
+  const resolveLinkTarget = config.resolveLinkTarget;
 
   return ViewPlugin.fromClass(
     class {
@@ -593,7 +617,12 @@ function previewPlugin(config: LivePreviewConfig): Extension {
       composing: boolean;
 
       constructor(view: EditorView) {
-        this.decorations = buildDecorations(view, reveal, taskCheckboxes);
+        this.decorations = buildDecorations(
+          view,
+          reveal,
+          taskCheckboxes,
+          resolveLinkTarget,
+        );
         this.composing = view.composing;
       }
 
@@ -629,6 +658,7 @@ function previewPlugin(config: LivePreviewConfig): Extension {
             update.view,
             reveal,
             taskCheckboxes,
+            resolveLinkTarget,
           );
         }
       }

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -93,6 +93,42 @@ describe("tablePreviewPlugin", () => {
     expect(view.state.doc.toString()).toBe(doc);
   });
 
+  it("renders anchors for custom-resolved link targets inside visual table cells", () => {
+    const doc = [
+      "| Attachment | Site |",
+      "| --- | --- |",
+      "| [Reference.pdf](FILE:///mock-files/Reference.pdf) | [Open](https://example.test) |",
+      "",
+      "Edit",
+    ].join("\n");
+    const resolveTarget = vi.fn(({ source }: { source: string }) =>
+      source.startsWith("FILE:") ? source : null,
+    );
+    const view = createView(
+      doc,
+      tablePreviewPlugin({ links: { open: () => true, resolveTarget } }),
+    );
+    const cells = view.dom.querySelectorAll<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+    const attachment = cells[0]?.querySelector("a");
+    const rejected = cells[1]?.querySelector("[data-markra-link-markdown]");
+
+    expect(attachment?.textContent).toBe("Reference.pdf");
+    expect(attachment?.getAttribute("href")).toBe(
+      "FILE:///mock-files/Reference.pdf",
+    );
+    const resolveContext = resolveTarget.mock.calls[0]?.[0] as
+      | { source: string; state: EditorState; view: EditorView }
+      | undefined;
+    expect(resolveContext?.source).toBe("FILE:///mock-files/Reference.pdf");
+    expect(resolveContext?.state).toBeInstanceOf(EditorState);
+    expect(resolveContext?.view).toBe(view);
+    expect(rejected?.tagName).toBe("SPAN");
+    expect(rejected?.hasAttribute("href")).toBe(false);
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
   it("renders and preserves images inside visual table cells", async () => {
     const doc = [
       "| Name | Media |",

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -695,14 +695,24 @@ function renderVisualTableCell(
   cell: HTMLTableCellElement,
   source: string,
   images: ImagePreviewPluginOptions | undefined,
+  links: LinksPluginOptions | undefined,
 ) {
-  const resolver = images?.resolveSource;
-  renderInlineMarkdown(cell, source, resolver
-    ? {
-        resolveImageSource: (details: InlineMarkdownImageDetails) =>
-          resolver({ ...details, state: view.state, view }),
-      }
-    : undefined);
+  const imageResolver = images?.resolveSource;
+  const linkResolver = links?.resolveTarget;
+  renderInlineMarkdown(cell, source, {
+    ...(imageResolver
+      ? {
+          resolveImageSource: (details: InlineMarkdownImageDetails) =>
+            imageResolver({ ...details, state: view.state, view }),
+        }
+      : {}),
+    ...(linkResolver
+      ? {
+          resolveLinkTarget: (linkSource: string) =>
+            linkResolver({ source: linkSource, state: view.state, view }),
+        }
+      : {}),
+  });
 }
 
 function appendCell(
@@ -727,7 +737,7 @@ function appendCell(
     currentSession.header === header &&
     currentSession.inlineSourceVisible;
   if (keepInlineSourceVisible) cell.textContent = cellPreview.source;
-  else renderVisualTableCell(view, cell, cellPreview.source, images);
+  else renderVisualTableCell(view, cell, cellPreview.source, images, links);
   cell.tabIndex = view.state.readOnly ? -1 : 0;
   cell.dataset.tableColumn = String(columnIndex);
   cell.dataset.tableHeader = String(header);
@@ -830,7 +840,7 @@ function appendCell(
       ) {
         tableEditingSessions.delete(view);
         if (session.inlineSourceVisible && cell.isConnected) {
-          renderVisualTableCell(view, cell, cellPreview.source, images);
+          renderVisualTableCell(view, cell, cellPreview.source, images, links);
         }
       }
     }, 0);
@@ -884,6 +894,7 @@ function appendCell(
           cell,
           visualTableCellSource(cell),
           images,
+          links,
         );
       }
       view.focus();
@@ -905,7 +916,7 @@ function appendCell(
         session.originalSource,
       );
       if (!changed && session.inlineSourceVisible) {
-        renderVisualTableCell(view, cell, session.originalSource, images);
+        renderVisualTableCell(view, cell, session.originalSource, images, links);
       }
     }
     view.focus();


### PR DESCRIPTION
Fixes #559

## What

Local attachment links (`FILE://`) lost their `<a href>` rendering in live preview after the Milkdown → CodeMirror migration: `buildDecorations` in `preview.ts` hardcoded `resolveSafeLinkTarget`, so only `http`/`https`/`mailto`/`tel` and scheme-less targets could render as anchors, with no way for the host app to allow its local-attachment scheme.

- Add an optional `resolveLinkTarget` hook to `LivePreviewConfig` (mirrors `linksPlugin.resolveTarget` and `imagePreviewPlugin.resolveSource`, including the try/catch + trim semantics of `resolvedLinkSource`). Default behavior is unchanged when the hook is not provided.
- Pass the existing app resolver from `CodeMirrorPaperSurface` so imported attachments render as anchors again.
- Align the `clears finalized image source editing` app test with the current CodeMirror widget UX (preview stays visible, inline source row opens); its old expectations described removed Milkdown behavior and always failed.
- Test-infra: raise `asyncUtilTimeout` to 5s and `testTimeout` to 15s in `@markra/app` — on slower machines the 1s/5s defaults produced rotating timeout flakes across the suite. Feel free to drop this commit if you prefer.

## Why it went unnoticed

`ci.yml` only triggers on `main`, so pushes to `v2` never ran the frontend suite. Two `App.test.tsx` tests covering this behavior fail deterministically on `v2`:

- `imports local attachments into an unsaved document when external files are not copied`
- `clears finalized image source editing when document search opens`

(The pre-existing `typecheck:test` failure in `packages/editor/src/codemirror/ai-preview.test.ts` on `v2` is unrelated and left untouched.)

## Verification

- `@markra/editor` tests: 245 passed (adds 2 focused tests for the new hook: resolver-allowed target renders an anchor, resolver-rejected target renders a plain span).
- `@markra/app` tests: 1357 passed, including the two previously failing tests.
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
