### PR TITLE
fix(editor): mute Markdown syntax markers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,7 @@ colors:
   text: "#555555"
   text-strong: "#333333"
   text-muted: "#999999"
-  markdown-syntax: "#C7C5C5"
+  markdown-syntax: "#D7D5D5"
   border: "#EEEEEE"
   border-strong: "#DDDDDD"
   ghost: "#C0C0C0"
@@ -216,7 +216,7 @@ The palette is based on clean neutrals and one restrained ink-black accent.
 - **Surface (#FAFAFA), Surface Muted (#F8F8F8), Surface Hover (#F5F5F5), Surface Active (#EEEEEE):** Layered neutral surfaces for panels, code, hover feedback, and selected controls.
 - **Text (#555555) and Text Strong (#333333):** Body text and headings. Strong text is for document headings, selected labels, and critical UI labels.
 - **Text Muted (#999999):** Secondary labels, empty states, helper text, metadata, and inactive controls.
-- **Markdown Syntax (#C7C5C5):** Low-emphasis rendered Markdown markers and source-mode syntax characters.
+- **Markdown Syntax (#D7D5D5):** Low-emphasis rendered Markdown markers and source-mode syntax characters. Theme variants derive the same quiet role by mixing their syntax token toward the editor background.
 - **Border (#EEEEEE) and Border Strong (#DDDDDD):** Fine separation for tool surfaces, tables, inputs, and editor structure.
 
 Do not introduce extra brand colors for primary flows. Semantic colors may appear for table delete affordances, callout types, syntax highlighting, or destructive confirmation, but they should stay localized to those contexts.

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -50,7 +50,8 @@ describe("MarkdownSourceEditor", () => {
       "```ts",
       "const answer = 42;",
       "```",
-      "- Item"
+      "- Item",
+      "==highlight=="
     ].join("\n");
     const handleChange = vi.fn();
 
@@ -70,6 +71,12 @@ describe("MarkdownSourceEditor", () => {
     await waitFor(() => {
       expect(container.querySelector(".cm-line span[class]")).toBeInTheDocument();
     });
+    const syntaxCharacters = Array.from(
+      container.querySelectorAll(".cm-markra-syntax-character"),
+      (element) => element.textContent ?? "",
+    ).join("");
+    expect(syntaxCharacters).toContain("#");
+    expect(syntaxCharacters).toContain("====");
 
     replaceCodeMirrorDoc(view, "# Changed");
 

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -6,6 +6,8 @@ import { minimalSetup } from "codemirror";
 import { t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
   codeMirrorTypewriterMode,
+  markdownSyntaxHighlighting,
+  markraHighlight,
   reconfigureCodeMirrorVimMode
 } from "@markra/editor/codemirror";
 import {
@@ -287,8 +289,10 @@ export function MarkdownSourceEditor({
       markdownSourceSharedHistoryExtension(onUndoRef, onRedoRef),
       markdown({
         base: markdownLanguage,
-        codeLanguages: []
+        codeLanguages: [],
+        extensions: [markraHighlight]
       }),
+      markdownSyntaxHighlighting,
       EditorView.lineWrapping,
       contentAttributesCompartmentRef.current.of(markdownSourceContentAttributes(sourceLabel, readOnly)),
       editableCompartmentRef.current.of(EditorView.editable.of(!readOnly)),

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -812,6 +812,7 @@
 
   .markdown-paper,
   .markdown-source-paper {
+    --editor-markdown-syntax-color: color-mix(in srgb, var(--text-md-char) 72%, var(--editor-paper-bg, var(--bg-primary)));
     --editor-text-cursor: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http://www.w3.org/2000/svg%27%20width%3D%2724%27%20height%3D%2724%27%20viewBox%3D%270%200%2024%2024%27%3E%3Cpath%20d%3D%27M12%204v16M8.5%204h7M8.5%2020h7%27%20fill%3D%27none%27%20stroke%3D%27%23ffffff%27%20stroke-width%3D%274%27%20stroke-linecap%3D%27round%27/%3E%3Cpath%20d%3D%27M12%204v16M8.5%204h7M8.5%2020h7%27%20fill%3D%27none%27%20stroke%3D%27%231a1c1e%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%3C/svg%3E") 12 12, text;
   }
 
@@ -852,6 +853,11 @@
     @apply wrap-break-word whitespace-pre-wrap;
     color: var(--editor-text-primary);
     font-family: inherit;
+  }
+
+  .markdown-paper .cm-markra-syntax-character,
+  .markdown-source-paper .cm-markra-syntax-character {
+    color: var(--editor-markdown-syntax-color) !important;
   }
 
   .markdown-paper .cm-cursor,
@@ -3313,7 +3319,7 @@
 
   .markdown-paper .cm-markra-link-source,
   .markdown-paper .cm-markra-link-source * {
-    color: var(--text-md-char) !important;
+    color: var(--editor-markdown-syntax-color) !important;
     text-decoration: none !important;
   }
 
@@ -3703,7 +3709,7 @@
   }
 
   .markdown-paper .markra-md-delimiter {
-    @apply text-(--text-md-char);
+    @apply text-(--editor-markdown-syntax-color);
   }
 
   .markdown-paper .markra-md-hidden-delimiter {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -753,7 +753,7 @@ describe("editor stylesheet", () => {
       ".markdown-paper .cm-markra-link-source,\n  .markdown-paper .cm-markra-link-source * {",
     );
     expect(styles.slice(sourceStart, sourceLabelStart)).toContain(
-      "color: var(--text-md-char)",
+      "color: var(--editor-markdown-syntax-color)",
     );
     expect(styles.slice(sourceStart, sourceLabelStart)).toContain(
       "text-decoration: none !important",
@@ -762,6 +762,33 @@ describe("editor stylesheet", () => {
     expect(sourceLabelStyles).toContain("cursor: var(--editor-text-cursor)");
     expect(iconStyles).toContain('content: "↗"');
     expect(iconStyles).toContain("pointer-events: none");
+  });
+
+  it("uses one quieter theme color for Markdown syntax characters", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const syntaxColorStart = styles.indexOf(
+      "--editor-markdown-syntax-color:",
+    );
+    const syntaxRuleStart = styles.indexOf(
+      ".markdown-paper .cm-markra-syntax-character,",
+    );
+    const syntaxRuleEnd = styles.indexOf("\n  }", syntaxRuleStart);
+    const syntaxRule = styles.slice(syntaxRuleStart, syntaxRuleEnd);
+
+    expect(syntaxColorStart).toBeGreaterThanOrEqual(0);
+    expect(styles.slice(syntaxColorStart, syntaxColorStart + 180)).toContain(
+      "color-mix(in srgb, var(--text-md-char) 72%, var(--editor-paper-bg, var(--bg-primary)))",
+    );
+    expect(syntaxRuleStart).toBeGreaterThanOrEqual(0);
+    expect(syntaxRule).toContain(
+      ".markdown-source-paper .cm-markra-syntax-character",
+    );
+    expect(syntaxRule).toContain(
+      "color: var(--editor-markdown-syntax-color) !important",
+    );
+    expect(styles).toContain(
+      ".markdown-paper .markra-md-delimiter {\n    @apply text-(--editor-markdown-syntax-color);",
+    );
   });
 
   it("removes CodeMirror's inline baseline around standalone image editors", () => {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -28,6 +28,7 @@
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.41.1",
     "@cspell/cspell-types": "10.0.1",
+    "@lezer/highlight": "1.2.3",
     "@lezer/markdown": "1.6.3",
     "@markra/ai": "workspace:*",
     "@markra/markdown": "workspace:*",

--- a/packages/editor/src/codemirror/highlight.ts
+++ b/packages/editor/src/codemirror/highlight.ts
@@ -1,15 +1,38 @@
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import type {
   DelimiterType,
   MarkdownExtension,
 } from "@lezer/markdown";
+import { tags } from "@lezer/highlight";
 
 const highlightDelimiter: DelimiterType = {
   mark: "HighlightMark",
   resolve: "Highlight",
 };
 
+export const markdownSyntaxHighlighting = syntaxHighlighting(
+  HighlightStyle.define([
+    {
+      class: "cm-markra-syntax-character",
+      // GFM task markers and horizontal rules use atom/contentSeparator
+      // instead of the processingInstruction tag used by other delimiters.
+      tag: [
+        tags.processingInstruction,
+        tags.contentSeparator,
+        tags.atom,
+      ],
+    },
+  ]),
+);
+
 export const markraHighlight: MarkdownExtension = {
-  defineNodes: ["Highlight", "HighlightMark"],
+  defineNodes: [
+    "Highlight",
+    {
+      name: "HighlightMark",
+      style: tags.processingInstruction,
+    },
+  ],
   parseInline: [
     {
       after: "Emphasis",

--- a/packages/editor/src/codemirror/index.ts
+++ b/packages/editor/src/codemirror/index.ts
@@ -2,7 +2,10 @@ import { markdown } from "@codemirror/lang-markdown";
 import { codeFolding } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 import { GFM } from "@lezer/markdown";
-import { markraHighlight } from "./highlight.ts";
+import {
+  markdownSyntaxHighlighting,
+  markraHighlight,
+} from "./highlight.ts";
 import {
   markraPlugins,
   type MarkraPlugin,
@@ -131,7 +134,10 @@ export type {
   MarkraImageSourceContext,
 } from "./image.ts";
 export { imagePreviewPlugin, resolveSafeImageSource } from "./image.ts";
-export { markraHighlight } from "./highlight.ts";
+export {
+  markdownSyntaxHighlighting,
+  markraHighlight,
+} from "./highlight.ts";
 export { horizontalRulePlugin } from "./horizontal-rule.ts";
 export { markdownEditingPlugin } from "./markdown-editing.ts";
 export type { MarkdownShortcutsPluginOptions } from "./markdown-shortcuts.ts";
@@ -246,6 +252,7 @@ export function liveMarkdown(config: LiveMarkdownConfig = {}): Extension {
     highlight
       ? markraLanguage
       : markdown({ extensions: [GFM] }),
+    markdownSyntaxHighlighting,
     codeFolding(),
     livePreview(previewConfig),
     markraTheme,

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -113,6 +113,32 @@ describe("liveMarkdown", () => {
     ]);
   });
 
+  it.each([
+    ["heading", "# Synthetic heading", 3, "#"],
+    ["strong", "**Synthetic**", 4, "****"],
+    ["emphasis", "*Synthetic*", 3, "**"],
+    ["inline code", "`Synthetic`", 3, "``"],
+    ["strikethrough", "~~Synthetic~~", 4, "~~~~"],
+    ["highlight", "==Synthetic==", 4, "===="],
+    ["blockquote", "> Synthetic quote", 0, ">"],
+    ["list", "- Synthetic item", 0, "-"],
+    ["link", "[Synthetic](https://example.test)", 3, "[]()"],
+    ["horizontal rule", "---", 1, "---"],
+  ])("uses the muted syntax class for %s markers", (
+    _label,
+    doc,
+    anchor,
+    expectedMarkers,
+  ) => {
+    const view = createView({ doc, anchor });
+    const syntaxCharacters = Array.from(
+      view.dom.querySelectorAll(".cm-markra-syntax-character"),
+      (element) => element.textContent ?? "",
+    ).join("");
+
+    expect(syntaxCharacters).toBe(expectedMarkers);
+  });
+
   it("reveals the heading marker while the cursor edits heading text", () => {
     const view = createView();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@cspell/cspell-types':
         specifier: 10.0.1
         version: 10.0.1
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
       '@lezer/markdown':
         specifier: 1.6.3
         version: 1.6.3


### PR DESCRIPTION
## Summary

- Give Markdown syntax markers one shared CodeMirror highlight class, including `==highlight==` delimiters.
- Derive a quieter marker color from each theme's editor background and apply it consistently in visual and source modes.
- Align the design token and add regression coverage for the supported marker types.

## Affected areas

- `packages/editor`: Markdown parser highlighting and marker-class coverage.
- `packages/app`: source-editor integration, theme styling, and stylesheet/component tests.
- `DESIGN.md` and `pnpm-lock.yaml`: documented token and direct highlight dependency.

## Desktop and web

Desktop and web use the same shared editor implementation, so there is no platform-specific behavior difference.

## Validation

- `corepack pnpm --filter @markra/editor test` — 336 tests passed.
- `corepack pnpm --filter @markra/editor build` — passed.
- `corepack pnpm --filter @markra/app test` — 1,411 tests passed.
- `corepack pnpm --filter @markra/app build` — passed.
- `corepack pnpm --filter @markra/web build` — passed.
- Chrome QA in visual and source modes with light and dark themes; all 17 representative markers used the shared syntax color.

## Risk

Low. The change is limited to Markdown syntax highlighting and a theme-derived marker color.
