### PR TITLE
fix(editor): preserve Mermaid source selections

### DIFF
--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -277,6 +277,23 @@ describe("codeBlockPreviewPlugin", () => {
     expect(view.state.doc.toString()).toBe(source);
   });
 
+  it("keeps Mermaid source visible while selecting from inside the code block", () => {
+    const source = "```mermaid\nflowchart TD\n  A --> B\n```\n\nEdit";
+    const view = createView(source);
+    const anchor = source.indexOf("flowchart");
+    const head = source.indexOf("B");
+
+    view.dispatch({ selection: { anchor } });
+    expect(view.dom.querySelector(".markra-mermaid-render")).toBeNull();
+
+    view.dispatch({ selection: { anchor, head } });
+
+    expect(view.state.selection.main.empty).toBe(false);
+    expect(view.dom.querySelector(".markra-mermaid-render")).toBeNull();
+    expect(renderedLines(view)).toContain("flowchart TD");
+    expect(renderedLines(view)).toContain("  A --> B");
+  });
+
   it("opens, zooms, pans, and resets an enlarged Mermaid preview", async () => {
     const source = "```mermaid\nflowchart TD\n  A --> B\n```\n\nEdit";
     const view = createView(

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -923,8 +923,21 @@ export function codeBlockPreviewPlugin(
           const firstLine = state.doc.lineAt(node.from);
           const lastLine = state.doc.lineAt(node.to);
           const revealed = context.revealed("line");
+          // A Mermaid source selection must not collapse as soon as dragging
+          // makes it non-empty. Anchor-only matching preserves drags that
+          // start inside the block without revealing source for selections
+          // that merely pass over the preview from outside.
+          const selectionAnchoredInside =
+            context.view.hasFocus &&
+            state.selection.ranges.some(
+              (selection) =>
+                !selection.empty &&
+                selection.anchor >= node.from &&
+                selection.anchor <= node.to,
+            );
           const sourceRevealed =
-            isMermaidLanguage(parts.language) && revealed;
+            isMermaidLanguage(parts.language) &&
+            (revealed || selectionAnchoredInside);
           if (
             !sourceRevealed &&
             parts.codeNode &&


### PR DESCRIPTION
## Summary
- keep Mermaid source mode active while a drag selection remains anchored inside the code block
- avoid revealing source when a selection starts outside and merely crosses the Mermaid preview
- add regression coverage for non-empty source selections

## Why
The generic live-preview reveal policy intentionally ignores non-empty range selections. When a user started dragging inside an active Mermaid source block, that policy immediately folded the source back into the rendered preview and interrupted text selection.

## Validation
- `pnpm --filter @markra/editor test` — 31 files, 303 tests passed
- `pnpm --filter @markra/editor test -- src/codemirror/code-block.test.ts` — 14 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app build` — passed
- local browser QA confirmed dragging across Mermaid source keeps the source visible and shows the selection highlight

## Risk
Low. The additional reveal condition is limited to non-empty selections whose anchor starts inside a Mermaid fenced code block.

Follow-up to #564.
