### PR TITLE
fix(editor): stabilize blank-line editing

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1057,13 +1057,10 @@
     color: var(--editor-text-primary);
   }
 
-  /* Keep CodeMirror's child <br> in layout. WebKit uses it to map a drag
-     endpoint through the visual gap instead of falling back to document end. */
-  .markdown-paper .cm-line.cm-markra-empty-line[data-markra-empty-source="hidden"] {
-    height: var(--editor-paragraph-spacing);
-    min-height: var(--editor-paragraph-spacing);
-    font-size: 0;
-    line-height: var(--editor-paragraph-spacing);
+  /* Paragraph spacing is extra rhythm after content, not a replacement for
+     an authored blank line, which must retain the editor's normal line height. */
+  .markdown-paper .cm-line.cm-markra-paragraph-end {
+    padding-block-end: var(--editor-paragraph-spacing) !important;
   }
 
   .markdown-paper .cm-line.cm-markra-list-item {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -364,6 +364,24 @@ describe("editor stylesheet", () => {
     expect(styles).not.toContain(emptyLineBreakRule);
   });
 
+  it("keeps empty lines full-height and applies spacing after paragraphs", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+
+    expect(styles).not.toContain(
+      ".markdown-paper .cm-line.cm-markra-empty-line {",
+    );
+    expect(styles).toContain(
+      ".markdown-paper .cm-line.cm-markra-paragraph-end {",
+    );
+    expect(styles).toContain(
+      "padding-block-end: var(--editor-paragraph-spacing) !important;",
+    );
+    expect(styles).not.toContain("cm-markra-paragraph-separator");
+    expect(styles).not.toContain(
+      '.cm-markra-empty-line[data-markra-empty-source="hidden"] {',
+    );
+  });
+
   it("keeps CodeMirror block rhythm aligned with the original visual editor", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -85,6 +85,20 @@ function renderedLines(view: EditorView) {
   );
 }
 
+function paragraphSeparatorStates(view: EditorView) {
+  return Array.from(
+    view.dom.querySelectorAll(".cm-markra-empty-line"),
+    (line) => line.classList.contains("cm-markra-paragraph-separator"),
+  );
+}
+
+function paragraphEndStates(view: EditorView) {
+  return Array.from(
+    view.dom.querySelectorAll(".cm-markra-paragraph"),
+    (line) => line.classList.contains("cm-markra-paragraph-end"),
+  );
+}
+
 afterEach(() => {
   for (const view of views.splice(0)) view.destroy();
   document.body.replaceChildren();
@@ -492,11 +506,56 @@ describe("liveMarkdown", () => {
     view.dispatch({ selection: EditorSelection.range(0, doc.length) });
 
     expect(renderedLines(view)).toEqual(before);
-    expect(
-      view.dom
-        .querySelector(".cm-markra-empty-line")
-        ?.getAttribute("data-markra-empty-source"),
-    ).toBe("hidden");
+    const emptyLine = view.dom.querySelector(".cm-markra-empty-line");
+    expect(emptyLine?.hasAttribute("data-markra-empty-source")).toBe(false);
+    expect(paragraphSeparatorStates(view)).toEqual([false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
+  });
+
+  it("keeps empty-line rendering stable when the cursor enters a separator", () => {
+    const doc = "Before\n\nAfter";
+    const view = createView({ doc, anchor: doc.length });
+    const emptyLine = view.dom.querySelector<HTMLElement>(
+      ".cm-markra-empty-line",
+    );
+
+    expect(emptyLine?.hasAttribute("data-markra-empty-source")).toBe(false);
+    expect(paragraphSeparatorStates(view)).toEqual([false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
+
+    view.dispatch({ selection: EditorSelection.cursor("Before\n".length) });
+
+    expect(view.state.doc.toString()).toBe(doc);
+    const activeEmptyLine = view.dom.querySelector(".cm-markra-empty-line");
+    expect(activeEmptyLine?.hasAttribute("data-markra-empty-source")).toBe(
+      false,
+    );
+    expect(paragraphSeparatorStates(view)).toEqual([false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
+  });
+
+  it("marks paragraph ends separately from full-height empty lines", () => {
+    const view = createView({ doc: "First\nSecond\n\n\nAfter" });
+
+    expect(paragraphSeparatorStates(view)).toEqual([false, false]);
+    expect(paragraphEndStates(view)).toEqual([false, true, false]);
+  });
+
+  it("keeps a trailing editing line free from paragraph spacing", () => {
+    const doc = "Before\n";
+    const view = createView({ doc });
+
+    expect(paragraphEndStates(view)).toEqual([false]);
+
+    view.dispatch({ changes: { from: doc.length, insert: " " } });
+
+    expect(paragraphEndStates(view)).toEqual([false]);
+
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: "After" },
+    });
+
+    expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
   it("does not rebuild preview decorations while a range endpoint moves", () => {

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -509,7 +509,7 @@ describe("liveMarkdown", () => {
     const emptyLine = view.dom.querySelector(".cm-markra-empty-line");
     expect(emptyLine?.hasAttribute("data-markra-empty-source")).toBe(false);
     expect(paragraphSeparatorStates(view)).toEqual([false]);
-    expect(paragraphEndStates(view)).toEqual([true, false]);
+    expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
   it("keeps empty-line rendering stable when the cursor enters a separator", () => {
@@ -521,7 +521,7 @@ describe("liveMarkdown", () => {
 
     expect(emptyLine?.hasAttribute("data-markra-empty-source")).toBe(false);
     expect(paragraphSeparatorStates(view)).toEqual([false]);
-    expect(paragraphEndStates(view)).toEqual([true, false]);
+    expect(paragraphEndStates(view)).toEqual([false, false]);
 
     view.dispatch({ selection: EditorSelection.cursor("Before\n".length) });
 
@@ -531,14 +531,20 @@ describe("liveMarkdown", () => {
       false,
     );
     expect(paragraphSeparatorStates(view)).toEqual([false]);
-    expect(paragraphEndStates(view)).toEqual([true, false]);
+    expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("marks paragraph ends separately from full-height empty lines", () => {
+  it("keeps authored blank lines separate from paragraph-end spacing", () => {
     const view = createView({ doc: "First\nSecond\n\n\nAfter" });
 
     expect(paragraphSeparatorStates(view)).toEqual([false, false]);
-    expect(paragraphEndStates(view)).toEqual([false, true, false]);
+    expect(paragraphEndStates(view)).toEqual([false, false, false]);
+  });
+
+  it("adds paragraph spacing when another block starts directly", () => {
+    const view = createView({ doc: "Before\n# Heading" });
+
+    expect(paragraphEndStates(view)).toEqual([true]);
   });
 
   it("keeps a trailing editing line free from paragraph spacing", () => {
@@ -556,6 +562,22 @@ describe("liveMarkdown", () => {
     });
 
     expect(paragraphEndStates(view)).toEqual([false, false]);
+  });
+
+  it("keeps an authored blank line stable while text is entered", () => {
+    const doc = "Before\n\nAfter";
+    const position = "Before\n".length;
+    const view = createView({ doc, anchor: position });
+
+    expect(paragraphEndStates(view)).toEqual([false, false]);
+
+    view.dispatch({
+      changes: { from: position, insert: "Middle" },
+      selection: EditorSelection.cursor(position + "Middle".length),
+    });
+
+    expect(view.state.doc.toString()).toBe("Before\nMiddle\nAfter");
+    expect(paragraphEndStates(view)).toEqual([false, false, false]);
   });
 
   it("does not rebuild preview decorations while a range endpoint moves", () => {

--- a/packages/editor/src/codemirror/markdown-editing.test.ts
+++ b/packages/editor/src/codemirror/markdown-editing.test.ts
@@ -1,14 +1,24 @@
 import { defaultKeymap } from "@codemirror/commands";
-import { EditorSelection, EditorState } from "@codemirror/state";
+import {
+  EditorSelection,
+  EditorState,
+  type Transaction,
+} from "@codemirror/state";
 import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
 import { afterEach, describe, expect, it } from "vitest";
+import { codeMirrorBlockDragPlugin } from "./block-drag.ts";
 import { liveMarkdown } from "./index.ts";
 import { markdownEditingPlugin } from "./markdown-editing.ts";
 import "./dom.test-support.ts";
 
 const views: EditorView[] = [];
 
-function createView(doc: string, position: number) {
+function createView(
+  doc: string,
+  selection: number | EditorSelection,
+  blockToolbar = false,
+  observedTransactions?: Transaction[],
+) {
   const parent = document.createElement("div");
   document.body.append(parent);
   const view = new EditorView({
@@ -16,10 +26,23 @@ function createView(doc: string, position: number) {
     state: EditorState.create({
       doc,
       extensions: [
+        EditorState.allowMultipleSelections.of(true),
         keymap.of(defaultKeymap),
-        liveMarkdown({ plugins: [markdownEditingPlugin()] }),
+        liveMarkdown({
+          plugins: [
+            ...(blockToolbar ? [codeMirrorBlockDragPlugin()] : []),
+            markdownEditingPlugin(),
+          ],
+        }),
+        observedTransactions
+          ? EditorView.updateListener.of((update) => {
+            observedTransactions.push(...update.transactions);
+          })
+          : [],
       ],
-      selection: EditorSelection.cursor(position),
+      selection: typeof selection === "number"
+        ? EditorSelection.cursor(selection)
+        : selection,
     }),
   });
   views.push(view);
@@ -44,6 +67,97 @@ afterEach(() => {
 });
 
 describe("markdownEditingPlugin", () => {
+  it("keeps CodeMirror's native Enter behavior in a paragraph", () => {
+    const doc = "MockBeforeMockAfter";
+    const position = "MockBefore".length;
+    const view = createView(doc, position);
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("MockBefore\nMockAfter");
+    expect(view.state.selection.main.head).toBe(position + 1);
+  });
+
+  it("keeps the caret associated with text after joining lines backward", () => {
+    const view = createView("MockText", 0);
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("\nMockText");
+    expect(press(view, "Backspace")).toBe(true);
+    expect(view.state.doc.toString()).toBe("MockText");
+    expect(view.state.selection.main.head).toBe(0);
+    expect(view.state.selection.main.assoc).toBe(1);
+  });
+
+  it("keeps the native caret on the text side of the block toolbar", () => {
+    const transactions: Transaction[] = [];
+    const view = createView("\nMockText", 1, true, transactions);
+    view.focus();
+
+    expect(press(view, "Backspace")).toBe(true);
+
+    const line = view.dom.querySelector<HTMLElement>(".cm-line");
+    const toolbar = line?.querySelector(":scope > .cm-markra-block-toolbar");
+    const nativeSelection = document.getSelection();
+    expect(line).not.toBeNull();
+    expect(toolbar).not.toBeNull();
+    expect(nativeSelection?.anchorNode).not.toBeNull();
+
+    const anchorNode = nativeSelection?.anchorNode;
+    const anchorOffset = nativeSelection?.anchorOffset ?? -1;
+    const toolbarIndex = line && toolbar
+      ? [...line.childNodes].indexOf(toolbar)
+      : -1;
+    const isOnTextSide = anchorNode === line
+      ? anchorOffset > toolbarIndex + 1
+      : Boolean(
+        anchorNode && line?.contains(anchorNode) && !toolbar?.contains(anchorNode),
+      );
+    expect(isOnTextSide).toBe(true);
+    // The affinity must be part of the deleting transaction. A follow-up
+    // selection update leaves real browsers on the equivalent widget edge.
+    expect(transactions).toHaveLength(1);
+  });
+
+  it("keeps every caret associated with text when joining empty lines backward", () => {
+    const doc = "\nMockOne\n\nMockTwo";
+    const view = createView(
+      doc,
+      EditorSelection.create([
+        EditorSelection.cursor(1),
+        EditorSelection.cursor(doc.indexOf("MockTwo")),
+      ]),
+    );
+
+    expect(press(view, "Backspace")).toBe(true);
+    expect(view.state.doc.toString()).toBe("MockOne\nMockTwo");
+    expect(view.state.selection.ranges.map((range) => range.head)).toEqual([
+      0,
+      "MockOne\n".length,
+    ]);
+    expect(view.state.selection.ranges.map((range) => range.assoc)).toEqual([
+      1,
+      1,
+    ]);
+  });
+
+  it("corrects only affected carets in a mixed multi-cursor deletion", () => {
+    const doc = "\nMockOne\nTail";
+    const view = createView(
+      doc,
+      EditorSelection.create([
+        EditorSelection.cursor(1),
+        EditorSelection.cursor(doc.length),
+      ]),
+    );
+
+    expect(press(view, "Backspace")).toBe(true);
+    expect(view.state.doc.toString()).toBe("MockOne\nTai");
+    expect(view.state.selection.ranges.map((range) => range.assoc)).toEqual([
+      1,
+      -1,
+    ]);
+  });
+
   it("completes a typed image destination when Enter confirms it", () => {
     const doc = "![a](https://images.example.test/mock.jpg?w=1280&h=960";
     const view = createView(doc, doc.length);

--- a/packages/editor/src/codemirror/markdown-editing.ts
+++ b/packages/editor/src/codemirror/markdown-editing.ts
@@ -5,6 +5,7 @@ import {
   Prec,
   type ChangeSpec,
   type SelectionRange,
+  type Transaction,
 } from "@codemirror/state";
 import { keymap, type EditorView } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
@@ -92,6 +93,57 @@ function handleShiftTab(view: EditorView) {
   return indentList(view, true);
 }
 
+function keepJoinedLineCaretsAfterText(transaction: Transaction) {
+  if (!transaction.docChanged || !transaction.isUserEvent("delete.backward")) {
+    return transaction;
+  }
+
+  const affectedPositions = new Set<number>();
+  for (const range of transaction.startState.selection.ranges) {
+    if (!range.empty || range.head === 0) continue;
+    const line = transaction.startState.doc.lineAt(range.head);
+    if (
+      line.from === range.head &&
+      transaction.startState.doc.lineAt(range.head - 1).length === 0
+    ) {
+      affectedPositions.add(transaction.changes.mapPos(range.head, -1));
+    }
+  }
+  if (affectedPositions.size === 0) return transaction;
+
+  let corrected = false;
+  const selection = EditorSelection.create(
+    transaction.newSelection.ranges.map((range) => {
+      if (
+        range.empty &&
+        range.assoc !== 1 &&
+        affectedPositions.has(range.head)
+      ) {
+        corrected = true;
+        return EditorSelection.cursor(
+          range.head,
+          1,
+          range.bidiLevel ?? undefined,
+          range.goalColumn ?? undefined,
+        );
+      }
+      return range;
+    }),
+    transaction.newSelection.mainIndex,
+  );
+  if (!corrected) return transaction;
+
+  // Apply affinity in the deleting transaction. A later selection-only
+  // update is treated as an equivalent DOM boundary beside inline widgets.
+  return [
+    transaction,
+    {
+      selection,
+      sequential: true,
+    },
+  ];
+}
+
 function confirmIncompleteInlineDestination(view: EditorView) {
   if (!isEditable(view)) return false;
   const { ranges } = view.state.selection;
@@ -154,10 +206,13 @@ function insertContextualHardBreak(view: EditorView) {
 export function markdownEditingPlugin() {
   return defineMarkraPlugin({
     id: "markra.markdown-editing",
-    extension: Prec.high(keymap.of([
-      { key: "Enter", run: confirmIncompleteInlineDestination },
-      { key: "Tab", run: handleTab, shift: handleShiftTab },
-      { key: "Shift-Enter", run: insertContextualHardBreak },
-    ])),
+    extension: [
+      EditorState.transactionFilter.of(keepJoinedLineCaretsAfterText),
+      Prec.high(keymap.of([
+        { key: "Enter", run: confirmIncompleteInlineDestination },
+        { key: "Tab", run: handleTab, shift: handleShiftTab },
+        { key: "Shift-Enter", run: insertContextualHardBreak },
+      ])),
+    ],
   });
 }

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -346,18 +346,21 @@ function buildDecorations(
       if (blockClass) {
         const firstLine = state.doc.lineAt(visibleNodeFrom).number;
         const lastLine = state.doc.lineAt(visibleNodeTo - 1).number;
-        const sourceAfterNode = state.sliceDoc(node.to);
-        // A whitespace-only trailing line is still being edited. Only a
-        // following block or a second newline establishes stable block rhythm.
-        const isSpacedParagraph = node.name === "Paragraph" &&
-          listDepth(node.node as MarkraSyntaxNode) === 0 &&
-          (
-            /\S/u.test(sourceAfterNode) ||
-            /\n[^\S\n]*\n/u.test(sourceAfterNode)
-          );
-        const paragraphEndLine = isSpacedParagraph
-          ? state.doc.lineAt(node.to - 1).number
-          : null;
+        let paragraphEndLine: number | null = null;
+        if (
+          node.name === "Paragraph" &&
+          listDepth(node.node as MarkraSyntaxNode) === 0
+        ) {
+          const endLine = state.doc.lineAt(node.to - 1).number;
+          // An authored blank line already provides full-height block rhythm.
+          // Extra spacing is only needed when another block starts directly.
+          if (
+            endLine < state.doc.lines &&
+            state.doc.line(endLine + 1).text.trim().length > 0
+          ) {
+            paragraphEndLine = endLine;
+          }
+        }
         for (let lineNumber = firstLine; lineNumber <= lastLine; lineNumber += 1) {
           const line = state.doc.line(lineNumber);
           const key = `${blockClass}:${line.from}`;

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -346,12 +346,27 @@ function buildDecorations(
       if (blockClass) {
         const firstLine = state.doc.lineAt(visibleNodeFrom).number;
         const lastLine = state.doc.lineAt(visibleNodeTo - 1).number;
+        const sourceAfterNode = state.sliceDoc(node.to);
+        // A whitespace-only trailing line is still being edited. Only a
+        // following block or a second newline establishes stable block rhythm.
+        const isSpacedParagraph = node.name === "Paragraph" &&
+          listDepth(node.node as MarkraSyntaxNode) === 0 &&
+          (
+            /\S/u.test(sourceAfterNode) ||
+            /\n[^\S\n]*\n/u.test(sourceAfterNode)
+          );
+        const paragraphEndLine = isSpacedParagraph
+          ? state.doc.lineAt(node.to - 1).number
+          : null;
         for (let lineNumber = firstLine; lineNumber <= lastLine; lineNumber += 1) {
           const line = state.doc.line(lineNumber);
           const key = `${blockClass}:${line.from}`;
           if (!decoratedBlockLines.has(key)) {
             decoratedBlockLines.add(key);
-            ranges.push(Decoration.line({ class: blockClass }).range(line.from));
+            const className = lineNumber === paragraphEndLine
+              ? `${blockClass} cm-markra-paragraph-end`
+              : blockClass;
+            ranges.push(Decoration.line({ class: className }).range(line.from));
           }
         }
       }
@@ -703,18 +718,6 @@ function buildDecorations(
         decoratedEmptyLines.add(line.from);
         ranges.push(
           Decoration.line({
-            attributes: {
-              "data-markra-empty-source": isRevealed({
-                view,
-                state,
-                from: line.from,
-                to: line.to,
-                nodeName: "EmptyLine",
-                scope: "line",
-              })
-                ? "visible"
-                : "hidden",
-            },
             class: "cm-markra-empty-line",
           }).range(line.from),
         );


### PR DESCRIPTION
## Summary

- keep authored blank lines at the editor's normal line height instead of collapsing them to paragraph spacing
- avoid stacking paragraph-end spacing on authored blank lines, so entering text in a blank line does not shift the line upward; retain spacing when another Markdown block starts directly
- keep backward-joined carets on the text side of the block toolbar for single, multiple, and mixed selections

## Validation

- `pnpm --filter @markra/editor test` (381 tests)
- `pnpm --filter @markra/editor build`
- `pnpm --filter @markra/editor typecheck:test`
- `pnpm --filter @markra/app test -- src/styles.test.ts src/components/CodeMirrorPaperSurface.test.tsx` (96 tests)
- `pnpm --filter @markra/app build`
- `pnpm --filter @markra/app typecheck:test`

Closes #623