### PR TITLE
feat(app): add collapsible file list controls

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -367,6 +367,7 @@ describe("MarkdownFileTreeDrawer", () => {
     );
     const layoutTabs = screen.getByRole("group", { name: "Files / Outline" });
     const recentFolders = screen.getByRole("region", { name: "Recently used directories" });
+    const root = container.querySelector(".markdown-file-tree-root") as HTMLElement;
 
     expect(layoutTabs.compareDocumentPosition(recentFolders) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(layoutTabs).toHaveClass("markdown-file-tree-panel-tabs");
@@ -380,13 +381,28 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
     expect(screen.queryByRole("list", { name: "Document outline" })).not.toBeInTheDocument();
     expect(screen.queryByRole("separator", { name: "Resize outline" })).not.toBeInTheDocument();
+    expect(within(root).getByRole("button", { name: "Hide files" })).toBeInTheDocument();
+
+    fireEvent.click(within(root).getByRole("button", { name: "Hide files" }));
+
+    expect(within(layoutTabs).getByRole("button", { name: "Files" })).toHaveAttribute("aria-pressed", "true");
+    expect(within(layoutTabs).getByRole("button", { name: "Outline" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Recently used directories" })).toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-toolbar")).toBeInTheDocument();
+    expect(screen.getByText("Example Vault")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show files" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show files" }));
+
+    expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Recently used directories" })).toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-toolbar")).toBeInTheDocument();
 
     fireEvent.click(within(layoutTabs).getByRole("button", { name: "Outline" }));
 
     expect(within(layoutTabs).getByRole("button", { name: "Files" })).toHaveAttribute("aria-pressed", "false");
     expect(within(layoutTabs).getByRole("button", { name: "Outline" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("region", { name: "Recently used directories" })).not.toBeInTheDocument();
     const outlineToolbar = container.querySelector(".markdown-file-tree-outline-toolbar") as HTMLElement;
     const outlineList = screen.getByRole("list", { name: "Document outline" });
 
@@ -1018,6 +1034,99 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.getByRole("list", { name: "Document outline" })).toHaveTextContent("Details");
   });
 
+  it("collapses and restores only the file list while keeping neighboring file controls", () => {
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          { level: 1, title: "Intro" },
+          { level: 2, title: "Details" }
+        ]}
+        recentFolders={[{ name: "mock-workspace", path: "/mock-files/workspace" }]}
+        rootName="Example Vault"
+        onOpenFile={() => {}}
+        onOpenRecentFolder={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide files" }));
+
+    expect(screen.getByText("Files")).toBeInTheDocument();
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Recently used directories" })).toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-toolbar")).toBeInTheDocument();
+    expect(screen.getByText("Example Vault")).toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-files")).toHaveClass("shrink-0");
+    expect(container.querySelector(".markdown-file-tree-files")).not.toHaveClass("h-8");
+    expect(container.querySelector(".markdown-file-tree-outline-resizer")).not.toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-outline")).toHaveClass("flex-1");
+    expect(screen.getByRole("list", { name: "Document outline" })).toHaveTextContent("Intro");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show files" }));
+
+    expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Recently used directories" })).toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-toolbar")).toBeInTheDocument();
+    expect(container.querySelector(".markdown-file-tree-outline-resizer")).toBeInTheDocument();
+  });
+
+  it("keeps the file list collapsed when the outline is collapsed independently", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[
+          { level: 1, title: "Intro" },
+          { level: 2, title: "Details" }
+        ]}
+        rootName="Example Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide files" }));
+    fireEvent.click(screen.getByRole("button", { name: "Hide outline" }));
+
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show files" })).toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Document outline" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the file list independently collapsed when the outline becomes unavailable", () => {
+    const props = {
+      currentPath: "/vault/Untitled.md",
+      files: markdownFiles,
+      open: true,
+      outlineItems: [{ level: 1 as const, title: "Intro" }],
+      rootName: "Example Vault",
+      onOpenFile: () => {},
+      onSelectOutlineItem: () => {}
+    };
+    const { rerender } = render(
+      <MarkdownFileTreeDrawer
+        {...props}
+        outlineVisible
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide files" }));
+
+    rerender(
+      <MarkdownFileTreeDrawer
+        {...props}
+        outlineVisible={false}
+      />
+    );
+
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show files" })).toBeInTheDocument();
+  });
+
   it("resizes the file and outline panels from the divider", () => {
     const { container } = render(
       <MarkdownFileTreeDrawer
@@ -1093,7 +1202,7 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(openFolder).not.toHaveBeenCalled();
   });
 
-  it("places the Windows open folder action in the sidebar header before search", () => {
+  it("places the Windows open folder action in the file toolbar before search", () => {
     const openFolder = vi.fn();
     const { container } = render(
       <MarkdownFileTreeDrawer
@@ -1108,11 +1217,16 @@ describe("MarkdownFileTreeDrawer", () => {
         onSelectOutlineItem={() => {}}
       />
     );
-    const headerActions = container.querySelector(".markdown-file-tree-header-actions") as HTMLElement;
+    const toolbar = container.querySelector(".markdown-file-tree-toolbar") as HTMLElement;
 
     expect(
-      within(headerActions).getAllByRole("button").map((button) => button.getAttribute("aria-label"))
-    ).toEqual(["Open Folder", "Search Markdown files"]);
+      within(toolbar).getAllByRole("button").map((button) => button.getAttribute("aria-label"))
+    ).toEqual([
+      "Open Folder",
+      "Search Markdown files",
+      "Sort files",
+      "Expand folders"
+    ]);
     expect(screen.getByRole("button", { name: "Open Folder" })).toContainElement(
       container.querySelector(".lucide-folder-open")
     );
@@ -1120,6 +1234,55 @@ describe("MarkdownFileTreeDrawer", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open Folder" }));
 
     expect(openFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it("places file actions between recent folders and the workspace root", () => {
+    const { container } = render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={[
+          ...markdownFiles,
+          { kind: "folder", name: "assets", path: "/vault/assets", relativePath: "assets" },
+          { kind: "asset", name: "diagram.png", path: "/vault/assets/diagram.png", relativePath: "assets/diagram.png" }
+        ]}
+        open
+        outlineItems={[]}
+        platform="macos"
+        recentFolders={[{ name: "mock-workspace", path: "/mock-files/workspace" }]}
+        rootPath="/vault"
+        rootName="Example Vault"
+        sidebarLayoutMode="tabs"
+        onCleanUnusedImages={() => {}}
+        onCreateFile={() => {}}
+        onOpenFile={() => {}}
+        onOpenRecentFolder={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+    const recentFolders = screen.getByRole("region", { name: "Recently used directories" });
+    const toolbar = container.querySelector(".markdown-file-tree-toolbar") as HTMLElement;
+    const root = container.querySelector(".markdown-file-tree-root") as HTMLElement;
+
+    expect(toolbar).toHaveClass("h-8", "justify-start", "pl-2.5", "pr-4");
+    expect(toolbar).not.toHaveClass("px-4");
+    expect(toolbar).not.toHaveClass("absolute", "top-0");
+    expect(root).toHaveClass("h-8", "pl-4", "pr-2");
+    expect(root).not.toHaveClass("px-4");
+    expect(
+      within(toolbar).getAllByRole("button").map((button) => button.getAttribute("aria-label"))
+    ).toEqual([
+      "Search Markdown files",
+      "Sort files",
+      "Hide image assets",
+      "Clean up unused images",
+      "Expand folders",
+      "New"
+    ]);
+    expect(within(root).getAllByRole("button").map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Hide files"
+    ]);
+    expect(recentFolders.compareDocumentPosition(toolbar) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(toolbar.compareDocumentPosition(root) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("keeps folder creation unavailable until a folder root is open", () => {
@@ -1710,7 +1873,7 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.getByRole("button", { name: "deploy/deploy.md" })).toBeInTheDocument();
   });
 
-  it("toggles all folders from the root file row", () => {
+  it("toggles all folders from the file tree toolbar", () => {
     const { container } = render(
       <MarkdownFileTreeDrawer
         currentPath="/vault/Untitled.md"
@@ -1730,10 +1893,10 @@ describe("MarkdownFileTreeDrawer", () => {
     expect(screen.queryByRole("button", { name: "Reveal active file" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Expand folders" })).toContainElement(container.querySelector(".lucide-list-chevrons-up-down"));
     expect(
-      within(screen.getByText("Obsidian Vault").parentElement?.parentElement as HTMLElement)
+      within(container.querySelector(".markdown-file-tree-toolbar") as HTMLElement)
         .getAllByRole("button")
         .map((button) => button.getAttribute("aria-label"))
-    ).toEqual(["Sort files", "Expand folders", "New"]);
+    ).toEqual(["Search Markdown files", "Sort files", "Expand folders", "New"]);
 
     fireEvent.click(screen.getByRole("button", { name: "Expand folders" }));
 
@@ -1975,6 +2138,27 @@ describe("MarkdownFileTreeDrawer", () => {
       direction: "ascending",
       key: "name"
     });
+  });
+
+  it("opens the sort menu toward the inside of the left-aligned toolbar", () => {
+    render(
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Example Vault"
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort files" }));
+
+    const sortMenu = screen.getByRole("menu", { name: "Sort files" });
+
+    expect(sortMenu).toHaveClass("left-0");
+    expect(sortMenu).not.toHaveClass("right-0");
   });
 
   it("closes sidebar option menus after clicking outside them", () => {

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -530,6 +530,7 @@ export function MarkdownFileTreeDrawer({
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [localRecentFoldersOpen, setLocalRecentFoldersOpen] = useState(true);
+  const [fileTreeListOpen, setFileTreeListOpen] = useState(true);
   const [outlineOpen, setOutlineOpen] = useState(true);
   const [localDocumentLinksOpen, setLocalDocumentLinksOpen] = useState(true);
   const [outlineHeightPercent, setOutlineHeightPercent] = useState(defaultOutlineHeightPercent);
@@ -807,9 +808,19 @@ export function MarkdownFileTreeDrawer({
   const activeUnlinkedMentions = linkIndex && currentPath ? workspaceUnlinkedMentionsForPath(linkIndex, currentPath) : [];
   const filePanelAvailable = fileListVisible && (folderOpen || (open && fileCreationAvailable));
   const outlinePanelAvailable = outlineVisible;
-  const filePanelVisible = filePanelAvailable && (!tabbedSidebarLayout || activeSidebarPanel === "files");
-  const filePanelClassName = tabbedSidebarLayout || !outlineOpen ? "flex-1" : "min-h-24";
-  const filePanelStyle = !tabbedSidebarLayout && outlineOpen ? { flex: `0 1 ${100 - outlineHeightPercent}%` } : undefined;
+  const filePanelRendered =
+    filePanelAvailable &&
+    (!tabbedSidebarLayout || activeSidebarPanel === "files");
+  const filePanelVisible = filePanelRendered && fileTreeListOpen;
+  const filePanelClassName = !fileTreeListOpen
+    ? "shrink-0"
+    : tabbedSidebarLayout || !outlineOpen
+      ? "flex-1"
+      : "min-h-24";
+  const filePanelStyle =
+    !tabbedSidebarLayout && fileTreeListOpen && outlineOpen
+      ? { flex: `0 1 ${100 - outlineHeightPercent}%` }
+      : undefined;
   const outlinePanelVisible = outlinePanelAvailable && (!tabbedSidebarLayout || activeSidebarPanel === "outline");
   const linksPanelVisible = linkPanelAvailable && (!tabbedSidebarLayout || activeSidebarPanel === "links");
   const linksPanelOpen = tabbedSidebarLayout || documentLinksOpen;
@@ -823,12 +834,21 @@ export function MarkdownFileTreeDrawer({
     : undefined;
   const outlinePanelOpen = tabbedSidebarLayout || outlineOpen;
   const outlinePanelStyle =
-    !tabbedSidebarLayout && filePanelAvailable && outlineOpen ? { flex: `0 1 ${outlineHeightPercent}%` } : undefined;
-  const outlinePanelFlexible = tabbedSidebarLayout || !filePanelAvailable;
-  const outlineResizerVisible = !tabbedSidebarLayout && outlineOpen && filePanelAvailable;
+    !tabbedSidebarLayout && filePanelAvailable && fileTreeListOpen && outlineOpen
+      ? { flex: `0 1 ${outlineHeightPercent}%` }
+      : undefined;
+  const outlinePanelFlexible = tabbedSidebarLayout || !filePanelAvailable || !fileTreeListOpen;
+  const outlineResizerVisible =
+    !tabbedSidebarLayout &&
+    outlinePanelAvailable &&
+    outlineOpen &&
+    filePanelAvailable &&
+    fileTreeListOpen;
   const documentLinksResizerVisible = !tabbedSidebarLayout && linkPanelAvailable && documentLinksOpen;
-  const fileSearchVisible = filePanelAvailable && (!tabbedSidebarLayout || activeSidebarPanel === "files");
-  const folderAccessVisible = recentFolderAreaVisible && (!tabbedSidebarLayout || activeSidebarPanel === "files");
+  const fileSearchVisible = filePanelRendered;
+  const folderAccessVisible =
+    recentFolderAreaVisible &&
+    filePanelRendered;
   const fileTreeSurfaceClassName = platform === "windows" ? "bg-(--bg-chrome)" : "bg-(--bg-secondary)";
   const outlineToolbarVisible = !tabbedSidebarLayout ||
     (outlinePanelOpen && (outlineItems.length > 0 || outlineExpansionAvailable));
@@ -2639,6 +2659,180 @@ export function MarkdownFileTreeDrawer({
     if (panel !== "outline") setOutlineLevelMenuOpen(false);
   };
 
+  const renderFileTreeActions = (className: string) => {
+    const actionButtonClassName = "rounded-md";
+
+    return (
+      <div className={className}>
+        {showWindowsOpenFolderAction ? (
+          <IconButton
+            className={actionButtonClassName}
+            label={label("app.openFolder")}
+            onClick={onOpenFolder}
+          >
+            <FolderOpen aria-hidden="true" size={14} />
+          </IconButton>
+        ) : null}
+        {fileSearchVisible ? (
+          <IconButton
+            className={actionButtonClassName}
+            label={label("app.searchMarkdownFiles")}
+            pressed={searchOpen}
+            onClick={toggleFileSearch}
+          >
+            <Search aria-hidden="true" size={14} />
+          </IconButton>
+        ) : null}
+        <div className="relative" ref={fileTreeSortMenuRef}>
+          <IconButton
+            className={actionButtonClassName}
+            label={label("app.sortMarkdownFiles")}
+            pressed={fileTreeSortMenuOpen}
+            onClick={() => {
+              setFileTreeSortMenuOpen((open) => {
+                const nextOpen = !open;
+                if (nextOpen) setCreateMenuOpen(false);
+                return nextOpen;
+              });
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setFileTreeSortMenuOpen(false);
+              }
+            }}
+          >
+            <ArrowUpDown aria-hidden="true" size={14} />
+          </IconButton>
+          {fileTreeSortMenuOpen ? (
+            // The toolbar is left-aligned, so the menu must expand rightward to avoid the drawer's clipped edge.
+            <div
+              className="absolute top-8 left-0 z-40 min-w-40 rounded-md border border-(--border-default) bg-(--bg-primary) py-1 shadow-[0_12px_30px_color-mix(in_srgb,var(--text-heading)_14%,transparent)]"
+              role="menu"
+              aria-label={label("app.sortMarkdownFiles")}
+            >
+              {renderSortMenuItem("name", label("app.sortMarkdownFilesByName"))}
+              {renderSortMenuItem("modifiedAt", label("app.sortMarkdownFilesByModifiedTime"))}
+              {renderSortMenuItem("createdAt", label("app.sortMarkdownFilesByCreatedTime"))}
+              <div className="my-1 h-px bg-(--border-default)" role="separator" />
+              {renderSortDirectionMenuItem(
+                "ascending",
+                label("app.sortMarkdownFilesAscending"),
+                <ArrowDownAZ size={13} />
+              )}
+              {renderSortDirectionMenuItem(
+                "descending",
+                label("app.sortMarkdownFilesDescending"),
+                <ArrowUpZA size={13} />
+              )}
+            </div>
+          ) : null}
+        </div>
+        {assetVisibilityToggleAvailable ? (
+          <IconButton
+            className={actionButtonClassName}
+            label={fileTreeAssetsVisible ? label("app.hideImageAssets") : label("app.showImageAssets")}
+            pressed={!fileTreeAssetsVisible}
+            onClick={toggleFileTreeAssetsVisible}
+          >
+            {fileTreeAssetsVisible ? (
+              <ImageOff aria-hidden="true" size={14} />
+            ) : (
+              <ImageIcon aria-hidden="true" size={14} />
+            )}
+          </IconButton>
+        ) : null}
+        {rootPath && onCleanUnusedImages ? (
+          <IconButton
+            className={actionButtonClassName}
+            label={label("app.assetCleanup.title")}
+            onClick={() => onCleanUnusedImages()}
+          >
+            <Trash2 aria-hidden="true" size={14} />
+          </IconButton>
+        ) : null}
+        {folderExpansionAvailable ? (
+          <IconButton
+            className={actionButtonClassName}
+            label={allFoldersExpanded ? label("app.collapseMarkdownFolders") : label("app.expandMarkdownFolders")}
+            pressed={allFoldersExpanded}
+            onClick={toggleAllFolders}
+          >
+            {allFoldersExpanded ? (
+              <ListChevronsDownUp aria-hidden="true" size={14} />
+            ) : (
+              <ListChevronsUpDown aria-hidden="true" size={14} />
+            )}
+          </IconButton>
+        ) : null}
+        {folderActionsAvailable ? (
+          <div className="relative" ref={createMenuRef}>
+            <IconButton
+              className={actionButtonClassName}
+              label={label("app.newMarkdownItem")}
+              pressed={createMenuOpen}
+              onClick={() => {
+                setCreateMenuOpen((open) => {
+                  const nextOpen = !open;
+                  if (nextOpen) setFileTreeSortMenuOpen(false);
+                  return nextOpen;
+                });
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setCreateMenuOpen(false);
+                }
+              }}
+            >
+              <Plus aria-hidden="true" size={14} />
+            </IconButton>
+            {createMenuOpen ? (
+              <div
+                className="absolute top-8 right-0 z-40 min-w-44 rounded-md border border-(--border-default) bg-(--bg-primary) py-1 shadow-[0_12px_30px_color-mix(in_srgb,var(--text-heading)_14%,transparent)]"
+                role="menu"
+                aria-label={label("app.newMarkdownItem")}
+              >
+                {fileCreationAvailable ? renderCreateMenuItem(
+                  label("app.newMarkdownFile"),
+                  <FileText size={13} />,
+                  () => startCreatingFile(activeCreateParentPath)
+                ) : null}
+                {folderCreationAvailable ? renderCreateMenuItem(
+                  label("app.newMarkdownFolder"),
+                  <Folder size={13} />,
+                  () => startCreatingFolder(activeCreateParentPath)
+                ) : null}
+                {fileCreationAvailable ? (
+                  <>
+                    <div className="my-1 h-px bg-(--border-default)" role="separator" />
+                    <div className="px-2.5 pt-0.5 pb-1 text-[11px] leading-none font-[560] text-(--text-secondary)">
+                      {label("app.newMarkdownFileFromTemplate")}
+                    </div>
+                    {availableMarkdownTemplates.map((template, index) => (
+                      <button
+                        key={`${template.id}-${index}`}
+                        className="flex h-7 w-full items-center gap-2 border-0 bg-transparent px-2.5 text-left text-[12px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none"
+                        role="menuitem"
+                        type="button"
+                        onClick={() => startCreatingFile(activeCreateParentPath, template)}
+                      >
+                        <span className="flex w-3.5 justify-center" aria-hidden="true">
+                          <LayoutTemplate size={13} />
+                        </span>
+                        <span>{template.name}</span>
+                      </button>
+                    ))}
+                  </>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
   const renderSidebarPanelTabs = () => (
     tabbedSidebarLayout && sidebarPanelTabs.length > 1 ? (
       <div
@@ -2722,40 +2916,17 @@ export function MarkdownFileTreeDrawer({
           />
         ) : null}
         {!tabbedSidebarLayout && filePanelAvailable ? (
-          <div className="grid h-10 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center border-b border-(--border-default) px-3">
+          <div className="markdown-file-tree-files-header grid h-10 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center border-b border-(--border-default) pr-2 pl-3">
             <h2 className="m-0 truncate text-[14px] leading-5 font-[560] tracking-normal text-(--text-heading)">
               {label("app.files")}
             </h2>
-            <div className="markdown-file-tree-header-actions flex items-center gap-0.5">
-              {showWindowsOpenFolderAction ? (
-                <IconButton
-                  className="rounded-md"
-                  label={label("app.openFolder")}
-                  onClick={onOpenFolder}
-                >
-                  <FolderOpen aria-hidden="true" size={15} />
-                </IconButton>
-              ) : null}
-              {fileSearchVisible ? (
-                <IconButton
-                  className="rounded-md"
-                  label={label("app.searchMarkdownFiles")}
-                  pressed={searchOpen}
-                  onClick={toggleFileSearch}
-                >
-                  <Search aria-hidden="true" size={15} />
-                </IconButton>
-              ) : null}
-            </div>
           </div>
         ) : null}
-
-        {!tabbedSidebarLayout && filePanelAvailable ? renderFileSearchInput() : null}
 
         {folderAccessVisible ? renderFolderAccessArea() : null}
 
         <div ref={fileTreeBodyRef} className="markdown-file-tree-body flex min-h-0 flex-1 flex-col">
-          {filePanelVisible ? (
+          {filePanelRendered ? (
             <section
               className={`markdown-file-tree-files flex min-h-0 flex-col ${filePanelClassName}`}
               data-ai-workspace-file-tree="true"
@@ -2769,7 +2940,13 @@ export function MarkdownFileTreeDrawer({
                 onDragOver={handleFileTreeDragOver}
                 onDragStart={handleFileTreeDragStart}
               >
-                <div className="flex h-9 shrink-0 items-center gap-1 px-4 text-[13px] text-(--text-secondary)">
+                {renderFileTreeActions(
+                  "markdown-file-tree-toolbar flex h-8 shrink-0 items-center justify-start gap-1 pr-4 pl-2.5 text-(--text-secondary)"
+                )}
+
+                {renderFileSearchInput()}
+
+                <div className="markdown-file-tree-root flex h-8 shrink-0 items-center gap-1 pr-2 pl-4 text-[13px] text-(--text-secondary)">
                   <FileTreeDropTarget
                     disabled={!dragMoveAvailable}
                     id={fileTreeRootDropId("header")}
@@ -2786,202 +2963,52 @@ export function MarkdownFileTreeDrawer({
                       </div>
                     )}
                   </FileTreeDropTarget>
-                  {tabbedSidebarLayout && showWindowsOpenFolderAction ? (
-                    <IconButton
-                      className="rounded-md"
-                      label={label("app.openFolder")}
-                      onClick={onOpenFolder}
-                    >
-                      <FolderOpen aria-hidden="true" size={14} />
-                    </IconButton>
-                  ) : null}
-                  {tabbedSidebarLayout && fileSearchVisible ? (
-                    <IconButton
-                      className="rounded-md"
-                      label={label("app.searchMarkdownFiles")}
-                      pressed={searchOpen}
-                      onClick={toggleFileSearch}
-                    >
-                      <Search aria-hidden="true" size={14} />
-                    </IconButton>
-                  ) : null}
-                  <div className="relative" ref={fileTreeSortMenuRef}>
-                    <IconButton
-                      className="rounded-md"
-                      label={label("app.sortMarkdownFiles")}
-                      pressed={fileTreeSortMenuOpen}
-                      onClick={() => {
-                        setFileTreeSortMenuOpen((open) => {
-                          const nextOpen = !open;
-                          if (nextOpen) setCreateMenuOpen(false);
-                          return nextOpen;
-                        });
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Escape") {
-                          event.preventDefault();
-                          setFileTreeSortMenuOpen(false);
-                        }
-                      }}
-                    >
-                      <ArrowUpDown aria-hidden="true" size={14} />
-                    </IconButton>
-                    {fileTreeSortMenuOpen ? (
-                      <div
-                        className="absolute top-8 right-0 z-40 min-w-40 rounded-md border border-(--border-default) bg-(--bg-primary) py-1 shadow-[0_12px_30px_color-mix(in_srgb,var(--text-heading)_14%,transparent)]"
-                        role="menu"
-                        aria-label={label("app.sortMarkdownFiles")}
-                      >
-                      {renderSortMenuItem("name", label("app.sortMarkdownFilesByName"))}
-                      {renderSortMenuItem("modifiedAt", label("app.sortMarkdownFilesByModifiedTime"))}
-                      {renderSortMenuItem("createdAt", label("app.sortMarkdownFilesByCreatedTime"))}
-                      <div className="my-1 h-px bg-(--border-default)" role="separator" />
-                      {renderSortDirectionMenuItem(
-                        "ascending",
-                        label("app.sortMarkdownFilesAscending"),
-                        <ArrowDownAZ size={13} />
-                      )}
-                      {renderSortDirectionMenuItem(
-                        "descending",
-                        label("app.sortMarkdownFilesDescending"),
-                        <ArrowUpZA size={13} />
-                      )}
-                    </div>
-                  ) : null}
+                  <IconButton
+                    className="rounded-md"
+                    label={fileTreeListOpen ? label("app.hideFiles") : label("app.showFiles")}
+                    pressed={fileTreeListOpen}
+                    onClick={() => setFileTreeListOpen((open) => !open)}
+                  >
+                    {fileTreeListOpen ? (
+                      <ChevronDown aria-hidden="true" size={14} />
+                    ) : (
+                      <ChevronRight aria-hidden="true" size={14} />
+                    )}
+                  </IconButton>
                 </div>
-                {assetVisibilityToggleAvailable ? (
-                  <IconButton
-                    className="rounded-md"
-                    label={fileTreeAssetsVisible ? label("app.hideImageAssets") : label("app.showImageAssets")}
-                    pressed={!fileTreeAssetsVisible}
-                    onClick={toggleFileTreeAssetsVisible}
-                  >
-                    {fileTreeAssetsVisible ? (
-                      <ImageOff aria-hidden="true" size={14} />
-                    ) : (
-                      <ImageIcon aria-hidden="true" size={14} />
-                    )}
-                  </IconButton>
-                ) : null}
-                {rootPath && onCleanUnusedImages ? (
-                  <IconButton
-                    className="rounded-md"
-                    label={label("app.assetCleanup.title")}
-                    onClick={() => void onCleanUnusedImages()}
-                  >
-                    <Trash2 aria-hidden="true" size={14} />
-                  </IconButton>
-                ) : null}
-                {folderExpansionAvailable ? (
-                  <IconButton
-                    className="rounded-md"
-                    label={allFoldersExpanded ? label("app.collapseMarkdownFolders") : label("app.expandMarkdownFolders")}
-                    pressed={allFoldersExpanded}
-                    onClick={toggleAllFolders}
-                  >
-                    {allFoldersExpanded ? (
-                      <ListChevronsDownUp aria-hidden="true" size={14} />
-                    ) : (
-                      <ListChevronsUpDown aria-hidden="true" size={14} />
-                    )}
-                  </IconButton>
-                ) : null}
-                {folderActionsAvailable ? (
-                  <div className="relative" ref={createMenuRef}>
-                    <IconButton
-                      className="rounded-md"
-                      label={label("app.newMarkdownItem")}
-                      pressed={createMenuOpen}
-                      onClick={() => {
-                        setCreateMenuOpen((open) => {
-                          const nextOpen = !open;
-                          if (nextOpen) setFileTreeSortMenuOpen(false);
-                          return nextOpen;
-                        });
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Escape") {
-                          event.preventDefault();
-                          setCreateMenuOpen(false);
-                        }
-                      }}
+
+                {fileTreeListOpen ? (
+                  <>
+                    <FileTreeDropTarget
+                      disabled={!dragMoveAvailable}
+                      id={fileTreeRootDropId("scroll")}
+                      targetParentPath={null}
                     >
-                      <Plus aria-hidden="true" size={14} />
-                    </IconButton>
-                    {createMenuOpen ? (
-                      <div
-                        className="absolute top-8 right-0 z-40 min-w-44 rounded-md border border-(--border-default) bg-(--bg-primary) py-1 shadow-[0_12px_30px_color-mix(in_srgb,var(--text-heading)_14%,transparent)]"
-                        role="menu"
-                        aria-label={label("app.newMarkdownItem")}
-                      >
-                        {fileCreationAvailable ? renderCreateMenuItem(
-                          label("app.newMarkdownFile"),
-                          <FileText size={13} />,
-                          () => startCreatingFile(activeCreateParentPath)
-                        ) : null}
-                        {folderCreationAvailable ? renderCreateMenuItem(
-                          label("app.newMarkdownFolder"),
-                          <Folder size={13} />,
-                          () => startCreatingFolder(activeCreateParentPath)
-                        ) : null}
-                        {fileCreationAvailable ? (
-                          <>
-                            <div className="my-1 h-px bg-(--border-default)" role="separator" />
-                            <div className="px-2.5 pb-1 pt-0.5 text-[11px] leading-none font-[560] text-(--text-secondary)">
-                              {label("app.newMarkdownFileFromTemplate")}
+                      {(rootDropTarget) => (
+                        <div
+                          ref={combineNodeRefs<HTMLDivElement>(rootDropTarget.setNodeRef, setFileTreeScrollRef)}
+                          className={`file-tree-scroll min-h-0 flex-1 overflow-y-auto overscroll-none pb-4 ${dragOverTargetPath === dragTargetKey(null) ? fileTreeDropTargetClassName : ""}`}
+                          onScroll={handleFileTreeScroll}
+                          onMouseDown={cancelFileTreeInputsFromBlankArea}
+                          onContextMenu={(event) => openContextMenu(event)}
+                        >
+                          {tree.length > 0 || creatingFile || creatingFolder ? (
+                            virtualFileTreeEnabled ? renderVirtualFileTreeRows() : renderNodes(tree)
+                          ) : (
+                            <div className="min-h-full" role="tree" aria-label={label("app.markdownFiles")}>
+                              <p className="m-0 px-4 py-3 text-[12px] text-(--text-secondary)">
+                                {label("app.noMarkdownFiles")}
+                              </p>
                             </div>
-                            {availableMarkdownTemplates.map((template, index) => (
-                              <button
-                                key={`${template.id}-${index}`}
-                                className="flex h-7 w-full items-center gap-2 border-0 bg-transparent px-2.5 text-left text-[12px] leading-none text-(--text-secondary) hover:bg-(--bg-hover) hover:text-(--text-heading) focus-visible:bg-(--bg-hover) focus-visible:text-(--text-heading) focus-visible:outline-none"
-                                role="menuitem"
-                                type="button"
-                                onClick={() => startCreatingFile(activeCreateParentPath, template)}
-                              >
-                                <span className="flex w-3.5 justify-center" aria-hidden="true">
-                                  <LayoutTemplate size={13} />
-                                </span>
-                                <span>{template.name}</span>
-                              </button>
-                            ))}
-                          </>
-                        ) : null}
-                      </div>
-                    ) : null}
-                  </div>
+                          )}
+                        </div>
+                      )}
+                    </FileTreeDropTarget>
+                    <DragOverlay dropAnimation={null}>
+                      <FileTreeDragOverlay file={activeDragFile} />
+                    </DragOverlay>
+                  </>
                 ) : null}
-              </div>
-
-              {tabbedSidebarLayout ? renderFileSearchInput() : null}
-
-              <FileTreeDropTarget
-                disabled={!dragMoveAvailable}
-                id={fileTreeRootDropId("scroll")}
-                targetParentPath={null}
-              >
-                {(rootDropTarget) => (
-                  <div
-                    ref={combineNodeRefs<HTMLDivElement>(rootDropTarget.setNodeRef, setFileTreeScrollRef)}
-                    className={`file-tree-scroll min-h-0 flex-1 overflow-y-auto overscroll-none pb-4 ${dragOverTargetPath === dragTargetKey(null) ? fileTreeDropTargetClassName : ""}`}
-                    onScroll={handleFileTreeScroll}
-                    onMouseDown={cancelFileTreeInputsFromBlankArea}
-                    onContextMenu={(event) => openContextMenu(event)}
-                  >
-                    {tree.length > 0 || creatingFile || creatingFolder ? (
-                      virtualFileTreeEnabled ? renderVirtualFileTreeRows() : renderNodes(tree)
-                    ) : (
-                      <div className="min-h-full" role="tree" aria-label={label("app.markdownFiles")}>
-                        <p className="m-0 px-4 py-3 text-[12px] text-(--text-secondary)">
-                          {label("app.noMarkdownFiles")}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </FileTreeDropTarget>
-              <DragOverlay dropAnimation={null}>
-                <FileTreeDragOverlay file={activeDragFile} />
-              </DragOverlay>
               </DndContext>
             </section>
           ) : null}
@@ -3070,7 +3097,9 @@ export function MarkdownFileTreeDrawer({
                       onClick={() => {
                         setOutlineOpen((open) => {
                           const nextOpen = !open;
-                          if (!nextOpen) setOutlineLevelMenuOpen(false);
+                          if (!nextOpen) {
+                            setOutlineLevelMenuOpen(false);
+                          }
                           return nextOpen;
                         });
                       }}

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Dateien anzeigen",
+  "app.hideFiles": "Dateien ausblenden",
   "app.showOutline": "Gliederung anzeigen",
   "app.hideOutline": "Gliederung ausblenden",
   "app.resizeOutline": "Gliederungshöhe ändern",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -625,6 +625,7 @@ const messages: BaseLocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Show files",
+  "app.hideFiles": "Hide files",
   "app.showOutline": "Show outline",
   "app.hideOutline": "Hide outline",
   "app.resizeOutline": "Resize outline",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Mostrar archivos",
+  "app.hideFiles": "Ocultar archivos",
   "app.showOutline": "Mostrar esquema",
   "app.hideOutline": "Ocultar esquema",
   "app.resizeOutline": "Cambiar altura del esquema",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Afficher les fichiers",
+  "app.hideFiles": "Masquer les fichiers",
   "app.showOutline": "Afficher le plan",
   "app.hideOutline": "Masquer le plan",
   "app.resizeOutline": "Redimensionner le plan",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Mostra file",
+  "app.hideFiles": "Nascondi file",
   "app.showOutline": "Mostra struttura",
   "app.hideOutline": "Nascondi struttura",
   "app.resizeOutline": "Regola altezza struttura",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -315,6 +315,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "ファイルを表示",
+  "app.hideFiles": "ファイルを非表示",
   "app.showOutline": "アウトラインを表示",
   "app.hideOutline": "アウトラインを非表示",
   "app.resizeOutline": "アウトラインの高さを変更",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "파일 보기",
+  "app.hideFiles": "파일 숨기기",
   "app.showOutline": "개요 보기",
   "app.hideOutline": "개요 숨기기",
   "app.resizeOutline": "개요 높이 조정",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Mostrar arquivos",
+  "app.hideFiles": "Ocultar arquivos",
   "app.showOutline": "Mostrar estrutura",
   "app.hideOutline": "Ocultar estrutura",
   "app.resizeOutline": "Redimensionar altura da estrutura",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -307,6 +307,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "No backlinks",
   "app.noUnlinkedMentions": "No unlinked mentions",
   "app.showFiles": "Показать файлы",
+  "app.hideFiles": "Скрыть файлы",
   "app.showOutline": "Показать структуру",
   "app.hideOutline": "Скрыть структуру",
   "app.resizeOutline": "Изменить высоту структуры",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -636,6 +636,7 @@ export type I18nKey =
   | "app.noBacklinks"
   | "app.noUnlinkedMentions"
   | "app.showFiles"
+  | "app.hideFiles"
   | "app.showOutline"
   | "app.hideOutline"
   | "app.resizeOutline"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -625,6 +625,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "没有反向链接",
   "app.noUnlinkedMentions": "没有未链接提及",
   "app.showFiles": "显示文件",
+  "app.hideFiles": "隐藏文件",
   "app.showOutline": "显示大纲",
   "app.hideOutline": "隐藏大纲",
   "app.resizeOutline": "调整大纲高度",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -315,6 +315,7 @@ const messages: LocaleMessages = {
   "app.noBacklinks": "沒有反向連結",
   "app.noUnlinkedMentions": "沒有未連結提及",
   "app.showFiles": "顯示檔案",
+  "app.hideFiles": "隱藏檔案",
   "app.showOutline": "顯示大綱",
   "app.hideOutline": "隱藏大綱",
   "app.resizeOutline": "調整大綱高度",


### PR DESCRIPTION
## Summary
- move file tree actions into a compact toolbar above the workspace root
- add a root-row disclosure control that collapses only the file and folder list
- keep recent folders, file actions, search, and outline controls independent
- align sidebar disclosure controls and keep menus opening inside the sidebar
- add localized hide-files labels across supported languages

## Why
The stacked sidebar could collapse the outline but not the file list, which limited the space available for reviewing longer outlines. The new control mirrors the existing recent-folder disclosure behavior while preserving the surrounding file controls.

## Validation
- `pnpm --filter @markra/app test -- MarkdownFileTreeDrawer.test.tsx --run` — 104 tests passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/shared build` — passed
- `pnpm --filter @markra/shared typecheck:test` — passed
- `pnpm --filter @markra/shared test` — baseline failure: non-English locales are missing existing `app.assetCleanup.*` keys; reproduced unchanged on `origin/v2`

## Risk
- limited to file-tree sidebar layout and local disclosure state
- covered in both stacked and tabbed sidebar modes

## Related Issues
Closes #575
