### PR TITLE
fix(editor): preserve list formatting on context paste

### DIFF
--- a/apps/desktop/src/runtime/tauri/menu.test.ts
+++ b/apps/desktop/src/runtime/tauri/menu.test.ts
@@ -415,6 +415,45 @@ describe("native menu", () => {
     expect(execCommand).toHaveBeenNthCalledWith(1, "insertText", false, "native clipboard text");
   });
 
+  it("pastes into the editor that opened the native context menu", async () => {
+    const target = document.createElement("main");
+    const mainPaper = document.createElement("article");
+    const sidePaper = document.createElement("article");
+    const mainContent = document.createElement("div");
+    const sideContent = document.createElement("div");
+    const mainPaste = vi.fn();
+    const sidePaste = vi.fn((event: Event) => event.preventDefault());
+    const execCommand = vi.fn().mockReturnValue(false);
+    mainPaper.className = "markdown-paper";
+    sidePaper.className = "markdown-paper";
+    mainContent.className = "cm-content";
+    sideContent.className = "cm-content";
+    mainPaper.append(mainContent);
+    sidePaper.append(sideContent);
+    target.append(mainPaper, sidePaper);
+    document.body.append(target);
+    mainContent.addEventListener("paste", mainPaste);
+    sideContent.addEventListener("paste", sidePaste);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === "read_clipboard_text") return "side clipboard text";
+
+      return undefined;
+    });
+
+    await installNativeEditorContextMenu(target, {}, "en");
+
+    sideContent.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    domMenuItemById("markra:context:paste").click();
+    await vi.waitFor(() => expect(sidePaste).toHaveBeenCalledTimes(1));
+
+    expect(mainPaste).not.toHaveBeenCalled();
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
   it("passes customized app shortcuts to the native application menu", async () => {
     await installNativeApplicationMenu({}, "en", {
       openQuickOpen: "Alt+1",

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -226,7 +226,8 @@ export async function installNativeEditorContextMenu(
         handlers,
         language,
         withNativeClipboardText(options),
-        desktopContextMenuIdPrefixes
+        desktopContextMenuIdPrefixes,
+        element
       ),
       position: contextMenuPositionFromEvent(mouseEvent)
     });

--- a/apps/web/src/runtime/web/menu.test.ts
+++ b/apps/web/src/runtime/web/menu.test.ts
@@ -217,6 +217,49 @@ describe("web editor context menu", () => {
     expect(getMenu()).toBeNull();
   });
 
+  it("pastes into the editor that opened the web context menu", async () => {
+    const runtime = createWebRuntime({
+      indexedDB: new FakeIndexedDbFactory().indexedDB
+    });
+    const execCommand = vi.fn().mockReturnValue(false);
+    const mainPaste = vi.fn();
+    const sidePaste = vi.fn((event: Event) => event.preventDefault());
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText: vi.fn().mockResolvedValue("side clipboard text")
+      }
+    });
+    document.body.innerHTML = `
+      <main>
+        <article class="markdown-paper"><div class="cm-content" data-editor="main"></div></article>
+        <article class="markdown-paper"><div class="cm-content" data-editor="side"></div></article>
+      </main>
+    `;
+    const mainContent = document.querySelector<HTMLElement>("[data-editor='main']");
+    const sideContent = document.querySelector<HTMLElement>("[data-editor='side']");
+    if (!mainContent || !sideContent) throw new Error("Editor content was not rendered");
+    mainContent.addEventListener("paste", mainPaste);
+    sideContent.addEventListener("paste", sidePaste);
+
+    await runtime.menu.installEditorContextMenu(document, {}, "en");
+
+    sideContent.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true
+    }));
+    getMenuItem("Paste").click();
+    await vi.waitFor(() => expect(sidePaste).toHaveBeenCalledTimes(1));
+
+    expect(mainPaste).not.toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenCalledWith("paste");
+  });
+
   it("shows file tree context actions in the browser", async () => {
     const runtime = createWebRuntime({
       indexedDB: new FakeIndexedDbFactory().indexedDB

--- a/apps/web/src/runtime/web/menu.ts
+++ b/apps/web/src/runtime/web/menu.ts
@@ -52,7 +52,8 @@ export function createWebMenuRuntime(
             handlers,
             language,
             menuOptions,
-            webContextMenuIdPrefixes
+            webContextMenuIdPrefixes,
+            element
           ),
           position: contextMenuPositionFromEvent(mouseEvent)
         });

--- a/packages/app/src/runtime/context-menu-items.test.ts
+++ b/packages/app/src/runtime/context-menu-items.test.ts
@@ -1,8 +1,35 @@
+import { EditorSelection, EditorState, type Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { history, undo } from "@codemirror/commands";
+import { liveMarkdown } from "@markra/editor/codemirror";
 import {
   createEditorContextMenuEntries,
+  createEditorContextMenuEntriesFromOptions,
   createMarkdownFileTreeContextMenuEntries
 } from "./context-menu-items";
 import type { ContextMenuEntry, ContextMenuItem } from "../components/ContextMenu";
+
+const editorViews: EditorView[] = [];
+
+function createEditor(
+  doc: string,
+  selection: EditorSelection | { anchor: number; head?: number },
+  extensions: Extension[] = []
+) {
+  const paper = document.createElement("article");
+  paper.className = "markdown-paper";
+  document.body.append(paper);
+  const view = new EditorView({
+    parent: paper,
+    state: EditorState.create({
+      doc,
+      extensions,
+      selection
+    })
+  });
+  editorViews.push(view);
+  return { paper, view };
+}
 
 function menuItemById(entries: ContextMenuEntry[], id: string): ContextMenuItem {
   const item = entries.find((entry) => entry.kind === "item" && entry.id === id);
@@ -11,9 +38,81 @@ function menuItemById(entries: ContextMenuEntry[], id: string): ContextMenuItem 
   return item;
 }
 
+function clipboardPasteItem(target: Element, text: string) {
+  return menuItemById(
+    createEditorContextMenuEntriesFromOptions(
+      {},
+      "en",
+      { readClipboardText: () => text },
+      {},
+      target
+    ),
+    "markra:context:paste"
+  );
+}
+
 describe("editor context menu entries", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    for (const view of editorViews.splice(0)) view.destroy();
+    document.body.replaceChildren();
+  });
+
+  it("pastes through the originating editor with CodeMirror clipboard semantics", async () => {
+    const main = createEditor("Main", EditorSelection.cursor(4));
+    const side = createEditor(
+      "one\ntwo",
+      EditorSelection.create([
+        EditorSelection.cursor(0),
+        EditorSelection.cursor(4)
+      ]),
+      [
+        EditorState.allowMultipleSelections.of(true),
+        EditorView.clipboardInputFilter.of((text) => text.toUpperCase())
+      ]
+    );
+
+    await Promise.resolve(clipboardPasteItem(side.paper, "alpha\nbeta").onSelect?.());
+    expect(main.view.state.doc.toString()).toBe("Main");
+    expect(side.view.state.doc.toString()).toBe("ALPHAone\nBETAtwo");
+  });
+
+  it("keeps pasted text inside an empty live-preview list item", async () => {
+    const doc = "- Alpha\n- ";
+    const editor = createEditor(
+      doc,
+      EditorSelection.cursor(doc.length),
+      [history(), liveMarkdown()]
+    );
+
+    await Promise.resolve(clipboardPasteItem(editor.paper, "Pasted item").onSelect?.());
+    expect(editor.view.state.doc.toString()).toBe("- Alpha\n- Pasted item");
+    expect(editor.view.state.selection.main.head).toBe("- Alpha\n- Pasted item".length);
+    expect(undo(editor.view)).toBe(true);
+    expect(editor.view.state.doc.toString()).toBe(doc);
+  });
+
+  it("does not change a read-only editor", async () => {
+    const doc = "Read only";
+    const editor = createEditor(
+      doc,
+      EditorSelection.cursor(doc.length),
+      [EditorState.readOnly.of(true)]
+    );
+
+    await Promise.resolve(clipboardPasteItem(editor.paper, " blocked").onSelect?.());
+    expect(editor.view.state.doc.toString()).toBe(doc);
+  });
+
+  it("does not retarget paste after the originating editor is removed", async () => {
+    const main = createEditor("Main", EditorSelection.cursor(4));
+    const side = createEditor("Side", EditorSelection.cursor(4));
+    const paste = clipboardPasteItem(side.paper, " clipboard text");
+    side.paper.remove();
+
+    await Promise.resolve(paste.onSelect?.());
+    expect(main.view.state.doc.toString()).toBe("Main");
+    expect(side.view.state.doc.toString()).toBe("Side");
   });
 
   it("offers local image and file import as separate editor commands", () => {
@@ -117,6 +216,38 @@ describe("editor context menu entries", () => {
     expect(readText).not.toHaveBeenCalled();
     expect(execCommand).toHaveBeenCalledTimes(1);
     expect(execCommand).toHaveBeenNthCalledWith(1, "insertText", false, "platform clipboard text");
+  });
+
+  it("inserts injected clipboard text through the editor before DOM commands", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const readText = vi.fn().mockResolvedValue("browser clipboard text");
+    const readClipboardText = vi.fn().mockResolvedValue("platform clipboard text");
+    const insertClipboardText = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText
+      }
+    });
+
+    const paste = menuItemById(
+      createEditorContextMenuEntries({}, "en", {
+        insertClipboardText,
+        readClipboardText
+      }),
+      "markra:context:paste"
+    );
+
+    await Promise.resolve(paste.onSelect?.());
+
+    expect(readClipboardText).toHaveBeenCalledTimes(1);
+    expect(insertClipboardText).toHaveBeenCalledWith("platform clipboard text");
+    expect(readText).not.toHaveBeenCalled();
+    expect(execCommand).not.toHaveBeenCalled();
   });
 
   it("falls back to the browser paste command when injected clipboard text is unavailable", async () => {

--- a/packages/app/src/runtime/context-menu-items.ts
+++ b/packages/app/src/runtime/context-menu-items.ts
@@ -24,7 +24,11 @@ import type { NativeMarkdownFolderFile } from "../lib/tauri/file";
 
 type BrowserEditCommand = "copy" | "cut" | "paste" | "selectAll";
 
-type EditorContextMenuEntryOptions = NativeEditorContextMenuEntryOptions;
+type ClipboardTextInserter = (text: string) => boolean | Promise<boolean>;
+
+type EditorContextMenuEntryOptions = NativeEditorContextMenuEntryOptions & {
+  insertClipboardText?: ClipboardTextInserter;
+};
 
 export type ContextMenuIdPrefixes = {
   editor: string;
@@ -116,15 +120,51 @@ async function readBrowserClipboardText(documentTarget: Document) {
   return readText.call(clipboard);
 }
 
+function clipboardTextData(text: string) {
+  return {
+    files: Object.assign([], {
+      item: () => null
+    }),
+    getData: (type: string) => type === "text/plain" ? text : ""
+  };
+}
+
+function createClipboardTextInserter(target: Element) {
+  const paper = target.closest(".markdown-paper");
+  const content = paper?.querySelector<HTMLElement>(".cm-content");
+  if (!content) return undefined;
+
+  return (text: string) => {
+    // Native clipboard reads are asynchronous. If the originating editor was
+    // removed meanwhile, consume the paste instead of retargeting another tab.
+    if (!content.isConnected) return true;
+
+    const EventConstructor = content.ownerDocument.defaultView?.Event ?? Event;
+    const event = new EventConstructor("paste", {
+      bubbles: true,
+      cancelable: true
+    });
+    Object.defineProperty(event, "clipboardData", {
+      value: clipboardTextData(text)
+    });
+    content.dispatchEvent(event);
+    return true;
+  };
+}
+
 async function pasteClipboardText(
   documentTarget: Document,
-  readClipboardText?: NativeEditorContextMenuOptions["readClipboardText"]
+  readClipboardText?: NativeEditorContextMenuOptions["readClipboardText"],
+  insertClipboardText?: ClipboardTextInserter
 ) {
   const readText = readClipboardText ?? (() => readBrowserClipboardText(documentTarget));
 
   try {
     const text = await readText();
     if (!text) return false;
+    // Live preview replaces Markdown markers in the DOM, so DOM insertion can
+    // map pasted text before a hidden list marker instead of after it.
+    if (insertClipboardText && await insertClipboardText(text)) return true;
 
     return runDocumentEditCommand(documentTarget, "insertText", false, text);
   } catch {
@@ -134,26 +174,34 @@ async function pasteClipboardText(
 
 async function runInjectedClipboardPasteCommand(
   documentTarget: Document,
-  readClipboardText: NonNullable<NativeEditorContextMenuOptions["readClipboardText"]>
+  readClipboardText: NonNullable<NativeEditorContextMenuOptions["readClipboardText"]>,
+  insertClipboardText?: ClipboardTextInserter
 ) {
-  const handled = await pasteClipboardText(documentTarget, readClipboardText);
+  const handled = await pasteClipboardText(documentTarget, readClipboardText, insertClipboardText);
   if (handled) return true;
 
   return runDocumentEditCommand(documentTarget, "paste");
 }
 
-function runBrowserEditCommand(command: BrowserEditCommand, options: Pick<EditorContextMenuEntryOptions, "readClipboardText"> = {}) {
+function runBrowserEditCommand(
+  command: BrowserEditCommand,
+  options: Pick<EditorContextMenuEntryOptions, "insertClipboardText" | "readClipboardText"> = {}
+) {
   const documentTarget = typeof document === "undefined" ? null : document;
   if (!documentTarget) return false;
 
   if (command === "paste" && options.readClipboardText) {
-    return runInjectedClipboardPasteCommand(documentTarget, options.readClipboardText);
+    return runInjectedClipboardPasteCommand(
+      documentTarget,
+      options.readClipboardText,
+      options.insertClipboardText
+    );
   }
 
   const handled = runDocumentEditCommand(documentTarget, command);
   if (handled || command !== "paste") return handled;
 
-  return pasteClipboardText(documentTarget);
+  return pasteClipboardText(documentTarget, undefined, options.insertClipboardText);
 }
 
 function browserItem(
@@ -161,7 +209,7 @@ function browserItem(
   label: string,
   accelerator: string,
   command: BrowserEditCommand,
-  options: Pick<EditorContextMenuEntryOptions, "readClipboardText"> = {}
+  options: Pick<EditorContextMenuEntryOptions, "insertClipboardText" | "readClipboardText"> = {}
 ) {
   return contextMenuItem(id, label, accelerator, () => runBrowserEditCommand(command, options), false);
 }
@@ -258,13 +306,15 @@ export function createEditorContextMenuEntriesFromOptions(
   handlers: NativeMenuHandlers,
   language: AppLanguage,
   options: NativeEditorContextMenuOptions,
-  idPrefixes?: Partial<ContextMenuIdPrefixes>
+  idPrefixes?: Partial<ContextMenuIdPrefixes>,
+  target?: Element
 ) {
   return createEditorContextMenuEntries(
     handlers,
     language,
     {
       aiCommandsAvailable: readAiCommandsAvailable(options),
+      insertClipboardText: target ? createClipboardTextInserter(target) : undefined,
       markdownShortcuts: options.markdownShortcuts,
       readClipboardText: options.readClipboardText
     },


### PR DESCRIPTION
## Summary

- route context-menu text paste through the originating CodeMirror editor instead of DOM `insertText`
- preserve live-preview list markers while keeping split-pane targeting, multi-cursor paste, clipboard input filters, undo, and read-only behavior intact
- cover both native desktop clipboard reads and the web clipboard fallback with integration tests

## Why

The context-menu path read clipboard text asynchronously and then called `document.execCommand("insertText")`. In Live Preview, Markdown markers can be represented by hidden DOM nodes, so DOM insertion may map the text before an empty list marker. The vulnerable path is shared rather than Windows-only, even though the issue was reported on Windows and was not reproduced on macOS.

The fix captures the editor that opened the menu and dispatches a paste event to its CodeMirror content. If that editor disappears before the asynchronous clipboard read finishes, the paste is consumed instead of being redirected to another editor.

## Validation

- `pnpm --filter @markra/app test` — 130 files, 1477 tests passed
- `pnpm --filter @markra/desktop test` — 15 files, 146 tests passed
- `pnpm --filter @markra/web test` — 11 files, 43 tests passed
- `pnpm --filter @markra/app build && pnpm --filter @markra/app typecheck:test`
- `pnpm --filter @markra/desktop typecheck:test && pnpm --filter @markra/desktop build`
- `pnpm --filter @markra/web typecheck:test && pnpm --filter @markra/web build`
- `git diff --check origin/v2...HEAD`

## Risk

Low to moderate. Editor-origin paste now follows CodeMirror clipboard semantics; non-editor targets retain the existing document-command fallback. Automated coverage includes empty live-preview list items, main/side editor targeting, multiple selections, clipboard filters, undo, read-only editors, and an editor removed during the clipboard read.

A real Windows WebView2 environment was not available for manual verification.

Closes #620