### PR TITLE
fix(editor): anchor input in empty table cells

### DIFF
--- a/packages/editor/src/codemirror/slash-menu.test.ts
+++ b/packages/editor/src/codemirror/slash-menu.test.ts
@@ -124,7 +124,7 @@ describe("Markra slash menu", () => {
     expect(getMarkraSlashMenuState(execution).open).toBe(false);
   });
 
-  it("opens an inserted table in the visual editor", async () => {
+  it("keeps an inserted table visual while editing its first cell", async () => {
     const parent = document.createElement("div");
     document.body.append(parent);
     const view = new EditorView({
@@ -148,6 +148,22 @@ describe("Markra slash menu", () => {
 
     expect(view.state.doc.toString()).toBe(
       ["|  |  |", "| --- | --- |", "|  |  |"].join("\n"),
+    );
+    expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
+    const firstCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table thead th:first-child",
+    );
+    expect(document.activeElement).toBe(firstCell);
+    expect(
+      firstCell?.contains(document.getSelection()?.anchorNode ?? null),
+    ).toBe(true);
+
+    if (firstCell) firstCell.textContent = "Name";
+    firstCell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe(
+      ["| Name |  |", "| --- | --- |", "|  |  |"].join("\n"),
     );
     expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
     expect(document.activeElement).toBe(

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -809,6 +809,128 @@ describe("tablePreviewPlugin", () => {
     expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
   });
 
+  it.each([
+    "deleteContentBackward",
+    "deleteContentForward",
+  ])("reanchors an empty cell after a no-op %s", async (inputType) => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "|  | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const cell = table?.querySelector<HTMLTableCellElement>("tbody td");
+    const row = cell?.parentElement;
+
+    cell?.focus();
+    cell?.replaceChildren(document.createElement("br"));
+    table?.focus();
+    if (row) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(row, 0);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    table?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      inputType,
+    }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe(doc);
+    expect(document.activeElement).toBe(cell);
+    expect(cell?.contains(document.getSelection()?.anchorNode ?? null)).toBe(true);
+    expect(cell?.querySelector("br")).toBeNull();
+  });
+
+  it("repairs an escaped selection before insertion mutates the table DOM", () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "|  | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const cell = table?.querySelector<HTMLTableCellElement>("tbody td");
+    const row = cell?.parentElement;
+
+    cell?.focus();
+    cell?.replaceChildren(document.createElement("br"));
+    table?.focus();
+    if (row) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(row, 0);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    const event = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      data: "Again",
+      inputType: "insertText",
+    });
+    table?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(cell);
+    expect(cell?.contains(document.getSelection()?.anchorNode ?? null)).toBe(true);
+    expect(cell?.querySelector("br")).toBeNull();
+  });
+
+  it("repairs an escaped selection before IME composition", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "|  | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const cell = table?.querySelector<HTMLTableCellElement>("tbody td");
+    const row = cell?.parentElement;
+
+    cell?.focus();
+    table?.focus();
+    if (row) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(row, 0);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    table?.dispatchEvent(new CompositionEvent("compositionstart", {
+      bubbles: true,
+    }));
+
+    expect(document.activeElement).toBe(cell);
+    expect(cell?.contains(document.getSelection()?.anchorNode ?? null)).toBe(true);
+    if (cell) cell.textContent = "再次";
+    table?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      isComposing: true,
+    }));
+    expect(view.state.doc.toString()).toBe(doc);
+
+    table?.dispatchEvent(new CompositionEvent("compositionend", {
+      bubbles: true,
+    }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain("| 再次 | 1 |");
+    expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
+  });
+
   it("commits a visual table cell after IME composition finishes", async () => {
     const doc = [
       "| Name | Value |",

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -886,6 +886,79 @@ describe("tablePreviewPlugin", () => {
     expect(cell?.querySelector("br")).toBeNull();
   });
 
+  it.each([
+    {
+      expectedRow: "| Alpha | Forward |",
+      name: "Tab",
+      sourceSelector: "tbody td:first-child",
+      targetSelector: "tbody td:nth-child(2)",
+      targetValue: "Forward",
+      shiftKey: false,
+    },
+    {
+      expectedRow: "| Backward | 1 |",
+      name: "Shift+Tab",
+      sourceSelector: "tbody td:nth-child(2)",
+      targetSelector: "tbody td:first-child",
+      targetValue: "Backward",
+      shiftKey: true,
+    },
+  ])("moves the caret before typing in the cell reached by $name", async ({
+    expectedRow,
+    sourceSelector,
+    targetSelector,
+    targetValue,
+    shiftKey,
+  }) => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const sourceCell =
+      table?.querySelector<HTMLTableCellElement>(sourceSelector);
+    const targetCell =
+      table?.querySelector<HTMLTableCellElement>(targetSelector);
+    const sourceText = sourceCell?.firstChild;
+
+    sourceCell?.focus();
+    if (sourceText) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(sourceText, sourceText.textContent?.length ?? 0);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey,
+    });
+    sourceCell?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(targetCell);
+    expect(
+      targetCell?.contains(document.getSelection()?.anchorNode ?? null),
+    ).toBe(true);
+    if (targetCell) targetCell.textContent = targetValue;
+    targetCell?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      data: targetValue,
+      inputType: "insertText",
+    }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain(expectedRow);
+    expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
+  });
+
   it("repairs an escaped selection before IME composition", async () => {
     const doc = [
       "| Name | Value |",

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -766,6 +766,49 @@ describe("tablePreviewPlugin", () => {
     ).toBe("");
   });
 
+  it("recovers when WebKit moves an emptied cell selection to the table host", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| A | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const cell = table?.querySelector<HTMLTableCellElement>("tbody td");
+    const row = cell?.parentElement;
+
+    cell?.focus();
+    cell?.replaceChildren(document.createElement("br"));
+    table?.focus();
+    if (row) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(row, 0);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    table?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      inputType: "deleteContentBackward",
+    }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain("|  | 1 |");
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+    expect(document.activeElement).toBe(updatedCell);
+    if (updatedCell) updatedCell.textContent = "Again";
+    updatedCell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain("| Again | 1 |");
+    expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
+  });
+
   it("commits a visual table cell after IME composition finishes", async () => {
     const doc = [
       "| Name | Value |",

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -2,7 +2,10 @@ import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { liveMarkdown } from "./index.ts";
-import { tablePreviewPlugin } from "./table.ts";
+import {
+  focusVisualTableCell,
+  tablePreviewPlugin,
+} from "./table.ts";
 import "./dom.test-support.ts";
 
 const views: EditorView[] = [];
@@ -89,6 +92,37 @@ describe("tablePreviewPlugin", () => {
     expect(table?.getAttribute("contenteditable")).toBe("true");
     expect(cells).not.toHaveLength(0);
     expect(cells.every((cell) => !cell.hasAttribute("contenteditable"))).toBe(true);
+  });
+
+  it("places the native caret inside an empty visual table cell", async () => {
+    const doc = ["|  |  |", "| --- | --- |", "|  |  |"].join("\n");
+    const view = createView(doc);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table thead th:first-child",
+    );
+    const outside = document.createTextNode("Outside");
+    document.body.append(outside);
+    const nativeFocus = cell?.focus.bind(cell);
+
+    if (cell && nativeFocus) {
+      vi.spyOn(cell, "focus").mockImplementation(() => {
+        nativeFocus();
+        const selection = document.getSelection();
+        const range = document.createRange();
+        range.setStart(outside, 0);
+        range.collapse(true);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      });
+    }
+
+    focusVisualTableCell(view, 0, -1, 0, true, 0);
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(cell);
+    expect(document.getSelection()?.anchorNode?.nodeType).toBe(Node.TEXT_NODE);
+    expect(document.getSelection()?.anchorNode?.parentNode).toBe(cell);
+    expect(document.getSelection()?.anchorOffset).toBe(0);
   });
 
   it("renders inline Markdown inside visual table cells", () => {

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -584,15 +584,17 @@ function applyWidthModeToTableControls(
   }
 }
 
+function visualTableCellHasPlaceholderBreak(cell: HTMLTableCellElement) {
+  return (
+    cell.childNodes.length === 1 &&
+    cell.firstElementChild?.tagName === "BR"
+  );
+}
+
 function visualTableCellSource(cell: HTMLTableCellElement) {
   // Browsers keep a lone <br> as the caret placeholder after the last
   // character is deleted; visual table cells do not allow real line breaks.
-  if (
-    cell.childNodes.length === 1 &&
-    cell.firstElementChild?.tagName === "BR"
-  ) {
-    return "";
-  }
+  if (visualTableCellHasPlaceholderBreak(cell)) return "";
   return serializeInlineMarkdown(cell);
 }
 
@@ -676,6 +678,57 @@ function activeVisualTableCell(
   );
 }
 
+function placeVisualTableCellCaret(
+  cell: HTMLTableCellElement,
+  caretOffset: number,
+) {
+  cell.focus();
+  const walker = cell.ownerDocument.createTreeWalker(
+    cell,
+    NodeFilter.SHOW_TEXT,
+  );
+  let textNode = walker.nextNode();
+  let remaining = caretOffset;
+  while (
+    textNode &&
+    remaining > (textNode.textContent?.length ?? 0)
+  ) {
+    remaining -= textNode.textContent?.length ?? 0;
+    textNode = walker.nextNode();
+  }
+  // WebKit may place input outside an empty table cell when the range is
+  // anchored on the <th>/<td> itself, so always provide a text caret host.
+  if (!textNode) {
+    textNode = cell.ownerDocument.createTextNode("");
+    if (visualTableCellHasPlaceholderBreak(cell)) {
+      cell.replaceChildren(textNode);
+    } else {
+      cell.append(textNode);
+    }
+  }
+  const selection = cell.ownerDocument.getSelection();
+  if (!selection) return;
+  const range = cell.ownerDocument.createRange();
+  range.setStart(
+    textNode,
+    Math.min(remaining, textNode.textContent?.length ?? 0),
+  );
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function repairVisualTableCellSelection(
+  view: CodeMirrorView,
+  table: HTMLTableElement,
+) {
+  const cell = activeVisualTableCell(view, table);
+  const selectionNode = table.ownerDocument.getSelection()?.anchorNode;
+  if (cell && (!selectionNode || !cell.contains(selectionNode))) {
+    placeVisualTableCellCaret(cell, tableCellCaretOffset(cell));
+  }
+}
+
 export function focusVisualTableCell(
   view: CodeMirrorView,
   tableFrom: number,
@@ -693,36 +746,7 @@ export function focusVisualTableCell(
     );
     if (!cell) return;
 
-    cell.focus();
-    const walker = cell.ownerDocument.createTreeWalker(
-      cell,
-      NodeFilter.SHOW_TEXT,
-    );
-    let textNode = walker.nextNode();
-    let remaining = caretOffset;
-    while (
-      textNode &&
-      remaining > (textNode.textContent?.length ?? 0)
-    ) {
-      remaining -= textNode.textContent?.length ?? 0;
-      textNode = walker.nextNode();
-    }
-    // WebKit may place input outside an empty table cell when the range is
-    // anchored on the <th>/<td> itself, so always provide a text caret host.
-    if (!textNode) {
-      textNode = cell.ownerDocument.createTextNode("");
-      cell.append(textNode);
-    }
-    const selection = cell.ownerDocument.getSelection();
-    if (!selection) return;
-    const range = cell.ownerDocument.createRange();
-    range.setStart(
-      textNode,
-      Math.min(remaining, textNode.textContent?.length ?? 0),
-    );
-    range.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(range);
+    placeVisualTableCellCaret(cell, caretOffset);
   });
 }
 
@@ -747,7 +771,8 @@ function syncVisualTableCell(
     header,
     visualTableCellSource(cell),
   );
-  if (changed) {
+  const selectionNode = cell.ownerDocument.getSelection()?.anchorNode;
+  if (changed || !selectionNode || !cell.contains(selectionNode)) {
     focusVisualTableCell(
       view,
       preview.from,
@@ -1205,8 +1230,13 @@ class TableWidget extends WidgetType {
     table.classList.toggle("markra-table-width-auto", widthMode === "auto");
     // Browsers target editing events at the shared contenteditable table host,
     // so cell-level listeners miss real input even though the cell DOM changes.
+    table.addEventListener("beforeinput", (event) => {
+      if (event instanceof InputEvent && event.isComposing) return;
+      repairVisualTableCellSelection(view, table);
+    });
     table.addEventListener("compositionstart", (event) => {
       event.stopPropagation();
+      repairVisualTableCellSelection(view, table);
       composing = true;
     });
     table.addEventListener("compositionend", (event) => {

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -686,7 +686,12 @@ export function focusVisualTableCell(
       remaining -= textNode.textContent?.length ?? 0;
       textNode = walker.nextNode();
     }
-    if (!textNode) return;
+    // WebKit may place input outside an empty table cell when the range is
+    // anchored on the <th>/<td> itself, so always provide a text caret host.
+    if (!textNode) {
+      textNode = cell.ownerDocument.createTextNode("");
+      cell.append(textNode);
+    }
     const selection = cell.ownerDocument.getSelection();
     if (!selection) return;
     const range = cell.ownerDocument.createRange();

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -641,7 +641,10 @@ function tableCellCaretOffset(cell: HTMLTableCellElement) {
   return range.toString().length;
 }
 
-function activeVisualTableCell(table: HTMLTableElement) {
+function activeVisualTableCell(
+  view: CodeMirrorView,
+  table: HTMLTableElement,
+) {
   const selectionNode = table.ownerDocument.getSelection()?.anchorNode;
   const selectionElement =
     selectionNode instanceof Element ? selectionNode : selectionNode?.parentElement;
@@ -649,10 +652,28 @@ function activeVisualTableCell(table: HTMLTableElement) {
   if (selectedCell && table.contains(selectedCell)) return selectedCell;
 
   const activeElement = table.ownerDocument.activeElement;
-  return activeElement instanceof HTMLTableCellElement &&
+  if (
+    activeElement instanceof HTMLTableCellElement &&
     table.contains(activeElement)
-    ? activeElement
-    : null;
+  ) {
+    return activeElement;
+  }
+
+  // WebKit can lift the selection to the row/table after deleting the final
+  // character. The editing session still identifies the cell that must sync.
+  const session = tableEditingSessions.get(view);
+  const wrapper = table.closest<HTMLElement>(".cm-markra-table-wrap");
+  if (
+    !session ||
+    wrapper?.dataset.tableFrom !== String(session.tableFrom)
+  ) {
+    return null;
+  }
+  return table.querySelector<HTMLTableCellElement>(
+    `[data-table-row="${session.row}"]` +
+      `[data-table-column="${session.column}"]` +
+      `[data-table-header="${String(session.header)}"]`,
+  );
 }
 
 export function focusVisualTableCell(
@@ -1191,14 +1212,14 @@ class TableWidget extends WidgetType {
     table.addEventListener("compositionend", (event) => {
       event.stopPropagation();
       composing = false;
-      const cell = activeVisualTableCell(table);
+      const cell = activeVisualTableCell(view, table);
       if (cell) syncVisualTableCell(view, this.preview, cell);
     });
     table.addEventListener("input", (event) => {
       event.stopPropagation();
       // Replacing the widget mid-composition cancels native CJK input, so commit only after compositionend.
       if (composing || (event instanceof InputEvent && event.isComposing)) return;
-      const cell = activeVisualTableCell(table);
+      const cell = activeVisualTableCell(view, table);
       if (cell) syncVisualTableCell(view, this.preview, cell);
     });
 

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -647,19 +647,21 @@ function activeVisualTableCell(
   view: CodeMirrorView,
   table: HTMLTableElement,
 ) {
-  const selectionNode = table.ownerDocument.getSelection()?.anchorNode;
-  const selectionElement =
-    selectionNode instanceof Element ? selectionNode : selectionNode?.parentElement;
-  const selectedCell = selectionElement?.closest<HTMLTableCellElement>("th, td");
-  if (selectedCell && table.contains(selectedCell)) return selectedCell;
-
   const activeElement = table.ownerDocument.activeElement;
   if (
     activeElement instanceof HTMLTableCellElement &&
     table.contains(activeElement)
   ) {
+    // Safari can leave its native range in the prior cell after Tab moves
+    // focus, so the focused cell is the authoritative input destination.
     return activeElement;
   }
+
+  const selectionNode = table.ownerDocument.getSelection()?.anchorNode;
+  const selectionElement =
+    selectionNode instanceof Element ? selectionNode : selectionNode?.parentElement;
+  const selectedCell = selectionElement?.closest<HTMLTableCellElement>("th, td");
+  if (selectedCell && table.contains(selectedCell)) return selectedCell;
 
   // WebKit can lift the selection to the row/table after deleting the final
   // character. The editing session still identifies the cell that must sync.
@@ -727,6 +729,24 @@ function repairVisualTableCellSelection(
   if (cell && (!selectionNode || !cell.contains(selectionNode))) {
     placeVisualTableCellCaret(cell, tableCellCaretOffset(cell));
   }
+}
+
+function moveVisualTableCellFocus(
+  view: CodeMirrorView,
+  table: HTMLTableElement,
+  backward: boolean,
+) {
+  const cell = activeVisualTableCell(view, table);
+  if (!cell) return false;
+
+  const cells = Array.from(
+    table.querySelectorAll<HTMLTableCellElement>("th, td"),
+  );
+  const target = cells[cells.indexOf(cell) + (backward ? -1 : 1)];
+  if (!target) return false;
+
+  placeVisualTableCellCaret(target, tableCellCaretOffset(target));
+  return true;
 }
 
 export function focusVisualTableCell(
@@ -1228,6 +1248,21 @@ class TableWidget extends WidgetType {
     table.dataset.tableAlignment = tableAlignment;
     table.dataset.widthMode = widthMode;
     table.classList.toggle("markra-table-width-auto", widthMode === "auto");
+    table.addEventListener("keydown", (event) => {
+      if (
+        event.key !== "Tab" ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        !moveVisualTableCellFocus(view, table, event.shiftKey)
+      ) {
+        return;
+      }
+      // WebKit preserves the old editing position during native Tab focus
+      // navigation, so move the caret before its next insertion begins.
+      event.preventDefault();
+      event.stopPropagation();
+    });
     // Browsers target editing events at the shared contenteditable table host,
     // so cell-level listeners miss real input even though the cell DOM changes.
     table.addEventListener("beforeinput", (event) => {


### PR DESCRIPTION
## Summary
- anchor empty visual table cells to real text caret nodes and remove lone browser `<br>` placeholders
- recover the active cell from its editing session when WebKit lifts the selection to a row or table host
- repair escaped selections during `beforeinput` and before IME composition mutates the table DOM
- take ownership of Tab and Shift+Tab navigation before WebKit can insert at the stale cell position
- keep slash-inserted cells editable through initial input, deletion to empty, keyboard cell navigation, and subsequent input
- cover backward/forward deletion, escaped selection, IME recovery, placeholder cleanup, and both Tab directions with regression tests

## Why
WebKit has several related visual-table behaviors: it can insert text outside an empty cell when the range is anchored directly on `<th>` or `<td>`, retain a lone `<br>` after deletion, lift the selection to `<tr>` or `<table>` after deleting the final character, and preserve the prior editing position after Tab moves focus to another cell. Stable text-node caret hosts, editing-session recovery, pre-mutation selection repair, and keydown-time Tab navigation keep browser input inside the intended visual cell.

## Validation
- `pnpm --filter @markra/editor test` passed: 33 files, 367 tests
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- Safari/WebKit manual QA passed: insert with `/table`, type `First`, press Tab once, type `Second`, and confirm the values remain in separate cells
- Safari/WebKit reverse-navigation QA passed: press Shift+Tab from the second cell, type `Back`, and confirm the first cell becomes `FirstBack` while the second remains `Second`
- Synthetic IME composition coverage passed for an escaped empty-cell selection and Chinese replacement text
- Note: separate full-suite runs encountered unrelated transient `block-drag` and `image-preview` cases; each passed immediately in isolation, and subsequent full-suite runs passed

## Risk
- Low: the behavior change is limited to caret placement, placeholder cleanup, active-cell recovery, and Tab navigation inside visual table editing sessions

## Out of scope
- cross-cell destructive editing semantics
- multiline paste normalization