### PR TITLE
fix(editor): restore Mermaid zoom interactions

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -3873,7 +3873,7 @@
   }
 
   .markdown-paper .markra-mermaid-zoom-button {
-    @apply absolute top-2 right-2 z-[3] grid size-7 cursor-pointer place-items-center rounded-md border border-(--border-default) p-0 outline-none transition-[opacity,transform,color,background-color,border-color,box-shadow] duration-150 ease-out;
+    @apply absolute top-4 right-2 z-[3] grid size-7 cursor-pointer place-items-center rounded-md border border-(--border-default) p-0 outline-none transition-[opacity,transform,color,background-color,border-color,box-shadow] duration-150 ease-out;
     background: var(--editor-code-control-bg);
     border-color: var(--editor-border);
     color: var(--editor-text-secondary);

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -832,6 +832,10 @@ describe("editor stylesheet", () => {
     );
     const mermaidZoomRevealEnd = styles.indexOf(".markdown-paper .markra-mermaid-zoom-button:hover");
     const mermaidZoomRevealStyles = styles.slice(mermaidZoomRevealStart, mermaidZoomRevealEnd);
+    const mermaidZoomButtonStart = styles.indexOf(".markdown-paper .markra-mermaid-zoom-button {");
+    const mermaidZoomButtonEnd =
+      styles.indexOf("\n  }\n", mermaidZoomButtonStart) + "\n  }\n".length;
+    const mermaidZoomButtonStyles = styles.slice(mermaidZoomButtonStart, mermaidZoomButtonEnd);
     const mermaidZoomHoverStart = styles.indexOf(".markdown-paper .markra-mermaid-zoom-button:hover");
     const mermaidZoomHoverEnd = styles.indexOf("\n  }\n", mermaidZoomHoverStart) + "\n  }\n".length;
     const mermaidZoomHoverStyles = styles.slice(mermaidZoomHoverStart, mermaidZoomHoverEnd);
@@ -848,6 +852,7 @@ describe("editor stylesheet", () => {
     expect(mermaidFoldStyles).toContain(".markra-code-language-control");
     expect(styles).toContain(".markdown-paper .markra-mermaid-preview-button");
     expect(styles).toContain(".markdown-paper .markra-mermaid-zoom-button");
+    expect(mermaidZoomButtonStyles).toContain("top-4");
     expect(mermaidZoomRevealStyles).not.toContain(":focus-within");
     expect(mermaidZoomRevealStyles).toContain("opacity: 1");
     expect(mermaidZoomRevealStyles).toContain("pointer-events: auto");

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -277,7 +277,7 @@ describe("codeBlockPreviewPlugin", () => {
     expect(view.state.doc.toString()).toBe(source);
   });
 
-  it("opens and controls an enlarged Mermaid preview", async () => {
+  it("opens, zooms, pans, and resets an enlarged Mermaid preview", async () => {
     const source = "```mermaid\nflowchart TD\n  A --> B\n```\n\nEdit";
     const view = createView(
       source,
@@ -289,16 +289,68 @@ describe("codeBlockPreviewPlugin", () => {
       expect(view.dom.querySelector(".markra-mermaid-zoom-button")).not.toBeNull();
     });
 
-    view.dom.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-button")?.click();
+    const zoomButton = view.dom.querySelector<HTMLButtonElement>(
+      ".markra-mermaid-zoom-button",
+    );
+    const preview = view.dom.querySelector<HTMLElement>(".markra-mermaid-render");
+    expect(
+      zoomButton?.closest<HTMLElement>(".markra-code-block")?.dataset.mermaidMode,
+    ).toBe("preview");
+    expect(zoomButton?.parentElement).not.toBe(preview);
+    expect(zoomButton?.querySelector(".markra-mermaid-zoom-icon")).not.toBeNull();
+    expect(zoomButton?.textContent).toBe("");
+
+    zoomButton?.click();
     const dialog = document.querySelector<HTMLElement>(
       ".markra-mermaid-zoom-dialog",
     );
     expect(dialog?.getAttribute("role")).toBe("dialog");
     expect(dialog?.querySelector("svg")).not.toBeNull();
+    for (const className of [
+      ".markra-mermaid-zoom-out-button",
+      ".markra-mermaid-zoom-in-button",
+      ".markra-mermaid-zoom-reset-button",
+      ".markra-mermaid-zoom-close-button",
+    ]) {
+      const button = dialog?.querySelector<HTMLButtonElement>(className);
+      expect(button?.querySelector("svg")).not.toBeNull();
+      expect(button?.textContent).toBe("");
+    }
     dialog?.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-in-button")?.click();
     expect(
       dialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-canvas")?.style.transform,
     ).toContain("scale(1.25)");
+
+    const content = dialog?.querySelector<HTMLElement>(
+      ".markra-mermaid-zoom-content",
+    );
+    const canvas = dialog?.querySelector<HTMLElement>(
+      ".markra-mermaid-zoom-canvas",
+    );
+    content?.dispatchEvent(new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      clientX: 100,
+      clientY: 80,
+      pointerId: 9,
+    }));
+    content?.dispatchEvent(new PointerEvent("pointermove", {
+      bubbles: true,
+      clientX: 132,
+      clientY: 96,
+      pointerId: 9,
+    }));
+    expect(content?.dataset.dragging).toBe("true");
+    expect(canvas?.style.transform).toContain("translate(32px, 16px)");
+    content?.dispatchEvent(new PointerEvent("pointerup", {
+      bubbles: true,
+      button: 0,
+      pointerId: 9,
+    }));
+    expect(content?.dataset.dragging).toBeUndefined();
+
+    dialog?.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-reset-button")?.click();
+    expect(canvas?.style.transform).toBe("translate(0px, 0px) scale(1)");
 
     document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
     expect(document.querySelector(".markra-mermaid-zoom-dialog")).toBeNull();

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -145,6 +145,32 @@ const checkIconChildren = [
   },
 ] as const;
 
+const expandIconChildren = [
+  { tag: "path", attributes: { d: "M15 3h6v6" } },
+  { tag: "path", attributes: { d: "m21 3-7 7" } },
+  { tag: "path", attributes: { d: "M9 21H3v-6" } },
+  { tag: "path", attributes: { d: "m3 21 7-7" } },
+] as const;
+
+const closeIconChildren = [
+  { tag: "path", attributes: { d: "M18 6 6 18" } },
+  { tag: "path", attributes: { d: "m6 6 12 12" } },
+] as const;
+
+const zoomInIconChildren = [
+  { tag: "path", attributes: { d: "M12 5v14" } },
+  { tag: "path", attributes: { d: "M5 12h14" } },
+] as const;
+
+const zoomOutIconChildren = [
+  { tag: "path", attributes: { d: "M5 12h14" } },
+] as const;
+
+const resetViewIconChildren = [
+  { tag: "path", attributes: { d: "M3 12a9 9 0 1 0 3-6.7" } },
+  { tag: "path", attributes: { d: "M3 3v6h6" } },
+] as const;
+
 const codeBlockTheme = EditorView.baseTheme({
   ".cm-markra-code-line": {
     backgroundColor: "color-mix(in srgb, currentColor 5%, transparent)",
@@ -243,11 +269,6 @@ const codeBlockTheme = EditorView.baseTheme({
     padding: "0.85em",
     position: "relative",
     textAlign: "center",
-  },
-  ".markra-mermaid-render .markra-mermaid-zoom-button": {
-    opacity: "1",
-    pointerEvents: "auto",
-    transform: "none",
   },
   ".markra-mermaid-render svg": {
     height: "auto",
@@ -490,33 +511,45 @@ class MermaidPreviewWidget extends WidgetType {
     const zoomValue = document.createElement("span");
     const content = document.createElement("div");
     const canvas = document.createElement("div");
-    const makeButton = (className: string, label: string, text: string) => {
+    const makeButton = (
+      className: string,
+      label: string,
+      iconClassName: string,
+      iconChildren: Parameters<typeof createCodeControlIcon>[2],
+    ) => {
       const button = document.createElement("button");
       button.type = "button";
       button.className = className;
       button.ariaLabel = label;
-      button.textContent = text;
+      button.title = label;
+      button.append(
+        createCodeControlIcon(document, iconClassName, iconChildren),
+      );
       return button;
     };
     const zoomOut = makeButton(
       "markra-mermaid-zoom-control-button markra-mermaid-zoom-out-button",
       "Zoom out Mermaid diagram",
-      "−",
+      "markra-mermaid-zoom-out-icon",
+      zoomOutIconChildren,
     );
     const zoomIn = makeButton(
       "markra-mermaid-zoom-control-button markra-mermaid-zoom-in-button",
       "Zoom in Mermaid diagram",
-      "+",
+      "markra-mermaid-zoom-in-icon",
+      zoomInIconChildren,
     );
     const reset = makeButton(
       "markra-mermaid-zoom-control-button markra-mermaid-zoom-reset-button",
       "Reset Mermaid diagram view",
-      "Reset",
+      "markra-mermaid-zoom-reset-icon",
+      resetViewIconChildren,
     );
     const close = makeButton(
       "markra-mermaid-zoom-close-button",
       "Close enlarged Mermaid diagram",
-      "×",
+      "markra-mermaid-zoom-close-icon",
+      closeIconChildren,
     );
 
     dialog.className = "markra-mermaid-zoom-dialog";
@@ -533,9 +566,18 @@ class MermaidPreviewWidget extends WidgetType {
     canvas.className = "markra-mermaid-zoom-canvas";
     canvas.append(sourceSvg.cloneNode(true));
 
+    let translateX = 0;
+    let translateY = 0;
+    let drag: {
+      originX: number;
+      originY: number;
+      pointerId: number;
+      startX: number;
+      startY: number;
+    } | null = null;
     const syncZoom = () => {
       const scale = String(this.zoomScale);
-      canvas.style.transform = `translate(0px, 0px) scale(${scale})`;
+      canvas.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`;
       content.dataset.zoom = scale;
       zoomValue.textContent = `${Math.round(this.zoomScale * 100)}%`;
     };
@@ -545,12 +587,49 @@ class MermaidPreviewWidget extends WidgetType {
     };
     zoomOut.addEventListener("click", () => setZoom(this.zoomScale - 0.25));
     zoomIn.addEventListener("click", () => setZoom(this.zoomScale + 0.25));
-    reset.addEventListener("click", () => setZoom(1));
+    reset.addEventListener("click", () => {
+      this.zoomScale = 1;
+      translateX = 0;
+      translateY = 0;
+      syncZoom();
+    });
     close.addEventListener("click", () => this.closeZoom(trigger));
     content.addEventListener("wheel", (event) => {
       event.preventDefault();
       setZoom(this.zoomScale * (event.deltaY < 0 ? 1.12 : 1 / 1.12));
     }, { passive: false });
+    content.addEventListener("pointerdown", (event) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      // Pointer capture keeps Windows WebView drag updates flowing after the
+      // cursor leaves the viewport while a large diagram is being panned.
+      content.setPointerCapture?.(event.pointerId);
+      content.dataset.dragging = "true";
+      drag = {
+        originX: translateX,
+        originY: translateY,
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+      };
+    });
+    content.addEventListener("pointermove", (event) => {
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      translateX = drag.originX + event.clientX - drag.startX;
+      translateY = drag.originY + event.clientY - drag.startY;
+      syncZoom();
+    });
+    const stopDragging = (event: PointerEvent) => {
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      if (content.hasPointerCapture?.(event.pointerId)) {
+        content.releasePointerCapture(event.pointerId);
+      }
+      delete content.dataset.dragging;
+      drag = null;
+    };
+    content.addEventListener("pointerup", stopDragging);
+    content.addEventListener("pointercancel", stopDragging);
     dialog.addEventListener("mousedown", (event) => {
       if (event.target === dialog) this.closeZoom(trigger);
     });
@@ -574,26 +653,37 @@ class MermaidPreviewWidget extends WidgetType {
   private appendZoomButton(
     view: CodeMirrorView,
     preview: HTMLElement,
+    wrapper: HTMLElement,
   ) {
     if (!preview.querySelector("svg")) return;
+    wrapper.querySelector(".markra-mermaid-zoom-button")?.remove();
     const button = view.dom.ownerDocument.createElement("button");
     button.type = "button";
     button.className = "markra-mermaid-zoom-button";
     button.ariaLabel = "Enlarge Mermaid diagram";
     button.title = "Enlarge Mermaid diagram";
-    button.textContent = "↗";
+    button.append(
+      createCodeControlIcon(
+        view.dom.ownerDocument,
+        "markra-mermaid-zoom-icon",
+        expandIconChildren,
+      ),
+    );
     button.addEventListener("mousedown", (event) => event.stopPropagation());
     button.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
       this.openZoom(view, preview, button);
     });
-    preview.append(button);
+    wrapper.append(button);
   }
 
   toDOM(view: CodeMirrorView) {
     const document = view.dom.ownerDocument;
+    const wrapper = document.createElement("div");
     const preview = document.createElement("div");
+    wrapper.className = "markra-code-block";
+    wrapper.dataset.mermaidMode = "preview";
     preview.className = "markra-mermaid-render";
     preview.tabIndex = 0;
     preview.ariaLabel = this.labels.mermaidDiagram;
@@ -623,7 +713,7 @@ class MermaidPreviewWidget extends WidgetType {
           if (token !== this.renderToken) return;
           this.closeZoom();
           preview.innerHTML = svg;
-          this.appendZoomButton(view, preview);
+          this.appendZoomButton(view, preview, wrapper);
           preview.setAttribute("aria-busy", "false");
         })
         .catch(() => {
@@ -646,7 +736,8 @@ class MermaidPreviewWidget extends WidgetType {
       if (paper) this.observer.observe(paper, options);
       this.observer.observe(document.documentElement, options);
     }
-    return preview;
+    wrapper.append(preview);
+    return wrapper;
   }
 
   destroy() {


### PR DESCRIPTION
## Summary
- restore pointer-captured panning for enlarged Mermaid diagrams, including drag cancellation and view reset
- restore the previous SVG zoom controls and keep the expand action outside the scrolling diagram content
- add stable top spacing so the preview action does not sit against the diagram edge

## Why
The CodeMirror migration retained the grab cursor styling but omitted the pointer handlers that move the enlarged diagram. As a result, Windows users could zoom a Mermaid diagram but could not pan it. The migration also replaced the previous icon controls with text and nested the expand action inside the diagram content.

## Validation
- `pnpm --filter @markra/editor test` — 31 files, 302 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app test -- src/styles.test.ts` — 53 tests passed
- `pnpm --filter @markra/app build` — passed
- local browser QA confirmed the expand control is outside the SVG and does not overlap the diagram

## Risk
Low. The change is limited to the CodeMirror Mermaid preview widget and its existing zoom control styles.

Fixes #563
