### PR TITLE
fix(editor): handle shifted-digit menu shortcuts

### DIFF
--- a/packages/app/src/hooks/useCodeMirrorEditorController.test.tsx
+++ b/packages/app/src/hooks/useCodeMirrorEditorController.test.tsx
@@ -10,7 +10,7 @@ import {
   liveMarkdown,
 } from "@markra/editor/codemirror";
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useCodeMirrorEditorController } from "./useCodeMirrorEditorController";
 
 const views: EditorView[] = [];
@@ -40,6 +40,7 @@ function createView(
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const view of views.splice(0)) view.destroy();
   document.body.replaceChildren();
 });
@@ -139,6 +140,63 @@ describe("useCodeMirrorEditorController", () => {
       expect(result.current.runEditorShortcut("X", { shiftKey: true })).toBe(true);
     });
     expect(view.state.doc.toString()).toBe("Before text after");
+  });
+
+  it.each([
+    ["bullet list", "*", "Digit8", "- "],
+    ["ordered list", "&", "Digit7", "1. "],
+  ])(
+    "normalizes synthetic shifted-digit shortcuts for %s",
+    (_label, key, code, marker) => {
+      const doc = "Alpha\n";
+      const view = createView(doc, EditorSelection.cursor(doc.length));
+      const { result } = renderHook(() => useCodeMirrorEditorController());
+      act(() => result.current.handleEditorReady(view));
+
+      act(() => {
+        expect(
+          result.current.runEditorShortcut(key, {
+            code,
+            shiftKey: true,
+          }),
+        ).toBe(true);
+      });
+
+      expect(view.state.doc.toString()).toBe(`${doc}${marker}`);
+    },
+  );
+
+  it("normalizes synthetic shifted-digit shortcuts on macOS", () => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+    const parent = document.createElement("div");
+    document.body.append(parent);
+    let shortcutHandled = false;
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        extensions: [
+          keymap.of([{
+            key: "Meta-Shift-8",
+            run: () => {
+              shortcutHandled = true;
+              return true;
+            },
+          }]),
+        ],
+      }),
+    });
+    views.push(view);
+    const { result } = renderHook(() => useCodeMirrorEditorController());
+    act(() => result.current.handleEditorReady(view));
+
+    act(() => {
+      expect(result.current.runEditorShortcut("*", {
+        code: "Digit8",
+        shiftKey: true,
+      })).toBe(true);
+    });
+
+    expect(shortcutHandled).toBe(true);
   });
 
   it("preserves an Alt-only shortcut when dispatching a synthetic editor event", () => {

--- a/packages/app/src/hooks/useCodeMirrorEditorController.ts
+++ b/packages/app/src/hooks/useCodeMirrorEditorController.ts
@@ -36,7 +36,11 @@ import {
   type ReplaceCodeMirrorMarkdownOptions,
 } from "@markra/editor/codemirror";
 import type { AiDiffResult, AiSelectionContext } from "@markra/ai";
-import type { SearchRange } from "@markra/shared";
+import {
+  keyboardShortcutFromKeyboardEvent,
+  parseKeyboardShortcut,
+  type SearchRange,
+} from "@markra/shared";
 import { useCallback, useEffect, useRef } from "react";
 import type {
   SelectionFormattingAction,
@@ -262,19 +266,37 @@ export function useCodeMirrorEditorController() {
         return handled;
       }
 
-      // CodeMirror matches synthetic shifted-letter events against a lowercase
-      // key plus `shiftKey`; native menu payloads may provide the uppercase key.
-      const normalizedKey =
-        modifiers.shiftKey && /^[A-Z]$/u.test(key)
+      const { modKey = true, ...eventModifiers } = modifiers;
+      const ctrlKey = modKey && !mac;
+      const metaKey = modKey && mac;
+      const physicalShortcut = eventModifiers.code
+        ? keyboardShortcutFromKeyboardEvent({
+            altKey: Boolean(eventModifiers.altKey),
+            code: eventModifiers.code,
+            ctrlKey,
+            key,
+            metaKey,
+            shiftKey: Boolean(eventModifiers.shiftKey),
+          })
+        : null;
+      const physicalShortcutKey =
+        parseKeyboardShortcut(physicalShortcut)?.key;
+      // Synthetic events have keyCode 0, so CodeMirror cannot recover the
+      // unshifted digit or punctuation key from values such as "*" or "&".
+      const shiftedLetterKey =
+        eventModifiers.shiftKey && /^[A-Z]$/u.test(key)
           ? key.toLocaleLowerCase()
           : key;
-      const { modKey = true, ...eventModifiers } = modifiers;
+      const normalizedKey =
+        physicalShortcutKey && !/^[A-Z]$/u.test(physicalShortcutKey)
+          ? physicalShortcutKey
+          : shiftedLetterKey;
       const event = new KeyboardEvent("keydown", {
         bubbles: true,
         cancelable: true,
-        ctrlKey: modKey && !mac,
+        ctrlKey,
         key: normalizedKey,
-        metaKey: modKey && mac,
+        metaKey,
         ...eventModifiers,
       });
       const handled = runScopeHandlers(view, event, "editor");


### PR DESCRIPTION
## Summary

- normalize synthetic shifted-digit and punctuation shortcuts from their physical key codes before dispatching them to CodeMirror
- restore Format menu insertion for bullet and ordered lists
- cover Ctrl-based desktop platforms and the macOS Meta shortcut path

## Why

Native menu actions synthesize keyboard events whose shifted keys are `*` or `&`. Those events have `keyCode` 0, so CodeMirror cannot recover the base `8` or `7` key and does not run the list command.

## Validation

- `pnpm --filter @markra/app test -- src/hooks/useNativeBindings.test.tsx src/hooks/useCodeMirrorEditorController.test.tsx` — 49 passed
- `pnpm --filter @markra/shared test -- keyboard-shortcuts.test.ts` — 27 passed
- `pnpm --filter @markra/editor test -- blocks.test.ts markdown-shortcuts.test.ts` — 18 passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed

## Risk

Low. The change is scoped to synthetic shortcut key normalization and retains coverage for shifted-letter and Alt-only shortcuts.

Closes #611