### PR TITLE
feat(release): add Arch Linux package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,7 @@ jobs:
               ".dmg",
               ".exe",
               ".msi",
+              ".pkg.tar.zst",
               ".rpm",
               ".sig",
               ".tar.gz",
@@ -561,6 +562,37 @@ jobs:
         with:
           pattern: ${{ env.APP_SLUG }}-*-bundles
           path: release-assets
+
+      - name: Prepare Arch Linux package
+        env:
+          ARCH_PACKAGE_DIR: generated/arch
+          RELEASE_ASSETS_ROOT: release-assets
+          RELEASE_VERSION: ${{ env.RELEASE_TAG }}
+        run: node .release-scripts/scripts/release/prepare-arch-package.mjs
+
+      - name: Build Arch Linux package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            --platform linux/amd64 \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp \
+            --volume "${PWD}/generated/arch:/pkg" \
+            --workdir /pkg \
+            archlinux:base-devel \
+            makepkg --noconfirm --nodeps
+
+          package_path="$(find generated/arch -maxdepth 1 -type f -name 'markra-*.pkg.tar.zst' -print -quit)"
+
+          if [[ -z "${package_path}" ]]; then
+            echo "Arch Linux package was not created." >&2
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          cp "${package_path}" "release-assets/Markra_${version}_linux_x64.pkg.tar.zst"
 
       - name: Generate updater manifest
         env:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ On macOS, install with Homebrew:
 brew install --cask markrahq/tap/markra
 ```
 
-Download the latest desktop builds from [GitHub Releases](https://github.com/markrahq/markra/releases/latest): macOS Apple Silicon/Intel, Windows installer/portable, and Linux AppImage.
+Download the latest desktop builds from [GitHub Releases](https://github.com/markrahq/markra/releases/latest): macOS Apple Silicon/Intel, Windows installer/portable, and Linux AppImage/DEB/RPM/Arch Linux packages.
+
+On Arch Linux, download the x64 package from the release and install it with:
+
+```sh
+sudo pacman -U ./Markra_<version>_linux_x64.pkg.tar.zst
+```
 
 ## Demo
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,7 +63,13 @@ macOS 用户也可以通过 Homebrew 安装：
 brew install --cask markrahq/tap/markra
 ```
 
-从 [GitHub Releases](https://github.com/markrahq/markra/releases/latest) 下载最新桌面版：macOS Apple Silicon/Intel、Windows 安装包/便携包和 Linux AppImage。
+从 [GitHub Releases](https://github.com/markrahq/markra/releases/latest) 下载最新桌面版：macOS Apple Silicon/Intel、Windows 安装包/便携包，以及 Linux AppImage、DEB、RPM 和 Arch Linux 安装包。
+
+在 Arch Linux 上，下载 x64 安装包后运行：
+
+```sh
+sudo pacman -U ./Markra_<版本号>_linux_x64.pkg.tar.zst
+```
 
 ## 演示
 

--- a/scripts/release/prepare-arch-package.mjs
+++ b/scripts/release/prepare-arch-package.mjs
@@ -1,0 +1,77 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+
+  return value;
+}
+
+function walkFiles(rootDir) {
+  const stack = [rootDir];
+  const files = [];
+
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile()) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function sha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+const releaseAssetsRoot = requireEnv("RELEASE_ASSETS_ROOT");
+const packageDir = requireEnv("ARCH_PACKAGE_DIR");
+const releaseVersion = requireEnv("RELEASE_VERSION").replace(/^v/u, "");
+// PKGBUILD versions cannot contain hyphens, while semver prerelease tags can.
+const packageVersion = releaseVersion.replace(/-/gu, "_");
+const debName = `Markra_${releaseVersion}_linux_x64.deb`;
+const matchingDebs = walkFiles(releaseAssetsRoot).filter((filePath) => path.basename(filePath) === debName);
+
+if (matchingDebs.length !== 1) {
+  throw new Error(`Expected exactly one ${debName} release artifact, found ${matchingDebs.length}.`);
+}
+
+const debPath = matchingDebs[0];
+const pkgbuild = `pkgname=markra
+pkgver=${packageVersion}
+pkgrel=1
+pkgdesc='AI-native Markdown editor'
+arch=('x86_64')
+url='https://github.com/markrahq/markra'
+license=('AGPL-3.0-only')
+depends=('gtk3' 'libayatana-appindicator' 'webkit2gtk-4.1')
+conflicts=('markra-bin')
+options=('!strip' '!debug')
+source=('${debName}')
+noextract=('${debName}')
+sha256sums=('${sha256(debPath)}')
+
+_deb='${debName}'
+
+package() {
+  bsdtar -xf "\${srcdir}/\${_deb}" -C "\${srcdir}"
+  bsdtar -xf "\${srcdir}"/data.tar.* -C "\${pkgdir}"
+}
+`;
+
+fs.mkdirSync(packageDir, { recursive: true });
+fs.copyFileSync(debPath, path.join(packageDir, debName));
+fs.writeFileSync(path.join(packageDir, "PKGBUILD"), pkgbuild);

--- a/scripts/release/prepare-arch-package.test.mjs
+++ b/scripts/release/prepare-arch-package.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function runPrepareScript(rootDir, env = {}) {
+  return spawnSync(process.execPath, ["scripts/release/prepare-arch-package.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ARCH_PACKAGE_DIR: path.join(rootDir, "generated", "arch"),
+      RELEASE_ASSETS_ROOT: path.join(rootDir, "release-assets"),
+      RELEASE_VERSION: "v2.4.0",
+      ...env,
+    },
+  });
+}
+
+test("prepare-arch-package creates a reproducible x86_64 PKGBUILD from the release deb", () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "markra-arch-package-"));
+  const debPath = path.join(rootDir, "release-assets", "Linux-x64", "Markra_2.4.0_linux_x64.deb");
+  const debContents = Buffer.from("synthetic deb payload");
+
+  fs.mkdirSync(path.dirname(debPath), { recursive: true });
+  fs.writeFileSync(debPath, debContents);
+
+  const result = runPrepareScript(rootDir);
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const packageDir = path.join(rootDir, "generated", "arch");
+  const copiedDebPath = path.join(packageDir, path.basename(debPath));
+  const pkgbuild = fs.readFileSync(path.join(packageDir, "PKGBUILD"), "utf8");
+  const expectedHash = crypto.createHash("sha256").update(debContents).digest("hex");
+
+  assert.deepEqual(fs.readFileSync(copiedDebPath), debContents);
+  assert.match(pkgbuild, /^pkgname=markra$/m);
+  assert.match(pkgbuild, /^pkgver=2\.4\.0$/m);
+  assert.match(pkgbuild, /^pkgrel=1$/m);
+  assert.match(pkgbuild, /^arch=\('x86_64'\)$/m);
+  assert.match(pkgbuild, /^license=\('AGPL-3\.0-only'\)$/m);
+  assert.match(pkgbuild, /^depends=\('gtk3' 'libayatana-appindicator' 'webkit2gtk-4\.1'\)$/m);
+  assert.match(pkgbuild, /^options=\('!strip' '!debug'\)$/m);
+  assert.match(pkgbuild, /^noextract=\('Markra_2\.4\.0_linux_x64\.deb'\)$/m);
+  assert.match(pkgbuild, new RegExp(`^sha256sums=\\('${expectedHash}'\\)$`, "m"));
+  assert.match(pkgbuild, /bsdtar -xf "\$\{srcdir\}\/\$\{_deb\}" -C "\$\{srcdir\}"/);
+  assert.match(pkgbuild, /bsdtar -xf "\$\{srcdir\}"\/data\.tar\.\* -C "\$\{pkgdir\}"/);
+});
+
+test("prepare-arch-package fails when the normalized x64 deb is missing", () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "markra-arch-package-missing-"));
+  fs.mkdirSync(path.join(rootDir, "release-assets"), { recursive: true });
+
+  const result = runPrepareScript(rootDir);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Markra_2\.4\.0_linux_x64\.deb/);
+});
+
+test("prepare-arch-package converts semver prerelease hyphens for PKGBUILD", () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "markra-arch-package-prerelease-"));
+  const debPath = path.join(rootDir, "release-assets", "Markra_2.5.0-beta.1_linux_x64.deb");
+
+  fs.mkdirSync(path.dirname(debPath), { recursive: true });
+  fs.writeFileSync(debPath, "synthetic prerelease deb payload");
+
+  const result = runPrepareScript(rootDir, { RELEASE_VERSION: "v2.5.0-beta.1" });
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const pkgbuild = fs.readFileSync(path.join(rootDir, "generated", "arch", "PKGBUILD"), "utf8");
+  assert.match(pkgbuild, /^pkgver=2\.5\.0_beta\.1$/m);
+  assert.match(pkgbuild, /^source=\('Markra_2\.5\.0-beta\.1_linux_x64\.deb'\)$/m);
+});

--- a/scripts/release/release-workflow.test.mjs
+++ b/scripts/release/release-workflow.test.mjs
@@ -31,3 +31,14 @@ test("release workflow excludes deb package internals from GitHub release assets
   assert.match(workflow, /! -name 'control\.tar\.gz'/);
   assert.match(workflow, /! -name 'data\.tar\.gz'/);
 });
+
+test("release workflow builds and publishes an Arch Linux package from the x64 deb", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /name: Prepare Arch Linux package/);
+  assert.match(workflow, /prepare-arch-package\.mjs/);
+  assert.match(workflow, /archlinux:base-devel/);
+  assert.match(workflow, /makepkg --noconfirm --nodeps/);
+  assert.match(workflow, /Markra_\$\{version\}_linux_x64\.pkg\.tar\.zst/);
+  assert.match(workflow, /"\.pkg\.tar\.zst"/);
+});


### PR DESCRIPTION
## Summary
- generate a checksum-pinned x86_64 `PKGBUILD` from the normalized Linux `.deb`
- build and publish `Markra_<version>_linux_x64.pkg.tar.zst` from the release workflow using Arch Linux `makepkg`
- document installation with `pacman -U` in the English and Chinese READMEs

## Why
Arch Linux users currently have to use the AppImage or adapt another distro package. This adds a package that integrates with pacman while reusing the existing Linux release binary.

## Validation
- `pnpm test:release` passed: 50 tests
- release workflow YAML parsed successfully with Ruby Psych
- `git diff --check` passed
- downloaded the v2.4.0 x64 `.deb`, validated the generated `PKGBUILD` with `bash -n`, and extracted its payload successfully with `bsdtar`
- not run locally: the final `makepkg` container build because the local Docker daemon was not running; the release workflow now performs this step

## Risk
- the initial Arch Linux package is x86_64 only
- the first end-to-end package build will be exercised by the release workflow
