### PR TITLE
feat(app): unify default fonts across platforms

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,43 +24,43 @@ colors:
   overlay-ink: "#1F232C"
 typography:
   editor-h1:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 44px
     fontWeight: 760
     lineHeight: 1.15
     letterSpacing: 0em
   editor-h2:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 31px
     fontWeight: 760
     lineHeight: 1.22
     letterSpacing: 0em
   editor-h3:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 24px
     fontWeight: 760
     lineHeight: 1.28
     letterSpacing: 0em
   editor-body:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 16px
     fontWeight: 400
     lineHeight: 1.65
     letterSpacing: 0em
   ui-body:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 13px
     fontWeight: 520
     lineHeight: 1.54
     letterSpacing: 0em
   ui-label:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 12px
     fontWeight: 560
     lineHeight: 1.67
     letterSpacing: 0em
   ui-control:
-    fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+    fontFamily: '"Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif'
     fontSize: 12px
     fontWeight: 620
     lineHeight: 1.67
@@ -223,7 +223,7 @@ Do not introduce extra brand colors for primary flows. Semantic colors may appea
 
 ## Typography
 
-Markra uses the system UI stack for both application chrome and the default editor theme. This keeps the desktop app native-feeling across macOS, Windows, and Linux while avoiding font loading cost.
+Markra bundles Noto Sans SC Variable for application chrome and the default editor theme. This gives macOS, Windows, Linux, and the web app the same typographic voice while retaining a generic sans-serif fallback if the bundled font cannot load.
 
 Editor typography is larger and calmer than UI typography. Body copy defaults to 16px with a 1.65 line-height for comfortable long-form writing. Headings use strong weight, normal tracking, and clear scale jumps: H1 at 44px, H2 at 31px, and H3 at 24px.
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,6 +37,7 @@
     "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@earendil-works/pi-agent-core": "0.75.5",
+    "@fontsource-variable/noto-sans-sc": "5.3.0",
     "@markra/ai": "workspace:*",
     "@markra/editor": "workspace:*",
     "@markra/editor-react": "workspace:*",

--- a/packages/app/src/lib/editor-font.test.ts
+++ b/packages/app/src/lib/editor-font.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { editorFontFamilyCssValue } from "./editor-font";
+
+describe("editor font", () => {
+  it("falls back to the shared UI font when a selected system font is unavailable", () => {
+    expect(
+      editorFontFamilyCssValue({
+        family: "Example Sans",
+        source: "system"
+      })
+    ).toBe('"Example Sans", var(--font-ui)');
+  });
+});

--- a/packages/app/src/lib/editor-font.ts
+++ b/packages/app/src/lib/editor-font.ts
@@ -13,7 +13,7 @@ export const defaultEditorFontFamily: EditorFontFamilyPreference = {
   source: "theme"
 };
 
-const visualEditorFontFallback = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
+const visualEditorFontFallback = "var(--font-ui)";
 
 function quoteCssFontFamilyName(family: string) {
   return `"${family.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}"`;

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@fontsource-variable/noto-sans-sc/wght.css";
 @source ".";
 @source "../../../packages/ui/src";
 @import "katex/dist/katex.css";
@@ -204,10 +205,14 @@
     --ai-ghost: #c0c0c0;
     --ai-border: #dddddd;
 
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --font-ui: "Noto Sans SC Variable", "Noto Sans SC", "Noto Sans CJK SC", sans-serif;
+
+    font-family: var(--font-ui);
     color: var(--text-primary);
     background: var(--bg-primary);
     color-scheme: light;
+    font-kerning: normal;
+    font-optical-sizing: auto;
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -1610,7 +1615,7 @@
     --editor-hl-meta: oklch(44% 0.15 330);
     --editor-hl-symbol: oklch(40% 0.12 190);
     --editor-hl-deletion: oklch(45% 0.17 29);
-    --editor-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --editor-font-family: var(--font-ui);
     --editor-heading-font-family: var(--editor-font-family);
     --editor-paragraph-spacing: 8px;
     --editor-caret-color: var(--accent);
@@ -1707,7 +1712,7 @@
   }
 
   .markdown-paper[data-editor-theme="minimal"] {
-    --editor-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --editor-font-family: var(--font-ui);
   }
 
   .markdown-paper[data-editor-theme="custom"] {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -8,6 +8,15 @@ describe("editor stylesheet", () => {
     expect(styles).toContain('@source "../../../packages/ui/src"');
   });
 
+  it("uses the bundled UI font for app chrome and default editor themes", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).toContain('@import "@fontsource-variable/noto-sans-sc/wght.css";');
+    expect(styles).toContain('--font-ui: "Noto Sans SC Variable"');
+    expect(styles).toContain("font-family: var(--font-ui);");
+    expect(styles).toContain("--editor-font-family: var(--font-ui);");
+  });
+
   it("uses theme-aware custom text cursors for visual editor text surfaces", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -46,9 +46,11 @@ afterEach(() => {
 describe("codeBlockPreviewPlugin", () => {
   it("renders a language header and code body while preserving Markdown", () => {
     const view = createView();
+    const header = view.dom.querySelector<HTMLElement>(".cm-markra-code-header");
 
-    expect(view.dom.querySelector(".cm-markra-code-header")?.textContent).toBe(
-      "ts",
+    expect(header?.textContent).toBe("ts");
+    expect(header && getComputedStyle(header).fontFamily).toContain(
+      "var(--font-ui",
     );
     expect(
       view.dom.querySelectorAll(".cm-markra-code-content-line"),

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -186,7 +186,7 @@ const codeBlockTheme = EditorView.baseTheme({
   ".cm-markra-code-header": {
     color: "color-mix(in srgb, currentColor 62%, transparent)",
     display: "inline-block",
-    fontFamily: "ui-sans-serif, system-ui, sans-serif",
+    fontFamily: 'var(--font-ui, "Noto Sans SC Variable", sans-serif)',
     fontSize: "0.78em",
     fontWeight: "650",
     letterSpacing: "0.04em",

--- a/packages/editor/src/codemirror/frontmatter-preview.test.ts
+++ b/packages/editor/src/codemirror/frontmatter-preview.test.ts
@@ -67,9 +67,15 @@ describe("frontmatterPreviewPlugin", () => {
     const editor = view.dom.querySelector<HTMLTextAreaElement>(
       ".cm-markra-frontmatter-editor",
     );
+    const label = view.dom.querySelector<HTMLElement>(
+      ".cm-markra-frontmatter-label",
+    );
 
     expect(editor?.value).toBe("title: Synthetic");
     expect(view.dom.querySelector(".cm-markra-frontmatter")).not.toBeNull();
+    expect(label && getComputedStyle(label).fontFamily).toContain(
+      "var(--font-ui",
+    );
     expect(editor && getComputedStyle(editor).fontFamily).toContain("ui-monospace");
     expect(
       [...view.dom.querySelectorAll<HTMLElement>(".cm-markra-frontmatter-hidden-line")]

--- a/packages/editor/src/codemirror/frontmatter-preview.ts
+++ b/packages/editor/src/codemirror/frontmatter-preview.ts
@@ -329,7 +329,7 @@ const frontmatterTheme = EditorView.baseTheme({
   },
   ".cm-markra-frontmatter-label": {
     display: "block",
-    fontFamily: "system-ui, sans-serif",
+    fontFamily: 'var(--font-ui, "Noto Sans SC Variable", sans-serif)',
     fontSize: "0.72em",
     fontWeight: "650",
     marginBottom: "0.4em",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@earendil-works/pi-agent-core':
         specifier: 0.75.5
         version: 0.75.5(ws@8.20.0)(zod@4.4.3)
+      '@fontsource-variable/noto-sans-sc':
+        specifier: 5.3.0
+        version: 5.3.0
       '@markra/ai':
         specifier: workspace:*
         version: link:../ai
@@ -981,6 +984,9 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource-variable/noto-sans-sc@5.3.0':
+    resolution: {integrity: sha512-lNar1dF7Ik/lHNPo/7JWG0TolXY29LtsqYgMvEysooZ5bsO9uH4shJmRrwyJ3PjyTPljhpMJEK0jDuLSU4vJ1w==}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -3668,6 +3674,8 @@ snapshots:
   '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
     optionalDependencies:
       '@noble/hashes': 2.2.0
+
+  '@fontsource-variable/noto-sans-sc@5.3.0': {}
 
   '@google/genai@1.52.0':
     dependencies:


### PR DESCRIPTION
## Summary
- bundle Noto Sans SC Variable for shared app chrome and default/Minimal editor typography
- route CodeMirror chrome and selected-font fallbacks through the shared `--font-ui` token
- preserve explicit typography overrides for Gothic, Newsprint, Pixyll, and Academic themes, along with monospace code surfaces
- update the design system documentation and focused regression coverage

## Why
The previous system font stack resolved to different typefaces on macOS, Windows, and Linux. Shipping one variable font gives the app and default editor a consistent cross-platform typographic baseline while keeping theme-specific and user-selected editor fonts intact.

## Validation
- `corepack pnpm --filter @markra/app exec vitest run src/styles.test.ts src/lib/editor-font.test.ts` — 60 tests passed
- `corepack pnpm --filter @markra/editor exec vitest run --environment jsdom --globals src/codemirror/code-block.test.ts src/codemirror/frontmatter-preview.test.ts` — 35 tests passed
- `corepack pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- `corepack pnpm --filter @markra/web build` — passed
- local Web preview confirmed matching computed fonts for the root UI, app body, Markdown paper, and CodeMirror editor, with no console errors

## Risk
- production builds gain approximately 4.7 MB of WOFF2 font assets; the font CSS uses Unicode ranges so clients load the glyph subsets they need
- native operating-system menus continue to use the host system font
