### PR TITLE
feat(settings): add custom theme toggle

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2214,8 +2214,9 @@ describe("Markra workspace", () => {
     mockedConsumeWelcomeDocumentState.mockResolvedValue(false);
     mockedGetStoredThemePreferences.mockResolvedValue({
       appearanceMode: "light",
-      darkTheme: "custom",
-      lightTheme: "custom"
+      customThemeEnabled: true,
+      darkTheme: "dark",
+      lightTheme: "light"
     });
     mockedGetStoredCustomThemeCss.mockResolvedValue({
       dark: ":root[data-theme=\"custom\"] { --bg-primary: #0d1117; }",
@@ -2495,9 +2496,24 @@ describe("Markra workspace", () => {
       lightTheme: "light"
     }));
 
-    fireEvent.click(within(lightPalette).getByRole("radio", { name: "Personnalisé" }));
+    const customThemeSwitch = screen.getByRole("switch", { name: "Thème personnalisé" });
+    fireEvent.click(customThemeSwitch);
+
+    expect(customThemeSwitch).toBeChecked();
+    expect(within(lightPalette).getByRole("radio", { name: "Personnalisé" })).toHaveAttribute("aria-checked", "true");
+    expect(within(darkPalette).getByRole("radio", { name: "Personnalisé" })).toHaveAttribute("aria-checked", "true");
+    expect(within(darkPalette).getByRole("radio", { name: "Night" })).toHaveAttribute("aria-checked", "false");
+    expect(document.documentElement).toHaveAttribute("data-theme", "custom");
+    expect(document.getElementById("markra-custom-theme-style")).toHaveTextContent("--bg-primary: #0d1117");
+    await waitFor(() => expect(mockedSaveStoredThemePreferences).toHaveBeenCalledWith({
+      appearanceMode: "dark",
+      customThemeEnabled: true,
+      darkTheme: "night",
+      lightTheme: "light"
+    }));
+
     fireEvent.click(within(appearanceMode).getByRole("radio", { name: "Clair" }));
-    const customCss = await screen.findByRole("textbox");
+    const customCss = await screen.findByRole("textbox", { name: "CSS du thème personnalisé clair" });
     fireEvent.change(customCss, {
       target: { value: ":root[data-theme=\"custom\"] { --accent: #0969da; }" }
     });
@@ -2512,6 +2528,21 @@ describe("Markra workspace", () => {
       dark: ":root[data-theme=\"custom\"] { --bg-primary: #0d1117; }",
       light: ":root[data-theme=\"custom\"] { --accent: #0969da; }"
     }));
+
+    fireEvent.click(customThemeSwitch);
+
+    expect(customThemeSwitch).not.toBeChecked();
+    expect(within(lightPalette).getByRole("radio", { name: "Clair" })).toHaveAttribute("aria-checked", "true");
+    expect(within(darkPalette).getByRole("radio", { name: "Night" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByRole("textbox", { name: "CSS du thème personnalisé clair" })).not.toBeInTheDocument();
+
+    fireEvent.click(within(lightPalette).getByRole("radio", { name: "Personnalisé" }));
+    expect(customThemeSwitch).toBeChecked();
+    expect(within(darkPalette).getByRole("radio", { name: "Personnalisé" })).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(within(lightPalette).getByRole("radio", { name: "Clair" }));
+    expect(customThemeSwitch).not.toBeChecked();
+    expect(within(darkPalette).getByRole("radio", { name: "Night" })).toHaveAttribute("aria-checked", "true");
 
     const templatesCategoryButton = screen.getByRole("button", { name: "Modèles" });
     fireEvent.click(templatesCategoryButton);

--- a/packages/app/src/components/SettingsWindow.tsx
+++ b/packages/app/src/components/SettingsWindow.tsx
@@ -323,6 +323,7 @@ export function SettingsWindow() {
           ) : null}
           {activeSettingsCategory === "appearance" ? (
             <AppearanceSettings
+              customThemeEnabled={appTheme.customThemeEnabled}
               darkCustomThemeCss={appTheme.darkCustomThemeCss}
               lightCustomThemeCss={appTheme.lightCustomThemeCss}
               selectedAppearanceMode={appTheme.appearanceMode}
@@ -334,6 +335,7 @@ export function SettingsWindow() {
               onSelectAppearanceMode={appTheme.selectAppearanceMode}
               onSelectDarkTheme={appTheme.selectDarkTheme}
               onSelectLightTheme={appTheme.selectLightTheme}
+              onToggleCustomTheme={appTheme.toggleCustomTheme}
             />
           ) : null}
           {activeSettingsCategory === "view" ? (

--- a/packages/app/src/components/settings/AppearanceSettings.test.tsx
+++ b/packages/app/src/components/settings/AppearanceSettings.test.tsx
@@ -11,6 +11,7 @@ describe("AppearanceSettings", () => {
 
     render(
       <AppearanceSettings
+        customThemeEnabled={false}
         darkCustomThemeCss=""
         lightCustomThemeCss=""
         selectedAppearanceMode="system"
@@ -20,6 +21,7 @@ describe("AppearanceSettings", () => {
         onSelectAppearanceMode={onSelectAppearanceMode}
         onSelectDarkTheme={onSelectDarkTheme}
         onSelectLightTheme={onSelectLightTheme}
+        onToggleCustomTheme={vi.fn()}
         onUpdateDarkCustomThemeCss={vi.fn()}
         onUpdateLightCustomThemeCss={vi.fn()}
       />
@@ -59,15 +61,17 @@ describe("AppearanceSettings", () => {
 
     render(
       <AppearanceSettings
+        customThemeEnabled
         darkCustomThemeCss={darkCss}
         lightCustomThemeCss={lightCss}
         selectedAppearanceMode="light"
-        selectedDarkTheme="custom"
-        selectedLightTheme="custom"
+        selectedDarkTheme="dark"
+        selectedLightTheme="light"
         translate={translate}
         onSelectAppearanceMode={vi.fn()}
         onSelectDarkTheme={vi.fn()}
         onSelectLightTheme={vi.fn()}
+        onToggleCustomTheme={vi.fn()}
         onUpdateDarkCustomThemeCss={onUpdateDarkCustomThemeCss}
         onUpdateLightCustomThemeCss={onUpdateLightCustomThemeCss}
       />
@@ -75,9 +79,25 @@ describe("AppearanceSettings", () => {
 
     const lightCustomCss = screen.getByRole("textbox", { name: "Light custom theme CSS" });
     const darkCustomCss = screen.getByRole("textbox", { name: "Dark custom theme CSS" });
+    const lightPalette = screen.getByRole("radiogroup", { name: "Light palette" });
+    const darkPalette = screen.getByRole("radiogroup", { name: "Dark palette" });
+    const customThemeSwitch = screen.getByRole("switch", { name: "Custom theme" });
+    const lightCustomThemePanel = screen.getByRole("region", { name: "Light custom theme CSS" });
+    const darkCustomThemePanel = screen.getByRole("region", { name: "Dark custom theme CSS" });
 
     expect(lightCustomCss).toHaveValue(lightCss);
     expect(darkCustomCss).toHaveValue(darkCss);
+    expect(customThemeSwitch).toBeChecked();
+    expect(customThemeSwitch.closest(".settings-row")?.nextElementSibling).toBe(lightPalette.closest(".settings-row"));
+    expect(within(lightPalette).getByRole("radio", { name: "Custom" })).toHaveAttribute("aria-checked", "true");
+    expect(within(darkPalette).getByRole("radio", { name: "Custom" })).toHaveAttribute("aria-checked", "true");
+    expect(within(lightPalette).getByRole("radio", { name: "Light" })).toHaveAttribute("aria-checked", "false");
+    expect(within(darkPalette).getByRole("radio", { name: "Dark" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getAllByText(/Applies only when Custom is selected/)).toHaveLength(1);
+    expect(lightCustomThemePanel.querySelector(".rounded-lg")).not.toBeInTheDocument();
+    expect(darkCustomThemePanel.querySelector(".rounded-lg")).not.toBeInTheDocument();
+    expect(lightCustomCss).toHaveClass("min-h-24");
+    expect(darkCustomCss).toHaveClass("min-h-24");
 
     fireEvent.change(lightCustomCss, {
       target: { value: ":root[data-theme=\"custom\"] { --accent: #0969da; }" }
@@ -90,11 +110,50 @@ describe("AppearanceSettings", () => {
     expect(onUpdateDarkCustomThemeCss).toHaveBeenCalledWith(":root[data-theme=\"custom\"] { --accent: #58a6ff; }");
   });
 
+  it("exposes custom theme as a switch while retaining both palette buttons", () => {
+    const onToggleCustomTheme = vi.fn();
+
+    render(
+      <AppearanceSettings
+        customThemeEnabled={false}
+        darkCustomThemeCss=""
+        lightCustomThemeCss=""
+        selectedAppearanceMode="system"
+        selectedDarkTheme="night"
+        selectedLightTheme="sepia"
+        translate={translate}
+        onSelectAppearanceMode={vi.fn()}
+        onSelectDarkTheme={vi.fn()}
+        onSelectLightTheme={vi.fn()}
+        onToggleCustomTheme={onToggleCustomTheme}
+        onUpdateDarkCustomThemeCss={vi.fn()}
+        onUpdateLightCustomThemeCss={vi.fn()}
+      />
+    );
+
+    const appearanceMode = screen.getByRole("radiogroup", { name: "Appearance mode" });
+    const lightPalette = screen.getByRole("radiogroup", { name: "Light palette" });
+    const darkPalette = screen.getByRole("radiogroup", { name: "Dark palette" });
+    const customThemeSwitch = screen.getByRole("switch", { name: "Custom theme" });
+
+    expect(appearanceMode.closest(".settings-row")?.nextElementSibling).toBe(customThemeSwitch.closest(".settings-row"));
+    expect(within(lightPalette).getByRole("radio", { name: "Custom" })).toHaveAttribute("aria-checked", "false");
+    expect(within(darkPalette).getByRole("radio", { name: "Custom" })).toHaveAttribute("aria-checked", "false");
+    expect(customThemeSwitch).not.toBeChecked();
+    expect(screen.queryByRole("textbox", { name: "Light custom theme CSS" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Dark custom theme CSS" })).not.toBeInTheDocument();
+
+    fireEvent.click(customThemeSwitch);
+
+    expect(onToggleCustomTheme).toHaveBeenCalledTimes(1);
+  });
+
   it("marks selected themes in each preview group", () => {
     const onSelectLightTheme = vi.fn();
 
     render(
       <AppearanceSettings
+        customThemeEnabled={false}
         darkCustomThemeCss=""
         lightCustomThemeCss=""
         selectedAppearanceMode="system"
@@ -104,6 +163,7 @@ describe("AppearanceSettings", () => {
         onSelectAppearanceMode={vi.fn()}
         onSelectDarkTheme={vi.fn()}
         onSelectLightTheme={onSelectLightTheme}
+        onToggleCustomTheme={vi.fn()}
         onUpdateDarkCustomThemeCss={vi.fn()}
         onUpdateLightCustomThemeCss={vi.fn()}
       />
@@ -126,21 +186,25 @@ describe("AppearanceSettings", () => {
 
     render(
       <AppearanceSettings
+        customThemeEnabled
         darkCustomThemeCss=""
         lightCustomThemeCss={":root[data-theme=\"custom\"] { --accent: #b91c1c; }"}
         selectedAppearanceMode="light"
         selectedDarkTheme="dark"
-        selectedLightTheme="custom"
+        selectedLightTheme="light"
         translate={translate}
         onSelectAppearanceMode={vi.fn()}
         onSelectDarkTheme={vi.fn()}
         onSelectLightTheme={vi.fn()}
+        onToggleCustomTheme={vi.fn()}
         onUpdateDarkCustomThemeCss={vi.fn()}
         onUpdateLightCustomThemeCss={onUpdateLightCustomThemeCss}
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Reset template" }));
+    const lightCustomThemePanel = screen.getByRole("region", { name: "Light custom theme CSS" });
+
+    fireEvent.click(within(lightCustomThemePanel).getByRole("button", { name: "Reset template" }));
 
     expect(onUpdateLightCustomThemeCss).toHaveBeenCalledWith(defaultCustomThemeCss);
   });
@@ -151,21 +215,24 @@ describe("AppearanceSettings", () => {
 
     render(
       <AppearanceSettings
+        customThemeEnabled
         darkCustomThemeCss=""
         lightCustomThemeCss=""
         selectedAppearanceMode="dark"
-        selectedDarkTheme="custom"
+        selectedDarkTheme="dark"
         selectedLightTheme="light"
         translate={translate}
         onSelectAppearanceMode={vi.fn()}
         onSelectDarkTheme={vi.fn()}
         onSelectLightTheme={vi.fn()}
+        onToggleCustomTheme={vi.fn()}
         onUpdateDarkCustomThemeCss={onUpdateDarkCustomThemeCss}
         onUpdateLightCustomThemeCss={vi.fn()}
       />
     );
 
-    const fileInput = document.querySelector("input[type=\"file\"]") as HTMLInputElement;
+    const darkCustomThemePanel = screen.getByRole("region", { name: "Dark custom theme CSS" });
+    const fileInput = darkCustomThemePanel.querySelector("input[type=\"file\"]") as HTMLInputElement;
 
     expect(fileInput).toHaveAttribute("accept", ".css,text/css");
 
@@ -186,21 +253,25 @@ describe("AppearanceSettings", () => {
 
     render(
       <AppearanceSettings
+        customThemeEnabled
         darkCustomThemeCss={css}
         lightCustomThemeCss=""
         selectedAppearanceMode="dark"
-        selectedDarkTheme="custom"
+        selectedDarkTheme="dark"
         selectedLightTheme="light"
         translate={translate}
         onSelectAppearanceMode={vi.fn()}
         onSelectDarkTheme={vi.fn()}
         onSelectLightTheme={vi.fn()}
+        onToggleCustomTheme={vi.fn()}
         onUpdateDarkCustomThemeCss={vi.fn()}
         onUpdateLightCustomThemeCss={vi.fn()}
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Export CSS" }));
+    const darkCustomThemePanel = screen.getByRole("region", { name: "Dark custom theme CSS" });
+
+    fireEvent.click(within(darkCustomThemePanel).getByRole("button", { name: "Export CSS" }));
 
     expect(createObjectUrl).toHaveBeenCalledWith(expect.any(Blob));
     const exportedBlob = createObjectUrl.mock.calls[0]?.[0] as Blob;

--- a/packages/app/src/components/settings/AppearanceSettings.tsx
+++ b/packages/app/src/components/settings/AppearanceSettings.tsx
@@ -1,4 +1,5 @@
-import { Monitor, Moon, Sun, type LucideIcon } from "lucide-react";
+import { Code2, Monitor, Moon, Sun, type LucideIcon } from "lucide-react";
+import { useId } from "react";
 import {
   appAppearanceModeOptions,
   darkEditorThemeOptions,
@@ -9,7 +10,8 @@ import {
 } from "../../lib/settings/app-settings";
 import {
   SettingsRow,
-  SettingsSection
+  SettingsSection,
+  SettingsSwitch
 } from "./SettingsControls";
 import {
   CustomThemeCssControl,
@@ -75,24 +77,65 @@ function AppearanceModeControl({
   );
 }
 
+function CustomThemeCssPanel({
+  customThemeCss,
+  onUpdateCustomThemeCss,
+  title,
+  translate
+}: {
+  customThemeCss: string;
+  onUpdateCustomThemeCss: (css: string) => unknown;
+  title: string;
+  translate: SettingsTranslate;
+}) {
+  const titleId = useId();
+
+  return (
+    <section
+      className="custom-theme-css-panel py-3"
+      aria-labelledby={titleId}
+    >
+      <div className="mb-2 flex items-center gap-1.5 px-0.5">
+        <Code2 className="shrink-0 text-(--text-secondary)" aria-hidden="true" size={13} strokeWidth={2} />
+        <h4
+          className="m-0 text-[12px] leading-5 font-[650] tracking-normal text-(--text-heading)"
+          id={titleId}
+        >
+          {title}
+        </h4>
+      </div>
+      <CustomThemeCssControl
+        customThemeCss={customThemeCss}
+        label={title}
+        translate={translate}
+        onUpdateCustomThemeCss={onUpdateCustomThemeCss}
+      />
+    </section>
+  );
+}
+
 export function AppearanceSettings({
+  customThemeEnabled,
   selectedAppearanceMode,
   darkCustomThemeCss,
   lightCustomThemeCss,
   onSelectAppearanceMode,
   onSelectDarkTheme,
   onSelectLightTheme,
+  onToggleCustomTheme,
   onUpdateDarkCustomThemeCss,
   onUpdateLightCustomThemeCss,
   selectedDarkTheme,
   selectedLightTheme,
   translate
 }: {
+  customThemeEnabled: boolean;
   darkCustomThemeCss: string;
   lightCustomThemeCss: string;
   onSelectAppearanceMode: (mode: AppAppearanceMode) => unknown;
   onSelectDarkTheme: (theme: DarkEditorTheme) => unknown;
   onSelectLightTheme: (theme: LightEditorTheme) => unknown;
+  onToggleCustomTheme: () => unknown;
   onUpdateDarkCustomThemeCss: (css: string) => unknown;
   onUpdateLightCustomThemeCss: (css: string) => unknown;
   selectedAppearanceMode: AppAppearanceMode;
@@ -114,11 +157,22 @@ export function AppearanceSettings({
         }
       />
       <SettingsRow
+        title={translate("settings.theme.customThemeTitle")}
+        description={translate("settings.theme.customCssDescription")}
+        action={
+          <SettingsSwitch
+            checked={customThemeEnabled}
+            label={translate("settings.theme.customThemeTitle")}
+            onChange={onToggleCustomTheme}
+          />
+        }
+      />
+      <SettingsRow
         title={translate("settings.theme.lightPaletteTitle")}
         action={
           <ThemePreviewGrid
             ariaLabel={translate("settings.theme.lightPaletteTitle")}
-            selectedTheme={selectedLightTheme}
+            selectedTheme={customThemeEnabled ? "custom" : selectedLightTheme}
             themes={lightEditorThemeOptions}
             translate={translate}
             onSelectTheme={onSelectLightTheme}
@@ -130,40 +184,28 @@ export function AppearanceSettings({
         action={
           <ThemePreviewGrid
             ariaLabel={translate("settings.theme.darkPaletteTitle")}
-            selectedTheme={selectedDarkTheme}
+            selectedTheme={customThemeEnabled ? "custom" : selectedDarkTheme}
             themes={darkEditorThemeOptions}
             translate={translate}
             onSelectTheme={onSelectDarkTheme}
           />
         }
       />
-      {selectedLightTheme === "custom" ? (
-        <SettingsRow
-          title={translate("settings.theme.lightCustomCssTitle")}
-          description={translate("settings.theme.customCssDescription")}
-          action={
-            <CustomThemeCssControl
-              customThemeCss={lightCustomThemeCss}
-              label={translate("settings.theme.lightCustomCssTitle")}
-              translate={translate}
-              onUpdateCustomThemeCss={onUpdateLightCustomThemeCss}
-            />
-          }
-        />
-      ) : null}
-      {selectedDarkTheme === "custom" ? (
-        <SettingsRow
-          title={translate("settings.theme.darkCustomCssTitle")}
-          description={translate("settings.theme.customCssDescription")}
-          action={
-            <CustomThemeCssControl
-              customThemeCss={darkCustomThemeCss}
-              label={translate("settings.theme.darkCustomCssTitle")}
-              translate={translate}
-              onUpdateCustomThemeCss={onUpdateDarkCustomThemeCss}
-            />
-          }
-        />
+      {customThemeEnabled ? (
+        <>
+          <CustomThemeCssPanel
+            customThemeCss={lightCustomThemeCss}
+            title={translate("settings.theme.lightCustomCssTitle")}
+            translate={translate}
+            onUpdateCustomThemeCss={onUpdateLightCustomThemeCss}
+          />
+          <CustomThemeCssPanel
+            customThemeCss={darkCustomThemeCss}
+            title={translate("settings.theme.darkCustomCssTitle")}
+            translate={translate}
+            onUpdateCustomThemeCss={onUpdateDarkCustomThemeCss}
+          />
+        </>
       ) : null}
     </SettingsSection>
   );

--- a/packages/app/src/components/settings/ThemeSettingsControls.tsx
+++ b/packages/app/src/components/settings/ThemeSettingsControls.tsx
@@ -1,4 +1,4 @@
-import { Download, RotateCcw, Upload } from "lucide-react";
+import { Code2, Download, RotateCcw, Upload } from "lucide-react";
 import { type ChangeEvent, type CSSProperties, useRef } from "react";
 import {
   defaultCustomThemeCss,
@@ -272,31 +272,45 @@ export function ThemePreviewGrid<Theme extends EditorTheme>({
               style={createThemePreviewStyle(themePreviewSwatches[theme])}
               onClick={() => onSelectTheme(theme)}
             >
-              <span
-                className="relative h-6 w-6 overflow-hidden rounded-[5px] border"
-                style={{
-                  background: "var(--theme-preview-bg)",
-                  borderColor: "var(--theme-preview-border)"
-                }}
-                aria-hidden="true"
-              >
+              {theme === "custom" ? (
                 <span
-                  className="absolute top-1 left-1 h-1 w-3 rounded-full"
-                  style={{ background: "var(--theme-preview-text)" }}
-                />
+                  className="relative flex h-6 w-6 items-center justify-center rounded-[5px] border text-(--text-heading)"
+                  style={{
+                    background: "var(--theme-preview-panel)",
+                    borderColor: "var(--theme-preview-border)"
+                  }}
+                  aria-hidden="true"
+                >
+                  <Code2 size={15} strokeWidth={2.2} />
+                  <span className="absolute right-0.5 bottom-0.5 size-1.5 rounded-full bg-(--accent)" />
+                </span>
+              ) : (
                 <span
-                  className="absolute top-2.5 left-1 h-1 w-3.5 rounded-full"
-                  style={{ background: "var(--theme-preview-muted)" }}
-                />
-                <span
-                  className="absolute right-1 bottom-1 h-2 w-2 rounded-full"
-                  style={{ background: "var(--theme-preview-accent)" }}
-                />
-                <span
-                  className="absolute bottom-1 left-1 h-1.5 w-3.5 rounded-sm"
-                  style={{ background: "var(--theme-preview-panel)" }}
-                />
-              </span>
+                  className="relative h-6 w-6 overflow-hidden rounded-[5px] border"
+                  style={{
+                    background: "var(--theme-preview-bg)",
+                    borderColor: "var(--theme-preview-border)"
+                  }}
+                  aria-hidden="true"
+                >
+                  <span
+                    className="absolute top-1 left-1 h-1 w-3 rounded-full"
+                    style={{ background: "var(--theme-preview-text)" }}
+                  />
+                  <span
+                    className="absolute top-2.5 left-1 h-1 w-3.5 rounded-full"
+                    style={{ background: "var(--theme-preview-muted)" }}
+                  />
+                  <span
+                    className="absolute right-1 bottom-1 h-2 w-2 rounded-full"
+                    style={{ background: "var(--theme-preview-accent)" }}
+                  />
+                  <span
+                    className="absolute bottom-1 left-1 h-1.5 w-3.5 rounded-sm"
+                    style={{ background: "var(--theme-preview-panel)" }}
+                  />
+                </span>
+              )}
               {selected ? <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-(--accent)" aria-hidden="true" /> : null}
             </button>
           </Tooltip>
@@ -350,13 +364,15 @@ export function CustomThemeCssControl({
   }
 
   return (
-    <div className="flex w-80 max-w-full flex-col items-stretch gap-2">
+    <div className="flex w-full flex-col items-stretch gap-2">
       <SettingsTextarea
+        className="min-h-24 font-mono font-[500]"
         label={label}
         value={customThemeCss}
+        widthClassName="w-full"
         onChange={onUpdateCustomThemeCss}
       />
-      <div className="flex flex-wrap justify-end gap-2">
+      <div className="flex flex-wrap justify-end gap-1.5">
         <SettingsButton label={importLabel} onClick={() => fileInputRef.current?.click()}>
           <Upload aria-hidden="true" size={13} />
           {importLabel}

--- a/packages/app/src/hooks/useAppTheme.ts
+++ b/packages/app/src/hooks/useAppTheme.ts
@@ -124,6 +124,7 @@ export function useAppTheme() {
   const liveThemePreferencesReceivedRef = useRef(false);
   const editorTheme = resolveAppThemePreferencesEditorTheme(themePreferences, systemTheme);
   const resolvedTheme = resolveAppThemePreferencesAppearance(themePreferences, systemTheme);
+  const customThemeEnabled = themePreferences.customThemeEnabled === true;
   const ready = themePreferencesReady && (editorTheme !== "custom" || customThemeCssReady);
 
   useEffect(() => {
@@ -234,17 +235,20 @@ export function useAppTheme() {
     });
   }, [themePreferences, updateThemePreferences]);
 
+  // The custom swatches mirror the global switch; keep the saved palettes so turning custom off restores them.
   const selectLightTheme = useCallback((lightTheme: LightEditorTheme) => {
     updateThemePreferences({
       ...themePreferences,
-      lightTheme
+      customThemeEnabled: lightTheme === "custom",
+      ...(lightTheme === "custom" ? {} : { lightTheme })
     });
   }, [themePreferences, updateThemePreferences]);
 
   const selectDarkTheme = useCallback((darkTheme: DarkEditorTheme) => {
     updateThemePreferences({
       ...themePreferences,
-      darkTheme
+      customThemeEnabled: darkTheme === "custom",
+      ...(darkTheme === "custom" ? {} : { darkTheme })
     });
   }, [themePreferences, updateThemePreferences]);
 
@@ -254,6 +258,13 @@ export function useAppTheme() {
       appearanceMode: resolvedTheme === "dark" ? "light" : "dark"
     });
   }, [resolvedTheme, themePreferences, updateThemePreferences]);
+
+  const toggleCustomTheme = useCallback(() => {
+    updateThemePreferences({
+      ...themePreferences,
+      customThemeEnabled: !customThemeEnabled
+    });
+  }, [customThemeEnabled, themePreferences, updateThemePreferences]);
 
   const updateCustomThemeCss = useCallback((nextCss: string) => {
     const normalizedCss = normalizeCustomThemeCssValues({
@@ -293,6 +304,7 @@ export function useAppTheme() {
 
   return {
     customThemeCss,
+    customThemeEnabled,
     darkCustomThemeCss: customThemeCss.dark,
     editorTheme,
     appearanceMode: themePreferences.appearanceMode,
@@ -305,6 +317,7 @@ export function useAppTheme() {
     selectDarkTheme,
     selectLightTheme,
     themePreferences,
+    toggleCustomTheme,
     toggleTheme,
     updateCustomThemeCss,
     updateDarkCustomThemeCss,

--- a/packages/app/src/lib/settings/app-settings.test.ts
+++ b/packages/app/src/lib/settings/app-settings.test.ts
@@ -128,6 +128,7 @@ describe("app settings", () => {
   it("loads and persists split appearance preferences", async () => {
     store.get.mockImplementation(async (key: string) => {
       if (key === "appearanceMode") return "system";
+      if (key === "customThemeEnabled") return true;
       if (key === "lightTheme") return "solarized-light";
       if (key === "darkTheme") return "night";
 
@@ -136,17 +137,20 @@ describe("app settings", () => {
 
     await expect(getStoredThemePreferences()).resolves.toEqual({
       appearanceMode: "system",
+      customThemeEnabled: true,
       darkTheme: "night",
       lightTheme: "solarized-light"
     });
 
     await saveStoredThemePreferences({
       appearanceMode: "dark",
+      customThemeEnabled: true,
       darkTheme: "catppuccin-mocha",
       lightTheme: "catppuccin-latte"
     });
 
     expect(store.set).toHaveBeenCalledWith("appearanceMode", "dark");
+    expect(store.set).toHaveBeenCalledWith("customThemeEnabled", true);
     expect(store.set).toHaveBeenCalledWith("lightTheme", "catppuccin-latte");
     expect(store.set).toHaveBeenCalledWith("darkTheme", "catppuccin-mocha");
     expect(store.set).not.toHaveBeenCalledWith("theme", expect.any(String));
@@ -169,6 +173,20 @@ describe("app settings", () => {
     expect(resolveAppThemePreferencesAppearance(preferences, "dark")).toBe("dark");
     expect(resolveAppThemePreferencesEditorTheme(preferences, "dark")).toBe("night");
     expect(resolveAppThemePreferencesEditorTheme(preferences, "light")).toBe("sepia");
+  });
+
+  it("uses the custom theme without replacing the saved light and dark palettes", () => {
+    const preferences = {
+      appearanceMode: "system" as const,
+      customThemeEnabled: true,
+      darkTheme: "night" as const,
+      lightTheme: "sepia" as const
+    };
+
+    expect(resolveAppThemePreferencesEditorTheme(preferences, "dark")).toBe("custom");
+    expect(resolveAppThemePreferencesEditorTheme(preferences, "light")).toBe("custom");
+    expect(preferences.darkTheme).toBe("night");
+    expect(preferences.lightTheme).toBe("sepia");
   });
 
   it("recognizes GitHub and One theme options", () => {

--- a/packages/app/src/lib/settings/app-settings.ts
+++ b/packages/app/src/lib/settings/app-settings.ts
@@ -184,6 +184,7 @@ const themeKey = "theme";
 const appearanceModeKey = "appearanceMode";
 const lightThemeKey = "lightTheme";
 const darkThemeKey = "darkTheme";
+const customThemeEnabledKey = "customThemeEnabled";
 const customThemeCssKey = "customThemeCss";
 const lightCustomThemeCssKey = "lightCustomThemeCss";
 const darkCustomThemeCssKey = "darkCustomThemeCss";
@@ -289,6 +290,7 @@ export const darkEditorThemeOptions = [
 export type DarkEditorTheme = typeof darkEditorThemeOptions[number];
 export type AppThemePreferences = {
   appearanceMode: AppAppearanceMode;
+  customThemeEnabled?: boolean;
   darkTheme: DarkEditorTheme;
   lightTheme: LightEditorTheme;
 };
@@ -347,6 +349,7 @@ export type PortableStoredAppSettings = {
   appearanceMode: AppAppearanceMode;
   backupSettings: BackupSettings;
   customThemeCss: CustomThemeCssValues;
+  customThemeEnabled?: boolean;
   darkTheme: DarkEditorTheme;
   editorPreferences: EditorPreferences;
   exportSettings: ExportSettings;
@@ -629,6 +632,7 @@ function normalizePortableStoredAppSettings(value: Record<string, unknown>): Por
     appearanceMode: themePreferences.appearanceMode,
     backupSettings: normalizeBackupSettings(value.backupSettings),
     customThemeCss: normalizeCustomThemeCssValues(value.customThemeCss),
+    ...(themePreferences.customThemeEnabled ? { customThemeEnabled: true } : {}),
     darkTheme: themePreferences.darkTheme,
     editorPreferences: normalizeEditorPreferences(value.editorPreferences),
     exportSettings: normalizeExportSettings(value.exportSettings),
@@ -649,6 +653,7 @@ async function readPortableStoredAppSettings(): Promise<PortableStoredAppSetting
     : defaultAppThemePreferences;
   const themePreferences = normalizeAppThemePreferences({
     appearanceMode: await store.get<AppAppearanceMode>(appearanceModeKey),
+    customThemeEnabled: await store.get<boolean>(customThemeEnabledKey),
     darkTheme: await store.get<DarkEditorTheme>(darkThemeKey),
     lightTheme: await store.get<LightEditorTheme>(lightThemeKey)
   }, legacyPreferences);
@@ -676,6 +681,7 @@ async function readPortableStoredAppSettings(): Promise<PortableStoredAppSetting
     appearanceMode: themePreferences.appearanceMode,
     backupSettings: normalizeBackupSettings(backupSettings),
     customThemeCss,
+    ...(themePreferences.customThemeEnabled ? { customThemeEnabled: true } : {}),
     darkTheme: themePreferences.darkTheme,
     editorPreferences: normalizeEditorPreferences(editorPreferences),
     exportSettings: normalizeExportSettings(exportSettings),
@@ -696,6 +702,7 @@ async function writePortableStoredAppSettings(settings: PortableStoredAppSetting
   await store.set(aiProvidersKey, settings.aiProviders);
   await store.set(appearanceModeKey, settings.appearanceMode);
   await store.set(backupSettingsKey, settings.backupSettings);
+  await store.set(customThemeEnabledKey, settings.customThemeEnabled === true);
   await store.set(darkCustomThemeCssKey, settings.customThemeCss.dark);
   await store.set(darkThemeKey, settings.darkTheme);
   await store.set(editorPreferencesKey, settings.editorPreferences);
@@ -786,13 +793,28 @@ export function normalizeAppThemePreferences(
   if (typeof value !== "object" || value === null) return fallback;
 
   const preferences = value as Partial<Record<keyof AppThemePreferences, unknown>>;
+  const fallbackDarkTheme = fallback.darkTheme === "custom"
+    ? defaultAppThemePreferences.darkTheme
+    : fallback.darkTheme;
+  const fallbackLightTheme = fallback.lightTheme === "custom"
+    ? defaultAppThemePreferences.lightTheme
+    : fallback.lightTheme;
+  const storedCustomTheme = preferences.darkTheme === "custom" || preferences.lightTheme === "custom";
+  const customThemeEnabled = typeof preferences.customThemeEnabled === "boolean"
+    ? preferences.customThemeEnabled
+    : storedCustomTheme || fallback.customThemeEnabled === true;
 
   return {
     appearanceMode: isAppAppearanceMode(preferences.appearanceMode)
       ? preferences.appearanceMode
       : fallback.appearanceMode,
-    darkTheme: isDarkEditorTheme(preferences.darkTheme) ? preferences.darkTheme : fallback.darkTheme,
-    lightTheme: isLightEditorTheme(preferences.lightTheme) ? preferences.lightTheme : fallback.lightTheme
+    ...(customThemeEnabled ? { customThemeEnabled: true } : {}),
+    darkTheme: isDarkEditorTheme(preferences.darkTheme) && preferences.darkTheme !== "custom"
+      ? preferences.darkTheme
+      : fallbackDarkTheme,
+    lightTheme: isLightEditorTheme(preferences.lightTheme) && preferences.lightTheme !== "custom"
+      ? preferences.lightTheme
+      : fallbackLightTheme
   };
 }
 
@@ -811,7 +833,14 @@ export function resolveAppEditorTheme(theme: AppTheme, systemTheme: ResolvedAppT
 
 export function createThemePreferencesFromLegacyTheme(theme: AppTheme): AppThemePreferences {
   if (theme === "system") return defaultAppThemePreferences;
-  if (isDarkEditorTheme(theme) && theme !== "custom") {
+  if (theme === "custom") {
+    return {
+      ...defaultAppThemePreferences,
+      appearanceMode: "light",
+      customThemeEnabled: true
+    };
+  }
+  if (isDarkEditorTheme(theme)) {
     return {
       ...defaultAppThemePreferences,
       appearanceMode: "dark",
@@ -840,6 +869,8 @@ export function resolveAppThemePreferencesEditorTheme(
   preferences: AppThemePreferences,
   systemTheme: ResolvedAppTheme
 ): EditorTheme {
+  if (preferences.customThemeEnabled) return "custom";
+
   return resolveAppThemePreferencesAppearance(preferences, systemTheme) === "dark"
     ? preferences.darkTheme
     : preferences.lightTheme;
@@ -874,6 +905,7 @@ export async function saveStoredTheme(theme: AppTheme) {
 export async function getStoredThemePreferences(): Promise<AppThemePreferences> {
   const store = await loadSettingsStore();
   const appearanceMode = await store.get<AppAppearanceMode>(appearanceModeKey);
+  const customThemeEnabled = await store.get<boolean>(customThemeEnabledKey);
   const lightTheme = await store.get<LightEditorTheme>(lightThemeKey);
   const darkTheme = await store.get<DarkEditorTheme>(darkThemeKey);
   const legacyTheme = await store.get<AppTheme>(themeKey);
@@ -881,11 +913,12 @@ export async function getStoredThemePreferences(): Promise<AppThemePreferences> 
     ? createThemePreferencesFromLegacyTheme(legacyTheme)
     : defaultAppThemePreferences;
 
-  return {
-    appearanceMode: isAppAppearanceMode(appearanceMode) ? appearanceMode : legacyPreferences.appearanceMode,
-    darkTheme: isDarkEditorTheme(darkTheme) ? darkTheme : legacyPreferences.darkTheme,
-    lightTheme: isLightEditorTheme(lightTheme) ? lightTheme : legacyPreferences.lightTheme
-  };
+  return normalizeAppThemePreferences({
+    appearanceMode,
+    customThemeEnabled,
+    darkTheme,
+    lightTheme
+  }, legacyPreferences);
 }
 
 export async function saveStoredThemePreferences(preferences: AppThemePreferences) {
@@ -893,6 +926,7 @@ export async function saveStoredThemePreferences(preferences: AppThemePreference
   const normalizedPreferences = normalizeAppThemePreferences(preferences);
 
   await store.set(appearanceModeKey, normalizedPreferences.appearanceMode);
+  await store.set(customThemeEnabledKey, normalizedPreferences.customThemeEnabled === true);
   await store.set(lightThemeKey, normalizedPreferences.lightTheme);
   await store.set(darkThemeKey, normalizedPreferences.darkTheme);
   await store.save();

--- a/packages/app/src/test/app-harness.tsx
+++ b/packages/app/src/test/app-harness.tsx
@@ -458,7 +458,7 @@ vi.mock("../lib/settings/app-settings", () => ({
     const appearanceMode = ["system", "light", "dark"].includes(String(value.appearanceMode))
       ? value.appearanceMode
       : "system";
-    const lightTheme = [
+    const requestedLightTheme = [
       "light",
       "github",
       "one-light",
@@ -473,7 +473,7 @@ vi.mock("../lib/settings/app-settings", () => ({
       "minimal",
       "custom"
     ].includes(String(value.lightTheme)) ? value.lightTheme : "light";
-    const darkTheme = [
+    const requestedDarkTheme = [
       "dark",
       "github-dark",
       "one-dark",
@@ -484,11 +484,15 @@ vi.mock("../lib/settings/app-settings", () => ({
       "catppuccin-mocha",
       "custom"
     ].includes(String(value.darkTheme)) ? value.darkTheme : "dark";
+    const customThemeEnabled = value.customThemeEnabled === true
+      || requestedLightTheme === "custom"
+      || requestedDarkTheme === "custom";
 
     return {
       appearanceMode,
-      darkTheme,
-      lightTheme
+      ...(customThemeEnabled ? { customThemeEnabled: true } : {}),
+      darkTheme: requestedDarkTheme === "custom" ? "dark" : requestedDarkTheme,
+      lightTheme: requestedLightTheme === "custom" ? "light" : requestedLightTheme
     };
   }),
   resolveAppAppearanceTheme: vi.fn((theme, systemTheme) => {
@@ -509,6 +513,8 @@ vi.mock("../lib/settings/app-settings", () => ({
     preferences.appearanceMode === "system" ? systemTheme : preferences.appearanceMode
   ),
   resolveAppThemePreferencesEditorTheme: vi.fn((preferences, systemTheme) => {
+    if (preferences.customThemeEnabled) return "custom";
+
     const appearance = preferences.appearanceMode === "system" ? systemTheme : preferences.appearanceMode;
 
     return appearance === "dark" ? preferences.darkTheme : preferences.lightTheme;

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Benutzerdefiniert",
+  "settings.theme.customThemeTitle": "Benutzerdefiniertes Theme",
   "settings.theme.customCssTitle": "Benutzerdefiniertes Theme-CSS",
   "settings.theme.customCssDescription": "Wird nur angewendet, wenn Benutzerdefiniert ausgewählt ist. Verwenden Sie [data-theme=\"custom\"] und .markdown-paper[data-editor-theme=\"custom\"], um Überschreibungen einzugrenzen.",
   "settings.theme.previewTitle": "Theme-Vorschau",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -112,6 +112,7 @@ const messages: BaseLocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Custom",
+  "settings.theme.customThemeTitle": "Custom theme",
   "settings.theme.customCssTitle": "Custom theme CSS",
   "settings.theme.lightCustomCssTitle": "Light custom theme CSS",
   "settings.theme.darkCustomCssTitle": "Dark custom theme CSS",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Personalizado",
+  "settings.theme.customThemeTitle": "Tema personalizado",
   "settings.theme.customCssTitle": "CSS del tema personalizado",
   "settings.theme.customCssDescription": "Solo se aplica cuando Personalizado está seleccionado. Usa [data-theme=\"custom\"] y .markdown-paper[data-editor-theme=\"custom\"] para limitar los cambios.",
   "settings.theme.previewTitle": "Vistas previas de temas",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Personnalisé",
+  "settings.theme.customThemeTitle": "Thème personnalisé",
   "settings.theme.customCssTitle": "CSS du thème personnalisé",
   "settings.theme.customCssDescription": "S’applique uniquement lorsque Personnalisé est sélectionné. Utilisez [data-theme=\"custom\"] et .markdown-paper[data-editor-theme=\"custom\"] pour limiter les remplacements.",
   "settings.theme.previewTitle": "Aperçus des thèmes",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Personalizzato",
+  "settings.theme.customThemeTitle": "Tema personalizzato",
   "settings.theme.customCssTitle": "CSS tema personalizzato",
   "settings.theme.customCssDescription": "Si applica solo quando è selezionato Personalizzato. Usa [data-theme=\"custom\"] e .markdown-paper[data-editor-theme=\"custom\"] per limitare le modifiche.",
   "settings.theme.previewTitle": "Anteprime temi",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -98,6 +98,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "カスタム",
+  "settings.theme.customThemeTitle": "カスタムテーマ",
   "settings.theme.customCssTitle": "カスタムテーマ CSS",
   "settings.theme.customCssDescription": "カスタムテーマを選んだときだけ適用されます。[data-theme=\"custom\"] と .markdown-paper[data-editor-theme=\"custom\"] で範囲を限定できます。",
   "settings.theme.previewTitle": "テーマプレビュー",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "사용자 지정",
+  "settings.theme.customThemeTitle": "사용자 지정 테마",
   "settings.theme.customCssTitle": "사용자 지정 테마 CSS",
   "settings.theme.customCssDescription": "사용자 지정 테마를 선택했을 때만 적용됩니다. [data-theme=\"custom\"] 및 .markdown-paper[data-editor-theme=\"custom\"]로 범위를 제한할 수 있습니다.",
   "settings.theme.previewTitle": "테마 미리보기",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Personalizado",
+  "settings.theme.customThemeTitle": "Tema personalizado",
   "settings.theme.customCssTitle": "CSS do tema personalizado",
   "settings.theme.customCssDescription": "Aplica somente quando Personalizado estiver selecionado. Use [data-theme=\"custom\"] e .markdown-paper[data-editor-theme=\"custom\"] para limitar as alterações.",
   "settings.theme.previewTitle": "Pré-visualizações de tema",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -90,6 +90,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "Пользовательская",
+  "settings.theme.customThemeTitle": "Пользовательская тема",
   "settings.theme.customCssTitle": "CSS пользовательской темы",
   "settings.theme.customCssDescription": "Применяется только при выборе пользовательской темы. Используйте [data-theme=\"custom\"] и .markdown-paper[data-editor-theme=\"custom\"], чтобы ограничить переопределения.",
   "settings.theme.previewTitle": "Предпросмотр тем",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -123,6 +123,7 @@ export type I18nKey =
   | "settings.theme.academic"
   | "settings.theme.minimal"
   | "settings.theme.custom"
+  | "settings.theme.customThemeTitle"
   | "settings.theme.customCssTitle"
   | "settings.theme.lightCustomCssTitle"
   | "settings.theme.darkCustomCssTitle"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -112,6 +112,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "自定义",
+  "settings.theme.customThemeTitle": "自定义主题",
   "settings.theme.customCssTitle": "自定义主题 CSS",
   "settings.theme.lightCustomCssTitle": "浅色自定义主题 CSS",
   "settings.theme.darkCustomCssTitle": "深色自定义主题 CSS",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -98,6 +98,7 @@ const messages: LocaleMessages = {
   "settings.theme.academic": "Academic",
   "settings.theme.minimal": "Minimal",
   "settings.theme.custom": "自訂",
+  "settings.theme.customThemeTitle": "自訂主題",
   "settings.theme.customCssTitle": "自訂主題 CSS",
   "settings.theme.customCssDescription": "只會在選取自訂主題時套用。可用 [data-theme=\"custom\"] 和 .markdown-paper[data-editor-theme=\"custom\"] 限定覆寫範圍。",
   "settings.theme.previewTitle": "主題預覽",


### PR DESCRIPTION
## Summary
- add a persistent Custom theme switch directly below Appearance mode
- keep the light and dark custom palette swatches and synchronize them with the switch while preserving saved palettes
- simplify the light and dark CSS editors into compact flat sections with import, export, and reset actions
- migrate legacy custom palette selections and localize the new setting label

## Validation
- `pnpm --filter @markra/app test -- AppearanceSettings.test.tsx app-settings.test.ts` — 32 tests passed
- `pnpm --filter @markra/app test -- App.test.tsx -t "renders an independent settings window route|applies the custom theme CSS for the active appearance mode"` — 2 tests passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- manual browser QA in the Chinese settings route confirmed switch and palette synchronization with no console errors

## Risk
- stores a new `customThemeEnabled` boolean; existing custom palette values are migrated to the new setting while retaining valid saved light and dark palettes