### PR TITLE
fix(editor): keep emptied table cells blank

### DIFF
--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -701,6 +701,37 @@ describe("tablePreviewPlugin", () => {
     ).toBe("Updated");
   });
 
+  it("keeps a visual table cell empty after deleting its last character", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| A | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+
+    cell?.focus();
+    cell?.replaceChildren(document.createElement("br"));
+    cell?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      inputType: "deleteContentBackward",
+    }));
+
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain("|  | 1 |");
+    expect(view.state.doc.toString()).not.toContain("<br>");
+    expect(
+      view.dom.querySelector<HTMLTableCellElement>(
+        ".cm-markra-table tbody td",
+      )?.textContent,
+    ).toBe("");
+  });
+
   it("commits a visual table cell after IME composition finishes", async () => {
     const doc = [
       "| Name | Value |",

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -577,6 +577,14 @@ function applyWidthModeToTableControls(
 }
 
 function visualTableCellSource(cell: HTMLTableCellElement) {
+  // Browsers keep a lone <br> as the caret placeholder after the last
+  // character is deleted; visual table cells do not allow real line breaks.
+  if (
+    cell.childNodes.length === 1 &&
+    cell.firstElementChild?.tagName === "BR"
+  ) {
+    return "";
+  }
   return serializeInlineMarkdown(cell);
 }
 


### PR DESCRIPTION
## Summary
- treat a lone browser-inserted `<br>` in an emptied visual table cell as a caret placeholder
- keep the Markdown cell empty after deleting its final character
- add a regression test for Backspace deletion in rendered tables

## Why
Browsers retain a lone `<br>` node when the final character is deleted from a contenteditable cell. The visual table serializer previously wrote that placeholder back to Markdown, causing the cell to display the literal `<br>` text.

## Validation
- `pnpm --filter @markra/editor test` — 358 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed

## Risk
- Low: the special case is limited to a lone `<br>` inside visual table cells, where real line breaks are already disabled.
