### PR TITLE
fix(editor): stabilize code block caret alignment

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1133,11 +1133,15 @@
     padding-inline-start: calc(1.4em + var(--markra-list-depth-offset)) !important;
   }
 
+  /* The opening fence is folded into this zero-height line. Keep controls
+     over the first code row: vertical height or margins on the hidden line
+     accumulate across blocks and shift WebKit's pointer mapping away from
+     the rendered caret. */
   .markdown-paper .cm-line.cm-markra-code-header-line {
     position: relative !important;
     height: 0 !important;
     min-height: 0 !important;
-    margin-block-start: 8px !important;
+    margin-block: 0 !important;
     overflow: visible !important;
     padding: 0 !important;
     border: 0 !important;
@@ -1151,13 +1155,31 @@
     height: 0 !important;
   }
 
+  .markdown-paper .cm-markra-code-top-gap {
+    box-sizing: border-box;
+    width: 100% !important;
+    height: 12px !important;
+    margin: 0 !important;
+    border-top: 1px solid var(--editor-border);
+    border-right: 1px solid var(--editor-border);
+    border-left: 1px solid var(--editor-border);
+    border-radius: 4px 4px 0 0;
+    background: linear-gradient(
+      90deg,
+      var(--editor-code-line-bg) 0 43px,
+      var(--editor-border) 43px 44px,
+      var(--editor-code-bg) 44px 100%
+    );
+    pointer-events: none;
+  }
+
   .markdown-paper .cm-markra-code-header {
     display: none !important;
   }
 
   .markdown-paper .cm-markra-code-header-actions {
     position: absolute !important;
-    top: 8px;
+    top: 0;
     right: 8px;
     z-index: 4;
     display: flex !important;
@@ -1179,9 +1201,10 @@
   }
 
   .markdown-paper .cm-markra-code-header-actions .markra-code-language-select {
-    height: 28px !important;
-    min-height: 28px !important;
+    height: 24px !important;
+    min-height: 24px !important;
     min-width: 160px !important;
+    width: 160px !important;
     padding: 0 10px !important;
     font-size: 13px !important;
     line-height: 1 !important;
@@ -1191,10 +1214,10 @@
     position: relative !important;
     top: auto !important;
     right: auto !important;
-    width: 28px !important;
-    min-width: 28px !important;
-    height: 28px !important;
-    min-height: 28px !important;
+    width: 24px !important;
+    min-width: 24px !important;
+    height: 24px !important;
+    min-height: 24px !important;
     padding: 0 !important;
     opacity: 1 !important;
     pointer-events: auto !important;
@@ -1207,13 +1230,17 @@
     /* The inline line-number marker only occupies the first visual row.
        A hanging indent keeps soft-wrapped continuations out of the gutter. */
     padding-inline: 59px 16px !important;
+    /* WebKit and CodeMirror disagree about pointer coordinates when selected
+       editable lines add vertical padding. Keep every code row geometrically
+       uniform so a click and its rendered caret stay on the same line. */
+    padding-block: 0 !important;
     text-indent: -59px;
     border: 0 !important;
     background: transparent !important;
     color: var(--editor-code-text) !important;
     font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace !important;
     font-size: 14.4px !important;
-    line-height: 23.76px !important;
+    line-height: 24px !important;
   }
 
   /* CodeMirror draws selections at z-index -1. Keeping the code surface at
@@ -1253,31 +1280,26 @@
 
   .markdown-paper .cm-line.cm-markra-code-header-line +
     .cm-line.cm-markra-code-content-line {
-    padding-block-start: 16px !important;
-  }
-
-  .markdown-paper .cm-line.cm-markra-code-header-line +
-    .cm-line.cm-markra-code-content-line::after {
-    border-top: 1px solid var(--editor-border);
-    border-radius: 4px 4px 0 0;
-  }
-
-  .markdown-paper .cm-line.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {
-    padding-block-end: 16px !important;
-  }
-
-  .markdown-paper .cm-line.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line)::after {
-    border-bottom: 1px solid var(--editor-border);
-    border-radius: 0 0 4px 4px;
+    padding-inline-end: 220px !important;
   }
 
   .markdown-paper .cm-line.cm-markra-code-closing-line {
     position: relative !important;
+    box-sizing: border-box;
     height: 12px !important;
     min-height: 12px !important;
     padding: 0 !important;
     border: 0 !important;
-    background: transparent !important;
+    border-right: 1px solid var(--editor-border) !important;
+    border-bottom: 1px solid var(--editor-border) !important;
+    border-left: 1px solid var(--editor-border) !important;
+    border-radius: 0 0 4px 4px !important;
+    background: linear-gradient(
+      90deg,
+      var(--editor-code-line-bg) 0 43px,
+      var(--editor-border) 43px 44px,
+      var(--editor-code-bg) 44px 100%
+    ) !important;
     line-height: 12px !important;
     overflow: visible !important;
   }
@@ -2732,23 +2754,6 @@
 
   .markdown-paper .cm-editor[data-typewriter-mode="true"].cm-focused
     .cm-line.cm-activeLine.markra-callout-first.markra-callout-last {
-    --typewriter-active-line-offset: 0px;
-  }
-
-  .markdown-paper .cm-editor[data-typewriter-mode="true"].cm-focused
-    .cm-line.cm-markra-code-header-line +
-    .cm-line.cm-activeLine.cm-markra-code-content-line {
-    --typewriter-active-line-offset: 8px;
-  }
-
-  .markdown-paper .cm-editor[data-typewriter-mode="true"].cm-focused
-    .cm-line.cm-activeLine.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {
-    --typewriter-active-line-offset: -8px;
-  }
-
-  .markdown-paper .cm-editor[data-typewriter-mode="true"].cm-focused
-    .cm-line.cm-markra-code-header-line +
-    .cm-line.cm-activeLine.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {
     --typewriter-active-line-offset: 0px;
   }
 
@@ -4343,7 +4348,7 @@
   .markdown-paper .hljs-comment,
   .markdown-paper .hljs-quote {
     color: var(--editor-text-secondary);
-    font-style: italic;
+    font-style: normal;
   }
 
   .markdown-paper hr {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -127,7 +127,9 @@ describe("editor stylesheet", () => {
     expect(codeLineRule).toContain("position: relative");
     expect(codeLineRule).toContain("background: transparent !important");
     expect(codeLineRule).toContain("padding-inline: 59px 16px !important");
+    expect(codeLineRule).toContain("padding-block: 0 !important");
     expect(codeLineRule).toContain("text-indent: -59px");
+    expect(codeLineRule).toContain("line-height: 24px !important");
     expect(backdropStart).toBeGreaterThanOrEqual(0);
     expect(backdropRule).toContain("z-index: -2");
     expect(backdropRule).toContain("background: linear-gradient(");
@@ -208,14 +210,32 @@ describe("editor stylesheet", () => {
       ".cm-line.cm-activeLine.markra-callout-first.markra-callout-last {\n" +
       "    --typewriter-active-line-offset: 0px;",
     );
-    expect(styles).toContain(
-      ".cm-line.cm-activeLine.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {\n" +
-      "    --typewriter-active-line-offset: -8px;",
+    expect(styles).not.toContain(
+      ".cm-line.cm-markra-code-header-line +\n" +
+      "    .cm-line.cm-activeLine.cm-markra-code-content-line {",
+    );
+    expect(styles).not.toContain(
+      ".cm-line.cm-activeLine.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {",
     );
   });
 
-  it("keeps code block controls in the header without extra closing space", () => {
+  it("overlays code block controls without inserting a blank header line", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const headerLineStart = styles.indexOf(
+      ".markdown-paper .cm-line.cm-markra-code-header-line {",
+    );
+    const headerLineEnd = styles.indexOf("\n  }", headerLineStart);
+    const headerLineRule = styles.slice(headerLineStart, headerLineEnd);
+    const headerWrapStart = styles.indexOf(
+      ".markdown-paper .cm-markra-code-header-wrap {",
+    );
+    const headerWrapEnd = styles.indexOf("\n  }", headerWrapStart);
+    const headerWrapRule = styles.slice(headerWrapStart, headerWrapEnd);
+    const topGapStart = styles.indexOf(
+      ".markdown-paper .cm-markra-code-top-gap {",
+    );
+    const topGapEnd = styles.indexOf("\n  }", topGapStart);
+    const topGapRule = styles.slice(topGapStart, topGapEnd);
     const headerActionsStart = styles.indexOf(
       ".markdown-paper .cm-markra-code-header-actions {",
     );
@@ -237,10 +257,60 @@ describe("editor stylesheet", () => {
       languageControlStart,
       languageControlEnd,
     );
+    const languageSelectStart = styles.indexOf(
+      ".markdown-paper .cm-markra-code-header-actions .markra-code-language-select {",
+    );
+    const languageSelectEnd = styles.indexOf("\n  }", languageSelectStart);
+    const languageSelectRule = styles.slice(
+      languageSelectStart,
+      languageSelectEnd,
+    );
+    const copyButtonStart = styles.indexOf(
+      ".markdown-paper .cm-markra-code-header-actions .markra-code-copy-button {",
+    );
+    const copyButtonEnd = styles.indexOf("\n  }", copyButtonStart);
+    const copyButtonRule = styles.slice(copyButtonStart, copyButtonEnd);
+    const firstContentLineStart = styles.indexOf(
+      ".markdown-paper .cm-line.cm-markra-code-header-line +\n" +
+      "    .cm-line.cm-markra-code-content-line {",
+    );
+    const firstContentLineEnd = styles.indexOf(
+      "\n  }",
+      firstContentLineStart,
+    );
+    const firstContentLineRule = styles.slice(
+      firstContentLineStart,
+      firstContentLineEnd,
+    );
+    const firstContentBackdropStart = styles.indexOf(
+      ".markdown-paper .cm-line.cm-markra-code-header-line +\n" +
+      "    .cm-line.cm-markra-code-content-line::after {",
+    );
+    const lastContentBackdropStart = styles.indexOf(
+      ".markdown-paper .cm-line.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line)::after {",
+    );
 
+    expect(headerLineStart).toBeGreaterThanOrEqual(0);
+    expect(headerLineRule).toContain("height: 0 !important");
+    expect(headerLineRule).toContain("min-height: 0 !important");
+    expect(headerLineRule).toContain("margin-block: 0 !important");
+    expect(headerLineRule).not.toContain("margin-block-start: 8px");
+    expect(headerLineRule).toContain("border: 0 !important");
+    expect(headerLineRule).toContain("background: transparent !important");
+    expect(headerWrapRule).toContain("height: 0 !important");
+    expect(topGapStart).toBeGreaterThanOrEqual(0);
+    expect(topGapRule).toContain("height: 12px !important");
+    expect(topGapRule).toContain("margin: 0 !important");
+    expect(topGapRule).toContain("pointer-events: none");
+    expect(topGapRule).toContain(
+      "border-top: 1px solid var(--editor-border)",
+    );
+    expect(topGapRule).toContain("border-radius: 4px 4px 0 0");
+    expect(topGapRule).toContain("var(--editor-code-line-bg) 0 43px");
     expect(headerActionsRule).toContain("opacity: 1 !important");
     expect(headerActionsRule).toContain("pointer-events: auto !important");
     expect(headerActionsRule).toContain("transform: none");
+    expect(headerActionsRule).toContain("top: 0");
     expect(closingLineRule).toContain("position: relative");
     expect(closingLineRule).toContain("height: 12px");
     expect(closingLineRule).toContain("min-height: 12px");
@@ -249,6 +319,29 @@ describe("editor stylesheet", () => {
     expect(languageControlRule).toContain("padding: 0");
     expect(languageControlRule).toContain("opacity: 1 !important");
     expect(languageControlRule).toContain("pointer-events: auto !important");
+    expect(languageSelectRule).toContain("width: 160px !important");
+    expect(languageSelectRule).toContain("height: 24px !important");
+    expect(languageSelectRule).toContain("min-height: 24px !important");
+    expect(copyButtonRule).toContain("width: 24px !important");
+    expect(copyButtonRule).toContain("height: 24px !important");
+    expect(firstContentLineStart).toBeGreaterThanOrEqual(0);
+    expect(firstContentLineRule).not.toContain("padding-block");
+    expect(firstContentLineRule).toContain(
+      "padding-inline-end: 220px !important",
+    );
+    expect(firstContentBackdropStart).toBe(-1);
+    expect(lastContentBackdropStart).toBe(-1);
+    expect(closingLineRule).toContain(
+      "border-bottom: 1px solid var(--editor-border)",
+    );
+    expect(closingLineRule).toContain("border-radius: 0 0 4px 4px");
+    expect(closingLineRule).toContain(
+      "var(--editor-code-line-bg) 0 43px",
+    );
+    expect(styles).not.toContain(
+      ".markdown-paper .cm-line.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {\n" +
+      "    padding-block-end:",
+    );
     expect(styles).not.toContain(
       ".markdown-paper .cm-line.cm-markra-code-closing-line .markra-code-language-control {",
     );
@@ -1070,6 +1163,11 @@ describe("editor stylesheet", () => {
     const activeInlineCodeStart = styles.indexOf(".markdown-paper code .markra-live-mark-inlineCode {");
     const activeInlineCodeEnd = styles.indexOf(".markdown-paper .markra-ai-preview-delete");
     const activeInlineCodeStyles = styles.slice(activeInlineCodeStart, activeInlineCodeEnd);
+    const commentStart = styles.indexOf(
+      ".markdown-paper .hljs-comment,",
+    );
+    const commentEnd = styles.indexOf("\n  }", commentStart);
+    const commentStyles = styles.slice(commentStart, commentEnd);
 
     expect(inlineCodeStyles).toContain("color: oklch");
     expect(inlineCodeStyles).toContain("box-shadow");
@@ -1080,6 +1178,9 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .hljs-meta");
     expect(styles).toContain(".markdown-paper .hljs-symbol");
     expect(styles).toContain(".markdown-paper .hljs-type");
+    expect(commentStart).toBeGreaterThanOrEqual(0);
+    expect(commentStyles).toContain("font-style: normal");
+    expect(commentStyles).not.toContain("font-style: italic");
   });
 
   it("defines Typora-style editor themes and code block copy controls", () => {

--- a/packages/editor/src/codemirror/blocks.test.ts
+++ b/packages/editor/src/codemirror/blocks.test.ts
@@ -151,6 +151,16 @@ describe("blocksPlugin", () => {
     expect(view.dom.querySelector(".markra-heading-level-list")).toBeNull();
   });
 
+  it("does not show a heading-level control for a code comment", () => {
+    const doc = "```python\n# Synthetic comment\n```";
+    const comment = doc.indexOf("Synthetic");
+    const view = createView({ doc, from: comment, to: comment });
+    view.focus();
+    view.dispatch({ selection: view.state.selection });
+
+    expect(view.dom.querySelector(".markra-heading-level-button")).toBeNull();
+  });
+
   it("does not transform the next line when a selection ends at its start", () => {
     const view = createView({ doc: "Alpha\nBeta", from: 0, to: 6 });
 

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -83,6 +83,29 @@ describe("codeBlockPreviewPlugin", () => {
     expect(view.dom.querySelector(".markra-code-language-select")).not.toBeNull();
   });
 
+  it("uses measured top gaps for consecutive code blocks", () => {
+    const source = [
+      "```sh",
+      "first_command",
+      "```",
+      "",
+      "```python",
+      "second_value = 2",
+      "```",
+    ].join("\n");
+    const view = createView(source);
+    const topGaps = [
+      ...view.dom.querySelectorAll<HTMLElement>(".cm-markra-code-top-gap"),
+    ];
+
+    expect(topGaps).toHaveLength(2);
+    expect(topGaps.map((gap) => getComputedStyle(gap).height)).toEqual([
+      "12px",
+      "12px",
+    ]);
+    expect(view.state.doc.toString()).toBe(source);
+  });
+
   it("keeps a lone unfinished opening fence editable until Enter", () => {
     const source = "```";
     const view = createView(source);

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -2,6 +2,8 @@ import { syntaxTree } from "@codemirror/language";
 import {
   EditorSelection,
   Prec,
+  StateField,
+  type Range,
   type EditorState,
   type Text,
 } from "@codemirror/state";
@@ -10,6 +12,7 @@ import {
   EditorView,
   keymap,
   WidgetType,
+  type DecorationSet,
   type EditorView as CodeMirrorView,
 } from "@codemirror/view";
 import {
@@ -183,6 +186,12 @@ const codeBlockTheme = EditorView.baseTheme({
     paddingBottom: "0.35em",
     paddingTop: "0.35em",
   },
+  ".cm-markra-code-top-gap": {
+    height: "12px",
+    margin: "0",
+    pointerEvents: "none",
+    width: "100%",
+  },
   ".cm-markra-code-header": {
     color: "color-mix(in srgb, currentColor 62%, transparent)",
     display: "inline-block",
@@ -277,6 +286,53 @@ const codeBlockTheme = EditorView.baseTheme({
   ".cm-markra-mermaid-hidden-line": {
     display: "none",
   },
+});
+
+class CodeBlockTopGapWidget extends WidgetType {
+  eq() {
+    return true;
+  }
+
+  get estimatedHeight() {
+    return 12;
+  }
+
+  toDOM(view: CodeMirrorView) {
+    const gap = view.dom.ownerDocument.createElement("div");
+    gap.className = "cm-markra-code-top-gap";
+    gap.setAttribute("aria-hidden", "true");
+    return gap;
+  }
+}
+
+function codeBlockTopGapDecorations(state: EditorState) {
+  const gaps: Range<Decoration>[] = [];
+  syntaxTree(state).iterate({
+    enter(node) {
+      if (node.type.name !== "FencedCode") return;
+      const firstLine = state.doc.lineAt(node.from);
+      const lastLine = state.doc.lineAt(node.to);
+      if (firstLine.number === lastLine.number) return;
+      gaps.push(
+        Decoration.widget({
+          block: true,
+          side: -100,
+          widget: new CodeBlockTopGapWidget(),
+        }).range(node.from),
+      );
+    },
+  });
+  return Decoration.set(gaps, true);
+}
+
+const codeBlockTopGapField = StateField.define<DecorationSet>({
+  create: codeBlockTopGapDecorations,
+  update(gaps, transaction) {
+    return transaction.docChanged
+      ? codeBlockTopGapDecorations(transaction.state)
+      : gaps;
+  },
+  provide: (field) => EditorView.decorations.from(field),
 });
 
 class CodeBlockHeaderWidget extends WidgetType {
@@ -987,6 +1043,11 @@ export function codeBlockPreviewPlugin(
   return defineMarkraPlugin({
     id: "markra.code-block-preview",
     extension: [
+      // Vertical margins and padding on editable lines are not part of
+      // CodeMirror's height map in every WebView. State-field block widgets
+      // are measured explicitly, so repeated blocks cannot accumulate a
+      // pointer-to-caret offset.
+      codeBlockTopGapField,
       markraRenderer({
         id: "markra.code-block-preview",
         nodeNames: ["FencedCode"],

--- a/packages/editor/src/codemirror/heading-level.ts
+++ b/packages/editor/src/codemirror/heading-level.ts
@@ -1,3 +1,4 @@
+import { syntaxTree } from "@codemirror/language";
 import { StateEffect, StateField, type EditorState } from "@codemirror/state";
 import {
   Decoration,
@@ -24,7 +25,21 @@ function activeHeading(state: EditorState): ActiveHeading | null {
   const line = state.doc.lineAt(selection.head);
   if (selection.from < line.from || selection.to > line.to) return null;
   const match = headingPattern.exec(line.text);
-  return match ? { from: line.from, level: match[1]?.length ?? 1 } : null;
+  if (!match) return null;
+  const level = match[1]?.length ?? 1;
+  const markerOffset = match[0].indexOf("#");
+  let node = syntaxTree(state).resolveInner(line.from + markerOffset, 1);
+  // A line-start hash is ambiguous inside fenced code. Require the Markdown
+  // parser to classify the marker as the matching ATX heading before showing
+  // controls that can rewrite the line.
+  while (true) {
+    if (node.name === `ATXHeading${level}`) {
+      return { from: line.from, level };
+    }
+    const parent = node.parent;
+    if (!parent) return null;
+    node = parent;
+  }
 }
 
 const openHeadingField = StateField.define<number | null>({


### PR DESCRIPTION
## Summary
- keep code block language and copy controls aligned without overlapping code text
- replace vertical margins and editable-line padding with measured 12px block spacing so repeated code blocks retain accurate pointer mapping
- preserve the visual top and bottom inset, line-number gutter, borders, and rounded corners without changing code-row geometry
- use a consistent monospace presentation with non-italic comments
- require parsed ATX heading syntax before showing heading controls, preventing fenced-code comments from appearing as headings

## Why
Tauri WebKit could map a click on one code row to the following row when hidden fence margins or vertical padding accumulated across consecutive code blocks. The spacing now participates in CodeMirror's height map instead of altering editable line boxes.

## Validation
- `pnpm --filter @markra/app test` — 127 files, 1447 tests passed
- `pnpm --filter @markra/editor test` — 32 files, 353 tests passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- `git diff --cached --check` passed before commit
- browser QA: verified consecutive code blocks line by line after a 300ms render delay; every caret stayed inside the clicked row
- browser QA: verified 25 text-row clicks and direct interactions with frontmatter, tables, horizontal rules, math, raw HTML, images, and Mermaid without cumulative offset

## Risk
- limited to visual editor decorations and code block styling; no document-format or data migration changes
- the main regression surface is wrapped code on narrow layouts, so the first row reserves inline space for the controls while all rows keep uniform vertical geometry