### PR TITLE
fix: resolve outstanding issue regressions

### DIFF
--- a/apps/desktop/src-tauri/src/ai_http.rs
+++ b/apps/desktop/src-tauri/src/ai_http.rs
@@ -11,6 +11,12 @@ use crate::network::{apply_network_settings, NetworkSettings};
 const AI_PROVIDER_REQUEST_TIMEOUT_SECS: u64 = 20;
 const AI_CHAT_REQUEST_TIMEOUT_SECS: u64 = 60;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequestTimeoutPolicy {
+    Connect(Duration),
+    Total(Duration),
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AiProviderJsonRequest {
@@ -95,12 +101,9 @@ async fn execute_native_chat_request(
 ) -> Result<AiProviderJsonResponse, String> {
     let url = validated_http_url(&request.url)?;
     let headers = parse_headers(&request.headers)?;
-    let client = apply_network_settings(
-        reqwest::Client::builder().timeout(Duration::from_secs(AI_CHAT_REQUEST_TIMEOUT_SECS)),
-        request.network.as_ref(),
-    )?
-    .build()
-    .map_err(|error| error.to_string())?;
+    let client = apply_network_settings(chat_client_builder(false), request.network.as_ref())?
+        .build()
+        .map_err(|error| error.to_string())?;
 
     let response = client
         .post(url)
@@ -122,12 +125,9 @@ async fn execute_native_chat_stream_request(
 ) -> Result<AiProviderJsonResponse, String> {
     let url = validated_http_url(&request.url)?;
     let headers = parse_headers(&request.headers)?;
-    let client = apply_network_settings(
-        reqwest::Client::builder().timeout(Duration::from_secs(AI_CHAT_REQUEST_TIMEOUT_SECS)),
-        request.network.as_ref(),
-    )?
-    .build()
-    .map_err(|error| error.to_string())?;
+    let client = apply_network_settings(chat_client_builder(true), request.network.as_ref())?
+        .build()
+        .map_err(|error| error.to_string())?;
 
     let mut response = client
         .post(url)
@@ -173,6 +173,25 @@ async fn execute_native_chat_stream_request(
         status,
         body: Value::Null,
     })
+}
+
+fn chat_client_builder(streaming: bool) -> reqwest::ClientBuilder {
+    let builder = reqwest::Client::builder();
+
+    match chat_request_timeout_policy(streaming) {
+        // A total timeout would abort an otherwise healthy response stream after 60 seconds.
+        RequestTimeoutPolicy::Connect(timeout) => builder.connect_timeout(timeout),
+        RequestTimeoutPolicy::Total(timeout) => builder.timeout(timeout),
+    }
+}
+
+fn chat_request_timeout_policy(streaming: bool) -> RequestTimeoutPolicy {
+    let timeout = Duration::from_secs(AI_CHAT_REQUEST_TIMEOUT_SECS);
+    if streaming {
+        RequestTimeoutPolicy::Connect(timeout)
+    } else {
+        RequestTimeoutPolicy::Total(timeout)
+    }
 }
 
 fn take_utf8_text(pending: &mut Vec<u8>, chunk: &[u8]) -> Option<String> {
@@ -342,5 +361,17 @@ mod tests {
             Some("你好".to_string())
         );
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn limits_only_connection_setup_for_streaming_chat_requests() {
+        assert_eq!(
+            chat_request_timeout_policy(true),
+            RequestTimeoutPolicy::Connect(Duration::from_secs(AI_CHAT_REQUEST_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            chat_request_timeout_policy(false),
+            RequestTimeoutPolicy::Total(Duration::from_secs(AI_CHAT_REQUEST_TIMEOUT_SECS))
+        );
     }
 }

--- a/packages/app/src/App.document-history.test.tsx
+++ b/packages/app/src/App.document-history.test.tsx
@@ -117,11 +117,13 @@ describe("Markra document history restore", () => {
     expect(screen.queryByRole("dialog", { name: "History versions" })).not.toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("option"));
+    fireEvent.click(await screen.findByRole("button", { name: "Restore version" }));
 
     await waitFor(() => {
       expect(debugSpy.mock.calls.map((call) => call[0])).toEqual(expect.arrayContaining([
+        "[markra-history] preview click",
+        "[markra-history] preview contents resolved",
         "[markra-history] restore click",
-        "[markra-history] restore contents resolved",
         "[markra-history] app restore requested",
         "[markra-history] document restore state updated",
         "[markra-history] editor replace requested",
@@ -234,6 +236,7 @@ describe("Markra document history restore", () => {
     expect(await screen.findByRole("region", { name: "History versions" })).toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("option"));
+    fireEvent.click(await screen.findByRole("button", { name: "Restore version" }));
 
     await waitFor(() => {
       expect(editorControllerSpies.replaceMarkdown).toHaveBeenCalledWith("# Earlier\n\nSynthetic body.");
@@ -272,15 +275,66 @@ describe("Markra document history restore", () => {
     expect(await screen.findByRole("region", { name: "History versions" })).toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("option"));
+    fireEvent.click(await screen.findByRole("button", { name: "Restore version" }));
 
     await waitFor(() => {
       expect(mockedSaveNativeMarkdownFile).toHaveBeenCalledWith({
         contents: "# Earlier\n\nSynthetic body.",
-        historyCursorId: "history-current",
         path: mockNativePath,
-        skipHistorySnapshot: true,
         suggestedName: "native.md"
       });
+    });
+  });
+
+  it("preserves unsaved contents in history before restoring an earlier version", async () => {
+    mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
+    mockOpenMarkdownFile({
+      content: "# Current\n\nSynthetic body.",
+      name: "native.md",
+      path: mockNativePath
+    });
+    mockedListNativeMarkdownFileHistory.mockResolvedValue([
+      {
+        id: "history-current",
+        createdAt: 1_700_000_001_000,
+        sizeBytes: 27
+      }
+    ]);
+    mockedReadNativeMarkdownFileHistory.mockResolvedValue({
+      id: "history-current",
+      contents: "# Earlier\n\nSynthetic body."
+    });
+    mockedSaveNativeMarkdownFile.mockResolvedValue({
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    await expectVisualMarkdownText("Current");
+    await selectEditorViewMode("Source code");
+    replaceMarkdownSource(
+      await screen.findByRole("textbox", { name: "Markdown source" }),
+      "# Unsaved\n\nSynthetic draft."
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show history" }));
+    fireEvent.click(await screen.findByRole("option"));
+    fireEvent.click(await screen.findByRole("button", { name: "Restore version" }));
+
+    await waitFor(() => {
+      expect(mockedSaveNativeMarkdownFile).toHaveBeenCalledTimes(2);
+    });
+    expect(mockedSaveNativeMarkdownFile).toHaveBeenNthCalledWith(1, {
+      contents: "# Unsaved\n\nSynthetic draft.",
+      path: mockNativePath,
+      suggestedName: "native.md"
+    });
+    expect(mockedSaveNativeMarkdownFile).toHaveBeenNthCalledWith(2, {
+      contents: "# Earlier\n\nSynthetic body.",
+      path: mockNativePath,
+      suggestedName: "native.md"
     });
   });
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1115,6 +1115,7 @@ describe("Markra workspace", () => {
     expect(screen.queryByRole("dialog", { name: "History versions" })).not.toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("option"));
+    fireEvent.click(await screen.findByRole("button", { name: "Restore version" }));
 
     await waitFor(() => {
       const editor = screen.getByLabelText("Markdown editor");
@@ -1296,6 +1297,107 @@ describe("Markra workspace", () => {
     expect(container.querySelector(".titlebar-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".document-tabs-drag-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".native-title-slot")?.getAttribute("style") ?? "").not.toContain("margin-left");
+  });
+
+  it("uses an overlay file tree instead of squeezing the editor on narrow web screens", async () => {
+    const restoreViewportWidth = mockWindowInnerWidth(390);
+    mockedResolveDesktopPlatform.mockReturnValue("linux");
+    configureAppRuntime({
+      ...createDefaultAppRuntime(),
+      features: {
+        ai: true,
+        export: true,
+        nativeWindowChrome: false,
+        networkProxy: true,
+        pandoc: true,
+        s3ImageUpload: true,
+        spellcheck: true,
+        updater: true
+      },
+      platform: {
+        resolveDesktopOsVersion: () => null,
+        resolveDesktopPlatform: () => "linux"
+      }
+    });
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-mobile-browser",
+      filePath: mockNativePath,
+      fileTreeOpen: true,
+      folderName: "mock-files",
+      folderPath: mockFolderPath,
+      openFilePaths: [mockNativePath]
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "mobile.md", path: mockNativePath, relativePath: "mobile.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Mobile browser",
+      name: "mobile.md",
+      path: mockNativePath
+    });
+
+    try {
+      const { container } = renderApp();
+
+      await expectVisibleMarkdownText("Mobile browser");
+      expect(container.querySelector(".workspace-layout")).toHaveStyle({
+        gridTemplateColumns: "0px minmax(0,1fr)"
+      });
+      expect(container.querySelector(".markdown-file-tree-slot")).toHaveClass(
+        "fixed",
+        "top-10",
+        "bottom-0",
+        "left-0"
+      );
+      expect(container.querySelector(".native-titlebar")).not.toHaveStyle({
+        left: "289px"
+      });
+      expect(screen.getByRole("button", { name: "Toggle file list" })).toBeInTheDocument();
+    } finally {
+      restoreViewportWidth();
+    }
+  });
+
+  it("keeps the file tree docked in narrow native windows", async () => {
+    const restoreViewportWidth = mockWindowInnerWidth(390);
+    const runtime = createDefaultAppRuntime();
+    configureAppRuntime({
+      ...runtime,
+      events: {
+        ...runtime.events,
+        isAvailable: () => true
+      }
+    });
+    mockedGetStoredWorkspaceState.mockResolvedValue({
+      aiAgentSessionId: "session-narrow-native",
+      filePath: mockNativePath,
+      fileTreeOpen: true,
+      folderName: "mock-files",
+      folderPath: mockFolderPath,
+      openFilePaths: [mockNativePath]
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "native.md", path: mockNativePath, relativePath: "native.md" }
+    ]);
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Narrow native window",
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    try {
+      const { container } = renderApp();
+
+      await expectVisibleMarkdownText("Narrow native window");
+      expect(container.querySelector(".workspace-layout")).not.toHaveStyle({
+        gridTemplateColumns: "0px minmax(0,1fr)"
+      });
+      expect(container.querySelector(".markdown-file-tree-slot")).not.toHaveClass(
+        "fixed"
+      );
+    } finally {
+      restoreViewportWidth();
+    }
   });
 
   it("persists titlebar action order changes by holding and dragging", async () => {
@@ -1603,7 +1705,7 @@ describe("Markra workspace", () => {
     expect(container.querySelector(".quiet-status")).not.toBeInTheDocument();
   });
 
-  it("selects the workspace view mode from the titlebar action menu", async () => {
+  it("keeps an exit control in immersive mode and exits it with Escape", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
       viewMode: "daily"
     }));
@@ -1619,10 +1721,26 @@ describe("Markra workspace", () => {
     expect(mockedNotifyAppEditorPreferencesChanged).toHaveBeenCalledWith(expect.objectContaining({
       viewMode: "immersive"
     }));
-    await waitFor(() =>
-      expect(screen.queryByRole("button", { name: "View mode: Immersive" })).not.toBeInTheDocument()
-    );
+    expect(await screen.findByRole("button", { name: "View mode: Immersive" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
+
+    mockedSaveStoredEditorPreferences.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "View mode: Immersive" }));
+    expect(await screen.findByRole("menu", { name: "View mode" })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu", { name: "View mode" })).not.toBeInTheDocument();
+    });
+    expect(mockedSaveStoredEditorPreferences).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "View mode: Immersive" })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => expect(mockedSaveStoredEditorPreferences).toHaveBeenCalledWith(
+      expect.objectContaining({ viewMode: "full" })
+    ));
+    expect(await screen.findByRole("button", { name: "View mode: Full" })).toBeInTheDocument();
   });
 
   it("hides fixed titlebar buttons from custom view mode visibility", async () => {
@@ -2461,6 +2579,10 @@ describe("Markra workspace", () => {
     const { container } = renderApp();
 
     await waitFor(() => expect(container.querySelector(".settings-window")).toBeInTheDocument());
+    expect(container.querySelector(".settings-layout")).toHaveClass(
+      "max-[700px]:grid-cols-1",
+      "max-[700px]:grid-rows-[auto_minmax(0,1fr)]"
+    );
     expect(container.querySelector(".settings-drag-region")).not.toBeInTheDocument();
     expect(container.querySelector(".settings-content-header")).not.toHaveAttribute("data-tauri-drag-region");
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -806,9 +806,12 @@ function WorkspaceApp() {
     viewModeChrome.outline ||
     documentLinksVisible;
   const visibleFileTreeOpen = viewModeChrome.fileTree && fileTreeContentVisible && fileTreeOpen;
+  const compactViewport = !nativeRuntimeAvailable && viewportWidth <= 900;
   const visibleWorkspaceLayoutStyle = {
     ...workspaceLayoutStyle,
-    gridTemplateColumns: visibleFileTreeOpen ? `${fileTreeWidth}px minmax(0,1fr)` : "0px minmax(0,1fr)"
+    gridTemplateColumns: visibleFileTreeOpen && !compactViewport
+      ? `${fileTreeWidth}px minmax(0,1fr)`
+      : "0px minmax(0,1fr)"
   } satisfies CSSProperties;
   const sidebarLayoutMode = editorPreferences.preferences.sidebarLayoutMode;
   const documentLinksIndexEnabled = viewModeChrome.fileTree && documentLinksVisible === true && (
@@ -1399,7 +1402,7 @@ function WorkspaceApp() {
   const visibleAiAgentOpen = viewModeChrome.aiPanel && aiFeatureEnabled && aiAgentOpen;
   const aiAgentInset = visibleAiAgentOpen ? `${aiAgentPanelWidth}px` : "0px";
   const editorAreaWidth = Math.max(0, viewportWidth -
-    (visibleFileTreeOpen ? fileTreeWidth : 0) -
+    (visibleFileTreeOpen && !compactViewport ? fileTreeWidth : 0) -
     (visibleAiAgentOpen ? aiAgentPanelWidth : 0));
   const activeEditorContentWidthValue = activeEditorContentWidthPx ?? editorContentWidthPixels[activeEditorContentWidth];
   const editorWidthResizerVisible = shouldShowEditorWidthResizer({
@@ -2322,6 +2325,35 @@ function WorkspaceApp() {
       .then(() => notifyAppEditorPreferencesChanged(nextPreferences))
       .catch(() => {});
   }, [editorPreferences.preferences, editorPreferences.updatePreferences]);
+  useEffect(() => {
+    if (editorPreferences.preferences.viewMode !== "immersive") return;
+
+    const handleImmersiveEscape = (event: KeyboardEvent) => {
+      if (
+        event.key !== "Escape" ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+
+      // Let the first Escape close transient UI before it exits immersive mode.
+      const transientUiOpen = window.document.querySelector(
+        '[aria-modal="true"], [role="dialog"], [role="listbox"], [role="menu"], [role="toolbar"]'
+      );
+      if (transientUiOpen) return;
+
+      event.preventDefault();
+      handleViewModeSelect("full");
+    };
+
+    window.addEventListener("keydown", handleImmersiveEscape);
+    return () => window.removeEventListener("keydown", handleImmersiveEscape);
+  }, [editorPreferences.preferences.viewMode, handleViewModeSelect]);
   const handleCreateMarkdownTreeFile = useCallback(async (
     fileName: string,
     parentPath: string | null = null,
@@ -2687,7 +2719,7 @@ function WorkspaceApp() {
 
     setDocumentHistoryOpen((current) => !current);
   }, [documentHistoryAvailable]);
-  const handleDocumentHistoryRestore = useCallback((contents: string, historyId: string) => {
+  const handleDocumentHistoryRestore = useCallback(async (contents: string, historyId: string) => {
     debug(() => ["[markra-history] app restore requested", {
       contentsChars: contents.length,
       currentDirty: document.dirty,
@@ -2696,36 +2728,47 @@ function WorkspaceApp() {
       historyId
     }]);
 
+    if (document.dirty) {
+      const savedCurrent = await saveCurrentDocument();
+      if (!savedCurrent) {
+        debug(() => ["[markra-history] app restore canceled", {
+          historyId,
+          reason: "current document was not saved"
+        }]);
+        return false;
+      }
+    }
+
     const restored = restoreDocumentContent(contents);
     debug(() => ["[markra-history] app restore state result", {
       restored
     }]);
-    if (!restored) return;
+    if (!restored) return false;
 
     const editorReplaced = replaceEditorMarkdown(contents);
     debug(() => ["[markra-history] editor replace requested", {
       editorReplaced
     }]);
-    saveCurrentDocumentContent(contents, {
-      historyCursorId: historyId,
-      skipHistorySnapshot: true
-    })
-      .then((savedFile) => {
-        debug(() => ["[markra-history] save restored document success", {
-          savedPath: savedFile?.path ?? null
-        }]);
-      })
-      .catch((error: unknown) => {
-        debug(() => ["[markra-history] save restored document failed", {
-          error: error instanceof Error ? error.message : String(error)
-        }]);
-      });
+    try {
+      // A normal save snapshots the version that was current immediately before this restore.
+      const savedFile = await saveCurrentDocumentContent(contents);
+      debug(() => ["[markra-history] save restored document success", {
+        savedPath: savedFile?.path ?? null
+      }]);
+      return savedFile !== null;
+    } catch (error: unknown) {
+      debug(() => ["[markra-history] save restored document failed", {
+        error: error instanceof Error ? error.message : String(error)
+      }]);
+      return false;
+    }
   }, [
     document.dirty,
     document.path,
     document.revision,
     replaceEditorMarkdown,
     restoreDocumentContent,
+    saveCurrentDocument,
     saveCurrentDocumentContent
   ]);
   useEffect(() => {
@@ -4030,16 +4073,19 @@ function WorkspaceApp() {
         ? editorPreferences.preferences.titlebarActions
         : editorPreferences.preferences.titlebarActions.filter((action) => action.id !== "aiAgent");
 
-      if (viewModeChrome.titlebarActions) {
-        return viewModeChrome.viewModeToggle
-          ? availableActions
-          : availableActions.filter((action) => action.id !== "viewMode");
+      if (!viewModeChrome.titlebarActions) {
+        return editorPreferences.preferences.viewMode === "immersive" && viewModeChrome.viewModeToggle
+          ? availableActions.filter((action) => action.id === "viewMode")
+          : [];
       }
 
-      return [];
+      return viewModeChrome.viewModeToggle
+        ? availableActions
+        : availableActions.filter((action) => action.id !== "viewMode");
     },
     [
       aiFeatureEnabled,
+      editorPreferences.preferences.viewMode,
       editorPreferences.preferences.titlebarActions,
       viewModeChrome.titlebarActions,
       viewModeChrome.viewModeToggle
@@ -4246,6 +4292,7 @@ function WorkspaceApp() {
           aiAgentOpen={visibleAiAgentOpen}
           aiAgentResizing={aiAgentPanelResizing}
           aiAgentWidth={aiAgentPanelWidth}
+          compactLayout={compactViewport}
           dirty={!activeImageFile && hasOpenDocument && document.dirty}
           documentKind={titleDocumentKind}
           documentName={titleDocumentName}
@@ -4304,6 +4351,7 @@ function WorkspaceApp() {
 
         <WorkspaceLayout
           aiAgentPanel={aiAgentPanel}
+          compactFileTreeOverlay={compactViewport}
           documentSearchAvailable={documentSearchAvailable}
           documentSearchOpen={documentSearchOpen}
           editorAgentLayoutClassName={editorAgentLayoutClassName}
@@ -4324,8 +4372,12 @@ function WorkspaceApp() {
             language: appLanguage.language,
             linkIndex: workspaceLinkIndex.index,
             linkIndexLoading: workspaceLinkIndex.loading,
-            maxWidth: fileTreeMaxWidth,
-            minWidth: fileTreeMinWidth,
+            maxWidth: compactViewport
+              ? Math.max(fileTreeMinWidth, viewportWidth - 48)
+              : fileTreeMaxWidth,
+            minWidth: compactViewport
+              ? Math.min(fileTreeMinWidth, Math.max(0, viewportWidth - 48))
+              : fileTreeMinWidth,
             open: visibleFileTreeOpen,
             operationRevealPaths: workspaceOperationRevealPaths,
             outlineItems,
@@ -4339,7 +4391,9 @@ function WorkspaceApp() {
             rootName: fileTreeRootName,
             sidebarLayoutMode,
             updateAvailable: Boolean(appUpdater.availableUpdate),
-            width: fileTreeWidth,
+            width: compactViewport
+              ? Math.min(fileTreeWidth, Math.max(0, viewportWidth - 48))
+              : fileTreeWidth,
             onCreateFile: handleCreateMarkdownTreeFile,
             onCreateFolder: handleCreateMarkdownTreeFolder,
             onDeleteFile: handleDeleteMarkdownTreeFile,
@@ -4360,9 +4414,9 @@ function WorkspaceApp() {
             onRecentFoldersOpenChange: setRecentMarkdownFoldersOpen,
             onRemoveRecentFolder: removeRecentFolder,
             onRenameFile: handleRenameMarkdownTreeFile,
-            onResize: resizeFileTree,
-            onResizeEnd: endFileTreeResize,
-            onResizeStart: startFileTreeResize,
+            onResize: compactViewport ? undefined : resizeFileTree,
+            onResizeEnd: compactViewport ? undefined : endFileTreeResize,
+            onResizeStart: compactViewport ? undefined : startFileTreeResize,
             onSaveFileAsTemplate: handleSaveMarkdownFileAsTemplate,
             onSelectOutlineItem: editor.selectOutlineItem,
             onToggleMarkdownFiles: handleFileTreeToggle
@@ -4635,7 +4689,7 @@ function WorkspaceApp() {
           <AiCommandBar
           aiResult={aiResult}
           availableModels={aiSettings.availableTextModels}
-          editorLeftInset={visibleFileTreeOpen ? `${fileTreeWidth}px` : "0px"}
+          editorLeftInset={visibleFileTreeOpen && !compactViewport ? `${fileTreeWidth}px` : "0px"}
           editorRightInset={aiAgentInset}
           externalActionPending={aiContextMenuActionPending}
           language={appLanguage.language}

--- a/packages/app/src/components/DocumentHistoryDialog.test.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.test.tsx
@@ -21,7 +21,7 @@ describe("DocumentHistoryDialog", () => {
     mockedReadNativeMarkdownFileHistory.mockReset();
   });
 
-  it("loads history entries and restores a clicked state", async () => {
+  it("previews a clicked history entry before explicitly restoring it", async () => {
     const onClose = vi.fn();
     const onRestore = vi.fn();
     mockedListNativeMarkdownFileHistory.mockResolvedValue([
@@ -62,14 +62,24 @@ describe("DocumentHistoryDialog", () => {
     fireEvent.click(options[1]);
 
     await waitFor(() => {
-      expect(onRestore).toHaveBeenCalledWith("# Earlier\n\nSynthetic history.", "history-older");
+      expect(mockedReadNativeMarkdownFileHistory).toHaveBeenLastCalledWith(
+        "/mock-files/guide.md",
+        "history-older"
+      );
     });
+    expect(onRestore).not.toHaveBeenCalled();
     expect(mockedListNativeMarkdownFileHistory).toHaveBeenCalledWith("/mock-files/guide.md");
-    expect(mockedReadNativeMarkdownFileHistory).toHaveBeenLastCalledWith(
-      "/mock-files/guide.md",
-      "history-older"
-    );
     expect(options[1]).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("region", { name: "History preview" })).toHaveTextContent(
+      "# Earlier Synthetic history."
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+
+    expect(onRestore).toHaveBeenCalledWith("# Earlier\n\nSynthetic history.", "history-older");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Restore version" })).toBeEnabled();
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Close history" }));
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -209,8 +219,16 @@ describe("DocumentHistoryDialog", () => {
     const option = await screen.findByRole("option");
     fireEvent.click(option);
 
+    expect(await screen.findByRole("region", { name: "History preview" })).toHaveTextContent(
+      "# Earlier Synthetic history."
+    );
+    expect(onRestore).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+
+    expect(onRestore).toHaveBeenCalledWith("# Earlier\n\nSynthetic history.", "history-current");
     await waitFor(() => {
-      expect(onRestore).toHaveBeenCalledWith("# Earlier\n\nSynthetic history.", "history-current");
+      expect(screen.getByRole("button", { name: "Restore version" })).toBeEnabled();
     });
   });
 

--- a/packages/app/src/components/DocumentHistoryDialog.tsx
+++ b/packages/app/src/components/DocumentHistoryDialog.tsx
@@ -12,7 +12,7 @@ export type DocumentHistoryDialogProps = {
   documentPath: string;
   language?: AppLanguage;
   onClose: () => unknown;
-  onRestore: (contents: string, historyId: string) => unknown;
+  onRestore: (contents: string, historyId: string) => unknown | Promise<unknown>;
   refreshKey?: number;
   rightInsetPx?: number;
   windowsSelfDrawnChrome?: boolean;
@@ -51,11 +51,13 @@ export function DocumentHistoryDialog({
   const [entriesLoading, setEntriesLoading] = useState(true);
   const [entriesError, setEntriesError] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [restorePendingId, setRestorePendingId] = useState<string | null>(null);
-  const [restoreError, setRestoreError] = useState(false);
+  const [preview, setPreview] = useState<{ contents: string; id: string } | null>(null);
+  const [previewPendingId, setPreviewPendingId] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState(false);
+  const [restorePending, setRestorePending] = useState(false);
   const panelRef = useRef<HTMLElement | null>(null);
   const loadedDocumentPathRef = useRef<string | null>(null);
-  const mountedRef = useRef(true);
+  const previewRequestIdRef = useRef(0);
   const normalizedRightInsetPx = Math.max(0, rightInsetPx);
   const panelTopPx = titlebarRowHeightPx * (windowsSelfDrawnChrome ? 2 : 1) + documentHistoryPanelGapPx;
   const viewportWidthPx = typeof window === "undefined" ? Number.POSITIVE_INFINITY : window.innerWidth;
@@ -67,14 +69,6 @@ export function DocumentHistoryDialog({
   );
   const panelRightPx = Math.min(requestedPanelRightPx, maximumPanelRightPx);
   const panelWidthInsetPx = panelRightPx + documentHistoryPanelViewportMarginPx;
-
-  useEffect(() => {
-    mountedRef.current = true;
-
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     const handlePointerDown = (event: PointerEvent) => {
@@ -110,8 +104,11 @@ export function DocumentHistoryDialog({
       setEntries([]);
       setEntriesLoading(true);
       setSelectedId(null);
-      setRestoreError(false);
-      setRestorePendingId(null);
+      setPreview(null);
+      setPreviewError(false);
+      setPreviewPendingId(null);
+      setRestorePending(false);
+      previewRequestIdRef.current += 1;
     }
     setEntriesError(false);
 
@@ -134,6 +131,11 @@ export function DocumentHistoryDialog({
           if (current === null) return current;
 
           return historyEntries.some((entry) => entry.id === current) ? current : null;
+        });
+        setPreview((current) => {
+          if (current === null) return current;
+
+          return historyEntries.some((entry) => entry.id === current.id) ? current : null;
         });
       })
       .catch((error: unknown) => {
@@ -158,19 +160,23 @@ export function DocumentHistoryDialog({
     };
   }, [documentPath, refreshKey]);
 
-  const restoreEntry = (entry: NativeMarkdownFileHistoryEntry) => {
-    if (restorePendingId !== null) {
-      debug(() => ["[markra-history] restore ignored", {
+  const previewEntry = (entry: NativeMarkdownFileHistoryEntry) => {
+    if (previewPendingId !== null || restorePending) {
+      debug(() => ["[markra-history] preview ignored", {
         documentPath,
         historyId: entry.id,
-        restorePendingId
+        previewPendingId,
+        restorePending
       }]);
       return;
     }
 
-    setRestoreError(false);
-    setRestorePendingId(entry.id);
-    debug(() => ["[markra-history] restore click", {
+    const requestId = previewRequestIdRef.current + 1;
+    previewRequestIdRef.current = requestId;
+    setPreviewError(false);
+    setPreviewPendingId(entry.id);
+    setSelectedId(entry.id);
+    debug(() => ["[markra-history] preview click", {
       documentPath,
       historyId: entry.id,
       mode: "state-click"
@@ -178,28 +184,52 @@ export function DocumentHistoryDialog({
 
     readNativeMarkdownFileHistory(documentPath, entry.id)
       .then((file) => {
-        if (!mountedRef.current) return;
+        if (previewRequestIdRef.current !== requestId) return;
 
-        debug(() => ["[markra-history] restore contents resolved", {
+        debug(() => ["[markra-history] preview contents resolved", {
           documentPath,
           historyId: file.id,
           contentsChars: file.contents.length
         }]);
         setSelectedId(file.id);
-        setRestorePendingId(null);
-        onRestore(file.contents, file.id);
+        setPreview({ contents: file.contents, id: file.id });
+        setPreviewPendingId(null);
       })
       .catch((error: unknown) => {
-        if (!mountedRef.current) return;
+        if (previewRequestIdRef.current !== requestId) return;
 
-        debug(() => ["[markra-history] restore failed", {
+        debug(() => ["[markra-history] preview failed", {
           documentPath,
           historyId: entry.id,
           error: error instanceof Error ? error.message : String(error)
         }]);
-        setRestoreError(true);
-        setRestorePendingId(null);
+        setPreviewError(true);
+        setPreviewPendingId(null);
       });
+  };
+
+  const restorePreview = async () => {
+    if (preview === null || restorePending) return;
+
+    setRestorePending(true);
+    setPreviewError(false);
+    debug(() => ["[markra-history] restore click", {
+      documentPath,
+      historyId: preview.id,
+      mode: "preview-confirm"
+    }]);
+    try {
+      await onRestore(preview.contents, preview.id);
+    } catch (error: unknown) {
+      debug(() => ["[markra-history] restore failed", {
+        documentPath,
+        historyId: preview.id,
+        error: error instanceof Error ? error.message : String(error)
+      }]);
+      setPreviewError(true);
+    } finally {
+      setRestorePending(false);
+    }
   };
 
   return (
@@ -231,7 +261,8 @@ export function DocumentHistoryDialog({
           </button>
         </Tooltip>
       </div>
-      <div className="min-h-0 overflow-auto bg-(--bg-secondary) p-2">
+      <div className="grid min-h-0 grid-rows-[minmax(0,1fr)_auto] bg-(--bg-secondary)">
+        <div className="min-h-0 overflow-auto p-2">
         {entriesLoading ? (
           <p className="m-0 px-2 py-2 text-[12px] leading-5 text-(--text-secondary)">
             {label("app.historyLoading")}
@@ -248,12 +279,12 @@ export function DocumentHistoryDialog({
           <div className="grid gap-1" role="listbox" aria-label={label("app.documentHistory")}>
             {entries.map((entry) => {
               const selected = entry.id === selectedId;
-              const pending = entry.id === restorePendingId;
+              const pending = entry.id === previewPendingId;
 
               return (
                 <button
                   aria-selected={selected}
-                  disabled={restorePendingId !== null}
+                  disabled={previewPendingId !== null || restorePending}
                   className={`grid w-full min-w-0 rounded-md px-2 py-2 text-left transition-colors duration-150 ease-out ${
                     selected || pending
                       ? "bg-(--bg-active) text-(--text-heading)"
@@ -262,7 +293,7 @@ export function DocumentHistoryDialog({
                   key={entry.id}
                   role="option"
                   type="button"
-                  onClick={() => restoreEntry(entry)}
+                  onClick={() => previewEntry(entry)}
                 >
                   <span className="truncate text-[12px] leading-5 font-[650]">
                     {formatHistoryDate(language, entry.createdAt)}
@@ -273,13 +304,33 @@ export function DocumentHistoryDialog({
                 </button>
               );
             })}
-            {restoreError ? (
+            {previewError ? (
               <p className="m-0 px-2 py-2 text-[12px] leading-5 text-(--text-secondary)">
                 {label("app.historyLoadFailed")}
               </p>
             ) : null}
           </div>
         )}
+        </div>
+        {preview ? (
+          <section
+            aria-label={label("app.historyPreview")}
+            className="grid gap-2 border-t border-(--border-default) bg-(--bg-primary) p-3"
+            role="region"
+          >
+            <pre className="m-0 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md bg-(--bg-secondary) p-2 text-[11px] leading-5 text-(--text-secondary)">
+              {preview.contents}
+            </pre>
+            <button
+              className="inline-flex min-h-8 cursor-pointer items-center justify-center rounded-md border border-(--accent) bg-(--accent) px-3 text-[12px] font-semibold text-white transition-opacity disabled:cursor-default disabled:opacity-60"
+              disabled={restorePending || previewPendingId !== null}
+              type="button"
+              onClick={() => void restorePreview()}
+            >
+              {label("app.restoreHistoryVersion")}
+            </button>
+          </section>
+        ) : null}
       </div>
     </section>
   );

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1391,6 +1391,48 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(aws).not.toHaveAttribute("aria-selected");
   });
 
+  it("deletes focused tree rows from the keyboard", () => {
+    const deleteFile = vi.fn();
+    const architectureFile = {
+      name: "Architecture.md",
+      path: "/vault/Architecture.md",
+      relativePath: "Architecture.md"
+    };
+
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[...markdownFiles, architectureFile]}
+        open
+        outlineItems={[]}
+        platform="macos"
+        rootName="Obsidian Vault"
+        onDeleteFile={deleteFile}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    const architecture = screen.getByRole("button", { name: "Architecture.md" });
+    const aws = screen.getByRole("button", { name: "AWS.md" });
+    const folder = screen.getByRole("button", { name: "deploy" });
+
+    fireEvent.click(aws, { metaKey: true });
+    fireEvent.click(architecture, { metaKey: true });
+    fireEvent.keyDown(aws, { key: "Delete" });
+
+    expect(deleteFile).toHaveBeenCalledWith(markdownFiles[1], {
+      files: expect.arrayContaining([markdownFiles[1], architectureFile])
+    });
+
+    fireEvent.keyDown(folder, { key: "Backspace" });
+
+    expect(deleteFile).toHaveBeenLastCalledWith(expect.objectContaining({
+      kind: "folder",
+      path: "deploy"
+    }));
+  });
+
   it("uses selected file rows for supported file tree context menu actions", () => {
     const deleteFile = vi.fn();
     const openFileToSide = vi.fn();

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -1469,6 +1469,29 @@ export function MarkdownFileTreeDrawer({
     targetFile.kind !== "asset" && targetFile.kind !== "attachment" && !sameNativePath(targetFile.path, currentPath)
   );
 
+  const deleteFileTreeTarget = (targetFile: NativeMarkdownFolderFile) => {
+    if (!onDeleteFile) return;
+
+    const targetFiles = fileTreeContextTargets(targetFile);
+    const operation = targetFiles.length > 1
+      ? onDeleteFile(targetFile, { files: targetFiles })
+      : onDeleteFile(targetFile);
+    Promise.resolve(operation).catch(() => {});
+  };
+
+  const handleFileTreeRowDeleteKey = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    targetFile: NativeMarkdownFolderFile
+  ) => {
+    const deleteKey = event.key === "Delete";
+    const macDeleteKey = platform === "macos" && event.key === "Backspace";
+    if ((!deleteKey && !macDeleteKey) || event.repeat || !onDeleteFile) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    deleteFileTreeTarget(targetFile);
+  };
+
   const openContextMenu = (
     event: ReactMouseEvent,
     file?: NativeMarkdownFolderFile,
@@ -1495,12 +1518,7 @@ export function MarkdownFileTreeDrawer({
           }))
           : undefined,
         createFolder: folderCreationAvailable ? () => startCreatingFolder(createTargetFolderPath) : undefined,
-        deleteFile: (targetFile) => {
-          const targetFiles = fileTreeContextTargets(targetFile);
-          if (targetFiles.length > 1) return onDeleteFile?.(targetFile, { files: targetFiles });
-
-          return onDeleteFile?.(targetFile);
-        },
+        deleteFile: deleteFileTreeTarget,
         openContainingFolder: onOpenContainingFolder
           ? (targetFile) => {
             const path = targetFile?.path ?? rootPath;
@@ -2073,6 +2091,7 @@ export function MarkdownFileTreeDrawer({
                 }}
                 {...dragSource.attributes}
                 {...dragSource.listeners}
+                onKeyDown={(event) => handleFileTreeRowDeleteKey(event, folderFile)}
               >
                 {expanded ? (
                   <ChevronDown aria-hidden="true" className="shrink-0" size={13} />
@@ -2262,6 +2281,7 @@ export function MarkdownFileTreeDrawer({
             {...dragSource.listeners}
             draggable={asset}
             onDragStart={(event) => handleFileRowDragStart(event, node.file)}
+            onKeyDown={(event) => handleFileTreeRowDeleteKey(event, node.file)}
           >
             <FileIcon aria-hidden="true" className="shrink-0" size={15} />
             <span

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -63,6 +63,7 @@ type NativeTitleBarProps = {
   aiAgentOpen: boolean;
   aiAgentResizing?: boolean;
   aiAgentWidth?: number;
+  compactLayout?: boolean;
   dirty: boolean;
   documentKind?: "file" | "folder" | "image";
   documentName: string;
@@ -119,6 +120,7 @@ export function NativeTitleBar({
   aiAgentOpen,
   aiAgentResizing = false,
   aiAgentWidth = 384,
+  compactLayout = false,
   dirty,
   documentKind = "file",
   documentName,
@@ -637,7 +639,7 @@ export function NativeTitleBar({
     </div>
   );
 
-  const documentActionsClassName = `document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 group-hover/titlebar:opacity-100 focus-within:opacity-100 motion-reduce:transition-none ${
+  const documentActionsClassName = `document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 overflow-x-auto pr-3.5 text-(--text-secondary) opacity-40 group-hover/titlebar:opacity-100 focus-within:opacity-100 max-[600px]:max-w-[46vw] motion-reduce:transition-none ${
     aiAgentResizing
       ? "transition-none"
       : "transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]"
@@ -648,7 +650,7 @@ export function NativeTitleBar({
     ? "transition-none"
     : "transition-[width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none";
   const titlebarGridStyle: CSSProperties = {
-    ...(!nativeWindowChrome && markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
+    ...(!compactLayout && !nativeWindowChrome && markdownFilesOpen ? { left: markdownFilesWidth + 1 } : {}),
     gridTemplateColumns: nativeWindowChrome
       ? `${titlebarSideSlotWidth}px minmax(0,1fr) ${titlebarSideSlotWidth}px`
       : "auto minmax(0, 1fr) auto"

--- a/packages/app/src/components/SettingsShell.test.tsx
+++ b/packages/app/src/components/SettingsShell.test.tsx
@@ -31,6 +31,24 @@ function renderSettingsContent(platform?: "linux" | "macos" | "windows") {
 }
 
 describe("SettingsShell", () => {
+  it("uses a horizontally scrollable category strip on narrow settings screens", () => {
+    renderSettingsSidebar();
+
+    const sidebar = screen.getByRole("navigation", { name: "Settings categories" }).closest("aside");
+    const navigation = screen.getByRole("navigation", { name: "Settings categories" });
+
+    expect(sidebar).toHaveClass("max-[700px]:border-b", "max-[700px]:border-r-0");
+    expect(navigation).toHaveClass(
+      "max-[700px]:flex-row",
+      "max-[700px]:overflow-x-auto",
+      "max-[700px]:py-2"
+    );
+    expect(screen.getByRole("button", { name: "General" })).toHaveClass(
+      "max-[700px]:w-auto",
+      "max-[700px]:shrink-0"
+    );
+  });
+
   it("shows keyboard shortcuts as its own settings category", () => {
     const onCategoryChange = renderSettingsSidebar();
 

--- a/packages/app/src/components/SettingsShell.tsx
+++ b/packages/app/src/components/SettingsShell.tsx
@@ -136,22 +136,25 @@ export function SettingsSidebar({
   translate: Translate;
 }) {
   const headerClassName = platform === "windows"
-    ? "settings-sidebar-header flex h-14 items-center px-7"
-    : "settings-sidebar-header px-7 pt-14 pb-5";
+    ? "settings-sidebar-header flex h-14 items-center px-7 max-[700px]:hidden"
+    : "settings-sidebar-header px-7 pt-14 pb-5 max-[700px]:hidden";
   const sidebarSurfaceClassName = platform === "windows"
     ? "border-r-0 bg-(--bg-chrome)"
     : "border-r border-(--border-default) bg-(--bg-secondary)";
   const visibleCategories = settingsCategories.filter((category) => !hiddenCategories.includes(category.id));
 
   return (
-    <aside className={`settings-sidebar flex min-h-0 flex-col ${sidebarSurfaceClassName}`}>
+    <aside className={`settings-sidebar flex min-h-0 flex-col max-[700px]:shrink-0 max-[700px]:border-r-0 max-[700px]:border-b max-[700px]:border-(--border-default) ${sidebarSurfaceClassName}`}>
       <div className={headerClassName}>
         <h1 className="settings-sidebar-title m-0 text-[17px] leading-6 font-bold tracking-normal text-(--text-heading)">
           {translate("settings.title")}
         </h1>
       </div>
 
-      <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-auto px-3" aria-label={translate("settings.aria.categories")}>
+      <nav
+        className="flex min-h-0 flex-1 flex-col gap-1 overflow-auto px-3 max-[700px]:flex-none max-[700px]:flex-row max-[700px]:overflow-x-auto max-[700px]:px-2 max-[700px]:py-2"
+        aria-label={translate("settings.aria.categories")}
+      >
         {visibleCategories.map((category) => (
           <SettingsNavButton
             key={category.id}
@@ -163,7 +166,7 @@ export function SettingsSidebar({
         ))}
       </nav>
 
-      <div className="border-t border-(--border-default) px-7 py-4 text-[12px] leading-5 font-[560] text-(--text-secondary)">
+      <div className="border-t border-(--border-default) px-7 py-4 text-[12px] leading-5 font-[560] text-(--text-secondary) max-[700px]:hidden">
         Markra v{appVersion}
       </div>
     </aside>
@@ -186,7 +189,7 @@ function SettingsNavButton({
 
   return (
     <button
-      className="group inline-flex h-9 w-full items-center gap-3 rounded-md border-0 bg-transparent px-3 text-left text-[13px] leading-5 font-[620] tracking-normal text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) aria-current:bg-(--bg-active) aria-current:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+      className="group inline-flex h-9 w-full items-center gap-3 rounded-md border-0 bg-transparent px-3 text-left text-[13px] leading-5 font-[620] tracking-normal text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) aria-current:bg-(--bg-active) aria-current:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) max-[700px]:w-auto max-[700px]:shrink-0 max-[700px]:whitespace-nowrap"
       type="button"
       aria-current={active ? "page" : undefined}
       aria-label={label}
@@ -227,7 +230,7 @@ export function SettingsContent({
   return (
     <section className={`settings-content flex min-h-0 min-w-0 flex-col bg-(--bg-primary) ${contentSurfaceClassName}`}>
       <header
-        className="settings-content-header relative z-20 flex h-14 shrink-0 items-center border-b border-(--border-default) px-7"
+        className="settings-content-header relative z-20 flex h-14 shrink-0 items-center border-b border-(--border-default) px-7 max-[700px]:h-12 max-[700px]:px-4"
         data-tauri-drag-region={contentHeaderDragRegion}
       >
         <h2 className="settings-panel-title m-0 text-[16px] leading-6 font-bold tracking-normal text-(--text-heading)">
@@ -250,7 +253,7 @@ export function SettingsContent({
         className={
           activeCategory === "providers"
             ? "settings-scroll min-h-0 flex-1 overflow-hidden overscroll-none p-0"
-            : "settings-scroll min-h-0 flex-1 overflow-auto overscroll-none px-8 py-7"
+            : "settings-scroll min-h-0 flex-1 overflow-auto overscroll-none px-8 py-7 max-[700px]:px-4 max-[700px]:py-4"
         }
       >
         {children}

--- a/packages/app/src/components/SettingsWindow.tsx
+++ b/packages/app/src/components/SettingsWindow.tsx
@@ -110,8 +110,8 @@ export function SettingsWindow() {
   const showMacosWindowChrome = platform === "macos" && appFeatures.nativeWindowChrome;
   const settingsStartupReady = appLanguage.ready && appTheme.ready;
   const settingsLayoutClassName = showWindowsWindowChrome
-    ? "settings-layout absolute inset-x-0 top-10 bottom-0 grid grid-cols-[180px_minmax(0,1fr)]"
-    : "settings-layout grid h-screen grid-cols-[180px_minmax(0,1fr)]";
+    ? "settings-layout absolute inset-x-0 top-10 bottom-0 grid grid-cols-[180px_minmax(0,1fr)] max-[700px]:grid-cols-1 max-[700px]:grid-rows-[auto_minmax(0,1fr)]"
+    : "settings-layout grid h-screen grid-cols-[180px_minmax(0,1fr)] max-[700px]:grid-cols-1 max-[700px]:grid-rows-[auto_minmax(0,1fr)]";
   const handleCloseSettings = () => {
     hideSettingsWindow().catch(() => {});
   };

--- a/packages/app/src/components/WorkspaceLayout.tsx
+++ b/packages/app/src/components/WorkspaceLayout.tsx
@@ -11,6 +11,7 @@ type MarkdownFileTreeDrawerProps = ComponentProps<typeof MarkdownFileTreeDrawer>
 type WorkspaceLayoutProps = {
   aiAgentPanel: ReactNode;
   children: ReactNode;
+  compactFileTreeOverlay?: boolean;
   documentSearchAvailable: boolean;
   documentSearchOpen: boolean;
   editorAgentLayoutClassName: string;
@@ -29,6 +30,7 @@ type WorkspaceLayoutProps = {
 export function WorkspaceLayout({
   aiAgentPanel,
   children,
+  compactFileTreeOverlay = false,
   documentSearchAvailable,
   documentSearchOpen,
   editorAgentLayoutClassName,
@@ -43,12 +45,28 @@ export function WorkspaceLayout({
   onEditorContentDragOver,
   onEditorContentDrop
 }: WorkspaceLayoutProps) {
+  const fileTreeOverlayOpen = compactFileTreeOverlay && fileTree.open;
+
   return (
     <div
       className={`${workspaceLayoutClassName} ${windowsSelfDrawnChrome ? "pt-10" : ""}`}
       style={workspaceLayoutStyle}
     >
-      <div className="markdown-file-tree-slot min-h-0 overflow-hidden">
+      {fileTreeOverlayOpen ? (
+        <div
+          aria-hidden="true"
+          className="fixed inset-x-0 top-10 bottom-0 z-20 bg-black/20"
+          onPointerDown={() => fileTree.onToggleMarkdownFiles?.()}
+        />
+      ) : null}
+      <div
+        className={`markdown-file-tree-slot min-h-0 overflow-hidden ${
+          fileTreeOverlayOpen
+            ? "fixed top-10 bottom-0 left-0 z-30 shadow-[12px_0_32px_color-mix(in_srgb,var(--text-heading)_16%,transparent)]"
+            : ""
+        }`}
+        data-compact-overlay={fileTreeOverlayOpen ? "true" : undefined}
+      >
         <MarkdownFileTreeDrawer {...fileTree} />
       </div>
 

--- a/packages/app/src/components/settings/SettingsControls.test.tsx
+++ b/packages/app/src/components/settings/SettingsControls.test.tsx
@@ -1,8 +1,22 @@
 import { render, screen } from "@testing-library/react";
 
-import { SettingsTextarea, SettingsTextInput } from "./SettingsControls";
+import { SettingsRow, SettingsTextarea, SettingsTextInput } from "./SettingsControls";
 
 describe("SettingsControls", () => {
+  it("stacks setting labels and actions on narrow screens", () => {
+    const { container } = render(
+      <SettingsRow action={<button type="button">Choose</button>} title="Workspace" />
+    );
+
+    expect(container.querySelector(".settings-row")).toHaveClass(
+      "max-[520px]:grid-cols-1",
+      "max-[520px]:gap-2"
+    );
+    expect(screen.getByRole("button", { name: "Choose" }).parentElement).toHaveClass(
+      "max-[520px]:justify-start"
+    );
+  });
+
   it("turns off browser text correction for settings text inputs", () => {
     render(
       <SettingsTextInput

--- a/packages/app/src/components/settings/SettingsControls.tsx
+++ b/packages/app/src/components/settings/SettingsControls.tsx
@@ -40,14 +40,18 @@ export function SettingsRow({
   title: string;
 }) {
   return (
-    <div className="settings-row grid min-h-15 grid-cols-[minmax(0,1fr)_auto] items-center gap-5 py-4">
+    <div className="settings-row grid min-h-15 grid-cols-[minmax(0,1fr)_auto] items-center gap-5 py-4 max-[520px]:grid-cols-1 max-[520px]:gap-2">
       <div className="min-w-0">
         <p className="m-0 text-[13px] leading-5 font-[650] tracking-normal text-(--text-heading)">{title}</p>
         {description ? (
           <p className="m-0 mt-0.5 text-[12px] leading-4.5 font-[450] text-(--text-secondary)">{description}</p>
         ) : null}
       </div>
-      {action ? <div className="flex shrink-0 items-center justify-end">{action}</div> : null}
+      {action ? (
+        <div className="flex shrink-0 items-center justify-end max-[520px]:justify-start">
+          {action}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -593,8 +593,23 @@ describe("liveMarkdown", () => {
     expect(view.state.doc.toString()).toBe("- [x] Ship mock release\n\nEdit");
     expect(
       view.dom.querySelector<HTMLInputElement>(".cm-markra-task-checkbox")
-        ?.checked,
+      ?.checked,
     ).toBe(true);
+  });
+
+  it("renders task markers as checkboxes when the task text is empty", () => {
+    const view = createView({ doc: "- [ ]\n- [x]" });
+    const checkboxes = Array.from(
+      view.dom.querySelectorAll<HTMLInputElement>(".cm-markra-task-checkbox"),
+    );
+
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes[0]?.checked).toBe(false);
+    expect(checkboxes[1]?.checked).toBe(true);
+
+    checkboxes[0]?.click();
+
+    expect(view.state.doc.toString()).toBe("- [x]\n- [x]");
   });
 
   it("allows task checkbox rendering to be disabled", () => {
@@ -608,6 +623,15 @@ describe("liveMarkdown", () => {
       view.dom.querySelector(".cm-markra-task-checkbox"),
     ).toBeNull();
     expect(renderedLines(view)[0]).toBe("- [ ] Keep the marker visible");
+
+    const emptyView = createView({
+      doc: "- [x]",
+      extensions: [liveMarkdown({ taskCheckboxes: false })],
+    });
+    expect(
+      emptyView.dom.querySelector(".cm-markra-task-checkbox"),
+    ).toBeNull();
+    expect(renderedLines(emptyView)[0]).toBe("- [x]");
   });
 
   it("adds semantic classes without changing the Markdown document", () => {

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -102,7 +102,9 @@ const PREFORMATTED_BLOCKS = new Set([
   "HTMLBlock",
 ]);
 
-const LIST_ITEM_PATTERN = /^([\t ]*)([-+*]|\d+[.)])[\t ]+(\[[ xX]\][\t ]+)?/u;
+const LIST_ITEM_PATTERN = /^([\t ]*)([-+*]|\d+[.)])[\t ]+(\[[ xX]\](?:[\t ]+|$))?/u;
+const EMPTY_TASK_ITEM_PATTERN =
+  /^([\t ]*)([-+*]|\d+[.)])([\t ]+)(\[[ xX]\])[\t ]*$/u;
 
 function listLineAttributes(source: string) {
   const match = LIST_ITEM_PATTERN.exec(source);
@@ -118,6 +120,20 @@ function listLineAttributes(source: string) {
   return {
     kind,
     marker: kind === "ordered" ? sourceMarker : "•",
+  };
+}
+
+function emptyTaskMarkerRange(source: string) {
+  const match = EMPTY_TASK_ITEM_PATTERN.exec(source);
+  if (!match) return null;
+
+  const markerFrom =
+    (match[1]?.length ?? 0) +
+    (match[2]?.length ?? 0) +
+    (match[3]?.length ?? 0);
+  return {
+    from: markerFrom,
+    to: markerFrom + (match[4]?.length ?? 0),
   };
 }
 
@@ -385,29 +401,20 @@ function buildDecorations(
       }
     }
 
-    if (taskCheckboxes && node.name === "TaskMarker") {
-      const taskDecoration = createTaskDecoration(
-        state,
-        node.from,
-        node.to,
-      );
-      if (taskDecoration) ranges.push(taskDecoration);
-    }
-
     if (node.name === "ListItem") {
       const line = state.doc.lineAt(node.from);
       const listAttributes = listLineAttributes(line.text);
+      const listMark = node.node.getChild("ListMark");
+      const sourceVisible = isRevealed({
+        view,
+        state,
+        from: listMark?.from ?? line.from,
+        to: listMark?.to ?? line.from,
+        nodeName: "ListMark",
+        scope: "line",
+      });
       if (listAttributes && !decoratedListLines.has(line.from)) {
         decoratedListLines.add(line.from);
-        const listMark = node.node.getChild("ListMark");
-        const sourceVisible = isRevealed({
-          view,
-          state,
-          from: listMark?.from ?? line.from,
-          to: listMark?.to ?? line.from,
-          nodeName: "ListMark",
-          scope: "line",
-        });
         ranges.push(
           Decoration.line({
             attributes: {
@@ -422,6 +429,36 @@ function buildDecorations(
           }).range(line.from),
         );
       }
+
+      const emptyTask = emptyTaskMarkerRange(line.text);
+      if (emptyTask) {
+        if (taskCheckboxes) {
+          const taskFrom = line.from + emptyTask.from;
+          const taskDecoration = createTaskDecoration(
+            state,
+            taskFrom,
+            line.from + emptyTask.to,
+          );
+          if (taskDecoration) ranges.push(taskDecoration);
+          if (!sourceVisible) {
+            pushHiddenRange(ranges, state.doc, line.from, taskFrom);
+          }
+        }
+
+        // Lezer treats an empty task marker as a paragraph or link. Claim the
+        // item so those fallback nodes cannot hide its source or overlap the
+        // checkbox replacement.
+        return false;
+      }
+    }
+
+    if (taskCheckboxes && node.name === "TaskMarker") {
+      const taskDecoration = createTaskDecoration(
+        state,
+        node.from,
+        node.to,
+      );
+      if (taskDecoration) ranges.push(taskDecoration);
     }
 
     const headingClass = HEADING_CLASSES[node.name];


### PR DESCRIPTION
## Summary
- preview history entries before restore and preserve unsaved content before applying an older version
- keep native AI streams alive beyond the previous total timeout
- restore reliable exits from immersive mode
- render empty task markers and support keyboard deletion in the file tree
- make the Web file tree and settings usable on narrow mobile viewports

## Validation
- `pnpm --filter @markra/app exec vitest run --reporter=dot` passed
- `pnpm --filter @markra/editor test -- --reporter=dot` passed: 317 tests
- `cargo fmt --check && cargo test --lib` passed: 252 tests
- `pnpm build` passed, including desktop and Web production builds
- `pnpm typecheck:test` passed across the workspace
- Not run: manual browser QA for the responsive UI changes

## Risk
- History restore behavior now requires explicit confirmation and performs an additional safety save.
- Streaming requests keep the connection timeout but no longer use a 60-second total response timeout.
- Compact file-tree overlay behavior is limited to Web runtimes at widths up to 900px.

Closes #103
Closes #220
Closes #525
Closes #533
Closes #561
Closes #562