### PR TITLE
fix(editor): keep slash menu selection visible

### DIFF
--- a/packages/app/src/components/CodeMirrorEditorFloatingMenus.test.tsx
+++ b/packages/app/src/components/CodeMirrorEditorFloatingMenus.test.tsx
@@ -10,7 +10,7 @@ import {
   MarkraEditorProvider,
   markraEditorReactBridge,
 } from "@markra/editor-react";
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CodeMirrorEditorFloatingMenus,
@@ -100,6 +100,46 @@ describe("CodeMirrorEditorFloatingMenus", () => {
     expect(host.container.querySelector(".markra-slash-menu")).not.toBeNull();
     act(() => heading2?.click());
     expect(view.state.doc.toString()).toBe("## ");
+  });
+
+  it("keeps the slash command list compact and scrollable", async () => {
+    const view = createView();
+    const host = render(
+      <MarkraEditorProvider view={view}>
+        <CodeMirrorEditorFloatingMenus />
+      </MarkraEditorProvider>,
+    );
+
+    await flushMeasurement();
+    expect(host.container.querySelector(".markra-slash-menu")).toHaveStyle({
+      maxHeight: "320px",
+      overflowY: "auto",
+    });
+  });
+
+  it("scrolls the keyboard-selected slash command into view", async () => {
+    const view = createView();
+    const host = render(
+      <MarkraEditorProvider view={view}>
+        <CodeMirrorEditorFloatingMenus />
+      </MarkraEditorProvider>,
+    );
+
+    await flushMeasurement();
+    const options = host.container.querySelectorAll<HTMLButtonElement>(
+      ".markra-slash-menu-option",
+    );
+    const lastOption = options.item(options.length - 1);
+    const scrollIntoView = vi.fn();
+    lastOption.scrollIntoView = scrollIntoView;
+
+    fireEvent.keyDown(view.contentDOM, { key: "ArrowUp" });
+
+    expect(lastOption).toHaveAttribute("aria-selected", "true");
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      inline: "nearest",
+    });
   });
 
   it("dismisses slash commands when the user points outside the menu", async () => {

--- a/packages/app/src/components/CodeMirrorEditorFloatingMenus.tsx
+++ b/packages/app/src/components/CodeMirrorEditorFloatingMenus.tsx
@@ -38,6 +38,7 @@ interface FloatingMenuSize {
 }
 
 const floatingMenuMargin = 12;
+const slashMenuMaximumHeight = 320;
 
 export function fitCodeMirrorFloatingMenu(
   anchor: FloatingMenuPoint,
@@ -61,6 +62,7 @@ function useFloatingMenuStyle(
   open: boolean,
   fallback: FloatingMenuSize,
   revision: string,
+  maximumHeight?: number,
 ) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState(fallback);
@@ -85,10 +87,12 @@ function useFloatingMenuStyle(
     height: window.innerHeight,
     width: window.innerWidth,
   };
+  const availableHeight = viewport.height - floatingMenuMargin * 2;
+  const maxHeight = Math.min(maximumHeight ?? availableHeight, availableHeight);
   const fitted = fitCodeMirrorFloatingMenu(
     anchor,
     {
-      height: Math.min(size.height, viewport.height - floatingMenuMargin * 2),
+      height: Math.min(size.height, maxHeight),
       width: Math.min(size.width, viewport.width - floatingMenuMargin * 2),
     },
     viewport,
@@ -97,7 +101,7 @@ function useFloatingMenuStyle(
     ref,
     style: {
       left: fitted.left,
-      maxHeight: viewport.height - floatingMenuMargin * 2,
+      maxHeight,
       overflowY: "auto",
       top: fitted.top,
     } satisfies CSSProperties,
@@ -112,6 +116,7 @@ export function CodeMirrorEditorFloatingMenus({
   const slashMenu = useMarkraEditorSlashMenu();
   const documentLinks = useMarkraEditorDocumentLinks();
   const view = useMarkraEditorView();
+  const selectedSlashOptionRef = useRef<HTMLButtonElement | null>(null);
   const slashAnchor = useMarkraEditorCaretAnchor(slashMenu.to);
   const documentLinkAnchor = useMarkraEditorCaretAnchor(documentLinks.to);
   const slashPlacement = useFloatingMenuStyle(
@@ -119,6 +124,7 @@ export function CodeMirrorEditorFloatingMenus({
     slashMenu.open,
     { height: 320, width: 240 },
     `${slashMenu.query}:${slashMenu.actions.length}`,
+    slashMenuMaximumHeight,
   );
   const documentLinkPlacement = useFloatingMenuStyle(
     documentLinkAnchor,
@@ -126,6 +132,13 @@ export function CodeMirrorEditorFloatingMenus({
     { height: 280, width: 352 },
     `${documentLinks.query}:${documentLinks.items.length}`,
   );
+
+  useEffect(() => {
+    selectedSlashOptionRef.current?.scrollIntoView?.({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [slashMenu.open, slashMenu.query, slashMenu.selectedIndex]);
 
   useEffect(() => {
     if (!view || (!slashMenu.open && !documentLinks.open)) return;
@@ -166,6 +179,11 @@ export function CodeMirrorEditorFloatingMenus({
                   action.run();
                 }}
                 onMouseDown={keepEditorSelection}
+                ref={
+                  index === slashMenu.selectedIndex
+                    ? selectedSlashOptionRef
+                    : undefined
+                }
                 role="menuitem"
                 type="button"
               >


### PR DESCRIPTION
## Summary
- cap the slash command menu at 320px so longer command lists scroll inside the viewport
- keep the keyboard-selected command visible while navigating with Arrow Up and Arrow Down
- add focused coverage for scrollable sizing and keyboard-followed scrolling

## Why
When the caret was near the bottom of the editor, the slash command menu expanded to its full content height and the last commands were difficult to reach. Keyboard navigation also changed selection without scrolling the active item into view.

## Validation
- `pnpm --filter @markra/app test` — 130 files and 1469 tests passed
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/editor test -- slash-menu.test.ts` — 12 tests passed
- Not run: manual desktop QA; the interaction is covered by component and editor tests

## Risk
- Low; the change is isolated to floating slash-menu sizing and selected-option scrolling.