### PR TITLE
fix(editor): open inserted tables in visual mode

### DIFF
--- a/packages/editor/src/codemirror/controller.ts
+++ b/packages/editor/src/codemirror/controller.ts
@@ -17,6 +17,10 @@ import {
   type SearchRange,
 } from "@markra/shared";
 import { findCodeMirrorMathRanges } from "./math-preview.ts";
+import {
+  focusVisualTableCell,
+  tablePreviewEnabled,
+} from "./table.ts";
 
 export interface ReplaceCodeMirrorMarkdownOptions {
   addToHistory?: boolean;
@@ -579,11 +583,19 @@ export function insertCodeMirrorMarkdownTable(view: EditorView) {
   if (view.state.facet(EditorState.readOnly)) return false;
 
   const { from, to } = view.state.selection.main;
+  const visualPreview = tablePreviewEnabled(view.state);
   view.dispatch({
     changes: { from, insert: defaultMarkdownTable, to },
     scrollIntoView: true,
-    selection: EditorSelection.cursor(from + 2),
+    // A source cursor inside the table reveals the complete Markdown node.
+    // Keep it at the boundary while the visual cell owns the editing focus.
+    selection: EditorSelection.cursor(
+      from + (visualPreview ? defaultMarkdownTable.length : 2),
+    ),
   });
   view.focus();
+  if (visualPreview) {
+    focusVisualTableCell(view, from, -1, 0, true, 0);
+  }
   return true;
 }

--- a/packages/editor/src/codemirror/slash-menu.test.ts
+++ b/packages/editor/src/codemirror/slash-menu.test.ts
@@ -9,6 +9,7 @@ import {
   openMarkraSlashMenu,
   runMarkraSlashMenuAction,
   searchMarkraUi,
+  tablePreviewPlugin,
 } from "./index.ts";
 
 import "./dom.test-support.ts";
@@ -121,6 +122,37 @@ describe("Markra slash menu", () => {
     expect(execution.state.doc.toString()).toBe("## ");
     expect(execution.state.selection.main.head).toBe(3);
     expect(getMarkraSlashMenuState(execution).open).toBe(false);
+  });
+
+  it("opens an inserted table in the visual editor", async () => {
+    const parent = document.createElement("div");
+    document.body.append(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "/table",
+        extensions: [
+          liveMarkdown({
+            plugins: [blocksPlugin(), tablePreviewPlugin()],
+            slashMenu: true,
+          }),
+        ],
+        selection: EditorSelection.cursor("/table".length),
+      }),
+    });
+    views.push(view);
+    view.focus();
+
+    expect(runMarkraSlashMenuAction(view, "block.table")).toBe(true);
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe(
+      ["|  |  |", "| --- | --- |", "|  |  |"].join("\n"),
+    );
+    expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
+    expect(document.activeElement).toBe(
+      view.dom.querySelector(".cm-markra-table thead th:first-child"),
+    );
   });
 
   it.each([

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -1,3 +1,4 @@
+import type { EditorState } from "@codemirror/state";
 import {
   Decoration,
   EditorView,
@@ -17,7 +18,7 @@ import {
   type LinksPluginOptions,
 } from "./links.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
-import { markraRenderer } from "./renderers.ts";
+import { getMarkraRenderers, markraRenderer } from "./renderers.ts";
 
 export type CodeMirrorTableAlignment = "center" | "left" | "right" | null;
 export type CodeMirrorTableWidthMode = "auto" | "even";
@@ -93,8 +94,15 @@ const defaultLabels: TablePreviewLabels = {
 const tableSizePickerColumns = 8;
 const tableSizePickerRows = 10;
 const tableSizePopoverFallbackSize = { height: 248, width: 184 };
+const tablePreviewRendererId = "markra.table-preview";
 const tableWidthModeStoragePrefix = "markra:table-width-mode";
 const tableEditingSessions = new WeakMap<CodeMirrorView, TableEditingSession>();
+
+export function tablePreviewEnabled(state: EditorState) {
+  return getMarkraRenderers(state, "Table").some(
+    (renderer) => renderer.id === tablePreviewRendererId,
+  );
+}
 
 function tableWidthModeStorageKey(documentKey: string | null | undefined) {
   const normalizedKey = documentKey?.trim() || "untitled";
@@ -647,7 +655,7 @@ function activeVisualTableCell(table: HTMLTableElement) {
     : null;
 }
 
-function focusVisualTableCell(
+export function focusVisualTableCell(
   view: CodeMirrorView,
   tableFrom: number,
   rowIndex: number,
@@ -1531,10 +1539,10 @@ export function tablePreviewPlugin(
   const getDocumentKey = options.getDocumentKey ?? (() => undefined);
 
   return defineMarkraPlugin({
-    id: "markra.table-preview",
+    id: tablePreviewRendererId,
     extension: [
       markraRenderer({
-        id: "markra.table-preview",
+        id: tablePreviewRendererId,
         nodeNames: ["Table"],
         render(context) {
           if (context.revealed("node")) return true;


### PR DESCRIPTION
## Summary
- render newly inserted Markdown tables through the visual table preview when it is enabled
- focus the first header cell while preserving the raw-source cursor fallback
- add regression coverage for slash-menu table insertion

## Why
The insertion command placed the CodeMirror cursor inside the new table node, which immediately revealed the complete Markdown source instead of opening the visual table editor.

## Validation
- `pnpm --filter @markra/editor test` — 359 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `git diff --check` — passed
- Not run: packaged desktop UI QA

## Risk
Low. The behavior change is limited to table insertion when the visual table renderer is registered; source-only editors retain the existing caret placement.
