### PR TITLE
feat(editor): support Chinese slash-menu trigger

### DIFF
--- a/packages/editor/src/codemirror/slash-menu.test.ts
+++ b/packages/editor/src/codemirror/slash-menu.test.ts
@@ -88,6 +88,20 @@ describe("Markra slash menu", () => {
     ]);
   });
 
+  it("supports the Chinese dunhao as a typed slash-menu trigger", () => {
+    const view = createView("、h2");
+
+    expect(getMarkraSlashMenuState(view)).toMatchObject({
+      from: 0,
+      open: true,
+      query: "h2",
+      source: "typed",
+      to: 3,
+    });
+    expect(editorKey(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("## ");
+  });
+
   it("does not open from source text inside a fenced code block", () => {
     const view = createView("```text\n/hea\n```");
     view.dispatch({ selection: EditorSelection.cursor(12) });

--- a/packages/editor/src/codemirror/slash-menu.ts
+++ b/packages/editor/src/codemirror/slash-menu.ts
@@ -80,7 +80,7 @@ function typedRangeFromState(state: EditorState): SlashMenuRange | null {
   if (isInsideCodeBlock(state, selection.head)) return null;
 
   const beforeCursor = state.sliceDoc(line.from, selection.head);
-  const match = /^([\t ]*)\/([^\s/]*)$/u.exec(beforeCursor);
+  const match = /^([\t ]*)[/、]([^\s/、]*)$/u.exec(beforeCursor);
   if (!match) return null;
 
   const indentLength = match[1]?.length ?? 0;
@@ -105,7 +105,7 @@ function virtualRangeFromState(
   if (isInsideCodeBlock(state, selection.head)) return null;
 
   const query = state.sliceDoc(from, selection.head);
-  if (/\s|\//u.test(query)) return null;
+  if (/\s|[/、]/u.test(query)) return null;
 
   return {
     from,


### PR DESCRIPTION
## Summary
- allow the slash-command menu to use the Chinese dunhao (`、`) as a trigger in addition to `/`
- cover trigger detection and command execution with a regression test

## Why
Chinese input methods can produce `、` for the slash key. Supporting both characters keeps slash commands accessible without switching input modes.

## Validation
- `pnpm --filter @markra/editor test` — 350 tests passed
- `pnpm --filter @markra/editor build` — passed

## Risk
Low. The change is limited to typed slash-menu trigger recognition, and the existing `/` behavior remains covered.