### PR TITLE
fix(editor): align block controls and list interactions

### DIFF
--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -1263,8 +1263,8 @@ describe("MarkdownFileTreeDrawer", () => {
     const toolbar = container.querySelector(".markdown-file-tree-toolbar") as HTMLElement;
     const root = container.querySelector(".markdown-file-tree-root") as HTMLElement;
 
-    expect(toolbar).toHaveClass("h-8", "justify-start", "pl-2.5", "pr-4");
-    expect(toolbar).not.toHaveClass("px-4");
+    expect(toolbar).toHaveClass("h-8", "justify-start", "gap-0", "px-2");
+    expect(toolbar).not.toHaveClass("gap-1", "pl-2.5", "pr-4");
     expect(toolbar).not.toHaveClass("absolute", "top-0");
     expect(root).toHaveClass("h-8", "pl-4", "pr-2");
     expect(root).not.toHaveClass("px-4");

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -2941,7 +2941,7 @@ export function MarkdownFileTreeDrawer({
                 onDragStart={handleFileTreeDragStart}
               >
                 {renderFileTreeActions(
-                  "markdown-file-tree-toolbar flex h-8 shrink-0 items-center justify-start gap-1 pr-4 pl-2.5 text-(--text-secondary)"
+                  "markdown-file-tree-toolbar flex h-8 shrink-0 items-center justify-start gap-0 px-2 text-(--text-secondary)"
                 )}
 
                 {renderFileSearchInput()}

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1080,6 +1080,10 @@
     text-align: center;
   }
 
+  .markdown-paper .cm-line.cm-markra-list-item[data-markra-list-marker-selected="true"]::before {
+    background: color-mix(in srgb, var(--editor-caret-color, var(--accent)) 20%, transparent);
+  }
+
   .markdown-paper .cm-line.cm-markra-list-item[data-list-kind="task"][data-markra-list-source="hidden"] {
     padding-inline-start: 0 !important;
   }
@@ -1123,12 +1127,14 @@
   }
 
   .markdown-paper .cm-line.cm-markra-list-item + .cm-line.cm-markra-list-item {
-    padding-block-start: 8px !important;
+    --markra-block-toolbar-block-offset: 4px;
+    padding-block-start: 4px !important;
   }
 
   .markdown-paper .cm-line.cm-markra-list-item[data-list-depth="0"] +
     .cm-line.cm-markra-list-item[data-list-depth="1"] {
-    padding-block-start: 12px !important;
+    --markra-block-toolbar-block-offset: 8px;
+    padding-block-start: 8px !important;
   }
 
   .markdown-paper .cm-line.cm-markra-list-item[data-list-depth="1"] +
@@ -1137,7 +1143,8 @@
     .cm-line.cm-markra-list-item[data-list-kind="ordered"],
   .markdown-paper .cm-line.cm-markra-list-item[data-list-kind="ordered"] +
     .cm-line.cm-markra-list-item[data-list-kind="task"] {
-    padding-block-start: 24px !important;
+    --markra-block-toolbar-block-offset: 12px;
+    padding-block-start: 12px !important;
   }
 
   .markdown-paper .cm-line.cm-markra-list-item[data-markra-list-source="hidden"] {
@@ -1170,6 +1177,7 @@
      accumulate across blocks and shift WebKit's pointer mapping away from
      the rendered caret. */
   .markdown-paper .cm-line.cm-markra-code-header-line {
+    --markra-block-toolbar-block-offset: 12px;
     position: relative !important;
     height: 0 !important;
     min-height: 0 !important;
@@ -1418,6 +1426,7 @@
   }
 
   .markdown-paper .cm-line:has(> .cm-markra-horizontal-rule) {
+    --markra-block-toolbar-block-offset: 22px;
     font-size: 0 !important;
     line-height: 0 !important;
   }
@@ -1483,19 +1492,23 @@
     transform: translate(-50%, -50%);
   }
 
+  .markdown-paper .cm-line[data-markra-block-from] {
+    position: relative;
+  }
+
   .markdown-paper .cm-markra-block-toolbar {
-    /* 42px of controls plus a 12px gap offsets the -54px gutter without
-       shifting the document text column. */
-    position: relative !important;
+    /* Keep block tools anchored to the shared line gutter. List and callout
+       padding must move content without pulling controls into the block. */
+    position: absolute !important;
+    inset-inline-start: -54px;
+    top: calc(0.5lh + var(--markra-block-toolbar-block-offset, 0px));
+    z-index: 5;
     display: inline-flex !important;
     flex: none;
-    margin: 0 12px 0 -54px !important;
-    margin-inline-start: -54px !important;
-    margin-inline-end: 12px !important;
+    margin: 0 !important;
     opacity: 0 !important;
     pointer-events: auto;
-    transform: none;
-    vertical-align: middle;
+    transform: translateY(-50%);
   }
 
   /* The controls sit outside the line box. This invisible bridge keeps the
@@ -2413,7 +2426,26 @@
 
   .markdown-paper h2.markra-heading-toggle-heading,
   .markdown-paper .cm-line.cm-markra-h2.markra-heading-toggle-heading {
-    --markra-heading-toggle-center-offset: -3.5px;
+    --markra-heading-toggle-center-offset: 8px;
+  }
+
+  .markdown-paper h3.markra-heading-toggle-heading,
+  .markdown-paper .cm-line.cm-markra-h3.markra-heading-toggle-heading {
+    --markra-heading-toggle-center-offset: 9px;
+  }
+
+  .markdown-paper h4.markra-heading-toggle-heading,
+  .markdown-paper .cm-line.cm-markra-h4.markra-heading-toggle-heading {
+    --markra-heading-toggle-center-offset: 8px;
+  }
+
+  .markdown-paper h5.markra-heading-toggle-heading,
+  .markdown-paper .cm-line.cm-markra-h5.markra-heading-toggle-heading,
+  .markdown-paper h6.markra-heading-toggle-heading,
+  .markdown-paper .cm-line.cm-markra-h6.markra-heading-toggle-heading {
+    /* Heading rhythm uses top padding. Offset gutter controls by half the
+       padding imbalance so they remain centered on the editable text row. */
+    --markra-heading-toggle-center-offset: 7px;
   }
 
   .markdown-paper .markra-heading-toggle-button {
@@ -2587,6 +2619,7 @@
   }
 
   .markdown-paper .cm-line.markra-callout-first {
+    --markra-block-toolbar-block-offset: 14px;
     border-block-start: 1px solid var(--callout-border) !important;
     border-start-start-radius: 7px;
     border-start-end-radius: 7px;

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -299,6 +299,9 @@ describe("editor stylesheet", () => {
     expect(headerLineStart).toBeGreaterThanOrEqual(0);
     expect(headerLineRule).toContain("height: 0 !important");
     expect(headerLineRule).toContain("min-height: 0 !important");
+    expect(headerLineRule).toContain(
+      "--markra-block-toolbar-block-offset: 12px;",
+    );
     expect(headerLineRule).toContain("margin-block: 0 !important");
     expect(headerLineRule).not.toContain("margin-block-start: 8px");
     expect(headerLineRule).toContain("border: 0 !important");
@@ -394,7 +397,10 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(
       '.cm-line.cm-markra-list-item[data-list-depth="1"]',
     );
-    expect(styles).toContain("padding-block-start: 24px !important");
+    expect(styles).toContain("padding-block-start: 4px !important");
+    expect(styles).toContain("padding-block-start: 8px !important");
+    expect(styles).toContain("padding-block-start: 12px !important");
+    expect(styles).not.toContain("padding-block-start: 24px !important");
     expect(styles).toContain(".markdown-paper .cm-line.cm-markra-code-content-line");
     expect(styles).toContain("font-size: 14.4px !important");
     expect(styles).toContain(".markdown-paper .cm-markra-code-header-actions");
@@ -469,6 +475,11 @@ describe("editor stylesheet", () => {
 
   it("reveals inline CodeMirror block controls when their block is hovered", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const blockLineRuleStart = styles.indexOf(
+      ".markdown-paper .cm-line[data-markra-block-from] {",
+    );
+    const blockLineRuleEnd = styles.indexOf("\n  }", blockLineRuleStart);
+    const blockLineRule = styles.slice(blockLineRuleStart, blockLineRuleEnd);
     const toolbarRuleStart = styles.indexOf(
       ".markdown-paper .cm-markra-block-toolbar {",
     );
@@ -480,9 +491,16 @@ describe("editor stylesheet", () => {
     const revealRuleEnd = styles.indexOf("\n  }", revealRuleStart);
     const revealRule = styles.slice(revealRuleStart, revealRuleEnd);
 
+    expect(blockLineRuleStart).toBeGreaterThanOrEqual(0);
+    expect(blockLineRule).toContain("position: relative");
     expect(toolbarRuleStart).toBeGreaterThanOrEqual(0);
-    expect(toolbarRule).toContain("position: relative");
-    expect(toolbarRule).toContain("margin-inline-start: -54px");
+    expect(toolbarRule).toContain("position: absolute !important");
+    expect(toolbarRule).toContain("inset-inline-start: -54px");
+    expect(toolbarRule).toContain(
+      "top: calc(0.5lh + var(--markra-block-toolbar-block-offset, 0px))",
+    );
+    expect(toolbarRule).toContain("margin: 0 !important");
+    expect(toolbarRule).toContain("transform: translateY(-50%)");
     expect(toolbarRule).toContain("opacity: 0 !important");
     expect(toolbarRule).toContain("pointer-events: auto");
     expect(styles).toContain(
@@ -517,6 +535,24 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(
       ".markdown-paper .markra-heading-toggle-heading > .cm-markra-block-toolbar::after",
     );
+    expect(styles).toContain(
+      ".markdown-paper .cm-line.cm-markra-h2.markra-heading-toggle-heading {\n" +
+      "    --markra-heading-toggle-center-offset: 8px;",
+    );
+    expect(styles).toContain(
+      ".markdown-paper .cm-line.cm-markra-h3.markra-heading-toggle-heading {\n" +
+      "    --markra-heading-toggle-center-offset: 9px;",
+    );
+    expect(styles).toContain(
+      ".markdown-paper .cm-line.cm-markra-h4.markra-heading-toggle-heading {\n" +
+      "    --markra-heading-toggle-center-offset: 8px;",
+    );
+    expect(styles).toContain(
+      ".markdown-paper .cm-line.cm-markra-h5.markra-heading-toggle-heading,\n" +
+      "  .markdown-paper h6.markra-heading-toggle-heading,\n" +
+      "  .markdown-paper .cm-line.cm-markra-h6.markra-heading-toggle-heading {",
+    );
+    expect(styles).toContain("--markra-heading-toggle-center-offset: 7px;");
   });
 
   it("forces a grabbing cursor during document tab pointer drags", () => {
@@ -827,6 +863,11 @@ describe("editor stylesheet", () => {
     const renderedRuleStart = styles.indexOf(".markdown-paper .cm-markra-horizontal-rule {");
     const renderedRuleEnd = styles.indexOf(".markdown-paper .cm-markra-task-checkbox", renderedRuleStart);
     const renderedRuleStyles = styles.slice(renderedRuleStart, renderedRuleEnd);
+    const renderedLineStart = styles.indexOf(
+      ".markdown-paper .cm-line:has(> .cm-markra-horizontal-rule) {",
+    );
+    const renderedLineEnd = styles.indexOf("\n  }", renderedLineStart);
+    const renderedLineStyles = styles.slice(renderedLineStart, renderedLineEnd);
     const ruleStart = styles.indexOf(".markdown-paper hr {");
     const ruleEnd = styles.indexOf(".ai-chat-markdown", ruleStart);
     const ruleStyles = styles.slice(ruleStart, ruleEnd);
@@ -834,6 +875,9 @@ describe("editor stylesheet", () => {
     expect(renderedRuleStart).toBeGreaterThanOrEqual(0);
     expect(renderedRuleEnd).toBeGreaterThan(renderedRuleStart);
     expect(renderedRuleStyles).toContain("border-top: 0 !important");
+    expect(renderedLineStyles).toContain(
+      "--markra-block-toolbar-block-offset: 22px;",
+    );
     expect(ruleStart).toBeGreaterThanOrEqual(0);
     expect(ruleEnd).toBeGreaterThan(ruleStart);
     expect(ruleStyles).toContain("@apply my-5 border-0");
@@ -843,6 +887,23 @@ describe("editor stylesheet", () => {
     expect(ruleStyles).toContain("background:");
     expect(ruleStyles).toContain(".markdown-paper hr:hover");
     expect(ruleStyles).toContain("100% 2px");
+  });
+
+  it("extends range-selection feedback to hidden visual list markers", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const selectedMarkerStart = styles.indexOf(
+      '.markdown-paper .cm-line.cm-markra-list-item[data-markra-list-marker-selected="true"]::before {',
+    );
+    const selectedMarkerEnd = styles.indexOf("\n  }", selectedMarkerStart);
+    const selectedMarkerRule = styles.slice(
+      selectedMarkerStart,
+      selectedMarkerEnd,
+    );
+
+    expect(selectedMarkerStart).toBeGreaterThanOrEqual(0);
+    expect(selectedMarkerRule).toContain(
+      "background: color-mix(in srgb, var(--editor-caret-color, var(--accent)) 20%, transparent);",
+    );
   });
 
   it("suppresses editor selection chrome while document search is open", () => {

--- a/packages/editor-react/src/editor-react.test.tsx
+++ b/packages/editor-react/src/editor-react.test.tsx
@@ -176,9 +176,9 @@ describe("@markra/editor-react", () => {
     const host = render(view, <SlashProbe />);
 
     expect(host.querySelector("section")?.getAttribute("data-open")).toBe("true");
-    expect(host.querySelectorAll("button")).toHaveLength(13);
+    expect(host.querySelectorAll("button")).toHaveLength(14);
     expect([...host.querySelectorAll("button")].map((button) => button.textContent)).toEqual(
-      expect.arrayContaining(["Callout", "Table"]),
+      expect.arrayContaining(["Task list", "Callout", "Table"]),
     );
 
     act(() => {

--- a/packages/editor/src/codemirror/block-drag.test.ts
+++ b/packages/editor/src/codemirror/block-drag.test.ts
@@ -196,6 +196,51 @@ describe("codeMirrorBlockDragPlugin", () => {
     expect(movedLine?.getAttribute("data-markra-list-source")).toBe("hidden");
   });
 
+  it("preserves tab-expanded columns when nesting a second-level item deeper", () => {
+    const view = createView([
+      "- Parent",
+      "\t- First child",
+      "\t- Second child",
+      "\t\t- Grandchild",
+      "- Tail",
+    ].join("\n"));
+    const blocks = readCodeMirrorBlockRanges(view.state);
+    const firstChild = blocks.find((block) =>
+      view.state.sliceDoc(block.from, block.to).startsWith("\t- First child")
+    );
+    const secondChild = blocks.find((block) =>
+      view.state.sliceDoc(block.from, block.to).startsWith("\t- Second child")
+    );
+
+    expect(firstChild?.depth).toBe(1);
+    expect(secondChild?.depth).toBe(1);
+    expect(
+      secondChild && firstChild && moveCodeMirrorBlock(
+        view,
+        secondChild.from,
+        firstChild.from,
+        "after",
+        2,
+      ),
+    ).toBe(true);
+    expect(view.state.doc.toString()).toBe([
+      "- Parent",
+      "\t- First child",
+      "      - Second child",
+      "          - Grandchild",
+      "- Tail",
+    ].join("\n"));
+    const movedBlocks = readCodeMirrorBlockRanges(view.state);
+    const moved = movedBlocks.find((block) =>
+      view.state.doc.lineAt(block.from).text.includes("Second child")
+    );
+    const grandchild = movedBlocks.find((block) =>
+      view.state.doc.lineAt(block.from).text.includes("Grandchild")
+    );
+    expect(moved?.depth).toBe(2);
+    expect(grandchild?.depth).toBe(3);
+  });
+
   it("turns a paragraph dropped as a child into a nested list item", () => {
     const view = createView("- Parent\n\nChild paragraph\n\nAfter");
     const [parent, child] = readCodeMirrorBlockRanges(view.state);
@@ -335,6 +380,62 @@ describe("codeMirrorBlockDragPlugin", () => {
     );
     expect(view.dom.querySelector(".markra-block-drag-source")).toBeNull();
     expect(view.dom.querySelector(".markra-block-drop-indicator")).toBeNull();
+  });
+
+  it("nests a second-level item as a third-level item through pointer dragging", () => {
+    const view = createView([
+      "- Parent",
+      "  - First child",
+      "  - Second child",
+      "- Tail",
+    ].join("\n"));
+    const blocks = readCodeMirrorBlockRanges(view.state);
+    const firstChild = blocks.find((block) =>
+      view.state.sliceDoc(block.from, block.to).startsWith("  - First child")
+    );
+    const secondChild = blocks.find((block) =>
+      view.state.sliceDoc(block.from, block.to).startsWith("  - Second child")
+    );
+    const handle = view.dom.querySelector<HTMLElement>(
+      `[data-block-from="${secondChild?.from}"] .markra-block-drag-handle`,
+    );
+    const target = view.dom.querySelector<HTMLElement>(
+      `.cm-line[data-markra-block-from="${firstChild?.from}"]`,
+    );
+
+    handle?.dispatchEvent(new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      clientX: 44,
+      clientY: 10,
+      pointerId: 2,
+    }));
+    target?.dispatchEvent(new PointerEvent("pointermove", {
+      bubbles: true,
+      buttons: 1,
+      clientX: 66,
+      clientY: 40,
+      pointerId: 2,
+    }));
+    target?.dispatchEvent(new PointerEvent("pointerup", {
+      bubbles: true,
+      button: 0,
+      clientX: 66,
+      clientY: 40,
+      pointerId: 2,
+    }));
+
+    expect(view.state.doc.toString()).toBe([
+      "- Parent",
+      "  - First child",
+      "    - Second child",
+      "- Tail",
+    ].join("\n"));
+    const moved = readCodeMirrorBlockRanges(view.state).find((block) =>
+      view.state.sliceDoc(block.from, block.to).startsWith("    - Second child")
+    );
+    expect(moved?.depth).toBe(2);
   });
 
   it("adds an editable blank block below and opens the virtual slash menu", () => {

--- a/packages/editor/src/codemirror/block-drag.ts
+++ b/packages/editor/src/codemirror/block-drag.ts
@@ -157,6 +157,14 @@ function listMarkerMatch(state: CodeMirrorState, block: CodeMirrorBlockRange) {
   );
 }
 
+function markdownColumnWidth(value: string) {
+  let column = 0;
+  for (const character of value) {
+    column += character === "\t" ? 4 - column % 4 : 1;
+  }
+  return column;
+}
+
 function findLastListBlockAtDepth(
   blocks: readonly CodeMirrorBlockRange[],
   depth: number,
@@ -211,7 +219,9 @@ function normalizedListDrop(
       depth,
       // Ordered markers need wider child indentation than `- `, so align to
       // the parent's actual content column instead of assuming two spaces.
-      indentation: " ".repeat(parentMarker[0].length),
+      // Markdown expands tabs to four-column stops, so string length would
+      // under-indent pasted tab-indented lists and break their parsed depth.
+      indentation: " ".repeat(markdownColumnWidth(parentMarker[0])),
     };
   }
 
@@ -258,15 +268,19 @@ export function moveCodeMirrorBlock(
     : null;
   let sourceMarkdown = document.slice(source.from, source.to);
   if (source.name === "ListItem" && drop) {
-    const sourceIndentation = /^\s*/u.exec(sourceMarkdown)?.[0].length ?? 0;
-    const indentationDelta = drop.indentation.length - sourceIndentation;
+    const sourceIndentation = /^[\t ]*/u.exec(sourceMarkdown)?.[0] ?? "";
+    const indentationDelta = markdownColumnWidth(drop.indentation) -
+      markdownColumnWidth(sourceIndentation);
     if (indentationDelta !== 0) {
       sourceMarkdown = sourceMarkdown
         .split("\n")
         .map((line) => {
-          const indentation = /^\s*/u.exec(line)?.[0].length ?? 0;
-          const nextIndentation = Math.max(0, indentation + indentationDelta);
-          return `${" ".repeat(nextIndentation)}${line.slice(indentation)}`;
+          const indentation = /^[\t ]*/u.exec(line)?.[0] ?? "";
+          const nextIndentation = Math.max(
+            0,
+            markdownColumnWidth(indentation) + indentationDelta,
+          );
+          return `${" ".repeat(nextIndentation)}${line.slice(indentation.length)}`;
         })
         .join("\n");
     }

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -855,6 +855,41 @@ describe("liveMarkdown", () => {
     expect(lines[1]?.textContent).toBe("Second item");
   });
 
+  it("marks hidden list markers whose source is included in a range selection", () => {
+    const doc = "- First item\n- Second item\n\nTail";
+    const view = createView({
+      doc,
+      selection: EditorSelection.range(0, doc.length),
+    });
+    const listLines = () => [
+      ...view.dom.querySelectorAll<HTMLElement>(".cm-markra-list-item"),
+    ];
+
+    expect(
+      listLines().map((line) =>
+        line.getAttribute("data-markra-list-marker-selected")
+      ),
+    ).toEqual(["true", "true"]);
+
+    view.dispatch({
+      selection: EditorSelection.range(doc.indexOf("First"), doc.length),
+    });
+
+    expect(
+      listLines().map((line) =>
+        line.getAttribute("data-markra-list-marker-selected")
+      ),
+    ).toEqual([null, "true"]);
+
+    view.dispatch({ selection: EditorSelection.cursor(doc.length) });
+
+    expect(
+      listLines().map((line) =>
+        line.getAttribute("data-markra-list-marker-selected")
+      ),
+    ).toEqual([null, null]);
+  });
+
   it("preserves visual list depth without leaving source indentation in preview text", () => {
     const doc = [
       "- First bullet",

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -123,6 +123,70 @@ function listLineAttributes(source: string) {
   };
 }
 
+function rangeSelectionIncludesPosition(
+  view: EditorView,
+  position: number,
+) {
+  return view.state.selection.ranges.some(
+    (selection) =>
+      !selection.empty && selection.from <= position && selection.to > position,
+  );
+}
+
+function buildListMarkerSelectionDecorations(view: EditorView) {
+  const ranges: Range<Decoration>[] = [];
+  const decoratedLines = new Set<number>();
+
+  for (const visibleRange of view.visibleRanges) {
+    const firstLine = view.state.doc.lineAt(visibleRange.from).number;
+    const lastLine = view.state.doc.lineAt(visibleRange.to).number;
+
+    for (let lineNumber = firstLine; lineNumber <= lastLine; lineNumber += 1) {
+      const line = view.state.doc.line(lineNumber);
+      if (
+        decoratedLines.has(line.from) ||
+        !listLineAttributes(line.text) ||
+        !rangeSelectionIncludesPosition(view, line.from)
+      ) {
+        continue;
+      }
+
+      decoratedLines.add(line.from);
+      ranges.push(
+        Decoration.line({
+          attributes: { "data-markra-list-marker-selected": "true" },
+        }).range(line.from),
+      );
+    }
+  }
+
+  return Decoration.set(ranges, true);
+}
+
+const listMarkerSelectionPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildListMarkerSelectionDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (
+        update.docChanged ||
+        update.selectionSet ||
+        update.viewportChanged
+      ) {
+        // Visual list markers are pseudo-elements, so CodeMirror's selection
+        // layer cannot paint them. Mirror selection only when source includes
+        // the marker, without revealing Markdown or changing line geometry.
+        this.decorations = buildListMarkerSelectionDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (plugin) => plugin.decorations },
+);
+
 function emptyTaskMarkerRange(source: string) {
   const match = EMPTY_TASK_ITEM_PATTERN.exec(source);
   if (!match) return null;
@@ -851,5 +915,9 @@ function previewPlugin(config: LivePreviewConfig): Extension {
 }
 
 export function livePreview(config: LivePreviewConfig = {}): Extension {
-  return [sourceDragSelectionExtension, previewPlugin(config)];
+  return [
+    sourceDragSelectionExtension,
+    previewPlugin(config),
+    listMarkerSelectionPlugin,
+  ];
 }


### PR DESCRIPTION
## Summary

- keep file-tree actions within the minimum sidebar width and tighten nested-list rhythm
- anchor block controls to the gutter and align headings, callouts, rules, code blocks, and tables
- preserve nested-list depth for tab-indented drag moves and extend range-selection feedback to visual list markers
- refresh the existing slash-menu assertion for the Task list action

## Validation

- `pnpm test` — 2,476 tests passed across the workspace
- `pnpm build` — desktop and web production builds passed, including vendor-chunk verification
- `pnpm typecheck:test` — passed across all test TypeScript projects
- local browser QA — checked H1–H6, nested bullet/ordered/task lists, callouts, blockquotes, rules, code blocks, tables, CJK, emoji, and RTL content; no console errors
- Impeccable layout scan — 0 findings
- `git diff --check` — passed

## Risk

- alignment changes use scoped per-block offsets and do not change persisted data or public APIs
- moving tab-indented list items may normalize indentation to spaces while preserving Markdown nesting

## Related issues

- Refs #624
