### PR TITLE
fix(ai): extract inline thinking tags

### DIFF
--- a/packages/ai/src/agent/chat-completion.test.ts
+++ b/packages/ai/src/agent/chat-completion.test.ts
@@ -1115,6 +1115,45 @@ describe("chatCompletion", () => {
     expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
   });
 
+  it("extracts inline thinking tags from the Vercel AI SDK path without a thinking toggle", async () => {
+    const onDelta = vi.fn();
+    const onThinkingDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"MiniMax-M3","choices":[{"index":0,"delta":{"content":"<think>checking "}}]}\n\n');
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"MiniMax-M3","choices":[{"index":0,"delta":{"content":"the note</think>Final "}}]}\n\n');
+      onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"MiniMax-M3","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(
+        provider({
+          apiStyle: "openai-compatible",
+          baseUrl: "https://synthetic.minimax.example/v1"
+        }),
+        "MiniMax-M3",
+        [{ content: "Translate this.", role: "user" }],
+        {
+          fallbackTransport: vi.fn(),
+          onDelta,
+          onThinkingDelta,
+          streamTransport,
+          useVercelAiSdk: true
+        }
+      )
+    ).resolves.toEqual({
+      content: "Final answer",
+      finishReason: "stop"
+    });
+
+    expect(onThinkingDelta).toHaveBeenNthCalledWith(1, "checking ");
+    expect(onThinkingDelta).toHaveBeenNthCalledWith(2, "the note");
+    expect(onDelta).toHaveBeenNthCalledWith(1, "Final ");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+  });
+
   it("replays DeepSeek V4 reasoning content through the Vercel AI SDK after a tool call", async () => {
     const streamTransport = vi.fn(async (_request, onChunk) => {
       onChunk('data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":0,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"Done"},"finish_reason":"stop"}]}\n\n');
@@ -1637,7 +1676,7 @@ describe("chatCompletion", () => {
     expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
   });
 
-  it("extracts inline thinking tags from streamed content when thinking is enabled", async () => {
+  it("extracts inline thinking tags from native streamed content without a thinking toggle", async () => {
     const onDelta = vi.fn();
     const onThinkingDelta = vi.fn();
     const streamTransport = vi.fn(async (_request, onChunk) => {
@@ -1653,8 +1692,7 @@ describe("chatCompletion", () => {
       chatCompletionStream(provider(), "gpt-5.5", [{ content: "Hi", role: "user" }], {
         onDelta,
         onThinkingDelta,
-        streamTransport,
-        thinkingEnabled: true
+        streamTransport
       })
     ).resolves.toEqual({
       content: "Final answer",
@@ -1665,6 +1703,28 @@ describe("chatCompletion", () => {
     expect(onThinkingDelta).toHaveBeenNthCalledWith(2, "the note");
     expect(onDelta).toHaveBeenNthCalledWith(1, "Final ");
     expect(onDelta).toHaveBeenNthCalledWith(2, "answer");
+  });
+
+  it("preserves literal thinking tags after visible content without a thinking toggle", async () => {
+    const onThinkingDelta = vi.fn();
+    const streamTransport = vi.fn(async (_request, onChunk) => {
+      onChunk('data: {"choices":[{"delta":{"content":"Use <think>literal</think> tags."},"finish_reason":"stop"}]}\n\n');
+      onChunk("data: [DONE]\n\n");
+
+      return { status: 200 };
+    });
+
+    await expect(
+      chatCompletionStream(provider(), "gpt-5.5", [{ content: "Show the tag.", role: "user" }], {
+        onThinkingDelta,
+        streamTransport
+      })
+    ).resolves.toEqual({
+      content: "Use <think>literal</think> tags.",
+      finishReason: "stop"
+    });
+
+    expect(onThinkingDelta).not.toHaveBeenCalled();
   });
 
   it("reconstructs Responses API tool calls from function_call_arguments.done events", async () => {

--- a/packages/ai/src/agent/chat-completion.ts
+++ b/packages/ai/src/agent/chat-completion.ts
@@ -102,7 +102,10 @@ export async function chatCompletionStream(
   const toolCalls = new Map<number, { argumentsText: string; id: string; name: string; thoughtSignature?: string }>();
   let reasoningDetails: Record<string, unknown>[] = [];
   const parser = createServerSentEventParser();
-  const inlineThinkingExtractor = thinkingEnabled ? createInlineThinkingExtractor() : null;
+  // Compatible models may emit inline reasoning tags even when their catalog entry does not expose a thinking toggle.
+  const inlineThinkingExtractor = createInlineThinkingExtractor({
+    allowAfterContent: thinkingEnabled === true
+  });
   let streamErrorMessage: string | undefined;
   const emitContentDelta = (delta: string) => {
     content += delta;
@@ -112,11 +115,6 @@ export async function chatCompletionStream(
     onThinkingDelta?.(delta);
   };
   const processContentDelta = (delta: string) => {
-    if (!inlineThinkingExtractor) {
-      emitContentDelta(delta);
-      return;
-    }
-
     const extracted = inlineThinkingExtractor.push(delta);
     if (extracted.thinkingDelta) emitThinkingDelta(extracted.thinkingDelta);
     if (extracted.contentDelta) emitContentDelta(extracted.contentDelta);
@@ -266,17 +264,17 @@ export async function chatCompletionStream(
     })) {
       let sdkOutputEmitted = false;
       try {
-        return await chatCompletionStreamWithVercelAiSdk({
+        const sdkResponse = await chatCompletionStreamWithVercelAiSdk({
           fallbackTransport,
           messages,
           model,
           onDelta: (delta) => {
             sdkOutputEmitted = true;
-            onDelta?.(delta);
+            processContentDelta(delta);
           },
           onThinkingDelta: (delta) => {
             sdkOutputEmitted = true;
-            onThinkingDelta?.(delta);
+            emitThinkingDelta(delta);
           },
           onThinkingMetadata: (metadata) => {
             sdkOutputEmitted = true;
@@ -292,6 +290,12 @@ export async function chatCompletionStream(
           tools,
           webSearchEnabled
         });
+        flushInlineThinking();
+
+        return {
+          ...sdkResponse,
+          content
+        };
       } catch (error) {
         if (sdkOutputEmitted) throw error;
         if (canFallbackToNonStream()) return runNonStreamFallback();
@@ -433,8 +437,13 @@ type InlineThinkingExtraction = {
 
 const inlineThinkingTagNames = new Set(["reasoning", "seed:think", "think", "thinking", "thought"]);
 
-function createInlineThinkingExtractor() {
+function createInlineThinkingExtractor({
+  allowAfterContent
+}: {
+  allowAfterContent: boolean;
+}) {
   let activeThinkingTag: string | null = null;
+  let visibleContentStarted = false;
   let pending = "";
 
   const append = (result: { contentDelta: string; thinkingDelta: string }, text: string) => {
@@ -443,6 +452,7 @@ function createInlineThinkingExtractor() {
       result.thinkingDelta += text;
     } else {
       result.contentDelta += text;
+      if (text.trim()) visibleContentStarted = true;
     }
   };
 
@@ -483,7 +493,7 @@ function createInlineThinkingExtractor() {
       const tag = readTag(rawTag);
       if (tag?.closing && activeThinkingTag && tag.name === activeThinkingTag) {
         activeThinkingTag = null;
-      } else if (tag && !tag.closing && !activeThinkingTag) {
+      } else if (tag && !tag.closing && !activeThinkingTag && (allowAfterContent || !visibleContentStarted)) {
         activeThinkingTag = tag.name;
       } else {
         append(result, buffer.slice(tagStart, tagEnd + 1));


### PR DESCRIPTION
## Summary
- route inline reasoning tags through the thinking stream on both Vercel AI SDK and native transport paths
- extract leading reasoning blocks even when a compatible model does not expose a thinking toggle
- preserve literal `<think>` tags that appear after visible response content

## Validation
- `pnpm --filter @markra/ai test` — 19 test files and 247 tests passed
- `pnpm --filter @markra/ai build` passed
- `pnpm --filter @markra/ai typecheck:test` passed
- `git diff --check v2...HEAD` passed

## Risk
- limited to streamed response normalization; provider request shaping is unchanged
- a live MiniMax endpoint was not invoked; regression coverage uses synthetic OpenAI-compatible SSE chunks matching the reported response shape

Closes #605