### PR TITLE
fix(windows): open new windows from shortcuts and drops

### DIFF
--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -184,6 +184,7 @@ export const desktopRuntime = {
     listenSettingsWindowTarget: windowRuntime.listenNativeSettingsWindowTarget,
     listenWindowCloseRequested: windowRuntime.listenNativeWindowCloseRequested,
     minimizeWindow: windowRuntime.minimizeNativeWindow,
+    openBlankEditorWindow: windowRuntime.openNativeBlankEditorWindow,
     openExternalUrl: windowRuntime.openNativeExternalUrl,
     openSettingsWindow: windowRuntime.openSettingsWindow,
     prewarmSettingsWindow: windowRuntime.prewarmSettingsWindow,

--- a/apps/desktop/src/runtime/tauri/window.test.ts
+++ b/apps/desktop/src/runtime/tauri/window.test.ts
@@ -14,6 +14,7 @@ import {
   hideSettingsWindow,
   markSettingsWindowReady,
   minimizeNativeWindow,
+  openNativeBlankEditorWindow,
   openSettingsWindow,
   prewarmSettingsWindow,
   setNativeEditorWindowRestoreState,
@@ -142,6 +143,14 @@ describe("native window actions", () => {
 
     expect(mockedInvoke).toHaveBeenCalledWith("minimize_current_window");
     expect(mockedGetCurrentWindow).not.toHaveBeenCalled();
+  });
+
+  it("opens a blank editor window through the native command", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+
+    await openNativeBlankEditorWindow();
+
+    expect(mockedInvoke).toHaveBeenCalledWith("open_blank_editor_window");
   });
 
   it("shows the current Tauri window", async () => {

--- a/apps/desktop/src/runtime/tauri/window.ts
+++ b/apps/desktop/src/runtime/tauri/window.ts
@@ -48,6 +48,10 @@ export function hideSettingsWindow() {
   return invokeNative("hide_settings_window");
 }
 
+export function openNativeBlankEditorWindow() {
+  return invokeNative("open_blank_editor_window");
+}
+
 export async function listenNativeSettingsWindowTarget(onTarget: (target: NativeSettingsWindowTarget) => unknown) {
   if (!("__TAURI_INTERNALS__" in window)) {
     return () => {};

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -144,6 +144,7 @@ import type {
 import {
   closeNativeWindow,
   hideSettingsWindow,
+  openBlankEditorWindow,
   openNativeExternalUrl,
   openSettingsWindow,
   prewarmSettingsWindow,
@@ -2857,6 +2858,9 @@ function WorkspaceApp() {
   const handleOpenSettings = useCallback(() => {
     openSettingsWindow().catch(() => {});
   }, []);
+  const handleOpenBlankEditorWindow = useCallback(() => {
+    openBlankEditorWindow().catch(() => {});
+  }, []);
   const handleShowAbout = useCallback(() => {
     showNativeAppAbout().catch(() => {});
   }, []);
@@ -3860,6 +3864,7 @@ function WorkspaceApp() {
     exportHtml: exportFeatureEnabled ? exportHtmlDocument : undefined,
     exportPdf: exportFeatureEnabled ? exportPdfDocument : undefined,
     markdownShortcuts: editorPreferences.preferences.markdownShortcuts,
+    openBlankEditorWindow: windowsSelfDrawnChromeEnabled ? handleOpenBlankEditorWindow : undefined,
     openDocument: handleOpenMarkdownFile,
     openDocumentReplace: handleDocumentReplaceOpen,
     openDocumentSearch: handleDocumentSearchOpen,
@@ -4439,6 +4444,7 @@ function WorkspaceApp() {
           onSelectViewMode={handleViewModeSelect}
           onCreateMarkdownFile={handleQuickCreateMarkdownTreeFile}
           onExitApp={handleExitApp}
+          onOpenBlankEditorWindow={windowsSelfDrawnChromeEnabled ? handleOpenBlankEditorWindow : undefined}
           onOpenMarkdown={handleOpenMarkdownFile}
           onOpenMarkdownFolder={handleOpenMarkdownFolder}
           onOpenSettings={handleOpenSettings}

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -554,6 +554,7 @@ describe("NativeTitleBar", () => {
   });
 
   it("opens self-drawn Windows app menu dropdowns from the top chrome", () => {
+    const openBlankEditorWindow = vi.fn();
     const openMarkdown = vi.fn();
     const saveMarkdown = vi.fn();
     const saveMarkdownAs = vi.fn();
@@ -583,6 +584,7 @@ describe("NativeTitleBar", () => {
           </div>
         )}
         onToggleAiAgent={() => {}}
+        onOpenBlankEditorWindow={openBlankEditorWindow}
         onOpenMarkdown={openMarkdown}
         onSaveMarkdown={saveMarkdown}
         onShowAbout={showAbout}
@@ -625,6 +627,10 @@ describe("NativeTitleBar", () => {
     fireEvent.click(screen.getByRole("button", { name: "File" }));
 
     expect(screen.getByRole("menu", { name: "File" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "New Ctrl+N" }));
+    expect(openBlankEditorWindow).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "File" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Open... Ctrl+O" }));
     expect(openMarkdown).toHaveBeenCalledTimes(1);
 

--- a/packages/app/src/components/NativeTitleBar.tsx
+++ b/packages/app/src/components/NativeTitleBar.tsx
@@ -91,6 +91,7 @@ type NativeTitleBarProps = {
   onSelectViewMode?: (mode: ViewMode) => unknown;
   onCreateMarkdownFile?: () => unknown;
   onExitApp?: () => unknown;
+  onOpenBlankEditorWindow?: () => unknown;
   onOpenMarkdown: () => unknown;
   onOpenMarkdownFolder?: () => unknown;
   onOpenSettings?: () => unknown;
@@ -148,6 +149,7 @@ export function NativeTitleBar({
   onSelectViewMode,
   onCreateMarkdownFile,
   onExitApp,
+  onOpenBlankEditorWindow,
   onOpenMarkdown,
   onOpenMarkdownFolder,
   onOpenSettings,
@@ -718,6 +720,7 @@ export function NativeTitleBar({
         renderTitleContent={renderTitleContent}
         onCreateMarkdownFile={onCreateMarkdownFile}
         onExitApp={onExitApp}
+        onOpenBlankEditorWindow={onOpenBlankEditorWindow}
         onOpenMarkdown={onOpenMarkdown}
         onOpenMarkdownFolder={onOpenMarkdownFolder}
         onOpenSettings={onOpenSettings}

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -54,6 +54,7 @@ type WindowsNativeTitleBarProps = {
   renderTitleContent: (className: string, style?: CSSProperties) => ReactNode;
   onCreateMarkdownFile?: () => unknown;
   onExitApp?: () => unknown;
+  onOpenBlankEditorWindow?: () => unknown;
   onOpenMarkdown: () => unknown;
   onOpenMarkdownFolder?: () => unknown;
   onOpenSettings?: () => unknown;
@@ -124,6 +125,7 @@ export function WindowsNativeTitleBar({
   renderTitleContent,
   onCreateMarkdownFile,
   onExitApp,
+  onOpenBlankEditorWindow,
   onOpenMarkdown,
   onOpenMarkdownFolder,
   onOpenSettings,
@@ -193,7 +195,12 @@ export function WindowsNativeTitleBar({
 
     if (menuId === "file") {
       return [
-        contextMenuItem("newDocument", label("menu.newDocument"), "Ctrl+N", onCreateMarkdownFile),
+        contextMenuItem(
+          "newDocument",
+          label("menu.newDocument"),
+          "Ctrl+N",
+          onOpenBlankEditorWindow ?? onCreateMarkdownFile
+        ),
         contextMenuItem("openDocument", label("menu.openDocument"), "Ctrl+O", onOpenMarkdown),
         onOpenMarkdownFolder
           ? contextMenuItem("openFolder", label("app.openFolderDialog"), "Ctrl+Shift+O", onOpenMarkdownFolder)

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -4086,7 +4086,7 @@ describe("useMarkdownDocument", () => {
 
   it("opens dropped Markdown files in current workspace tabs when enabled", async () => {
     const currentPath = "/mock-files/vault/current.md";
-    const droppedPath = "/mock-files/external/dropped.md";
+    const droppedPath = "/mock-files/vault/dropped.md";
     const onTreeRootFromFilePath = vi.fn();
     mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
       content: path === droppedPath ? "# Dropped" : "# Current",
@@ -4124,8 +4124,8 @@ describe("useMarkdownDocument", () => {
     expect(result.current.tabs.map((tab) => tab.path)).toEqual([currentPath, droppedPath]);
   });
 
-  it("preserves the current workspace when a file replaces an empty tab", async () => {
-    const droppedPath = "/mock-files/external/dropped.md";
+  it("reuses an empty tab for a dropped file in the current workspace", async () => {
+    const droppedPath = "/mock-files/vault/dropped.md";
     const onTreeRootFromFilePath = vi.fn();
     mockedReadNativeMarkdownFile.mockResolvedValue({
       content: "# Dropped",
@@ -4161,7 +4161,7 @@ describe("useMarkdownDocument", () => {
 
   it("reuses an empty active tab while retaining other open documents", async () => {
     const currentPath = "/mock-files/vault/current.md";
-    const droppedPath = "/mock-files/external/dropped.md";
+    const droppedPath = "/mock-files/vault/dropped.md";
     const onTreeRootFromFilePath = vi.fn();
     mockedReadNativeMarkdownFile.mockImplementation(async (path) => ({
       content: path === droppedPath ? "# Dropped" : "# Current",
@@ -4197,6 +4197,38 @@ describe("useMarkdownDocument", () => {
     expect(onTreeRootFromFilePath).not.toHaveBeenCalled();
     expect(result.current.document.path).toBe(droppedPath);
     expect(result.current.tabs.map((tab) => tab.path)).toEqual([currentPath, droppedPath]);
+  });
+
+  it("opens a dropped file outside the current Windows workspace in a new window", async () => {
+    const droppedPath = "C:\\mock-incoming\\outside.md";
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Outside",
+      name: "outside.md",
+      path: droppedPath
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        openDroppedFilesInTabs: true,
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false,
+        workspaceSourcePath: "C:\\mock-vault"
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleDroppedMarkdownPath({
+        kind: "file",
+        name: "outside.md",
+        path: droppedPath
+      });
+    });
+
+    expect(mockedOpenNativeMarkdownFileInNewWindow).toHaveBeenCalledWith(droppedPath);
+    expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalledWith(droppedPath);
   });
 
   it("establishes a workspace from a file dropped into a fresh window", async () => {
@@ -4305,6 +4337,33 @@ describe("useMarkdownDocument", () => {
       "incoming",
       expect.any(String)
     );
+  });
+
+  it("opens a dropped folder outside the current Windows workspace in a new window", async () => {
+    const folderPath = "C:\\mock-incoming";
+    const onTreeRootFromFolderPath = vi.fn();
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath,
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false,
+        workspaceSourcePath: "C:\\mock-vault"
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleDroppedMarkdownPath({
+        kind: "folder",
+        name: "mock-incoming",
+        path: folderPath
+      });
+    });
+
+    expect(mockedOpenNativeMarkdownFolderInNewWindow).toHaveBeenCalledWith(folderPath);
+    expect(onTreeRootFromFolderPath).not.toHaveBeenCalled();
   });
 
   it("keeps opening dropped Markdown files in new windows by default", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -1768,6 +1768,21 @@ export function useMarkdownDocument({
 
   const handleDroppedMarkdownPath = useCallback(
     async (target: NativeMarkdownDroppedTarget) => {
+      const workspaceRootPath = workspaceRootForSource(workspaceSourcePath, documentRef.current.path);
+      if (
+        target.kind !== "image" &&
+        workspaceRootPath &&
+        !isPathWithinRoot(target.path, workspaceRootPath)
+      ) {
+        // Keep each window bound to one workspace; tab reuse only applies to paths inside it.
+        if (target.kind === "folder") {
+          await openNativeMarkdownFolderInNewWindow(target.path);
+        } else {
+          await openNativeMarkdownFileInNewWindow(target.path);
+        }
+        return;
+      }
+
       if (target.kind === "folder") {
         if (!isCurrentWindowEmptyUntitled()) {
           await openNativeMarkdownFolderInNewWindow(target.path);

--- a/packages/app/src/hooks/useNativeBindings.test.tsx
+++ b/packages/app/src/hooks/useNativeBindings.test.tsx
@@ -382,6 +382,25 @@ describe("useApplicationShortcuts", () => {
     expect(openSettings).toHaveBeenCalledTimes(1);
   });
 
+  it("opens a blank editor window from Ctrl+N on Windows", () => {
+    const openBlankEditorWindow = vi.fn();
+    renderHook(() =>
+      useApplicationShortcuts({
+        ...baseOptions,
+        openBlankEditorWindow,
+        platform: "windows"
+      })
+    );
+
+    const handled = fireEvent.keyDown(window, {
+      ctrlKey: true,
+      key: "n"
+    });
+
+    expect(handled).toBe(false);
+    expect(openBlankEditorWindow).toHaveBeenCalledTimes(1);
+  });
+
   it("does not treat Control+Meta as the platform modifier for static shortcuts", () => {
     const openSettings = vi.fn();
     renderHook(() =>

--- a/packages/app/src/hooks/useNativeBindings.ts
+++ b/packages/app/src/hooks/useNativeBindings.ts
@@ -72,6 +72,7 @@ type ApplicationShortcutOptions = {
   openDocument: () => unknown | Promise<unknown>;
   openDocumentReplace?: () => unknown | Promise<unknown>;
   openDocumentSearch?: () => unknown | Promise<unknown>;
+  openBlankEditorWindow?: () => unknown | Promise<unknown>;
   openSettings?: () => unknown | Promise<unknown>;
   openWorkspaceSearch?: () => unknown | Promise<unknown>;
   openFolder: () => unknown | Promise<unknown>;
@@ -435,6 +436,7 @@ export function useApplicationShortcuts({
   exportHtml,
   exportPdf,
   markdownShortcuts,
+  openBlankEditorWindow,
   openDocument,
   openDocumentReplace,
   openDocumentSearch,
@@ -519,6 +521,17 @@ export function useApplicationShortcuts({
           exportPdf();
         }
         return;
+      } else if (
+        platform === "windows" &&
+        key === "n" &&
+        event.ctrlKey &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        openBlankEditorWindow
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!event.repeat) openBlankEditorWindow();
       } else if (key === "s" && event.shiftKey) {
         event.preventDefault();
         saveDocumentAs();
@@ -552,6 +565,7 @@ export function useApplicationShortcuts({
     exportPdf,
     closeDocument,
     normalizedMarkdownShortcuts,
+    openBlankEditorWindow,
     openDocument,
     openDocumentReplace,
     openDocumentSearch,

--- a/packages/app/src/lib/tauri/window.ts
+++ b/packages/app/src/lib/tauri/window.ts
@@ -37,6 +37,10 @@ export function hideSettingsWindow() {
   return getAppRuntime().window.hideSettingsWindow();
 }
 
+export function openBlankEditorWindow() {
+  return getAppRuntime().window.openBlankEditorWindow();
+}
+
 export function listenNativeSettingsWindowTarget(onTarget: (target: NativeSettingsWindowTarget) => unknown) {
   return getAppRuntime().window.listenSettingsWindowTarget(onTarget);
 }

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -378,6 +378,7 @@ export type AppWindowRuntime = {
     onCloseRequested: (event: NativeWindowCloseRequestEvent) => unknown | Promise<unknown>
   ) => Promise<RuntimeCleanup>;
   minimizeWindow: () => Promise<unknown>;
+  openBlankEditorWindow: () => Promise<unknown>;
   openExternalUrl: (url: string) => Promise<unknown>;
   openSettingsWindow: (target?: NativeSettingsWindowTarget) => Promise<unknown>;
   prewarmSettingsWindow: () => Promise<unknown>;
@@ -593,6 +594,7 @@ export function createDefaultAppRuntime(): AppRuntime {
       listenSettingsWindowTarget: async () => () => undefined,
       listenWindowCloseRequested: async () => () => undefined,
       minimizeWindow: async () => undefined,
+      openBlankEditorWindow: async () => undefined,
       openExternalUrl: async (url) => {
         if (typeof window !== "undefined") {
           window.open(url, "_blank", "noopener,noreferrer");


### PR DESCRIPTION
## Summary
- Restore Windows `Ctrl+N` and File > New by invoking the native blank editor window command through the runtime bridge.
- Open dropped files and folders outside the active workspace in a new native window while preserving tab reuse for in-workspace paths.
- Add regression coverage for the shortcut, title-bar menu, runtime command bridge, and Windows path-boundary cases.

## Why
- macOS already receives `Cmd+N` through its native AppKit menu, while the Windows self-drawn chrome lacked the equivalent shortcut and its New menu action targeted the current document.
- External drops could attach to the current workspace instead of preserving the one-workspace-per-window boundary.

## Validation
- `pnpm --filter @markra/app test` — 127 files and 1451 tests passed.
- `pnpm --filter @markra/desktop test` — 15 files and 143 tests passed.
- `pnpm -r --if-present typecheck:test` — all 11 applicable workspace projects passed.
- `pnpm --filter @markra/desktop build` — production build and chunk verification passed.
- `cargo test` in `apps/desktop/src-tauri` — 258 tests passed.
- Not run: physical Windows smoke test, because the current development environment is macOS.

## Risk
- Shortcut interception is limited to Windows self-drawn desktop chrome.
- Drop routing changes only targets outside the current workspace; in-workspace tab behavior remains unchanged.