### PR TITLE
fix(editor): align indented code block chrome

### DIFF
--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -106,6 +106,21 @@ describe("codeBlockPreviewPlugin", () => {
     expect(view.state.doc.toString()).toBe(source);
   });
 
+  it("keeps indented fence chrome on the folded opening line", () => {
+    const source = [
+      "  ```",
+      "  https://example.test/folder/database.kdbx",
+      "  ```",
+    ].join("\n");
+    const view = createView(source);
+    const headerLine = view.dom.querySelector(".cm-markra-code-header-line");
+    const language = view.dom.querySelector(".markra-code-language-select");
+
+    expect(language?.closest(".cm-markra-code-header-line")).toBe(headerLine);
+    expect(headerLine?.textContent).not.toContain("  ");
+    expect(view.state.doc.toString()).toBe(source);
+  });
+
   it("keeps a lone unfinished opening fence editable until Enter", () => {
     const source = "```";
     const view = createView(source);

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -292,12 +292,14 @@ function codeBlockTopGapDecorations(state: EditorState) {
       const firstLine = state.doc.lineAt(node.from);
       const lastLine = state.doc.lineAt(node.to);
       if (firstLine.number === lastLine.number) return;
+      // Fenced code may be indented by up to three spaces. Block widgets
+      // anchored after that indentation split the folded header in WebKit.
       gaps.push(
         Decoration.widget({
           block: true,
           side: -100,
           widget: new CodeBlockTopGapWidget(),
-        }).range(node.from),
+        }).range(firstLine.from),
       );
     },
   });
@@ -997,7 +999,7 @@ export function codeBlockPreviewPlugin(
                   languages,
                   parts.openingMarkTo,
                 ),
-              }).range(node.from, firstLine.to),
+              }).range(firstLine.from, firstLine.to),
             );
           }
           if (


### PR DESCRIPTION
## Summary
- anchor fenced-code top gaps at the opening line start
- fold indentation together with the opening fence so controls stay on the code block header
- add regression coverage for two-space-indented fenced code blocks

## Why
Indented fenced code starts after its leading spaces. Anchoring block decorations at the syntax node offset caused CodeMirror/WebKit to split the folded header into a detached anonymous line, leaving a large gap above the code body.

## Validation
- `pnpm --filter @markra/editor test` — 33 files and 385 tests passed
- `pnpm --filter @markra/editor build` — passed
- Safari/WebKit manual QA — two-space-indented code blocks render as one contiguous surface
- Browser boundary QA — 0–3-space indentation, list and blockquote fences, and indented/unindented Mermaid previews retain their expected layout

## Risk
- Low: unindented fences keep the same offsets, Markdown source is unchanged, and existing Mermaid preview behavior is preserved.