### PR TITLE
feat(editor): add zoomable image viewer

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -3650,11 +3650,46 @@
     box-shadow: none;
   }
 
-  .markdown-paper .markra-image-node > img {
+  .markdown-paper .markra-image-frame {
+    @apply relative inline-block max-w-full align-top;
+    line-height: 0;
+  }
+
+  .markdown-paper .markra-image-frame > img {
     @apply my-0 border-0;
     display: block;
     -webkit-user-drag: none;
     user-select: none;
+  }
+
+  .markdown-paper .markra-image-viewer-button {
+    @apply absolute top-2 right-2 z-[3] grid size-7 cursor-pointer place-items-center rounded-md border border-(--border-default) p-0 outline-none transition-[opacity,transform,color,background-color,border-color,box-shadow] duration-150 ease-out;
+    background: var(--editor-code-control-bg);
+    border-color: var(--editor-border);
+    color: var(--editor-text-secondary);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-0.125rem);
+  }
+
+  .markdown-paper .markra-image-frame:hover .markra-image-viewer-button,
+  .markdown-paper .markra-image-viewer-button:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .markdown-paper .markra-image-viewer-button:hover {
+    background: var(--editor-bg-secondary);
+    border-color: var(--editor-border-strong);
+    color: var(--editor-text-heading);
+  }
+
+  .markdown-paper .markra-image-viewer-button:focus-visible {
+    background: var(--editor-bg-secondary);
+    border-color: var(--editor-border-strong);
+    color: var(--editor-text-heading);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
   }
 
   .markdown-paper .markra-image-upload-placeholder {
@@ -4234,12 +4269,12 @@
     text-align: left;
   }
 
-  .markra-mermaid-zoom-dialog {
+  .markra-media-viewer-dialog {
     @apply fixed inset-0 z-50 grid place-items-center p-4;
     background: color-mix(in srgb, oklch(23% 0.02 260) 72%, transparent);
   }
 
-  .markra-mermaid-zoom-panel {
+  .markra-media-viewer-panel {
     @apply relative flex max-h-[88vh] w-full flex-col overflow-hidden rounded-lg border border-(--border-default) bg-(--bg-primary) shadow-2xl;
     background: var(--editor-paper-bg, var(--bg-primary));
     border-color: color-mix(in srgb, var(--editor-border-strong, var(--border-strong)) 82%, transparent);
@@ -4249,11 +4284,11 @@
     min-height: min(28rem, 88vh);
   }
 
-  .markra-mermaid-zoom-dialog[data-fullscreen="true"] {
+  .markra-media-viewer-dialog[data-fullscreen="true"] {
     padding: 0;
   }
 
-  .markra-mermaid-zoom-dialog[data-fullscreen="true"] .markra-mermaid-zoom-panel {
+  .markra-media-viewer-dialog[data-fullscreen="true"] .markra-media-viewer-panel {
     width: 100%;
     height: 100%;
     max-width: none;
@@ -4264,73 +4299,86 @@
     box-shadow: none;
   }
 
-  .markra-mermaid-zoom-toolbar {
+  .markra-media-viewer-toolbar {
     @apply relative z-[2] flex items-center justify-end gap-1 border-b border-(--border-default) px-3 py-2;
     background: color-mix(in srgb, var(--editor-paper-bg, var(--bg-primary)) 94%, transparent);
     border-color: color-mix(in srgb, var(--editor-border, var(--border-default)) 82%, transparent);
   }
 
-  .markra-mermaid-zoom-value {
+  .markra-media-viewer-zoom-value {
     @apply min-w-12 px-1 text-center text-[12px] leading-5 font-[650] tabular-nums text-(--text-secondary);
     color: var(--editor-text-secondary, var(--text-secondary));
   }
 
-  .markra-mermaid-zoom-control-button,
-  .markra-mermaid-zoom-close-button {
+  .markra-media-viewer-control-button,
+  .markra-media-viewer-close-button {
     @apply grid size-8 cursor-pointer place-items-center rounded-md border border-(--border-default) bg-(--bg-primary) p-0 text-(--text-secondary) outline-none transition-[color,background-color,border-color,box-shadow] duration-150 ease-out;
     background: var(--editor-code-control-bg, var(--bg-primary));
     border-color: var(--editor-border, var(--border-default));
     color: var(--editor-text-secondary, var(--text-secondary));
   }
 
-  .markra-mermaid-zoom-control-button:hover,
-  .markra-mermaid-zoom-close-button:hover {
+  .markra-media-viewer-control-button:hover,
+  .markra-media-viewer-close-button:hover {
     background: var(--editor-bg-secondary, var(--bg-hover));
     border-color: var(--editor-border-strong, var(--border-strong));
     color: var(--editor-text-heading, var(--text-heading));
   }
 
-  .markra-mermaid-zoom-control-button:focus-visible,
-  .markra-mermaid-zoom-close-button:focus-visible {
+  .markra-media-viewer-control-button:focus-visible,
+  .markra-media-viewer-close-button:focus-visible {
     background: var(--editor-bg-secondary, var(--bg-hover));
     border-color: var(--editor-border-strong, var(--border-strong));
     color: var(--editor-text-heading, var(--text-heading));
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
   }
 
-  .markra-mermaid-zoom-content {
+  .markra-media-viewer-content {
     @apply relative min-h-0 flex-1 overflow-hidden px-8 py-8 outline-none;
     cursor: grab;
     touch-action: none;
   }
 
-  .markra-mermaid-zoom-content:focus-visible {
+  .markra-media-viewer-content:focus-visible {
     box-shadow: inset 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
   }
 
-  .markra-mermaid-zoom-content[data-dragging="true"] {
+  .markra-media-viewer-content[data-dragging="true"] {
     cursor: grabbing;
   }
 
-  .markra-mermaid-zoom-canvas {
+  .markra-media-viewer-canvas {
     @apply flex min-h-full items-center justify-center;
     transform-origin: center center;
     transition: transform 90ms ease-out;
     will-change: transform;
   }
 
-  .markra-mermaid-zoom-content[data-dragging="true"] .markra-mermaid-zoom-canvas {
+  .markra-media-viewer-content[data-dragging="true"] .markra-media-viewer-canvas {
     transition: none;
   }
 
-  .markra-mermaid-zoom-svg {
+  .markra-media-viewer-media {
     display: block;
     flex: 0 0 auto;
-    width: min(100%, 72rem);
-    min-width: min(48rem, calc(100vw - 5rem));
     max-width: none;
     height: auto;
     margin: 0 auto;
+  }
+
+  .markra-media-viewer-image,
+  .markdown-paper img.markra-media-viewer-image {
+    width: auto;
+    max-width: min(100%, 72rem);
+    max-height: calc(88vh - 7rem);
+    margin: 0 auto;
+    border: 0;
+    border-radius: 0;
+    object-fit: contain;
+  }
+
+  .markra-media-viewer-dialog[data-fullscreen="true"] .markra-media-viewer-image {
+    max-height: calc(100vh - 7rem);
   }
 
   .markdown-paper .markra-code-block code {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -1048,7 +1048,7 @@ describe("editor stylesheet", () => {
       imageNodeStart,
     );
     const imageNodeImageStart = styles.indexOf(
-      ".markdown-paper .markra-image-node > img {",
+      ".markdown-paper .markra-image-frame > img {",
       imageNodeStart,
     );
     const imageNodeImageStyles = styles.slice(
@@ -1062,6 +1062,7 @@ describe("editor stylesheet", () => {
     expect(standaloneNodeStyles).toContain("display: inline-block");
     expect(standaloneNodeStyles).toContain("vertical-align: top");
     expect(standaloneNodeStyles).toContain("width: 100%");
+    expect(imageNodeImageStart).toBeGreaterThan(imageNodeStart);
     expect(imageNodeImageStyles).toContain("@apply my-0");
     expect(imageNodeImageStyles).toContain("display: block");
   });
@@ -1210,7 +1211,7 @@ describe("editor stylesheet", () => {
     const mermaidZoomHoverStart = styles.indexOf(".markdown-paper .markra-mermaid-zoom-button:hover");
     const mermaidZoomHoverEnd = styles.indexOf("\n  }\n", mermaidZoomHoverStart) + "\n  }\n".length;
     const mermaidZoomHoverStyles = styles.slice(mermaidZoomHoverStart, mermaidZoomHoverEnd);
-    const mermaidZoomCloseHoverStart = styles.indexOf(".markra-mermaid-zoom-close-button:hover");
+    const mermaidZoomCloseHoverStart = styles.indexOf(".markra-media-viewer-close-button:hover");
     const mermaidZoomCloseHoverEnd =
       styles.indexOf("\n  }\n", mermaidZoomCloseHoverStart) + "\n  }\n".length;
     const mermaidZoomCloseHoverStyles = styles.slice(mermaidZoomCloseHoverStart, mermaidZoomCloseHoverEnd);
@@ -1235,12 +1236,12 @@ describe("editor stylesheet", () => {
     expect(mermaidZoomHoverStyles).not.toContain("box-shadow");
     expect(mermaidZoomCloseHoverStyles).not.toContain(":focus-visible");
     expect(mermaidZoomCloseHoverStyles).not.toContain("box-shadow");
-    expect(styles).toContain(".markra-mermaid-zoom-dialog");
-    expect(styles).toContain(".markra-mermaid-zoom-dialog[data-fullscreen=\"true\"]");
-    expect(styles).toContain(".markra-mermaid-zoom-toolbar");
-    expect(styles).toContain(".markra-mermaid-zoom-control-button");
-    expect(styles).toContain(".markra-mermaid-zoom-content[data-dragging=\"true\"]");
-    expect(styles).toContain(".markra-mermaid-zoom-canvas");
+    expect(styles).toContain(".markra-media-viewer-dialog");
+    expect(styles).toContain(".markra-media-viewer-dialog[data-fullscreen=\"true\"]");
+    expect(styles).toContain(".markra-media-viewer-toolbar");
+    expect(styles).toContain(".markra-media-viewer-control-button");
+    expect(styles).toContain(".markra-media-viewer-content[data-dragging=\"true\"]");
+    expect(styles).toContain(".markra-media-viewer-canvas");
     expect(styles).toContain(
       ".markdown-paper .markra-code-block[data-mermaid-mode=\"preview\"] .markra-mermaid-render"
     );

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -449,23 +449,23 @@ describe("codeBlockPreviewPlugin", () => {
 
     zoomButton?.click();
     const dialog = document.querySelector<HTMLElement>(
-      ".markra-mermaid-zoom-dialog",
+      ".markra-media-viewer-dialog",
     );
     expect(dialog?.getAttribute("role")).toBe("dialog");
     expect(dialog?.querySelector("svg")).not.toBeNull();
     for (const className of [
-      ".markra-mermaid-zoom-out-button",
-      ".markra-mermaid-zoom-in-button",
-      ".markra-mermaid-zoom-reset-button",
-      ".markra-mermaid-zoom-fullscreen-button",
-      ".markra-mermaid-zoom-close-button",
+      ".markra-media-viewer-zoom-out-button",
+      ".markra-media-viewer-zoom-in-button",
+      ".markra-media-viewer-reset-button",
+      ".markra-media-viewer-fullscreen-button",
+      ".markra-media-viewer-close-button",
     ]) {
       const button = dialog?.querySelector<HTMLButtonElement>(className);
       expect(button?.querySelector("svg")).not.toBeNull();
       expect(button?.textContent).toBe("");
     }
     const fullscreenIcon = dialog?.querySelector(
-      ".markra-mermaid-zoom-fullscreen-icon",
+      ".markra-media-viewer-fullscreen-icon",
     );
     expect(iconPaths(fullscreenIcon)).toEqual([
       "M8 3H5a2 2 0 0 0-2 2v3",
@@ -473,16 +473,16 @@ describe("codeBlockPreviewPlugin", () => {
       "M3 16v3a2 2 0 0 0 2 2h3",
       "M16 21h3a2 2 0 0 0 2-2v-3",
     ]);
-    dialog?.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-in-button")?.click();
+    dialog?.querySelector<HTMLButtonElement>(".markra-media-viewer-zoom-in-button")?.click();
     expect(
-      dialog?.querySelector<HTMLElement>(".markra-mermaid-zoom-canvas")?.style.transform,
+      dialog?.querySelector<HTMLElement>(".markra-media-viewer-canvas")?.style.transform,
     ).toContain("scale(1.25)");
 
     const content = dialog?.querySelector<HTMLElement>(
-      ".markra-mermaid-zoom-content",
+      ".markra-media-viewer-content",
     );
     const canvas = dialog?.querySelector<HTMLElement>(
-      ".markra-mermaid-zoom-canvas",
+      ".markra-media-viewer-canvas",
     );
     content?.dispatchEvent(new PointerEvent("pointerdown", {
       bubbles: true,
@@ -506,17 +506,17 @@ describe("codeBlockPreviewPlugin", () => {
     }));
     expect(content?.dataset.dragging).toBeUndefined();
 
-    dialog?.querySelector<HTMLButtonElement>(".markra-mermaid-zoom-reset-button")?.click();
+    dialog?.querySelector<HTMLButtonElement>(".markra-media-viewer-reset-button")?.click();
     expect(canvas?.style.transform).toBe("translate(0px, 0px) scale(1)");
 
     const fullscreen = dialog?.querySelector<HTMLButtonElement>(
-      ".markra-mermaid-zoom-fullscreen-button",
+      ".markra-media-viewer-fullscreen-button",
     );
     fullscreen?.click();
     expect(dialog?.dataset.fullscreen).toBe("true");
     expect(fullscreen?.ariaPressed).toBe("true");
     expect(fullscreen?.ariaLabel).toBe("Exit full screen");
-    expect(iconPaths(dialog?.querySelector(".markra-mermaid-zoom-fullscreen-icon"))).toEqual([
+    expect(iconPaths(dialog?.querySelector(".markra-media-viewer-fullscreen-icon"))).toEqual([
       "M8 3v3a2 2 0 0 1-2 2H3",
       "M21 8h-3a2 2 0 0 1-2-2V3",
       "M3 16h3a2 2 0 0 1 2 2v3",
@@ -530,12 +530,12 @@ describe("codeBlockPreviewPlugin", () => {
 
     fullscreen?.click();
     document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
-    expect(document.querySelector(".markra-mermaid-zoom-dialog")).toBe(dialog);
+    expect(document.querySelector(".markra-media-viewer-dialog")).toBe(dialog);
     expect(dialog?.dataset.fullscreen).toBeUndefined();
     expect(fullscreen?.ariaPressed).toBe("false");
     expect(fullscreen?.ariaLabel).toBe("Enter full screen");
 
     document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
-    expect(document.querySelector(".markra-mermaid-zoom-dialog")).toBeNull();
+    expect(document.querySelector(".markra-media-viewer-dialog")).toBeNull();
   });
 });

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -28,6 +28,11 @@ import {
 } from "../mermaid.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import {
+  createMediaViewerEnlargeIcon,
+  openMediaViewer,
+  type MediaViewerHandle,
+} from "./media-viewer.ts";
+import {
   markraRenderer,
   type MarkraRendererContext,
   type MarkraSyntaxNode,
@@ -146,46 +151,6 @@ const checkIconChildren = [
     tag: "path",
     attributes: { d: "M20 6 9 17l-5-5" },
   },
-] as const;
-
-const enlargeIconChildren = [
-  { tag: "path", attributes: { d: "M15 3h6v6" } },
-  { tag: "path", attributes: { d: "m21 3-7 7" } },
-  { tag: "path", attributes: { d: "M9 21H3v-6" } },
-  { tag: "path", attributes: { d: "m3 21 7-7" } },
-] as const;
-
-const fullscreenIconChildren = [
-  { tag: "path", attributes: { d: "M8 3H5a2 2 0 0 0-2 2v3" } },
-  { tag: "path", attributes: { d: "M21 8V5a2 2 0 0 0-2-2h-3" } },
-  { tag: "path", attributes: { d: "M3 16v3a2 2 0 0 0 2 2h3" } },
-  { tag: "path", attributes: { d: "M16 21h3a2 2 0 0 0 2-2v-3" } },
-] as const;
-
-const exitFullscreenIconChildren = [
-  { tag: "path", attributes: { d: "M8 3v3a2 2 0 0 1-2 2H3" } },
-  { tag: "path", attributes: { d: "M21 8h-3a2 2 0 0 1-2-2V3" } },
-  { tag: "path", attributes: { d: "M3 16h3a2 2 0 0 1 2 2v3" } },
-  { tag: "path", attributes: { d: "M16 21v-3a2 2 0 0 1 2-2h3" } },
-] as const;
-
-const closeIconChildren = [
-  { tag: "path", attributes: { d: "M18 6 6 18" } },
-  { tag: "path", attributes: { d: "m6 6 12 12" } },
-] as const;
-
-const zoomInIconChildren = [
-  { tag: "path", attributes: { d: "M12 5v14" } },
-  { tag: "path", attributes: { d: "M5 12h14" } },
-] as const;
-
-const zoomOutIconChildren = [
-  { tag: "path", attributes: { d: "M5 12h14" } },
-] as const;
-
-const resetViewIconChildren = [
-  { tag: "path", attributes: { d: "M3 12a9 9 0 1 0 3-6.7" } },
-  { tag: "path", attributes: { d: "M3 3v6h6" } },
 ] as const;
 
 const codeBlockTheme = EditorView.baseTheme({
@@ -524,9 +489,7 @@ class CodeBlockExitWidget extends WidgetType {
 class MermaidPreviewWidget extends WidgetType {
   private observer: MutationObserver | null = null;
   private renderToken = 0;
-  private zoomDialog: HTMLElement | null = null;
-  private zoomKeyDown: ((event: KeyboardEvent) => unknown) | null = null;
-  private zoomScale = 1;
+  private mediaViewer: MediaViewerHandle | null = null;
 
   constructor(
     readonly from: number,
@@ -545,21 +508,9 @@ class MermaidPreviewWidget extends WidgetType {
     return true;
   }
 
-  private closeZoom(restoreFocus?: HTMLElement | null) {
-    const dialog = this.zoomDialog;
-    if (!dialog) return;
-    if (this.zoomKeyDown) {
-      dialog.ownerDocument.removeEventListener(
-        "keydown",
-        this.zoomKeyDown,
-        true,
-      );
-    }
-    dialog.remove();
-    this.zoomDialog = null;
-    this.zoomKeyDown = null;
-    this.zoomScale = 1;
-    restoreFocus?.focus();
+  private closeViewer() {
+    this.mediaViewer?.close({ restoreFocus: false });
+    this.mediaViewer = null;
   }
 
   private openZoom(
@@ -569,186 +520,22 @@ class MermaidPreviewWidget extends WidgetType {
   ) {
     const sourceSvg = preview.querySelector("svg");
     if (!sourceSvg) return;
-    this.closeZoom();
-
-    const document = view.dom.ownerDocument;
-    const dialog = document.createElement("div");
-    const panel = document.createElement("div");
-    const toolbar = document.createElement("div");
-    const zoomValue = document.createElement("span");
-    const content = document.createElement("div");
-    const canvas = document.createElement("div");
-    const makeButton = (
-      className: string,
-      label: string,
-      iconClassName: string,
-      iconChildren: Parameters<typeof createCodeControlIcon>[2],
-    ) => {
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = className;
-      button.ariaLabel = label;
-      button.title = label;
-      button.append(
-        createCodeControlIcon(document, iconClassName, iconChildren),
-      );
-      return button;
-    };
-    const zoomOut = makeButton(
-      "markra-mermaid-zoom-control-button markra-mermaid-zoom-out-button",
-      "Zoom out Mermaid diagram",
-      "markra-mermaid-zoom-out-icon",
-      zoomOutIconChildren,
-    );
-    const zoomIn = makeButton(
-      "markra-mermaid-zoom-control-button markra-mermaid-zoom-in-button",
-      "Zoom in Mermaid diagram",
-      "markra-mermaid-zoom-in-icon",
-      zoomInIconChildren,
-    );
-    const reset = makeButton(
-      "markra-mermaid-zoom-control-button markra-mermaid-zoom-reset-button",
-      "Reset Mermaid diagram view",
-      "markra-mermaid-zoom-reset-icon",
-      resetViewIconChildren,
-    );
-    const fullscreen = makeButton(
-      "markra-mermaid-zoom-control-button markra-mermaid-zoom-fullscreen-button",
-      "Enter full screen",
-      "markra-mermaid-zoom-fullscreen-icon",
-      fullscreenIconChildren,
-    );
-    fullscreen.ariaPressed = "false";
-    const close = makeButton(
-      "markra-mermaid-zoom-close-button",
-      "Close enlarged Mermaid diagram",
-      "markra-mermaid-zoom-close-icon",
-      closeIconChildren,
-    );
-
-    dialog.className = "markra-mermaid-zoom-dialog";
-    dialog.setAttribute("role", "dialog");
-    dialog.setAttribute("aria-modal", "true");
-    dialog.ariaLabel = "Enlarged Mermaid diagram";
-    panel.className = "markra-mermaid-zoom-panel";
-    toolbar.className = "markra-mermaid-zoom-toolbar";
-    zoomValue.className = "markra-mermaid-zoom-value";
-    zoomValue.setAttribute("aria-live", "polite");
-    content.className = "markra-mermaid-zoom-content";
-    content.tabIndex = 0;
-    content.ariaLabel = "Mermaid diagram viewport";
-    canvas.className = "markra-mermaid-zoom-canvas";
-    canvas.append(sourceSvg.cloneNode(true));
-
-    let translateX = 0;
-    let translateY = 0;
-    let drag: {
-      originX: number;
-      originY: number;
-      pointerId: number;
-      startX: number;
-      startY: number;
-    } | null = null;
-    const syncZoom = () => {
-      const scale = String(this.zoomScale);
-      canvas.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`;
-      content.dataset.zoom = scale;
-      zoomValue.textContent = `${Math.round(this.zoomScale * 100)}%`;
-    };
-    const setZoom = (scale: number) => {
-      this.zoomScale = Math.max(0.25, Math.min(6, scale));
-      syncZoom();
-    };
-    const setFullscreen = (isFullscreen: boolean) => {
-      if (isFullscreen) {
-        dialog.dataset.fullscreen = "true";
-      } else {
-        delete dialog.dataset.fullscreen;
-      }
-      const label = isFullscreen ? "Exit full screen" : "Enter full screen";
-      fullscreen.ariaLabel = label;
-      fullscreen.title = label;
-      fullscreen.ariaPressed = String(isFullscreen);
-      fullscreen.replaceChildren(
-        createCodeControlIcon(
-          document,
-          "markra-mermaid-zoom-fullscreen-icon",
-          isFullscreen ? exitFullscreenIconChildren : fullscreenIconChildren,
-        ),
-      );
-    };
-    zoomOut.addEventListener("click", () => setZoom(this.zoomScale - 0.25));
-    zoomIn.addEventListener("click", () => setZoom(this.zoomScale + 0.25));
-    reset.addEventListener("click", () => {
-      this.zoomScale = 1;
-      translateX = 0;
-      translateY = 0;
-      syncZoom();
+    this.closeViewer();
+    this.mediaViewer = openMediaViewer({
+      labels: {
+        close: "Close enlarged Mermaid diagram",
+        dialog: "Enlarged Mermaid diagram",
+        enterFullscreen: "Enter full screen",
+        exitFullscreen: "Exit full screen",
+        reset: "Reset Mermaid diagram view",
+        viewport: "Mermaid diagram viewport",
+        zoomIn: "Zoom in Mermaid diagram",
+        zoomOut: "Zoom out Mermaid diagram",
+      },
+      media: sourceSvg,
+      mount: view.dom.closest(".markdown-paper") ?? view.dom.ownerDocument.body,
+      restoreFocus: trigger,
     });
-    fullscreen.addEventListener("click", () => {
-      setFullscreen(dialog.dataset.fullscreen !== "true");
-    });
-    close.addEventListener("click", () => this.closeZoom(trigger));
-    content.addEventListener("wheel", (event) => {
-      event.preventDefault();
-      setZoom(this.zoomScale * (event.deltaY < 0 ? 1.12 : 1 / 1.12));
-    }, { passive: false });
-    content.addEventListener("pointerdown", (event) => {
-      if (event.button !== 0) return;
-      event.preventDefault();
-      // Pointer capture keeps Windows WebView drag updates flowing after the
-      // cursor leaves the viewport while a large diagram is being panned.
-      content.setPointerCapture?.(event.pointerId);
-      content.dataset.dragging = "true";
-      drag = {
-        originX: translateX,
-        originY: translateY,
-        pointerId: event.pointerId,
-        startX: event.clientX,
-        startY: event.clientY,
-      };
-    });
-    content.addEventListener("pointermove", (event) => {
-      if (!drag || drag.pointerId !== event.pointerId) return;
-      event.preventDefault();
-      translateX = drag.originX + event.clientX - drag.startX;
-      translateY = drag.originY + event.clientY - drag.startY;
-      syncZoom();
-    });
-    const stopDragging = (event: PointerEvent) => {
-      if (!drag || drag.pointerId !== event.pointerId) return;
-      if (content.hasPointerCapture?.(event.pointerId)) {
-        content.releasePointerCapture(event.pointerId);
-      }
-      delete content.dataset.dragging;
-      drag = null;
-    };
-    content.addEventListener("pointerup", stopDragging);
-    content.addEventListener("pointercancel", stopDragging);
-    dialog.addEventListener("mousedown", (event) => {
-      if (event.target === dialog) this.closeZoom(trigger);
-    });
-    this.zoomKeyDown = (event) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      // Preserve the enlarged view on the first Escape by restoring the
-      // regular dialog before the next Escape closes it.
-      if (dialog.dataset.fullscreen === "true") {
-        setFullscreen(false);
-        return;
-      }
-      this.closeZoom(trigger);
-    };
-    document.addEventListener("keydown", this.zoomKeyDown, true);
-
-    toolbar.append(zoomOut, zoomValue, zoomIn, reset, fullscreen, close);
-    content.append(canvas);
-    panel.append(toolbar, content);
-    dialog.append(panel);
-    (view.dom.closest(".markdown-paper") ?? document.body).append(dialog);
-    this.zoomDialog = dialog;
-    syncZoom();
-    close.focus();
   }
 
   private appendZoomButton(
@@ -763,13 +550,10 @@ class MermaidPreviewWidget extends WidgetType {
     button.className = "markra-mermaid-zoom-button";
     button.ariaLabel = "Enlarge Mermaid diagram";
     button.title = "Enlarge Mermaid diagram";
-    button.append(
-      createCodeControlIcon(
-        view.dom.ownerDocument,
-        "markra-mermaid-zoom-icon",
-        enlargeIconChildren,
-      ),
-    );
+    button.append(createMediaViewerEnlargeIcon(
+      view.dom.ownerDocument,
+      "markra-mermaid-zoom-icon",
+    ));
     button.addEventListener("mousedown", (event) => event.stopPropagation());
     button.addEventListener("click", (event) => {
       event.preventDefault();
@@ -812,7 +596,7 @@ class MermaidPreviewWidget extends WidgetType {
       this.renderMermaid({ source: this.source, theme, view })
         .then((svg) => {
           if (token !== this.renderToken) return;
-          this.closeZoom();
+          this.closeViewer();
           preview.innerHTML = svg;
           this.appendZoomButton(view, preview, wrapper);
           preview.setAttribute("aria-busy", "false");
@@ -843,7 +627,7 @@ class MermaidPreviewWidget extends WidgetType {
 
   destroy() {
     this.renderToken += 1;
-    this.closeZoom();
+    this.closeViewer();
     this.observer?.disconnect();
     this.observer = null;
   }

--- a/packages/editor/src/codemirror/image-preview.test.ts
+++ b/packages/editor/src/codemirror/image-preview.test.ts
@@ -14,6 +14,7 @@ const views: EditorView[] = [];
 function createView(
   doc: string,
   plugin: ReturnType<typeof imagePreviewPlugin> | null = imagePreviewPlugin(),
+  readOnly = false,
 ) {
   const parent = document.createElement("div");
   document.body.append(parent);
@@ -21,7 +22,10 @@ function createView(
     parent,
     state: EditorState.create({
       doc,
-      extensions: [liveMarkdown({ plugins: plugin ? [plugin] : [] })],
+      extensions: [
+        EditorState.readOnly.of(readOnly),
+        liveMarkdown({ plugins: plugin ? [plugin] : [] }),
+      ],
       selection: { anchor: doc.length },
     }),
   });
@@ -168,6 +172,141 @@ describe("imagePreviewPlugin", () => {
         ?.value,
     ).toBe("![Synthetic alt](./assets/mock.png)");
     expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("opens an image in the shared media viewer from the enlarge button or a double click", () => {
+    const doc =
+      '![Synthetic detail](https://example.test/detail.png "Detailed preview")\n\nEdit';
+    const view = createView(doc);
+    const image = view.dom.querySelector<HTMLImageElement>(".cm-markra-image");
+    const enlargeButton = view.dom.querySelector<HTMLButtonElement>(
+      ".markra-image-viewer-button",
+    );
+
+    expect(image).not.toBeNull();
+    expect(enlargeButton?.ariaLabel).toBe("Enlarge image");
+    expect(enlargeButton?.querySelector("svg")).not.toBeNull();
+    expect(image?.parentElement).toBe(enlargeButton?.parentElement);
+    expect(image?.parentElement?.classList).toContain("markra-image-frame");
+
+    enlargeButton?.click();
+    let dialog = document.querySelector<HTMLElement>(
+      ".markra-media-viewer-dialog",
+    );
+    let enlargedImage = dialog?.querySelector<HTMLImageElement>(
+      ".markra-media-viewer-image",
+    );
+
+    expect(dialog?.getAttribute("role")).toBe("dialog");
+    expect(dialog?.ariaLabel).toBe("Enlarged image");
+    expect(enlargedImage?.getAttribute("src")).toBe(
+      "https://example.test/detail.png",
+    );
+    expect(enlargedImage?.alt).toBe("Synthetic detail");
+    expect(
+      dialog?.querySelector(".markra-media-viewer-zoom-in-button"),
+    ).not.toBeNull();
+
+    dialog
+      ?.querySelector<HTMLButtonElement>(".markra-media-viewer-close-button")
+      ?.click();
+    expect(document.querySelector(".markra-media-viewer-dialog")).toBeNull();
+
+    image?.dispatchEvent(new MouseEvent("dblclick", {
+      bubbles: true,
+      cancelable: true,
+    }));
+    dialog = document.querySelector<HTMLElement>(
+      ".markra-media-viewer-dialog",
+    );
+    enlargedImage = dialog?.querySelector<HTMLImageElement>(
+      ".markra-media-viewer-image",
+    );
+
+    expect(dialog).not.toBeNull();
+    expect(enlargedImage?.getAttribute("src")).toBe(
+      "https://example.test/detail.png",
+    );
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("opens the viewer in read-only mode without revealing editable source", () => {
+    const doc = "![Synthetic detail](https://example.test/detail.png)";
+    const view = createView(doc, imagePreviewPlugin(), true);
+    const image = view.dom.querySelector<HTMLImageElement>(".cm-markra-image");
+
+    image?.dispatchEvent(new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(view.dom.querySelector(".markra-image-node-source")).toBeNull();
+
+    image?.dispatchEvent(new MouseEvent("dblclick", {
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelector(".markra-media-viewer-dialog")).not.toBeNull();
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("keeps one active viewer and closes it when the shown image changes", () => {
+    const firstSource = "https://example.test/first.png";
+    const secondSource = "https://example.test/second.png";
+    const doc = [
+      `![First synthetic image](${firstSource})`,
+      "",
+      `![Second synthetic image](${secondSource})`,
+    ].join("\n");
+    const view = createView(doc);
+    const images = view.dom.querySelectorAll<HTMLImageElement>(
+      ".cm-markra-image",
+    );
+
+    images[0]?.dispatchEvent(new MouseEvent("dblclick", {
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(
+      document.querySelector<HTMLImageElement>(".markra-media-viewer-image")
+        ?.getAttribute("src"),
+    ).toBe(firstSource);
+
+    images[1]?.dispatchEvent(new MouseEvent("dblclick", {
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.querySelectorAll(".markra-media-viewer-dialog")).toHaveLength(1);
+    expect(
+      document.querySelector<HTMLImageElement>(".markra-media-viewer-image")
+        ?.getAttribute("src"),
+    ).toBe(secondSource);
+
+    const sourceFrom = view.state.doc.toString().indexOf(secondSource);
+    view.dispatch({
+      changes: {
+        from: sourceFrom,
+        to: sourceFrom + secondSource.length,
+        insert: "https://example.test/updated.png",
+      },
+      userEvent: "input",
+    });
+
+    expect(document.querySelector(".markra-media-viewer-dialog")).toBeNull();
+  });
+
+  it("closes an active viewer when its editor is destroyed", () => {
+    const view = createView(
+      "![Synthetic detail](https://example.test/detail.png)",
+    );
+    view.dom.querySelector<HTMLImageElement>(".cm-markra-image")?.dispatchEvent(
+      new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+    );
+    expect(document.querySelector(".markra-media-viewer-dialog")).not.toBeNull();
+
+    view.destroy();
+    views.splice(views.indexOf(view), 1);
+
+    expect(document.querySelector(".markra-media-viewer-dialog")).toBeNull();
   });
 
   it("updates and deletes an image through its inline Markdown source", () => {

--- a/packages/editor/src/codemirror/image.ts
+++ b/packages/editor/src/codemirror/image.ts
@@ -7,6 +7,11 @@ import {
 } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
 import {
+  createMediaViewerEnlargeIcon,
+  openMediaViewer,
+  type MediaViewerHandle,
+} from "./media-viewer.ts";
+import {
   markraRenderer,
   type MarkraRendererContext,
   type MarkraSyntaxNode,
@@ -34,13 +39,16 @@ interface ImageDetails {
 }
 
 interface ImageWidgetDomState {
+  frame: HTMLSpanElement;
   image: HTMLImageElement;
   imageRecord: ImageWidgetDomRecord;
+  mediaViewer: MediaViewerHandle | null;
   onOutsideMouseDown: (event: MouseEvent) => void;
   onViewKeyDown: (event: KeyboardEvent) => void;
   selected: boolean;
   sourceInput: HTMLInputElement;
   sourceRow: HTMLSpanElement;
+  viewerButton: HTMLButtonElement;
   widget: ImageWidget;
 }
 
@@ -255,7 +263,7 @@ function showImageSource(
   ) {
     state.sourceInput.value = state.widget.details.markdown;
   }
-  if (!sourceVisible) root.insertBefore(state.sourceRow, state.image);
+  if (!sourceVisible) root.insertBefore(state.sourceRow, state.frame);
   state.selected = true;
   root.classList.add("markra-image-node-selected");
   if (!sourceVisible) {
@@ -343,13 +351,16 @@ class ImageWidget extends WidgetType {
 
   toDOM(view: CodeMirrorView) {
     const root = view.dom.ownerDocument.createElement("span");
+    const frame = view.dom.ownerDocument.createElement("span");
     const sourceRow = view.dom.ownerDocument.createElement("span");
     const sourceInput = view.dom.ownerDocument.createElement("input");
+    const viewerButton = view.dom.ownerDocument.createElement("button");
     const imageRecord = claimImageElement(root, this);
     const { image } = imageRecord;
     root.className = "markra-image-node";
     root.contentEditable = "false";
     root.draggable = false;
+    frame.className = "markra-image-frame";
     sourceRow.className = "markra-image-node-source-row";
     sourceRow.contentEditable = "true";
     sourceInput.ariaLabel = "Image markdown source";
@@ -358,15 +369,26 @@ class ImageWidget extends WidgetType {
     sourceInput.spellcheck = false;
     sourceInput.type = "text";
     sourceRow.append(createImageSourceIcon(view.dom.ownerDocument), sourceInput);
+    viewerButton.type = "button";
+    viewerButton.className = "markra-image-viewer-button";
+    viewerButton.ariaLabel = "Enlarge image";
+    viewerButton.title = "Enlarge image";
+    viewerButton.append(createMediaViewerEnlargeIcon(
+      view.dom.ownerDocument,
+      "markra-image-viewer-icon",
+    ));
     image.decoding = "async";
     image.draggable = false;
     image.loading = "lazy";
     updateImageElement(image, this);
-    root.append(image);
+    frame.append(image, viewerButton);
+    root.append(frame);
 
-    const state = {
+    const state: ImageWidgetDomState = {
+      frame,
       image,
       imageRecord,
+      mediaViewer: null,
       onOutsideMouseDown: (event: MouseEvent) => {
         if (event.target instanceof Node && root.contains(event.target)) return;
         const current = imageWidgetDomState.get(root);
@@ -416,8 +438,9 @@ class ImageWidget extends WidgetType {
       selected: false,
       sourceInput,
       sourceRow,
+      viewerButton,
       widget: this,
-    } satisfies ImageWidgetDomState;
+    };
     imageWidgetDomState.set(root, state);
 
     const selectImage = (event: MouseEvent) => {
@@ -432,6 +455,26 @@ class ImageWidget extends WidgetType {
       );
       view.dispatch({ selection: EditorSelection.cursor(anchor) });
       showImageSource(root, state);
+    };
+    const openImageViewer = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      state.mediaViewer?.close({ restoreFocus: false });
+      state.mediaViewer = openMediaViewer({
+        labels: {
+          close: "Close enlarged image",
+          dialog: "Enlarged image",
+          enterFullscreen: "Enter full screen",
+          exitFullscreen: "Exit full screen",
+          reset: "Reset image view",
+          viewport: "Image viewport",
+          zoomIn: "Zoom in image",
+          zoomOut: "Zoom out image",
+        },
+        media: image,
+        mount: view.dom.closest(".markdown-paper") ?? view.dom.ownerDocument.body,
+        restoreFocus: viewerButton,
+      });
     };
     const keepSourceFocused = (event: MouseEvent) => {
       event.stopPropagation();
@@ -469,6 +512,11 @@ class ImageWidget extends WidgetType {
 
     root.addEventListener("mousedown", selectImage);
     root.addEventListener("click", selectImage);
+    image.addEventListener("dblclick", openImageViewer);
+    viewerButton.addEventListener("mousedown", (event) => {
+      event.stopPropagation();
+    });
+    viewerButton.addEventListener("click", openImageViewer);
     sourceRow.addEventListener("mousedown", keepSourceFocused);
     sourceRow.addEventListener("click", keepSourceFocused);
     sourceInput.addEventListener("input", () => syncImageSource(root, state));
@@ -481,6 +529,10 @@ class ImageWidget extends WidgetType {
   updateDOM(dom: HTMLElement) {
     const state = imageWidgetDomState.get(dom);
     if (!state) return false;
+    if (state.widget.source !== this.source) {
+      state.mediaViewer?.close({ restoreFocus: false });
+      state.mediaViewer = null;
+    }
     state.widget = this;
     state.imageRecord.from = this.from;
     state.imageRecord.key = imageWidgetDomKey(this);
@@ -510,6 +562,7 @@ class ImageWidget extends WidgetType {
       state.onViewKeyDown,
       true,
     );
+    state.mediaViewer?.close({ restoreFocus: false });
     if (state.imageRecord.root === dom) {
       const { view } = state.widget;
       const releaseRecord = () => {

--- a/packages/editor/src/codemirror/media-viewer.ts
+++ b/packages/editor/src/codemirror/media-viewer.ts
@@ -1,0 +1,312 @@
+const svgNamespace = "http://www.w3.org/2000/svg";
+
+type MediaViewerIconName =
+  | "close"
+  | "enlarge"
+  | "exit-fullscreen"
+  | "fullscreen"
+  | "reset"
+  | "zoom-in"
+  | "zoom-out";
+
+type MediaViewerIconChild = {
+  readonly attributes: Readonly<Record<string, string>>;
+  readonly tag: "path" | "rect";
+};
+
+const mediaViewerIconChildren = {
+  close: [
+    { tag: "path", attributes: { d: "M18 6 6 18" } },
+    { tag: "path", attributes: { d: "m6 6 12 12" } },
+  ],
+  enlarge: [
+    { tag: "path", attributes: { d: "M15 3h6v6" } },
+    { tag: "path", attributes: { d: "m21 3-7 7" } },
+    { tag: "path", attributes: { d: "M9 21H3v-6" } },
+    { tag: "path", attributes: { d: "m3 21 7-7" } },
+  ],
+  "exit-fullscreen": [
+    { tag: "path", attributes: { d: "M8 3v3a2 2 0 0 1-2 2H3" } },
+    { tag: "path", attributes: { d: "M21 8h-3a2 2 0 0 1-2-2V3" } },
+    { tag: "path", attributes: { d: "M3 16h3a2 2 0 0 1 2 2v3" } },
+    { tag: "path", attributes: { d: "M16 21v-3a2 2 0 0 1 2-2h3" } },
+  ],
+  fullscreen: [
+    { tag: "path", attributes: { d: "M8 3H5a2 2 0 0 0-2 2v3" } },
+    { tag: "path", attributes: { d: "M21 8V5a2 2 0 0 0-2-2h-3" } },
+    { tag: "path", attributes: { d: "M3 16v3a2 2 0 0 0 2 2h3" } },
+    { tag: "path", attributes: { d: "M16 21h3a2 2 0 0 0 2-2v-3" } },
+  ],
+  reset: [
+    { tag: "path", attributes: { d: "M3 12a9 9 0 1 0 3-6.7" } },
+    { tag: "path", attributes: { d: "M3 3v6h6" } },
+  ],
+  "zoom-in": [
+    { tag: "path", attributes: { d: "M12 5v14" } },
+    { tag: "path", attributes: { d: "M5 12h14" } },
+  ],
+  "zoom-out": [
+    { tag: "path", attributes: { d: "M5 12h14" } },
+  ],
+} as const satisfies Readonly<Record<MediaViewerIconName, readonly MediaViewerIconChild[]>>;
+
+export interface MediaViewerLabels {
+  readonly close: string;
+  readonly dialog: string;
+  readonly enterFullscreen: string;
+  readonly exitFullscreen: string;
+  readonly reset: string;
+  readonly viewport: string;
+  readonly zoomIn: string;
+  readonly zoomOut: string;
+}
+
+export interface MediaViewerHandle {
+  close(options?: { restoreFocus?: boolean }): unknown;
+}
+
+interface OpenMediaViewerOptions {
+  readonly labels: MediaViewerLabels;
+  readonly media: Element;
+  readonly mount: Element;
+  readonly restoreFocus?: HTMLElement | null;
+}
+
+const activeMediaViewers = new WeakMap<Document, MediaViewerHandle>();
+
+function createMediaViewerIcon(
+  document: Document,
+  className: string,
+  name: MediaViewerIconName,
+) {
+  const icon = document.createElementNS(svgNamespace, "svg");
+  icon.classList.add(className);
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("height", "15");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("width", "15");
+  for (const childDefinition of mediaViewerIconChildren[name]) {
+    const child = document.createElementNS(svgNamespace, childDefinition.tag);
+    for (const [attribute, value] of Object.entries(childDefinition.attributes)) {
+      child.setAttribute(attribute, value);
+    }
+    icon.append(child);
+  }
+  return icon;
+}
+
+export function createMediaViewerEnlargeIcon(
+  document: Document,
+  className: string,
+) {
+  return createMediaViewerIcon(document, className, "enlarge");
+}
+
+export function openMediaViewer({
+  labels,
+  media,
+  mount,
+  restoreFocus,
+}: OpenMediaViewerOptions): MediaViewerHandle {
+  const document = media.ownerDocument;
+  activeMediaViewers.get(document)?.close({ restoreFocus: false });
+
+  const dialog = document.createElement("div");
+  const panel = document.createElement("div");
+  const toolbar = document.createElement("div");
+  const zoomValue = document.createElement("span");
+  const content = document.createElement("div");
+  const canvas = document.createElement("div");
+  const clonedMedia = media.cloneNode(true) as Element;
+  const makeButton = (
+    className: string,
+    label: string,
+    iconClassName: string,
+    iconName: MediaViewerIconName,
+  ) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = className;
+    button.ariaLabel = label;
+    button.title = label;
+    button.append(createMediaViewerIcon(document, iconClassName, iconName));
+    return button;
+  };
+  const zoomOut = makeButton(
+    "markra-media-viewer-control-button markra-media-viewer-zoom-out-button",
+    labels.zoomOut,
+    "markra-media-viewer-zoom-out-icon",
+    "zoom-out",
+  );
+  const zoomIn = makeButton(
+    "markra-media-viewer-control-button markra-media-viewer-zoom-in-button",
+    labels.zoomIn,
+    "markra-media-viewer-zoom-in-icon",
+    "zoom-in",
+  );
+  const reset = makeButton(
+    "markra-media-viewer-control-button markra-media-viewer-reset-button",
+    labels.reset,
+    "markra-media-viewer-reset-icon",
+    "reset",
+  );
+  const fullscreen = makeButton(
+    "markra-media-viewer-control-button markra-media-viewer-fullscreen-button",
+    labels.enterFullscreen,
+    "markra-media-viewer-fullscreen-icon",
+    "fullscreen",
+  );
+  const closeButton = makeButton(
+    "markra-media-viewer-close-button",
+    labels.close,
+    "markra-media-viewer-close-icon",
+    "close",
+  );
+
+  dialog.className = "markra-media-viewer-dialog";
+  dialog.setAttribute("role", "dialog");
+  dialog.setAttribute("aria-modal", "true");
+  dialog.ariaLabel = labels.dialog;
+  panel.className = "markra-media-viewer-panel";
+  toolbar.className = "markra-media-viewer-toolbar";
+  zoomValue.className = "markra-media-viewer-zoom-value";
+  zoomValue.setAttribute("aria-live", "polite");
+  content.className = "markra-media-viewer-content";
+  content.tabIndex = 0;
+  content.ariaLabel = labels.viewport;
+  canvas.className = "markra-media-viewer-canvas";
+  clonedMedia.classList.add("markra-media-viewer-media");
+  if (clonedMedia.tagName.toLowerCase() === "img") {
+    clonedMedia.classList.add("markra-media-viewer-image");
+  }
+  canvas.append(clonedMedia);
+
+  let closed = false;
+  let scale = 1;
+  let translateX = 0;
+  let translateY = 0;
+  let drag: {
+    originX: number;
+    originY: number;
+    pointerId: number;
+    startX: number;
+    startY: number;
+  } | null = null;
+  const syncZoom = () => {
+    const scaleValue = String(scale);
+    canvas.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scaleValue})`;
+    content.dataset.zoom = scaleValue;
+    zoomValue.textContent = `${Math.round(scale * 100)}%`;
+  };
+  const setZoom = (nextScale: number) => {
+    scale = Math.max(0.25, Math.min(6, nextScale));
+    syncZoom();
+  };
+  const setFullscreen = (isFullscreen: boolean) => {
+    if (isFullscreen) dialog.dataset.fullscreen = "true";
+    else delete dialog.dataset.fullscreen;
+    const label = isFullscreen
+      ? labels.exitFullscreen
+      : labels.enterFullscreen;
+    fullscreen.ariaLabel = label;
+    fullscreen.title = label;
+    fullscreen.ariaPressed = String(isFullscreen);
+    fullscreen.replaceChildren(
+      createMediaViewerIcon(
+        document,
+        "markra-media-viewer-fullscreen-icon",
+        isFullscreen ? "exit-fullscreen" : "fullscreen",
+      ),
+    );
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    if (dialog.dataset.fullscreen === "true") {
+      setFullscreen(false);
+      return;
+    }
+    handle.close();
+  };
+  const handle: MediaViewerHandle = {
+    close(options = {}) {
+      if (closed) return;
+      closed = true;
+      document.removeEventListener("keydown", onKeyDown, true);
+      dialog.remove();
+      if (activeMediaViewers.get(document) === handle) {
+        activeMediaViewers.delete(document);
+      }
+      if (options.restoreFocus !== false) restoreFocus?.focus();
+    },
+  };
+
+  fullscreen.ariaPressed = "false";
+  zoomOut.addEventListener("click", () => setZoom(scale - 0.25));
+  zoomIn.addEventListener("click", () => setZoom(scale + 0.25));
+  reset.addEventListener("click", () => {
+    scale = 1;
+    translateX = 0;
+    translateY = 0;
+    syncZoom();
+  });
+  fullscreen.addEventListener("click", () => {
+    setFullscreen(dialog.dataset.fullscreen !== "true");
+  });
+  closeButton.addEventListener("click", () => handle.close());
+  content.addEventListener("wheel", (event) => {
+    event.preventDefault();
+    setZoom(scale * (event.deltaY < 0 ? 1.12 : 1 / 1.12));
+  }, { passive: false });
+  content.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    // Pointer capture keeps Windows WebView drag updates flowing after the
+    // cursor leaves the viewport while a large diagram or image is panned.
+    content.setPointerCapture?.(event.pointerId);
+    content.dataset.dragging = "true";
+    drag = {
+      originX: translateX,
+      originY: translateY,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+    };
+  });
+  content.addEventListener("pointermove", (event) => {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    translateX = drag.originX + event.clientX - drag.startX;
+    translateY = drag.originY + event.clientY - drag.startY;
+    syncZoom();
+  });
+  const stopDragging = (event: PointerEvent) => {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (content.hasPointerCapture?.(event.pointerId)) {
+      content.releasePointerCapture(event.pointerId);
+    }
+    delete content.dataset.dragging;
+    drag = null;
+  };
+  content.addEventListener("pointerup", stopDragging);
+  content.addEventListener("pointercancel", stopDragging);
+  dialog.addEventListener("mousedown", (event) => {
+    if (event.target === dialog) handle.close();
+  });
+  document.addEventListener("keydown", onKeyDown, true);
+
+  toolbar.append(zoomOut, zoomValue, zoomIn, reset, fullscreen, closeButton);
+  content.append(canvas);
+  panel.append(toolbar, content);
+  dialog.append(panel);
+  mount.append(dialog);
+  activeMediaViewers.set(document, handle);
+  syncZoom();
+  closeButton.focus();
+  return handle;
+}


### PR DESCRIPTION
## Summary
- add a hover enlarge control anchored to the image top-right corner and open the viewer on image double-click
- share the existing Mermaid zoom, pan, reset, fullscreen, backdrop, and Escape behavior through a reusable media viewer
- keep the viewer available in read-only documents and clean it up when another viewer opens, the image changes, or the editor is destroyed
- cover image entry points, positioning structure, read-only behavior, single-viewer ownership, source updates, and teardown with regression tests

## Why
Large or text-heavy images can be difficult to inspect within the editor width. Reusing the Mermaid viewing model provides a consistent enlarged view without changing the existing single-click Markdown source editing behavior.

The behavior is shared by the desktop and web editors; no platform-specific code paths were added.

## Validation
- `pnpm --filter @markra/editor test` — passed: 33 files, 371 tests
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- `git diff --check` — passed
- browser QA — confirmed the hover control stays 8px inside the image top-right corner instead of the editor row edge, and double-click opens the zoomable viewer

## Risk
Low to moderate. The new image behavior is localized, but the change also extracts the existing Mermaid viewer into a shared module. Mermaid zoom, pan, reset, fullscreen, and Escape behavior remain covered by the existing interaction test.

## Out of scope
- adding an image-specific action to the editor context menu

Closes #610