### PR TITLE
fix(settings): show active sidebar category

### DIFF
--- a/packages/app/src/components/SettingsShell.test.tsx
+++ b/packages/app/src/components/SettingsShell.test.tsx
@@ -63,6 +63,15 @@ describe("SettingsShell", () => {
     expect(screen.getByText("Markra v9.9.9")).toBeInTheDocument();
   });
 
+  it("styles the active settings category when aria-current is page", () => {
+    renderSettingsSidebar();
+
+    expect(screen.getByRole("button", { name: "General" })).toHaveClass(
+      "aria-[current=page]:bg-(--bg-active)",
+      "aria-[current=page]:text-(--accent)"
+    );
+  });
+
   it("keeps settings shell chrome treatment scoped to Windows", () => {
     const defaultContent = renderSettingsContent();
 

--- a/packages/app/src/components/SettingsShell.tsx
+++ b/packages/app/src/components/SettingsShell.tsx
@@ -189,7 +189,7 @@ function SettingsNavButton({
 
   return (
     <button
-      className="group inline-flex h-9 w-full items-center gap-3 rounded-md border-0 bg-transparent px-3 text-left text-[13px] leading-5 font-[620] tracking-normal text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) aria-current:bg-(--bg-active) aria-current:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) max-[700px]:w-auto max-[700px]:shrink-0 max-[700px]:whitespace-nowrap"
+      className="group inline-flex h-9 w-full items-center gap-3 rounded-md border-0 bg-transparent px-3 text-left text-[13px] leading-5 font-[620] tracking-normal text-(--text-secondary) transition-colors duration-150 ease-out hover:bg-(--bg-hover) hover:text-(--text-heading) aria-[current=page]:bg-(--bg-active) aria-[current=page]:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) max-[700px]:w-auto max-[700px]:shrink-0 max-[700px]:whitespace-nowrap"
       type="button"
       aria-current={active ? "page" : undefined}
       aria-label={label}


### PR DESCRIPTION
## Summary
- match the settings sidebar active styles against `aria-current="page"`
- add regression coverage for the active background and accent text utilities

## Why
The active category already exposed `aria-current="page"`, but the Tailwind variants only matched the boolean `aria-current="true"` form, so no selected styling was rendered.

## Validation
- `pnpm --filter @markra/app test -- SettingsShell.test.tsx` — 28 tests passed
- `pnpm --filter @markra/app test -- App.test.tsx` — 229 tests passed
- `pnpm --filter @markra/desktop build` — production build and vendor chunk verification passed
- `git diff --check` — passed

## Risk
Low. The change is limited to the settings navigation state selector and preserves the existing colors, layout, and accessibility attributes.