### PR TITLE
fix(editor): stabilize fenced code block editing

### DIFF
--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -53,11 +53,22 @@ describe("NativeTitleBar", () => {
     expect(screen.getByRole("button", { name: "Toggle file list" })).toBeInTheDocument();
     expect(container.querySelector("[data-titlebar-action='open']")).not.toBeInTheDocument();
     expect(within(container.querySelector(".document-actions") as HTMLElement).queryByRole("button", { name: "Open Markdown or Folder" })).not.toBeInTheDocument();
-    expect(titlebar).toHaveClass("grid-cols-[164px_minmax(0,1fr)_164px]");
+    expect(titlebar).toHaveClass("grid-cols-[196px_minmax(0,1fr)_196px]");
+    expect(titlebar).toHaveStyle({
+      gridTemplateColumns: "196px minmax(0,1fr) 196px",
+    });
     expect(titlebar).toHaveClass("h-10", "z-8");
     expect(container.querySelector(".windows-titlebar-corner-mask")).not.toBeInTheDocument();
-    expect(container.querySelector(".document-actions")).toHaveClass("h-10");
-    expect(container.querySelector(".document-actions")).toHaveClass("opacity-40");
+    expect(container.querySelector(".document-actions")).toHaveClass(
+      "h-10",
+      "min-w-0",
+      "overflow-visible",
+      "opacity-40",
+    );
+    expect(container.querySelector(".document-actions")).not.toHaveClass(
+      "overflow-x-auto",
+      "max-[600px]:max-w-[46vw]",
+    );
     expect(container.querySelector("[data-titlebar-action='aiAgent']")).toHaveClass("transition-transform");
   });
 
@@ -122,7 +133,7 @@ describe("NativeTitleBar", () => {
     expect(sidebarSurface).toContainElement(sidebarDivider);
     expect(sidebarDivider).toHaveClass("right-0", "opacity-100");
     expect(container.querySelector(".native-title-slot")).toHaveStyle({
-      marginLeft: "56px"
+      marginLeft: "24px"
     });
     expect(container.querySelector(".native-title-slot")).not.toHaveStyle({ transform: "translateX(110px)" });
   });
@@ -212,8 +223,8 @@ describe("NativeTitleBar", () => {
 
     expect(sidebarGap).toHaveAttribute("data-tauri-drag-region");
     expect(sidebarGap).toHaveStyle({
-      left: "164px",
-      width: "356px"
+      left: "196px",
+      width: "324px"
     });
     expect(screen.getByRole("tab", { name: "Draft.md" }).closest("[data-tauri-drag-region]")).toBeNull();
   });
@@ -280,7 +291,7 @@ describe("NativeTitleBar", () => {
     );
 
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 164px",
+      gridTemplateColumns: "minmax(0,1fr) 196px",
       left: "289px"
     });
     expect(container.querySelector(".windows-titlebar-corner-mask")).not.toBeInTheDocument();
@@ -315,7 +326,7 @@ describe("NativeTitleBar", () => {
     );
 
     expect(container.querySelector(".native-title-slot")).toHaveStyle({
-      marginLeft: "124px",
+      marginLeft: "92px",
       marginRight: "384px"
     });
   });
@@ -416,7 +427,7 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".document-actions")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".native-title-slot")).not.toHaveAttribute("data-tauri-drag-region");
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 164px 384px"
+      gridTemplateColumns: "minmax(0,1fr) 196px 384px"
     });
     expect(container.querySelector(".windows-titlebar-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
     expect(container.querySelector(".windows-app-chrome .windows-window-controls")).toBeInTheDocument();
@@ -471,7 +482,7 @@ describe("NativeTitleBar", () => {
     expect(container.querySelector(".native-title-slot")).toHaveClass("pl-3");
     expect(container.querySelector(".windows-titlebar-corner-mask")).not.toBeInTheDocument();
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 164px"
+      gridTemplateColumns: "minmax(0,1fr) 196px"
     });
     expect(container.querySelector(".windows-window-controls")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Minimize window" })).toBeInTheDocument();
@@ -742,7 +753,7 @@ describe("NativeTitleBar", () => {
     );
 
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 164px 384px"
+      gridTemplateColumns: "minmax(0,1fr) 196px 384px"
     });
     expect(container.querySelector(".windows-titlebar-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
     expect(container.querySelector(".windows-app-chrome .windows-window-controls")).toBeInTheDocument();
@@ -769,7 +780,7 @@ describe("NativeTitleBar", () => {
     );
 
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 164px 384px"
+      gridTemplateColumns: "minmax(0,1fr) 196px 384px"
     });
     expect(container.querySelector(".windows-titlebar-actions")).not.toHaveStyle({ transform: "translateX(-384px)" });
     expect(container.querySelector(".windows-app-chrome .windows-window-controls")).toBeInTheDocument();

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -177,7 +177,7 @@ export function NativeTitleBar({
   const editorViewMode = splitMode ? "split" : sourceMode ? "source" : "visual";
   const openChoiceMenuAvailable = Boolean(onOpenMarkdownFolder) && (!nativeWindowChrome || platform !== "macos");
   const openChoiceMenuAlignmentClassName = platform === "windows" ? "right-0" : "left-0";
-  const titlebarSideSlotWidth = 164;
+  const titlebarSideSlotWidth = 196;
   const normalizedTitlebarActions = useMemo(
     () => titlebarActions?.length === 0 ? [] : normalizeTitlebarActions(titlebarActions),
     [titlebarActions]
@@ -639,7 +639,7 @@ export function NativeTitleBar({
     </div>
   );
 
-  const documentActionsClassName = `document-actions relative z-10 flex h-10 items-center justify-end gap-0.5 overflow-x-auto pr-3.5 text-(--text-secondary) opacity-40 group-hover/titlebar:opacity-100 focus-within:opacity-100 max-[600px]:max-w-[46vw] motion-reduce:transition-none ${
+  const documentActionsClassName = `document-actions relative z-10 flex h-10 min-w-0 items-center justify-end gap-0.5 overflow-visible pr-3.5 text-(--text-secondary) opacity-40 group-hover/titlebar:opacity-100 focus-within:opacity-100 motion-reduce:transition-none ${
     aiAgentResizing
       ? "transition-none"
       : "transition-[opacity,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]"
@@ -760,7 +760,7 @@ export function NativeTitleBar({
 
   return (
     <header
-      className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-8 grid h-10 grid-cols-[164px_minmax(0,1fr)_164px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
+      className={`native-titlebar group/titlebar fixed inset-x-0 top-0 z-8 grid h-10 grid-cols-[196px_minmax(0,1fr)_196px] select-none items-center ${titlebarSurfaceClassName} [-webkit-user-select:none]`}
       style={titlebarGridStyle}
       aria-label={label("app.windowDragRegion")}
       data-tauri-drag-region={nativeWindowChrome && !titleContent ? true : undefined}

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1140,23 +1140,10 @@
     display: flex !important;
     align-items: center;
     gap: 6px;
-    opacity: 0 !important;
-    pointer-events: none !important;
-    transform: translateY(-2px);
-    transition: opacity 150ms ease-out, transform 150ms ease-out;
-  }
-
-  .markdown-paper .cm-content:has(.cm-markra-code-line:hover)
-    .cm-markra-code-header-actions,
-  .markdown-paper .cm-markra-code-header-actions:focus-within,
-  .markdown-paper .cm-content:has(.cm-markra-code-line:hover)
-    .cm-markra-code-closing-line
-    .markra-code-language-control,
-  .markdown-paper .cm-line.cm-markra-code-closing-line[data-code-block-active="true"] .markra-code-language-control,
-  .markdown-paper .cm-markra-code-closing-line .markra-code-language-control:focus-within {
     opacity: 1 !important;
     pointer-events: auto !important;
-    transform: translateY(0);
+    transform: none;
+    transition: opacity 150ms ease-out, transform 150ms ease-out;
   }
 
   .markdown-paper .cm-markra-code-header-actions .markra-code-language-control {
@@ -1194,7 +1181,10 @@
   .markdown-paper .cm-line.cm-markra-code-content-line {
     position: relative;
     box-sizing: border-box;
-    padding-inline: 0 16px !important;
+    /* The inline line-number marker only occupies the first visual row.
+       A hanging indent keeps soft-wrapped continuations out of the gutter. */
+    padding-inline: 59px 16px !important;
+    text-indent: -59px;
     border: 0 !important;
     background: transparent !important;
     color: var(--editor-code-text) !important;
@@ -1260,8 +1250,8 @@
 
   .markdown-paper .cm-line.cm-markra-code-closing-line {
     position: relative !important;
-    height: 56px !important;
-    min-height: 56px !important;
+    height: 12px !important;
+    min-height: 12px !important;
     padding: 0 !important;
     border: 0 !important;
     background: transparent !important;
@@ -1272,7 +1262,7 @@
   .markdown-paper .cm-markra-code-exit-wrap {
     display: inline-block !important;
     width: 100% !important;
-    height: 56px !important;
+    height: 12px !important;
   }
 
   .markdown-paper .cm-markra-code-exit {
@@ -1280,31 +1270,6 @@
     width: 100% !important;
     height: 12px !important;
     cursor: var(--editor-text-cursor);
-  }
-
-  /* Keep the selector visible like the original editor; WebView hover/reveal
-     state is not reliable enough for the only route to this control. */
-  .markdown-paper .cm-line.cm-markra-code-closing-line .markra-code-language-control {
-    position: absolute !important;
-    top: 12px;
-    right: 0;
-    z-index: 4;
-    display: flex !important;
-    padding: 0 !important;
-    opacity: 1 !important;
-    pointer-events: auto !important;
-    transform: translateY(0);
-    transition: opacity 150ms ease-out, transform 150ms ease-out;
-  }
-
-  .markdown-paper .cm-line.cm-markra-code-closing-line .markra-code-language-select {
-    height: 32px !important;
-    min-height: 32px !important;
-    min-width: 160px !important;
-    padding: 0 12px !important;
-    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace !important;
-    font-size: 13px !important;
-    line-height: 1 !important;
   }
 
   .markdown-paper .cm-markra-table-wrap {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -726,16 +726,6 @@
     background-color: color-mix(in srgb, var(--accent) 42%, transparent);
   }
 
-  html .document-actions {
-    scrollbar-width: none;
-  }
-
-  html .document-actions::-webkit-scrollbar {
-    display: none;
-    width: 0;
-    height: 0;
-  }
-
   .editor-content-slot .paper-scroll {
     height: calc(100% - 2.5rem);
     margin-top: 2.5rem;

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -726,6 +726,16 @@
     background-color: color-mix(in srgb, var(--accent) 42%, transparent);
   }
 
+  html .document-actions {
+    scrollbar-width: none;
+  }
+
+  html .document-actions::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
   .editor-content-slot .paper-scroll {
     height: calc(100% - 2.5rem);
     margin-top: 2.5rem;

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -80,6 +80,8 @@ describe("editor stylesheet", () => {
     expect(styles).not.toContain(".markdown-paper .cm-cursorLayer {");
     expect(codeLineRule).toContain("position: relative");
     expect(codeLineRule).toContain("background: transparent !important");
+    expect(codeLineRule).toContain("padding-inline: 59px 16px !important");
+    expect(codeLineRule).toContain("text-indent: -59px");
     expect(backdropStart).toBeGreaterThanOrEqual(0);
     expect(backdropRule).toContain("z-index: -2");
     expect(backdropRule).toContain("background: linear-gradient(");
@@ -166,15 +168,23 @@ describe("editor stylesheet", () => {
     );
   });
 
-  it("matches the original code block control layout", () => {
+  it("keeps code block controls in the header without extra closing space", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const headerActionsStart = styles.indexOf(
+      ".markdown-paper .cm-markra-code-header-actions {",
+    );
+    const headerActionsEnd = styles.indexOf("\n  }", headerActionsStart);
+    const headerActionsRule = styles.slice(
+      headerActionsStart,
+      headerActionsEnd,
+    );
     const closingLineStart = styles.indexOf(
       ".markdown-paper .cm-line.cm-markra-code-closing-line {",
     );
     const closingLineEnd = styles.indexOf("\n  }", closingLineStart);
     const closingLineRule = styles.slice(closingLineStart, closingLineEnd);
     const languageControlStart = styles.indexOf(
-      ".markdown-paper .cm-line.cm-markra-code-closing-line .markra-code-language-control {",
+      ".markdown-paper .cm-markra-code-header-actions .markra-code-language-control {",
     );
     const languageControlEnd = styles.indexOf("\n  }", languageControlStart);
     const languageControlRule = styles.slice(
@@ -182,20 +192,19 @@ describe("editor stylesheet", () => {
       languageControlEnd,
     );
 
+    expect(headerActionsRule).toContain("opacity: 1 !important");
+    expect(headerActionsRule).toContain("pointer-events: auto !important");
+    expect(headerActionsRule).toContain("transform: none");
     expect(closingLineRule).toContain("position: relative");
-    expect(closingLineRule).toContain("height: 56px");
+    expect(closingLineRule).toContain("height: 12px");
+    expect(closingLineRule).toContain("min-height: 12px");
     expect(languageControlStart).toBeGreaterThanOrEqual(0);
-    expect(languageControlRule).toContain("position: absolute");
-    expect(languageControlRule).toContain("top: 12px");
-    expect(languageControlRule).toContain("right: 0");
+    expect(languageControlRule).toContain("position: relative");
     expect(languageControlRule).toContain("padding: 0");
     expect(languageControlRule).toContain("opacity: 1 !important");
     expect(languageControlRule).toContain("pointer-events: auto !important");
-    expect(styles).toContain(
-      '.cm-markra-code-closing-line[data-code-block-active="true"] .markra-code-language-control',
-    );
-    expect(styles).toContain(
-      '.markdown-paper .cm-line.cm-markra-code-closing-line[data-code-block-active="true"] .markra-code-language-control',
+    expect(styles).not.toContain(
+      ".markdown-paper .cm-line.cm-markra-code-closing-line .markra-code-language-control {",
     );
   });
 

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -417,24 +417,6 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("background-clip: content-box");
   });
 
-  it("keeps the titlebar action scroller usable without a visible scrollbar", () => {
-    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
-    const actionRuleStart = styles.indexOf("html .document-actions {");
-    const actionRuleEnd = styles.indexOf("\n  }", actionRuleStart);
-    const actionRule = styles.slice(actionRuleStart, actionRuleEnd);
-    const webkitRuleStart = styles.indexOf(
-      "html .document-actions::-webkit-scrollbar {",
-    );
-    const webkitRuleEnd = styles.indexOf("\n  }", webkitRuleStart);
-    const webkitRule = styles.slice(webkitRuleStart, webkitRuleEnd);
-
-    expect(actionRuleStart).toBeGreaterThanOrEqual(0);
-    expect(actionRule).toContain("scrollbar-width: none");
-    expect(webkitRuleStart).toBeGreaterThanOrEqual(0);
-    expect(webkitRule).toContain("display: none");
-    expect(webkitRule).toContain("height: 0");
-  });
-
   it("keeps editor scrollbars below the titlebar tab area", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const scrollRuleStart = styles.indexOf(".editor-content-slot .paper-scroll {");

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -417,6 +417,24 @@ describe("editor stylesheet", () => {
     expect(styles).toContain("background-clip: content-box");
   });
 
+  it("keeps the titlebar action scroller usable without a visible scrollbar", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const actionRuleStart = styles.indexOf("html .document-actions {");
+    const actionRuleEnd = styles.indexOf("\n  }", actionRuleStart);
+    const actionRule = styles.slice(actionRuleStart, actionRuleEnd);
+    const webkitRuleStart = styles.indexOf(
+      "html .document-actions::-webkit-scrollbar {",
+    );
+    const webkitRuleEnd = styles.indexOf("\n  }", webkitRuleStart);
+    const webkitRule = styles.slice(webkitRuleStart, webkitRuleEnd);
+
+    expect(actionRuleStart).toBeGreaterThanOrEqual(0);
+    expect(actionRule).toContain("scrollbar-width: none");
+    expect(webkitRuleStart).toBeGreaterThanOrEqual(0);
+    expect(webkitRule).toContain("display: none");
+    expect(webkitRule).toContain("height: 0");
+  });
+
   it("keeps editor scrollbars below the titlebar tab area", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const scrollRuleStart = styles.indexOf(".editor-content-slot .paper-scroll {");

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -81,6 +81,16 @@ describe("codeBlockPreviewPlugin", () => {
     expect(view.dom.querySelector(".markra-code-language-select")).not.toBeNull();
   });
 
+  it("keeps a lone unfinished opening fence editable until Enter", () => {
+    const source = "```";
+    const view = createView(source);
+    view.dispatch({ selection: { anchor: source.length } });
+
+    expect(renderedLines(view)).toContain(source);
+    expect(view.dom.querySelector(".cm-markra-code-header")).toBeNull();
+    expect(view.dom.querySelector(".markra-code-language-select")).toBeNull();
+  });
+
   it("moves a click on the folded closing line to an editable line after the fence", () => {
     const view = createView("```ts\nconst answer = 42;\n```");
     const closingLine = view.dom.querySelector<HTMLElement>(
@@ -93,6 +103,88 @@ describe("codeBlockPreviewPlugin", () => {
 
     expect(view.state.doc.toString()).toBe(
       "```ts\nconst answer = 42;\n```\nOutside",
+    );
+    expect(view.state.selection.main.head).toBe(view.state.doc.length);
+  });
+
+  it("inserts a matching closing fence when Enter creates a code block", () => {
+    const source = "```sh";
+    const view = createView(source);
+    view.dispatch({ selection: { anchor: source.length } });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Enter",
+    }), "editor")).toBe(true);
+    expect(view.state.doc.toString()).toBe("```sh\n\n```");
+    expect(view.state.selection.main.head).toBe(source.length + 1);
+  });
+
+  it("exits after Enter on the trailing empty code line", () => {
+    const source = "```sh\nfirst command\n\n```\nAfter";
+    const trailingEmptyLine = source.indexOf("\n\n```") + 1;
+    const view = createView(source);
+    view.dispatch({ selection: { anchor: trailingEmptyLine } });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Enter",
+    }), "editor")).toBe(true);
+    expect(view.state.doc.toString()).toBe(source);
+    expect(view.state.selection.main.head).toBe(source.indexOf("After"));
+  });
+
+  it("exits when the trailing empty line was just inserted", () => {
+    const source = "```sh\nfirst command\n```\nAfter";
+    const view = createView(source);
+    view.dispatch({
+      selection: { anchor: source.indexOf("\n```") },
+    });
+
+    view.dispatch(view.state.replaceSelection("\n"));
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Enter",
+    }), "editor")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "```sh\nfirst command\n\n```\nAfter",
+    );
+    expect(view.state.selection.main.head).toBe(
+      view.state.doc.toString().indexOf("After"),
+    );
+  });
+
+  it("materializes an outside line when exiting a code block at document end", () => {
+    const source = "```sh\nfirst command\n```";
+    const view = createView(source);
+    view.dispatch({
+      selection: { anchor: source.indexOf("\n```") },
+    });
+
+    view.dispatch(view.state.replaceSelection("\n"));
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Enter",
+    }), "editor")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "```sh\nfirst command\n\n```\n",
+    );
+    expect(view.state.selection.main.head).toBe(view.state.doc.length);
+  });
+
+  it("closes and exits an unfinished code block after Enter on its final empty line", () => {
+    const source = "```sh\nfirst command\n";
+    const view = createView(source);
+    view.dispatch({ selection: { anchor: source.length } });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Enter",
+    }), "editor")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "```sh\nfirst command\n```\n",
     );
     expect(view.state.selection.main.head).toBe(view.state.doc.length);
   });
@@ -218,7 +310,9 @@ describe("codeBlockPreviewPlugin", () => {
     expect(copy?.querySelector(".markra-code-copy-check-icon")).not.toBeNull();
     expect(language?.closest(".markra-code-language-control")).not.toBeNull();
     expect(copy?.closest(".cm-markra-code-header-line")).not.toBeNull();
-    expect(language?.closest(".cm-markra-code-closing-line")).not.toBeNull();
+    expect(language?.closest(".cm-markra-code-header-actions")).not.toBeNull();
+    expect(language?.closest(".cm-markra-code-header-line")).not.toBeNull();
+    expect(language?.closest(".cm-markra-code-closing-line")).toBeNull();
     copy?.click();
 
     expect(writeText).toHaveBeenCalledWith(

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -284,6 +284,11 @@ class CodeBlockHeaderWidget extends WidgetType {
     readonly code: string,
     readonly displayLanguage: string,
     readonly labels: CodeBlockPreviewLabels,
+    readonly language: string,
+    readonly languageFrom: number,
+    readonly languageTo: number,
+    readonly languages: readonly MarkraCodeLanguageOption[],
+    readonly openingMarkTo: number,
   ) {
     super();
   }
@@ -292,7 +297,12 @@ class CodeBlockHeaderWidget extends WidgetType {
     return (
       this.code === other.code &&
       this.displayLanguage === other.displayLanguage &&
-      JSON.stringify(this.labels) === JSON.stringify(other.labels)
+      this.language === other.language &&
+      this.languageFrom === other.languageFrom &&
+      this.languageTo === other.languageTo &&
+      this.openingMarkTo === other.openingMarkTo &&
+      JSON.stringify(this.labels) === JSON.stringify(other.labels) &&
+      JSON.stringify(this.languages) === JSON.stringify(other.languages)
     );
   }
 
@@ -301,12 +311,18 @@ class CodeBlockHeaderWidget extends WidgetType {
     const wrapper = document.createElement("span");
     const label = document.createElement("span");
     const actions = document.createElement("span");
+    const languageControl = document.createElement("span");
+    const language = document.createElement("select");
     const copy = document.createElement("button");
 
     wrapper.className = "cm-markra-code-header-wrap";
     label.className = "cm-markra-code-header";
     label.textContent = this.displayLanguage;
     actions.className = "cm-markra-code-header-actions";
+    languageControl.className = "markra-code-language-control";
+    language.className = "markra-code-language-select";
+    language.ariaLabel = this.labels.language;
+    language.disabled = view.state.readOnly;
     copy.className = "markra-code-copy-button";
     copy.type = "button";
     copy.ariaLabel = this.labels.copyCode;
@@ -324,90 +340,6 @@ class CodeBlockHeaderWidget extends WidgetType {
         checkIconChildren,
       ),
     );
-
-    copy.addEventListener("mousedown", (event) => event.stopPropagation());
-    copy.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const clipboard = document.defaultView?.navigator.clipboard;
-      if (!clipboard?.writeText) return;
-      clipboard.writeText(this.code).then(() => {
-        copy.ariaLabel = this.labels.codeCopied;
-        copy.title = this.labels.codeCopied;
-        copy.dataset.copied = "true";
-      }).catch(() => undefined);
-    });
-
-    actions.append(copy);
-    wrapper.append(label, actions);
-    return wrapper;
-  }
-}
-
-function moveSelectionAfterCodeBlock(
-  view: CodeMirrorView,
-  requestedAfterFence: number,
-) {
-  const afterFence = Math.min(requestedAfterFence, view.state.doc.length);
-  const hasFollowingLineBreak =
-    view.state.sliceDoc(afterFence, afterFence + 1) === "\n";
-  const canMaterializeLine = !hasFollowingLineBreak && !view.state.readOnly;
-
-  // The closing fence is visually folded. Materialize/select the line after
-  // it so clicks in the visual gap can never append code inside the fence.
-  view.dispatch({
-    changes: canMaterializeLine
-      ? { from: afterFence, insert: "\n" }
-      : undefined,
-    scrollIntoView: true,
-    selection: EditorSelection.cursor(
-      afterFence + (hasFollowingLineBreak || canMaterializeLine ? 1 : 0),
-    ),
-  });
-  view.focus();
-}
-
-class CodeBlockExitWidget extends WidgetType {
-  constructor(
-    readonly afterFence: number,
-    readonly labels: CodeBlockPreviewLabels,
-    readonly language: string,
-    readonly languageFrom: number,
-    readonly languageTo: number,
-    readonly languages: readonly MarkraCodeLanguageOption[],
-    readonly openingMarkTo: number,
-  ) {
-    super();
-  }
-
-  eq(other: CodeBlockExitWidget) {
-    return (
-      this.afterFence === other.afterFence &&
-      this.language === other.language &&
-      this.languageFrom === other.languageFrom &&
-      this.languageTo === other.languageTo &&
-      JSON.stringify(this.labels) === JSON.stringify(other.labels) &&
-      JSON.stringify(this.languages) === JSON.stringify(other.languages)
-    );
-  }
-
-  ignoreEvent() {
-    return true;
-  }
-
-  toDOM(view: CodeMirrorView) {
-    const document = view.dom.ownerDocument;
-    const wrapper = document.createElement("span");
-    const exit = document.createElement("span");
-    const languageControl = document.createElement("span");
-    const language = document.createElement("select");
-    wrapper.className = "cm-markra-code-exit-wrap";
-    exit.className = "cm-markra-code-exit";
-    exit.setAttribute("aria-hidden", "true");
-    languageControl.className = "markra-code-language-control";
-    language.className = "markra-code-language-select";
-    language.ariaLabel = this.labels.language;
-    language.disabled = view.state.readOnly;
 
     const languageOptions = [...this.languages];
     if (
@@ -442,14 +374,79 @@ class CodeBlockExitWidget extends WidgetType {
       });
     });
 
+    copy.addEventListener("mousedown", (event) => event.stopPropagation());
+    copy.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const clipboard = document.defaultView?.navigator.clipboard;
+      if (!clipboard?.writeText) return;
+      clipboard.writeText(this.code).then(() => {
+        copy.ariaLabel = this.labels.codeCopied;
+        copy.title = this.labels.codeCopied;
+        copy.dataset.copied = "true";
+      }).catch(() => undefined);
+    });
+
+    // Keep both controls in one header surface. The closing widget stays a
+    // compact exit target instead of creating detached chrome below the block.
+    languageControl.append(language);
+    actions.append(languageControl, copy);
+    wrapper.append(label, actions);
+    return wrapper;
+  }
+}
+
+function moveSelectionAfterCodeBlock(
+  view: CodeMirrorView,
+  requestedAfterFence: number,
+) {
+  const afterFence = Math.min(requestedAfterFence, view.state.doc.length);
+  const hasFollowingLineBreak =
+    view.state.sliceDoc(afterFence, afterFence + 1) === "\n";
+  const canMaterializeLine = !hasFollowingLineBreak && !view.state.readOnly;
+
+  // The closing fence is visually folded. Materialize/select the line after
+  // it so clicks in the visual gap can never append code inside the fence.
+  view.dispatch({
+    changes: canMaterializeLine
+      ? { from: afterFence, insert: "\n" }
+      : undefined,
+    scrollIntoView: true,
+    selection: EditorSelection.cursor(
+      afterFence + (hasFollowingLineBreak || canMaterializeLine ? 1 : 0),
+    ),
+  });
+  view.focus();
+}
+
+class CodeBlockExitWidget extends WidgetType {
+  constructor(readonly afterFence: number) {
+    super();
+  }
+
+  eq(other: CodeBlockExitWidget) {
+    return this.afterFence === other.afterFence;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+
+  toDOM(view: CodeMirrorView) {
+    const document = view.dom.ownerDocument;
+    const wrapper = document.createElement("span");
+    const exit = document.createElement("span");
+    wrapper.className = "cm-markra-code-exit-wrap";
+    exit.className = "cm-markra-code-exit";
+    exit.setAttribute("aria-hidden", "true");
+
     exit.addEventListener("mousedown", (event) => {
       if (event.button !== 0 || view.state.readOnly) return;
       event.preventDefault();
       event.stopPropagation();
       moveSelectionAfterCodeBlock(view, this.afterFence);
     });
-    languageControl.append(language);
-    wrapper.append(exit, languageControl);
+    wrapper.append(exit);
     return wrapper;
   }
 }
@@ -821,6 +818,82 @@ function selectCurrentCodeBlockContent(view: CodeMirrorView) {
   return true;
 }
 
+function handleCodeBlockEnter(view: CodeMirrorView) {
+  const selection = view.state.selection.main;
+  if (!selection.empty || view.state.readOnly) return false;
+  const node = fencedCodeAt(view);
+  if (!node) return false;
+  const parts = codeBlockParts(view.state, node);
+  const cursorLine = view.state.doc.lineAt(selection.head);
+  const openingMark = parts.hasClosingFence
+    ? undefined
+    : node.getChildren("CodeMark")[0];
+  const openingLine = openingMark
+    ? view.state.doc.lineAt(openingMark.from)
+    : undefined;
+  const closingFence = openingMark && openingLine
+    ? `${view.state.sliceDoc(
+        openingLine.from,
+        openingMark.from,
+      )}${view.state.sliceDoc(openingMark.from, openingMark.to)}`
+    : undefined;
+
+  if (
+    openingLine &&
+    closingFence &&
+    cursorLine.number === openingLine.number &&
+    selection.head === cursorLine.to
+  ) {
+    // Pair on Enter so an info string such as ```sh can still be typed before
+    // the editor creates the content line and matching closing fence.
+    view.dispatch({
+      changes: {
+        from: cursorLine.to,
+        insert: `\n\n${closingFence}`,
+      },
+      scrollIntoView: true,
+      selection: EditorSelection.cursor(cursorLine.to + 1),
+    });
+    view.focus();
+    return true;
+  }
+
+  if (cursorLine.text.trim()) return false;
+
+  if (!parts.hasClosingFence) {
+    if (
+      cursorLine.number !== view.state.doc.lines ||
+      selection.head !== cursorLine.to ||
+      !closingFence
+    ) {
+      return false;
+    }
+
+    view.dispatch({
+      changes: {
+        from: cursorLine.from,
+        insert: `${closingFence}\n`,
+        to: cursorLine.to,
+      },
+      scrollIntoView: true,
+      selection: EditorSelection.cursor(
+        cursorLine.from + closingFence.length + 1,
+      ),
+    });
+    view.focus();
+    return true;
+  }
+
+  const closingLine = view.state.doc.lineAt(node.to);
+  if (cursorLine.number + 1 !== closingLine.number) return false;
+
+  // The first Enter creates this trailing empty code line. The next Enter
+  // exits. Unfinished blocks are closed first so the new cursor position is
+  // structurally outside the fence instead of extending code forever.
+  moveSelectionAfterCodeBlock(view, node.to);
+  return true;
+}
+
 function exitMermaidSource(view: CodeMirrorView) {
   const node = fencedCodeAt(view);
   if (!node) return false;
@@ -837,6 +910,7 @@ function exitMermaidSource(view: CodeMirrorView) {
 
 const codeBlockKeymap = Prec.high(
   keymap.of([
+    { key: "Enter", run: handleCodeBlockEnter },
     { key: "Mod-a", run: selectCurrentCodeBlockContent },
     { key: "Escape", run: exitMermaidSource },
   ]),
@@ -922,6 +996,14 @@ export function codeBlockPreviewPlugin(
           const parts = codeBlockParts(state, node);
           const firstLine = state.doc.lineAt(node.from);
           const lastLine = state.doc.lineAt(node.to);
+          if (
+            !parts.hasClosingFence &&
+            firstLine.number === lastLine.number
+          ) {
+            // Keep a newly typed fence visible until Enter pairs it. Folding
+            // its only line would leave a zero-height block with no caret.
+            return false;
+          }
           const revealed = context.revealed("line");
           // A Mermaid source selection must not collapse as soon as dragging
           // makes it non-empty. Anchor-only matching preserves drags that
@@ -1016,6 +1098,11 @@ export function codeBlockPreviewPlugin(
                   parts.code,
                   parts.language || plainTextLabel,
                   labels,
+                  parts.language,
+                  parts.languageFrom,
+                  parts.languageTo,
+                  languages,
+                  parts.openingMarkTo,
                 ),
               }).range(node.from, firstLine.to),
             );
@@ -1027,15 +1114,7 @@ export function codeBlockPreviewPlugin(
           ) {
             context.add(
               Decoration.replace({
-                widget: new CodeBlockExitWidget(
-                  node.to,
-                  labels,
-                  parts.language,
-                  parts.languageFrom,
-                  parts.languageTo,
-                  languages,
-                  parts.openingMarkTo,
-                ),
+                widget: new CodeBlockExitWidget(node.to),
               }).range(lastLine.from, node.to),
             );
           }


### PR DESCRIPTION
## Summary
- keep soft-wrapped code lines inside the editor while aligning continuations with the code gutter
- move the language selector beside the copy action and reduce the detached closing-line space
- keep a lone opening fence editable, pair it on Enter, and exit closed or unfinished blocks from a trailing empty line
- expand the titlebar action slot so all configured actions remain visible without scrolling

## Validation
- `pnpm --filter @markra/editor test` — 342 tests passed
- `pnpm --filter @markra/app exec vitest run src/components/NativeTitleBar.test.tsx` — 44 tests passed
- `pnpm --filter @markra/app exec vitest run src/styles.test.ts` — 58 tests passed
- `pnpm build` — all workspace packages, desktop/web bundles, and vendor chunk verification passed
- manually reproduced the code-block issue and verified wrapping, fence creation, content entry, and repeated-Enter exit behavior
- manually verified that all six titlebar actions render fully without a scrollbar

## Related Issues
Closes #570