### PR TITLE
fix(web): keep sidebar toggle available when collapsed

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1292,7 +1292,7 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("complementary", { name: "Markdown file tree" })).toHaveAttribute("aria-hidden", "false");
     expect(screen.getByRole("tab", { name: /browser\.md/ })).toBeInTheDocument();
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 196px",
+      gridTemplateColumns: "auto minmax(0,1fr) 196px",
       left: "289px"
     });
     expect(container.querySelector(".windows-app-chrome")).not.toBeInTheDocument();
@@ -1300,7 +1300,7 @@ describe("Markra workspace", () => {
     expect(container.querySelector(".markdown-file-tree-slot")?.parentElement).not.toHaveClass("pt-10");
     expect(container.querySelector(".windows-titlebar-actions")).toBeInTheDocument();
     expect(container.querySelector(".windows-window-controls")).not.toBeInTheDocument();
-    expect(container.querySelector(".titlebar-spacer")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle file list" })).toHaveAttribute("aria-pressed", "true");
     expect(container.querySelector(".document-tabs-drag-spacer")).not.toBeInTheDocument();
     expect(container.querySelector(".native-title-slot")?.getAttribute("style") ?? "").not.toContain("margin-left");
   });

--- a/packages/app/src/components/NativeTitleBar.test.tsx
+++ b/packages/app/src/components/NativeTitleBar.test.tsx
@@ -266,13 +266,14 @@ describe("NativeTitleBar", () => {
     expect(titleSlot?.getAttribute("style") ?? "").not.toContain("transform");
   });
 
-  it("uses the Windows titlebar layout for web chrome when the runtime resolves Windows", () => {
+  it("keeps the workspace sidebar toggle available in Windows web chrome", () => {
+    const toggleMarkdownFiles = vi.fn();
     const { container } = render(
       <NativeTitleBar
         aiAgentOpen={false}
         dirty={false}
         documentName="Draft.md"
-        markdownFilesOpen
+        markdownFilesOpen={false}
         markdownFilesWidth={288}
         nativeWindowChrome={false}
         platform="windows"
@@ -285,21 +286,25 @@ describe("NativeTitleBar", () => {
         onToggleAiAgent={() => {}}
         onOpenMarkdown={() => {}}
         onSaveMarkdown={() => {}}
-        onToggleMarkdownFiles={() => {}}
+        onToggleMarkdownFiles={toggleMarkdownFiles}
         onToggleTheme={() => {}}
       />
     );
 
     expect(container.querySelector(".native-titlebar")).toHaveStyle({
-      gridTemplateColumns: "minmax(0,1fr) 196px",
-      left: "289px"
+      gridTemplateColumns: "auto minmax(0,1fr) 196px"
     });
+    expect((container.querySelector(".native-titlebar") as HTMLElement).style.left).toBe("");
     expect(container.querySelector(".windows-titlebar-corner-mask")).not.toBeInTheDocument();
     expect(container.querySelector(".windows-app-chrome")).not.toBeInTheDocument();
     expect(container.querySelector(".native-titlebar")).toHaveClass("top-0");
     expect(container.querySelector(".windows-titlebar-actions")).toBeInTheDocument();
     expect(container.querySelector(".windows-window-controls")).not.toBeInTheDocument();
-    expect(container.querySelector(".titlebar-spacer")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle file list" })).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle file list" }));
+
+    expect(toggleMarkdownFiles).toHaveBeenCalledTimes(1);
   });
 
   it("keeps macOS titlebar tabs clear of transformed actions before the AI panel", () => {

--- a/packages/app/src/components/WindowsNativeTitleBar.tsx
+++ b/packages/app/src/components/WindowsNativeTitleBar.tsx
@@ -18,7 +18,7 @@ import {
   type ContextMenuEntry
 } from "./ContextMenu";
 import { WindowsWindowControls } from "./WindowsWindowControls";
-import { Tooltip } from "@markra/ui";
+import { IconButton, Tooltip } from "@markra/ui";
 
 type WindowsAppMenuId = "app" | "file" | "edit" | "format" | "view";
 
@@ -168,6 +168,21 @@ export function WindowsNativeTitleBar({
   const stopWindowsChromeToolMouseDown = (event: ReactMouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
   };
+  // The web runtime resolves Windows without rendering the native app chrome,
+  // so the document titlebar must keep the sidebar's only restore control.
+  const browserSidebarToggleVisible = !nativeWindowChrome && markdownFilesButtonVisible;
+  const renderBrowserSidebarToggle = () => browserSidebarToggleVisible ? (
+    <div className="titlebar-spacer relative z-20 flex h-10 items-center pl-2">
+      <IconButton
+        className="opacity-55 hover:opacity-100 focus-visible:opacity-100"
+        label={label("app.toggleMarkdownFiles")}
+        pressed={markdownFilesOpen}
+        onClick={onToggleMarkdownFiles}
+      >
+        <WindowsSidebarIcon aria-hidden="true" size={15} />
+      </IconButton>
+    </div>
+  ) : null;
   const windowsAppMenus: WindowsAppMenuConfig[] = [
     { id: "file", label: label("menu.file") },
     { id: "edit", label: label("menu.edit") },
@@ -411,6 +426,7 @@ export function WindowsNativeTitleBar({
     const windowsTitlebarStyle: CSSProperties = {
       ...(markdownFilesOpen ? { left: windowsTitlebarLeft } : {}),
       gridTemplateColumns: [
+        ...(browserSidebarToggleVisible ? ["auto"] : []),
         "minmax(0,1fr)",
         `${titlebarSideSlotWidth}px`,
         ...(windowsAiReserveWidth > 0 ? [`${windowsAiReserveWidth}px`] : [])
@@ -430,6 +446,7 @@ export function WindowsNativeTitleBar({
           {renderWindowsTitlebarCornerDivider()}
           {renderWindowsTitlebarTopDivider()}
           {renderWindowsTitlebarSidebarDivider()}
+          {renderBrowserSidebarToggle()}
           {renderTitleContent(`native-title-slot min-w-0 h-10 pr-3 ${windowsTitleSlotPaddingClassName}`)}
           <div
             className={`windows-titlebar-actions relative z-10 flex h-10 items-center justify-end gap-0.5 pr-3.5 text-(--text-secondary) opacity-40 ${windowsTitlebarActionsTransitionClassName} hover:opacity-100 focus-within:opacity-100 motion-reduce:transition-none`}
@@ -449,6 +466,7 @@ export function WindowsNativeTitleBar({
   const windowsTitlebarStyle: CSSProperties = {
     ...(markdownFilesOpen ? { left: windowsTitlebarLeft } : {}),
     gridTemplateColumns: [
+      ...(browserSidebarToggleVisible ? ["auto"] : []),
       "minmax(0,1fr)",
       `${titlebarSideSlotWidth}px`,
       ...(windowsAiReserveWidth > 0 ? [`${windowsAiReserveWidth}px`] : [])
@@ -470,6 +488,7 @@ export function WindowsNativeTitleBar({
         {renderWindowsTitlebarCornerDivider()}
         {renderWindowsTitlebarTopDivider()}
         {renderWindowsTitlebarSidebarDivider()}
+        {renderBrowserSidebarToggle()}
         {showWindowsDocumentTitle ? (
           <h1
             className={`native-title pointer-events-none m-0 flex h-10 min-w-0 items-center justify-center gap-1.5 text-[14px] leading-none font-[650] tracking-normal text-(--text-primary) motion-reduce:transition-none ${


### PR DESCRIPTION
## Summary
- keep the workspace sidebar toggle in the browser titlebar when native Windows chrome is disabled
- reserve titlebar space for the control and cover the collapsed state with an interaction test

## Why
The web runtime resolves the Windows layout without rendering the native app chrome. The sidebar toggle only existed in that omitted chrome, so collapsing the sidebar left no control to reopen it.

## Validation
- `pnpm --filter @markra/app test -- NativeTitleBar.test.tsx` — 44 tests passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/web build` — passed
- browser QA — collapsed and reopened the sidebar successfully; no console errors

## Risk
Low. The added control is limited to non-native Windows chrome, so the desktop Windows titlebar remains unchanged.