### PR TITLE
fix(editor): tighten table preview spacing

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1274,8 +1274,8 @@
 
   .markdown-paper .cm-markra-table-wrap {
     display: block !important;
-    margin: 24px 0 !important;
-    padding: 28px 36px 36px 0 !important;
+    margin: 0 !important;
+    padding: 20px 36px 12px 0 !important;
     overflow: visible !important;
     font-size: 16px !important;
     line-height: 26.4px !important;
@@ -3048,7 +3048,8 @@
   }
 
   .markdown-paper .markra-table-align-controls {
-    @apply absolute top-0 left-1.5 z-10 flex items-center gap-0.5;
+    @apply absolute left-1.5 z-10 flex items-center gap-0.5;
+    top: -12px !important;
   }
 
   .markdown-paper .markra-table-size-controls {
@@ -3251,7 +3252,7 @@
   }
 
   .markdown-paper .markra-table-add-row {
-    @apply bottom-1.5 -translate-x-1/2;
+    @apply -bottom-3 -translate-x-1/2;
     left: calc(50% + var(--markra-table-control-inline-center-offset));
   }
 

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -237,11 +237,11 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .cm-markra-code-header-actions");
     expect(styles).toContain("opacity: 0 !important");
     expect(styles).toContain(".markdown-paper .cm-markra-table-wrap");
-    expect(styles).toContain("padding: 28px 36px 36px 0 !important");
+    expect(styles).toContain("padding: 20px 36px 12px 0 !important");
     expect(styles).toContain(
       ".markdown-paper .cm-line:has(> .cm-markra-table-wrap)",
     );
-    expect(styles).toContain("margin: 24px 0 !important");
+    expect(styles).toContain("margin: 0 !important");
     expect(styles).toContain(
       '.markdown-paper .cm-markra-table[data-width-mode="auto"]',
     );


### PR DESCRIPTION
## Summary
- reduce excess vertical space around live Markdown tables
- keep the table toolbar separated from the table border
- move the add-row control outside the table's bottom padding
- update stylesheet expectations for the compact spacing

## Why
The table preview reserved large margins and control gutters even while controls were hidden, creating noticeably oversized gaps above and below short tables.

## Validation
- `pnpm --filter @markra/app exec vitest run src/styles.test.ts` — 58 tests passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification

## Risk
Low and limited to visual table layout. The toolbar and add-row control positions change across editor themes, so visual regressions would be confined to table controls.
