### PR TITLE
feat(editor): add task list and today slash commands

### DIFF
--- a/packages/app/src/components/CodeMirrorPaperSurface.test.tsx
+++ b/packages/app/src/components/CodeMirrorPaperSurface.test.tsx
@@ -520,8 +520,42 @@ describe("CodeMirrorPaperSurface", () => {
     expect(
       getMarkraSlashMenuState(view).actions.map((action) => action.command),
     ).toEqual(
-      expect.arrayContaining(["block.callout", "block.table"]),
+      expect.arrayContaining([
+        "block.callout",
+        "block.table",
+        "block.task-list",
+        "insert.today",
+      ]),
     );
+  });
+
+  it("inserts today's local date from the slash command", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2031, 4, 6, 10, 30));
+    const onEditorReady = vi.fn();
+
+    try {
+      render(
+        <CodeMirrorPaperSurface
+          autoFocus={false}
+          initialContent="Published: "
+          onEditorReady={onEditorReady}
+          onMarkdownChange={() => {}}
+        />,
+      );
+      const view = onEditorReady.mock.calls[0]?.[0] as EditorView;
+      act(() => {
+        view.dispatch({
+          selection: EditorSelection.cursor(view.state.doc.length),
+        });
+      });
+
+      expect(runMarkraCommand(view, "insert.today")).toBe(true);
+      expect(view.state.doc.toString()).toBe("Published: 2031-05-06");
+      expect(view.state.selection.main.head).toBe(view.state.doc.length);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("accepts host plugins and renders their toolbar actions", () => {

--- a/packages/app/src/components/CodeMirrorPaperSurface.tsx
+++ b/packages/app/src/components/CodeMirrorPaperSurface.tsx
@@ -18,6 +18,7 @@ import {
   getActiveCodeMirrorSpellcheckMatch,
   horizontalRulePlugin,
   imagePreviewPlugin,
+  insertionsPlugin,
   liveMarkdown,
   linksPlugin,
   markdownEditingPlugin,
@@ -204,6 +205,7 @@ function markdownExtension({
           "block.paragraph": t(language, "menu.paragraph"),
           "block.quote": t(language, "menu.quote"),
           "block.table": t(language, "menu.table"),
+          "block.task-list": t(language, "menu.taskList"),
         },
       }),
       codeMirrorBlockDragPlugin({
@@ -253,6 +255,11 @@ function markdownExtension({
       frontmatterPreviewPlugin(),
       horizontalRulePlugin(),
       imagePreviewPlugin(imageOptions),
+      insertionsPlugin({
+        labels: {
+          "insert.today": t(language, "menu.today"),
+        },
+      }),
       ...(linkOptions ? [linksPlugin(linkOptions)] : []),
       mathPreviewPlugin(),
       markdownEditingPlugin(),

--- a/packages/editor/src/codemirror/blocks.test.ts
+++ b/packages/editor/src/codemirror/blocks.test.ts
@@ -70,6 +70,11 @@ describe("blocksPlugin", () => {
         label: "Bullet list",
       },
       {
+        command: "block.task-list",
+        icon: "list-checks",
+        label: "Task list",
+      },
+      {
         command: "block.ordered-list",
         icon: "list-ordered",
         label: "Numbered list",
@@ -181,11 +186,28 @@ describe("blocksPlugin", () => {
     expect(runMarkraCommand(bullet, "block.bullet-list")).toBe(true);
     expect(bullet.state.doc.toString()).toBe("Alpha\nBeta");
 
+    const task = createView();
+    expect(runMarkraCommand(task, "block.task-list")).toBe(true);
+    expect(task.state.doc.toString()).toBe("- [ ] Alpha\n- [ ] Beta");
+    expect(runMarkraCommand(task, "block.task-list")).toBe(true);
+    expect(task.state.doc.toString()).toBe("Alpha\nBeta");
+
     const ordered = createView();
     expect(runMarkraCommand(ordered, "block.ordered-list")).toBe(true);
     expect(ordered.state.doc.toString()).toBe("1. Alpha\n2. Beta");
     expect(runMarkraCommand(ordered, "block.ordered-list")).toBe(true);
     expect(ordered.state.doc.toString()).toBe("Alpha\nBeta");
+  });
+
+  it("converts existing list markers without leaving task syntax behind", () => {
+    const view = createView({
+      doc: "- [x] Alpha\n* Beta",
+      from: 0,
+      to: "- [x] Alpha\n* Beta".length,
+    });
+
+    expect(runMarkraCommand(view, "block.ordered-list")).toBe(true);
+    expect(view.state.doc.toString()).toBe("1. Alpha\n2. Beta");
   });
 
   it("wraps and unwraps a selected block in a fenced code block", () => {

--- a/packages/editor/src/codemirror/blocks.ts
+++ b/packages/editor/src/codemirror/blocks.ts
@@ -23,6 +23,7 @@ export type BlockCommandId =
   | "block.heading.5"
   | "block.heading.6"
   | "block.bullet-list"
+  | "block.task-list"
   | "block.ordered-list"
   | "block.quote"
   | "block.callout"
@@ -62,6 +63,7 @@ const defaultBlockLabels: BlockLabels = {
   "block.heading.5": "Heading 5",
   "block.heading.6": "Heading 6",
   "block.bullet-list": "Bullet list",
+  "block.task-list": "Task list",
   "block.ordered-list": "Numbered list",
   "block.quote": "Quote",
   "block.callout": "Callout",
@@ -127,18 +129,32 @@ const blockSpecs: readonly BlockSpec[] = [
     order: 80,
   },
   {
+    id: "block.task-list",
+    icon: "list-checks",
+    keywords: [
+      "task",
+      "todo",
+      "checkbox",
+      "checklist",
+      "任务",
+      "待办",
+      "复选框",
+    ],
+    order: 90,
+  },
+  {
     id: "block.ordered-list",
     icon: "list-ordered",
     key: "Mod-Shift-7",
     keywords: ["numbered", "ordered", "list", "编号", "有序列表"],
-    order: 90,
+    order: 100,
   },
   {
     id: "block.quote",
     icon: "text-quote",
     key: "Mod-Shift-b",
     keywords: ["quote", "blockquote", "引用"],
-    order: 100,
+    order: 110,
   },
   {
     id: "block.callout",
@@ -155,27 +171,30 @@ const blockSpecs: readonly BlockSpec[] = [
       "提示",
       "警告",
     ],
-    order: 105,
+    order: 115,
   },
   {
     id: "block.code",
     icon: "square-code",
     key: "Mod-Alt-c",
     keywords: ["code", "fence", "代码", "代码块"],
-    order: 110,
+    order: 120,
   },
   {
     id: "block.table",
     icon: "table-2",
     keywords: ["table", "grid", "表格"],
-    order: 120,
+    order: 130,
   },
 ];
 
 const headingPattern = /^([\t ]{0,3})#{1,6}[\t ]+/;
-const bulletPattern = /^([\t ]*)[-+*][\t ]+/;
+const taskPattern = /^([\t ]*)[-+*][\t ]+\[[ xX]\](?:[\t ]+|$)/;
+const bulletPattern =
+  /^([\t ]*)[-+*][\t ]+(?!\[[ xX]\](?:[\t ]+|$))/;
 const orderedPattern = /^([\t ]*)\d+[.)][\t ]+/;
-const listPattern = /^([\t ]*)(?:[-+*][\t ]+|\d+[.)][\t ]+)/;
+const listPattern =
+  /^([\t ]*)(?:[-+*][\t ]+\[[ xX]\](?:[\t ]+|$)|[-+*][\t ]+|\d+[.)][\t ]+)/;
 const quotePattern = /^([\t ]*)>[\t ]?/;
 const openingFencePattern = /^[\t ]*```[^`]*$/;
 const closingFencePattern = /^[\t ]*```[\t ]*$/;
@@ -309,6 +328,20 @@ function toggleList(view: EditorView, ordered: boolean) {
     if (remove) return markerChange(line, targetPattern, "");
     return markerChange(line, listPattern, ordered ? `${index + 1}. ` : "- ");
   });
+  return dispatchLineChanges(view, changes);
+}
+
+function toggleTaskList(view: EditorView) {
+  if (!isEditable(view)) return false;
+  const lines = selectedLines(view.state);
+  const remove = lines.every((line) => taskPattern.test(line.text));
+  const changes = lines.map((line) =>
+    markerChange(
+      line,
+      remove ? taskPattern : listPattern,
+      remove ? "" : "- [ ] ",
+    ),
+  );
   return dispatchLineChanges(view, changes);
 }
 
@@ -470,6 +503,12 @@ function blockCommand(
         ...shared,
         isActive: (view) => everyLineMatches(view, bulletPattern),
         run: (view) => toggleList(view, false),
+      };
+    case "block.task-list":
+      return {
+        ...shared,
+        isActive: (view) => everyLineMatches(view, taskPattern),
+        run: toggleTaskList,
       };
     case "block.ordered-list":
       return {

--- a/packages/editor/src/codemirror/index.ts
+++ b/packages/editor/src/codemirror/index.ts
@@ -139,6 +139,12 @@ export {
   markraHighlight,
 } from "./highlight.ts";
 export { horizontalRulePlugin } from "./horizontal-rule.ts";
+export type {
+  InsertionCommandId,
+  InsertionLabels,
+  InsertionsPluginOptions,
+} from "./insertions.ts";
+export { insertionsPlugin } from "./insertions.ts";
 export { markdownEditingPlugin } from "./markdown-editing.ts";
 export type { MarkdownShortcutsPluginOptions } from "./markdown-shortcuts.ts";
 export { markdownShortcutsPlugin } from "./markdown-shortcuts.ts";

--- a/packages/editor/src/codemirror/insertions.test.ts
+++ b/packages/editor/src/codemirror/insertions.test.ts
@@ -1,0 +1,79 @@
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  insertionsPlugin,
+  listMarkraUi,
+  liveMarkdown,
+  runMarkraCommand,
+} from "./index.ts";
+
+import "./dom.test-support.ts";
+
+const views: EditorView[] = [];
+
+function createView(readOnly = false) {
+  const doc = "Published: placeholder";
+  const parent = document.createElement("div");
+  document.body.append(parent);
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({
+      doc,
+      extensions: [
+        EditorState.readOnly.of(readOnly),
+        liveMarkdown({
+          plugins: [
+            insertionsPlugin({
+              labels: { "insert.today": "Current date" },
+              now: () => new Date(2031, 4, 6, 10, 30),
+            }),
+          ],
+        }),
+      ],
+      selection: EditorSelection.range(
+        doc.indexOf("placeholder"),
+        doc.length,
+      ),
+    }),
+  });
+  views.push(view);
+  return view;
+}
+
+afterEach(() => {
+  for (const view of views.splice(0)) view.destroy();
+  document.body.replaceChildren();
+});
+
+describe("insertionsPlugin", () => {
+  it("publishes a Today slash command that replaces the selection", () => {
+    const view = createView();
+
+    expect(
+      listMarkraUi(view, "slash-menu").map((action) => ({
+        command: action.command,
+        icon: action.icon,
+        label: action.label,
+      })),
+    ).toEqual([
+      {
+        command: "insert.today",
+        icon: "calendar-days",
+        label: "Current date",
+      },
+    ]);
+
+    expect(runMarkraCommand(view, "insert.today")).toBe(true);
+    expect(view.state.doc.toString()).toBe("Published: 2031-05-06");
+    expect(view.state.selection.main.head).toBe(view.state.doc.length);
+  });
+
+  it("disables date insertion in a read-only editor", () => {
+    const view = createView(true);
+
+    expect(listMarkraUi(view, "slash-menu")[0]?.enabled).toBe(false);
+    expect(runMarkraCommand(view, "insert.today")).toBe(false);
+    expect(view.state.doc.toString()).toBe("Published: placeholder");
+  });
+});

--- a/packages/editor/src/codemirror/insertions.ts
+++ b/packages/editor/src/codemirror/insertions.ts
@@ -1,0 +1,91 @@
+import {
+  EditorSelection,
+  EditorState,
+  type ChangeSpec,
+} from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import { defineMarkraPlugin } from "./plugin.ts";
+
+export type InsertionCommandId = "insert.today";
+
+export type InsertionLabels = Record<InsertionCommandId, string>;
+
+export interface InsertionsPluginOptions {
+  labels?: Partial<InsertionLabels>;
+  now?: () => Date;
+}
+
+const defaultInsertionLabels: InsertionLabels = {
+  "insert.today": "Today",
+};
+
+function isEditable(view: EditorView) {
+  return !view.state.facet(EditorState.readOnly);
+}
+
+function twoDigits(value: number) {
+  return value.toString().padStart(2, "0");
+}
+
+function localDate(date: Date) {
+  // Keep the user's calendar day at UTC boundaries; toISOString() can produce
+  // yesterday or tomorrow for users outside UTC.
+  return [
+    date.getFullYear(),
+    twoDigits(date.getMonth() + 1),
+    twoDigits(date.getDate()),
+  ].join("-");
+}
+
+function insertText(view: EditorView, text: string) {
+  if (!isEditable(view)) return false;
+  const { state } = view;
+  const changes: ChangeSpec[] = state.selection.ranges.map((range) => ({
+    from: range.from,
+    insert: text,
+    to: range.to,
+  }));
+  const changeSet = state.changes(changes);
+  const selection = EditorSelection.create(
+    state.selection.ranges.map((range) =>
+      EditorSelection.cursor(changeSet.mapPos(range.to, 1)),
+    ),
+    state.selection.mainIndex,
+  );
+
+  view.dispatch({
+    changes: changeSet,
+    scrollIntoView: true,
+    selection,
+    userEvent: "input",
+  });
+  view.focus();
+  return true;
+}
+
+export function insertionsPlugin(options: InsertionsPluginOptions = {}) {
+  const labels = { ...defaultInsertionLabels, ...options.labels };
+  const now = options.now ?? (() => new Date());
+
+  return defineMarkraPlugin({
+    id: "markra.insertions",
+    commands: [
+      {
+        id: "insert.today",
+        isEnabled: isEditable,
+        label: labels["insert.today"],
+        run: (view) => insertText(view, localDate(now())),
+      },
+    ],
+    ui: [
+      {
+        command: "insert.today",
+        group: "insert",
+        icon: "calendar-days",
+        keywords: ["today", "date", "current date", "今天", "日期"],
+        order: 140,
+        placement: "slash-menu",
+      },
+    ],
+  });
+}

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "Überschrift 2",
   "menu.heading3": "Überschrift 3",
   "menu.bulletList": "Aufzählung",
+  "menu.taskList": "Aufgabenliste",
   "menu.orderedList": "Nummerierte Liste",
   "menu.quote": "Zitat",
   "menu.callout": "Hinweisblock",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "Bild",
   "menu.importLocalImages": "Lokale Bilder importieren...",
   "menu.importLocalFiles": "Lokale Dateien importieren...",
-  "menu.table": "Tabelle"
+  "menu.table": "Tabelle",
+  "menu.today": "Heute"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -923,6 +923,7 @@ const messages: BaseLocaleMessages = {
   "menu.heading2": "Heading 2",
   "menu.heading3": "Heading 3",
   "menu.bulletList": "Bullet List",
+  "menu.taskList": "Task List",
   "menu.orderedList": "Ordered List",
   "menu.quote": "Quote",
   "menu.callout": "Callout",
@@ -931,7 +932,8 @@ const messages: BaseLocaleMessages = {
   "menu.image": "Image",
   "menu.importLocalImages": "Import Local Images...",
   "menu.importLocalFiles": "Import Local Files...",
-  "menu.table": "Table"
+  "menu.table": "Table",
+  "menu.today": "Today"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "Encabezado 2",
   "menu.heading3": "Encabezado 3",
   "menu.bulletList": "Lista con viñetas",
+  "menu.taskList": "Lista de tareas",
   "menu.orderedList": "Lista numerada",
   "menu.quote": "Cita",
   "menu.callout": "Aviso",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "Imagen",
   "menu.importLocalImages": "Importar imágenes locales...",
   "menu.importLocalFiles": "Importar archivos locales...",
-  "menu.table": "Tabla"
+  "menu.table": "Tabla",
+  "menu.today": "Hoy"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "Titre 2",
   "menu.heading3": "Titre 3",
   "menu.bulletList": "Liste à puces",
+  "menu.taskList": "Liste de tâches",
   "menu.orderedList": "Liste numérotée",
   "menu.quote": "Citation",
   "menu.callout": "Encadré",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "Image",
   "menu.importLocalImages": "Importer des images locales...",
   "menu.importLocalFiles": "Importer des fichiers locaux...",
-  "menu.table": "Tableau"
+  "menu.table": "Tableau",
+  "menu.today": "Aujourd’hui"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "Titolo 2",
   "menu.heading3": "Titolo 3",
   "menu.bulletList": "Elenco puntato",
+  "menu.taskList": "Elenco attività",
   "menu.orderedList": "Elenco numerato",
   "menu.quote": "Citazione",
   "menu.callout": "Avviso",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "Immagine",
   "menu.importLocalImages": "Importa immagini locali...",
   "menu.importLocalFiles": "Importa file locali...",
-  "menu.table": "Tabella"
+  "menu.table": "Tabella",
+  "menu.today": "Oggi"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "見出し 2",
   "menu.heading3": "見出し 3",
   "menu.bulletList": "箇条書き",
+  "menu.taskList": "タスクリスト",
   "menu.orderedList": "番号付きリスト",
   "menu.quote": "引用",
   "menu.callout": "コールアウト",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "画像",
   "menu.importLocalImages": "ローカル画像を読み込む...",
   "menu.importLocalFiles": "ローカルファイルを読み込む...",
-  "menu.table": "表"
+  "menu.table": "表",
+  "menu.today": "今日"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "제목 2",
   "menu.heading3": "제목 3",
   "menu.bulletList": "글머리 기호 목록",
+  "menu.taskList": "작업 목록",
   "menu.orderedList": "번호 매기기 목록",
   "menu.quote": "인용",
   "menu.callout": "콜아웃",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "이미지",
   "menu.importLocalImages": "로컬 이미지 가져오기...",
   "menu.importLocalFiles": "로컬 파일 가져오기...",
-  "menu.table": "표"
+  "menu.table": "표",
+  "menu.today": "오늘"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "Título 2",
   "menu.heading3": "Título 3",
   "menu.bulletList": "Lista com marcadores",
+  "menu.taskList": "Lista de tarefas",
   "menu.orderedList": "Lista numerada",
   "menu.quote": "Citação",
   "menu.callout": "Aviso",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "Imagem",
   "menu.importLocalImages": "Importar imagens locais...",
   "menu.importLocalFiles": "Importar arquivos locais...",
-  "menu.table": "Tabela"
+  "menu.table": "Tabela",
+  "menu.today": "Hoje"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "Заголовок 2",
   "menu.heading3": "Заголовок 3",
   "menu.bulletList": "Маркированный список",
+  "menu.taskList": "Список задач",
   "menu.orderedList": "Нумерованный список",
   "menu.quote": "Цитата",
   "menu.callout": "Выноска",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "Изображение",
   "menu.importLocalImages": "Импорт локальных изображений...",
   "menu.importLocalFiles": "Импорт локальных файлов...",
-  "menu.table": "Таблица"
+  "menu.table": "Таблица",
+  "menu.today": "Сегодня"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -934,6 +934,7 @@ export type I18nKey =
   | "menu.heading2"
   | "menu.heading3"
   | "menu.bulletList"
+  | "menu.taskList"
   | "menu.orderedList"
   | "menu.quote"
   | "menu.callout"
@@ -942,7 +943,8 @@ export type I18nKey =
   | "menu.image"
   | "menu.importLocalImages"
   | "menu.importLocalFiles"
-  | "menu.table";
+  | "menu.table"
+  | "menu.today";
 
 export type BaseLocaleMessages = Record<I18nKey, string>;
 export type LocaleMessages = Partial<Record<I18nKey, string>>;

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "标题 2",
   "menu.heading3": "标题 3",
   "menu.bulletList": "无序列表",
+  "menu.taskList": "任务列表",
   "menu.orderedList": "有序列表",
   "menu.quote": "引用",
   "menu.callout": "提示块",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "图片",
   "menu.importLocalImages": "导入本地图片...",
   "menu.importLocalFiles": "导入本地文件...",
-  "menu.table": "表格"
+  "menu.table": "表格",
+  "menu.today": "今天"
 };
 
 export default messages;

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -923,6 +923,7 @@ const messages: LocaleMessages = {
   "menu.heading2": "標題 2",
   "menu.heading3": "標題 3",
   "menu.bulletList": "項目符號清單",
+  "menu.taskList": "任務清單",
   "menu.orderedList": "編號清單",
   "menu.quote": "引用",
   "menu.callout": "提示區塊",
@@ -931,7 +932,8 @@ const messages: LocaleMessages = {
   "menu.image": "圖片",
   "menu.importLocalImages": "匯入本機圖片...",
   "menu.importLocalFiles": "匯入本機檔案...",
-  "menu.table": "表格"
+  "menu.table": "表格",
+  "menu.today": "今天"
 };
 
 export default messages;


### PR DESCRIPTION
## Summary

- add a Task List slash command that toggles selected lines as Markdown task items
- add a Today slash command that inserts the local calendar date as `YYYY-MM-DD`
- localize both command labels across supported languages

## Why

The follow-up in #584 requested dedicated editor commands for creating `- [ ]` items and inserting today’s date.

## Validation

- `pnpm --filter @markra/editor test` — 356 tests passed
- `pnpm --filter @markra/app test` — 1,449 tests passed
- `pnpm --filter @markra/shared test` — 62 tests passed
- `pnpm build` — all workspace builds and desktop vendor chunk verification passed

## Risk

Low. The change is limited to the editor command registry, list-marker conversion, and slash-menu labels. Task-list conversions, read-only behavior, local date insertion, and app integration are covered by tests.

## Related Issues

Refs #584