### PR TITLE
fix(editor): stabilize blank lines across preview blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,19 @@ This document only defines engineering conventions for this repository.
 - Do not use the TypeScript `void` keyword or operator. Use `unknown`, omit explicit callback return annotations when practical, or call promises directly with their own error handling.
 - Do not revert user changes unless explicitly requested.
 
+## CodeMirror Editor Invariants
+
+- Treat the Markdown document, `EditorState`, and explicit editor configuration as the source of truth. Do not use DOM shape, focus state, selection state, component lifetime, or session-local maps to decide persistent document semantics or steady-state layout.
+- Structural preview output must be deterministic: recreating the editor with the same document and configuration must produce the same decorations, visible rows, and vertical geometry. Test recreation whenever a change classifies, hides, replaces, folds, or resizes source lines.
+- Keep transient state limited to transient interaction UI such as marker reveal, hover controls, drag feedback, and IME composition. Transient state must not change the settled height or ownership of Markdown lines after blur, click, mode switch, or reopen.
+- Use CodeMirror transactions, `StateField`, facets, view plugins, decorations, and widgets for editor behavior. Do not directly mutate CodeMirror-managed DOM or read it back as application state.
+- CSS that changes CodeMirror geometry requires editor-level review. Avoid generic `height`, `line-height`, `display`, margin, or padding rules on `.cm-line`, `.cm-content`, generated `<br>` elements, or other CodeMirror-managed nodes. If a source line must be hidden or collapsed, preserve measurable layout with an explicit CodeMirror decoration or block widget and verify caret hit testing and selection mapping.
+- Keep authored blank-line height separate from semantic block spacing. Paragraph or block spacing tokens must not be used to resize editable source lines; represent non-editable structural spacing independently.
+- Decorations and widgets must not mutate document text. Source changes belong in explicit editing commands, and one keyboard action must have a predictable source transformation and selection result.
+- Before classifying blank lines or block boundaries, account for preformatted and renderer-owned regions, including frontmatter, fenced and indented code, Mermaid, HTML, math, tables, images, lists, blockquotes, headings, and horizontal rules as applicable.
+- Any change to line visibility, vertical spacing, Enter, Backspace, or caret movement must test the relevant matrix: line start/end and repeated input, typing after blank lines, one-step deletion, range and multi-cursor selection, focus/blur, pointer clicks, editor recreation, file reopen, and Preview/Source/Split transitions.
+- For visual geometry changes, supplement unit tests with runtime browser or desktop QA. Verify both rendered layout and the underlying Markdown text; DOM snapshots or CSS string assertions alone are not sufficient evidence.
+
 ## Testing Boundaries
 
 - Add or update focused tests when changing business logic, user-facing behavior, editor behavior, file reliability, AI flows, or other product functionality.

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1057,6 +1057,22 @@
     color: var(--editor-text-primary);
   }
 
+  /* Keep the source line in CodeMirror's document model while removing one
+     stable Markdown-only separator from visual layout. */
+  .markdown-paper .cm-line.cm-markra-layout-separator {
+    display: none !important;
+  }
+
+  /* The hidden source separator still represents a Markdown block boundary.
+     Keep its visual rhythm in a non-editable CodeMirror block widget so every
+     block pairing is measured consistently. */
+  .markdown-paper .cm-markra-block-gap {
+    box-sizing: border-box;
+    width: 100% !important;
+    height: var(--editor-paragraph-spacing) !important;
+    pointer-events: none;
+  }
+
   /* Paragraph spacing is extra rhythm after content, not a replacement for
      an authored blank line, which must retain the editor's normal line height. */
   .markdown-paper .cm-line.cm-markra-paragraph-end {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -367,9 +367,19 @@ describe("editor stylesheet", () => {
     expect(styles).not.toContain(emptyLineBreakRule);
   });
 
-  it("keeps empty lines full-height and applies spacing after paragraphs", () => {
+  it("keeps editable lines full-height and uses a stable structural gap", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 
+    expect(styles).toContain(
+      ".markdown-paper .cm-line.cm-markra-layout-separator {",
+    );
+    expect(styles).toContain("display: none !important;");
+    expect(styles).toContain(
+      ".markdown-paper .cm-markra-block-gap {",
+    );
+    expect(styles).toContain(
+      "height: var(--editor-paragraph-spacing) !important;",
+    );
     expect(styles).not.toContain(
       ".markdown-paper .cm-line.cm-markra-empty-line {",
     );
@@ -382,6 +392,9 @@ describe("editor stylesheet", () => {
     expect(styles).not.toContain("cm-markra-paragraph-separator");
     expect(styles).not.toContain(
       '.cm-markra-empty-line[data-markra-empty-source="hidden"] {',
+    );
+    expect(styles).not.toMatch(
+      /cm-markra-layout-separator[^}]+(?:height|line-height):/su,
     );
   });
 

--- a/packages/editor/src/codemirror/blank-lines.test.ts
+++ b/packages/editor/src/codemirror/blank-lines.test.ts
@@ -1,0 +1,188 @@
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { liveMarkdown } from "./index.ts";
+import "./dom.test-support.ts";
+
+const views: EditorView[] = [];
+
+function createView(doc: string, anchor = doc.length) {
+  const parent = document.createElement("div");
+  document.body.append(parent);
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({
+      doc,
+      selection: EditorSelection.cursor(anchor),
+      extensions: [liveMarkdown()],
+    }),
+  });
+  views.push(view);
+  return view;
+}
+
+function renderedLines(view: EditorView) {
+  return Array.from(
+    view.dom.querySelectorAll(
+      ".cm-line:not(.cm-markra-layout-separator)",
+    ),
+    (line) => line.textContent ?? "",
+  );
+}
+
+function editableEmptyLines(view: EditorView) {
+  return view.dom.querySelectorAll(
+    ".cm-markra-empty-line:not(.cm-markra-layout-separator)",
+  );
+}
+
+function blockGaps(view: EditorView) {
+  return view.dom.querySelectorAll(".cm-markra-block-gap");
+}
+
+afterEach(() => {
+  for (const view of views.splice(0)) view.destroy();
+  document.body.replaceChildren();
+});
+
+describe("blank line layout", () => {
+  it("does not render a single internal Markdown separator as an editable line", () => {
+    const doc = "# Synthetic heading\n\n- Synthetic item";
+    const view = createView(doc);
+
+    expect(renderedLines(view)).toEqual([
+      "Synthetic heading",
+      "Synthetic item",
+    ]);
+    expect(
+      view.dom.querySelector(".cm-markra-layout-separator"),
+    ).not.toBeNull();
+    expect(blockGaps(view)).toHaveLength(1);
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("keeps additional internal blank lines at normal editable height", () => {
+    const doc = "Synthetic before\n\n\nSynthetic after";
+    const view = createView(doc);
+
+    expect(renderedLines(view)).toEqual([
+      "Synthetic before",
+      "",
+      "Synthetic after",
+    ]);
+    expect(editableEmptyLines(view)).toHaveLength(1);
+    expect(blockGaps(view)).toHaveLength(1);
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("uses the same stable gap between different Markdown block types", () => {
+    const doc = [
+      "# Synthetic heading",
+      "",
+      "> Synthetic quote",
+      "",
+      "- Synthetic item",
+      "",
+      "~~~js",
+      "const synthetic = true;",
+      "~~~",
+      "",
+      "Synthetic paragraph",
+    ].join("\n");
+    const view = createView(doc);
+
+    expect(blockGaps(view)).toHaveLength(4);
+    expect(
+      Array.from(blockGaps(view)).every((gap) =>
+        gap.getAttribute("aria-hidden") === "true"
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps leading and trailing blank lines editable", () => {
+    const doc = "\nSynthetic content\n";
+    const view = createView(doc);
+
+    expect(renderedLines(view)).toEqual(["", "Synthetic content", ""]);
+    expect(editableEmptyLines(view)).toHaveLength(2);
+  });
+
+  it("collapses whitespace-only Markdown separators without changing source", () => {
+    const doc = "Synthetic before\n \t\nSynthetic after";
+    const view = createView(doc);
+
+    expect(renderedLines(view)).toEqual([
+      "Synthetic before",
+      "Synthetic after",
+    ]);
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("does not collapse blank lines inside fenced code", () => {
+    const doc = [
+      "~~~txt",
+      "synthetic-before",
+      "",
+      "synthetic-after",
+      "~~~",
+    ].join("\n");
+    const view = createView(doc);
+
+    expect(renderedLines(view)).toEqual([
+      "txt",
+      "synthetic-before",
+      "",
+      "synthetic-after",
+      "",
+    ]);
+    expect(blockGaps(view)).toHaveLength(0);
+  });
+
+  it("separates fenced blocks without treating their internal blanks as gaps", () => {
+    const doc = [
+      "Synthetic before",
+      "",
+      "~~~mermaid",
+      "flowchart TD",
+      "",
+      "  A --> B",
+      "~~~",
+      "",
+      "~~~ts",
+      "const synthetic = true;",
+      "~~~",
+    ].join("\n");
+    const view = createView(doc);
+
+    expect(blockGaps(view)).toHaveLength(2);
+  });
+
+  it("keeps separator layout stable across selection, focus, and recreation", () => {
+    const doc = "Synthetic before\n\nSynthetic after";
+    const firstView = createView(doc, 0);
+
+    expect(renderedLines(firstView)).toEqual([
+      "Synthetic before",
+      "Synthetic after",
+    ]);
+    expect(blockGaps(firstView)).toHaveLength(1);
+    firstView.focus();
+    firstView.dispatch({
+      selection: EditorSelection.cursor("Synthetic before\n".length),
+      userEvent: "select.pointer",
+    });
+    firstView.contentDOM.blur();
+    expect(renderedLines(firstView)).toEqual([
+      "Synthetic before",
+      "Synthetic after",
+    ]);
+    expect(blockGaps(firstView)).toHaveLength(1);
+
+    const recreatedView = createView(doc);
+    expect(renderedLines(recreatedView)).toEqual([
+      "Synthetic before",
+      "Synthetic after",
+    ]);
+    expect(blockGaps(recreatedView)).toHaveLength(1);
+  });
+});

--- a/packages/editor/src/codemirror/blank-lines.ts
+++ b/packages/editor/src/codemirror/blank-lines.ts
@@ -1,0 +1,258 @@
+import { syntaxTree } from "@codemirror/language";
+import {
+  EditorSelection,
+  EditorState,
+  type Range,
+  StateField,
+  type Extension,
+  type Text,
+  type Transaction,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  WidgetType,
+} from "@codemirror/view";
+import { readCodeMirrorFrontmatter } from "./frontmatter-preview.ts";
+
+const PREFORMATTED_BLOCKS = new Set([
+  "BlockMath",
+  "CodeBlock",
+  "FencedCode",
+  "Frontmatter",
+  "HTMLBlock",
+]);
+const frontmatterCache = new WeakMap<
+  EditorState,
+  ReturnType<typeof readCodeMirrorFrontmatter>
+>();
+
+function mayStartWithFrontmatter(state: EditorState) {
+  const prefix = state.sliceDoc(0, 4);
+  const sourceStart = prefix.charCodeAt(0) === 0xfeff
+    ? prefix.slice(1)
+    : prefix;
+  return sourceStart.startsWith("---") ||
+    sourceStart.startsWith("+++") ||
+    sourceStart.startsWith("{");
+}
+
+interface BlankLineLayout {
+  atomicRanges: DecorationSet;
+  decorations: DecorationSet;
+}
+
+class BlockGapWidget extends WidgetType {
+  eq() {
+    return true;
+  }
+
+  get estimatedHeight() {
+    return 8;
+  }
+
+  toDOM(view: EditorView) {
+    const gap = view.dom.ownerDocument.createElement("div");
+    gap.className = "cm-markra-block-gap";
+    gap.setAttribute("aria-hidden", "true");
+    return gap;
+  }
+}
+
+export function isInsidePreformattedBlock(
+  state: EditorState,
+  position: number,
+) {
+  let frontmatter = frontmatterCache.get(state);
+  if (frontmatter === undefined) {
+    // Most documents have no frontmatter. Avoid materializing the full source
+    // on every EditorState while blank-line layout is rebuilt during typing.
+    frontmatter = mayStartWithFrontmatter(state)
+      ? readCodeMirrorFrontmatter(state.doc.toString())
+      : null;
+    frontmatterCache.set(state, frontmatter);
+  }
+  if (
+    frontmatter &&
+    position >= frontmatter.contentFrom &&
+    position <= frontmatter.contentTo
+  ) {
+    return true;
+  }
+
+  let node: ReturnType<ReturnType<typeof syntaxTree>["resolveInner"]> | null =
+    syntaxTree(state).resolveInner(position, 1);
+  while (node) {
+    if (PREFORMATTED_BLOCKS.has(node.name)) return true;
+    node = node.parent;
+  }
+  return false;
+}
+
+function isCollapsibleBlankLine(
+  state: EditorState,
+  line: ReturnType<Text["line"]>,
+) {
+  return line.text.trim().length === 0 &&
+    !isInsidePreformattedBlock(state, line.from);
+}
+
+function buildBlankLineLayout(state: EditorState): BlankLineLayout {
+  const layoutDecorations: Range<Decoration>[] = [];
+  const atomicRanges: Range<Decoration>[] = [];
+
+  for (let lineNumber = 1; lineNumber <= state.doc.lines;) {
+    const firstBlank = state.doc.line(lineNumber);
+    if (!isCollapsibleBlankLine(state, firstBlank)) {
+      lineNumber += 1;
+      continue;
+    }
+
+    let lastBlankNumber = lineNumber;
+    while (lastBlankNumber < state.doc.lines) {
+      const nextLine = state.doc.line(lastBlankNumber + 1);
+      if (!isCollapsibleBlankLine(state, nextLine)) break;
+      lastBlankNumber += 1;
+    }
+
+    const previousLine = lineNumber > 1
+      ? state.doc.line(lineNumber - 1)
+      : null;
+    const nextLine = lastBlankNumber < state.doc.lines
+      ? state.doc.line(lastBlankNumber + 1)
+      : null;
+    if (
+      previousLine?.text.trim().length &&
+      nextLine?.text.trim().length
+    ) {
+      // Markdown does not preserve whether the first blank source line was
+      // intended as content. Treating one internal line as layout whitespace
+      // gives reopened files a stable, source-only separator while leaving
+      // every additional blank line editable.
+      layoutDecorations.push(
+        Decoration.line({
+          attributes: { "data-markra-empty-source": "separator" },
+          class: "cm-markra-layout-separator",
+        }).range(firstBlank.from),
+      );
+      // The source separator is not an editable row in preview, but it still
+      // represents a block boundary. A measured block widget keeps that
+      // rhythm stable across every block type without changing caret height.
+      layoutDecorations.push(
+        Decoration.widget({
+          block: true,
+          side: -100,
+          widget: new BlockGapWidget(),
+        }).range(firstBlank.from),
+      );
+      atomicRanges.push(
+        Decoration.mark({}).range(previousLine.to, firstBlank.to),
+      );
+    }
+
+    lineNumber = lastBlankNumber + 1;
+  }
+
+  return {
+    atomicRanges: Decoration.set(atomicRanges, true),
+    decorations: Decoration.set(layoutDecorations, true),
+  };
+}
+
+function layoutSeparatorExit(state: EditorState, position: number) {
+  const line = state.doc.lineAt(position);
+  if (line.number === 1 || !isCollapsibleBlankLine(state, line)) return null;
+  const previousLine = state.doc.line(line.number - 1);
+  if (previousLine.text.trim().length === 0) return null;
+
+  let lastBlankNumber = line.number;
+  while (lastBlankNumber < state.doc.lines) {
+    const next = state.doc.line(lastBlankNumber + 1);
+    if (!isCollapsibleBlankLine(state, next)) break;
+    lastBlankNumber += 1;
+  }
+
+  if (lastBlankNumber === state.doc.lines) return null;
+  return state.doc.line(line.number + 1).from;
+}
+
+export function moveToEditableLine(view: EditorView, position: number) {
+  const boundedPosition = Math.max(0, Math.min(position, view.state.doc.length));
+  const separatorExit = layoutSeparatorExit(view.state, boundedPosition);
+  if (
+    separatorExit !== null &&
+    !view.state.facet(EditorState.readOnly)
+  ) {
+    view.dispatch({
+      changes: { from: boundedPosition, insert: "\n" },
+      selection: EditorSelection.cursor(boundedPosition + 1, 1),
+      userEvent: "input",
+    });
+    return;
+  }
+  view.dispatch({
+    selection: EditorSelection.cursor(separatorExit ?? boundedPosition, 1),
+  });
+}
+
+function keepSelectionsOutOfLayoutSeparators(transaction: Transaction) {
+  let corrected = false;
+  const selection = EditorSelection.create(
+    transaction.newSelection.ranges.map((range) => {
+      if (!range.empty) return range;
+      const target = layoutSeparatorExit(transaction.state, range.head);
+      if (target === null) return range;
+      corrected = true;
+      return EditorSelection.cursor(
+        target,
+        1,
+        range.bidiLevel ?? undefined,
+        range.goalColumn ?? undefined,
+      );
+    }),
+    transaction.newSelection.mainIndex,
+  );
+  if (!corrected) return transaction;
+  return [transaction, { selection, sequential: true }];
+}
+
+const blankLineLayoutField = StateField.define<BlankLineLayout>({
+  create: buildBlankLineLayout,
+  update(layout, transaction) {
+    if (
+      !transaction.docChanged &&
+      syntaxTree(transaction.startState) === syntaxTree(transaction.state)
+    ) {
+      return layout;
+    }
+    return buildBlankLineLayout(transaction.state);
+  },
+  provide(field) {
+    return [
+      EditorView.decorations.from(field, (layout) => layout.decorations),
+      EditorView.atomicRanges.of((view) =>
+        view.state.field(field).atomicRanges
+      ),
+    ];
+  },
+});
+
+const blankLineLayoutTheme = EditorView.baseTheme({
+  ".cm-markra-layout-separator": {
+    display: "none",
+  },
+  ".cm-markra-block-gap": {
+    height: "var(--editor-paragraph-spacing, 8px)",
+    pointerEvents: "none",
+    width: "100%",
+  },
+});
+
+export function blankLineLayout(): Extension {
+  return [
+    blankLineLayoutField,
+    blankLineLayoutTheme,
+    EditorState.transactionFilter.of(keepSelectionsOutOfLayoutSeparators),
+  ];
+}

--- a/packages/editor/src/codemirror/image-preview.test.ts
+++ b/packages/editor/src/codemirror/image-preview.test.ts
@@ -361,7 +361,10 @@ describe("imagePreviewPlugin", () => {
       key: "Enter",
     }));
 
-    expect(view.state.selection.main.head).toBe(doc.indexOf("\n") + 1);
+    expect(view.state.doc.toString()).toBe(
+      "![Synthetic alt](./assets/mock.png)\n\n\nEdit",
+    );
+    expect(view.state.selection.main.head).toBe(doc.indexOf("\n") + 2);
     expect(view.dom.querySelector(".markra-image-node-source")).toBeNull();
   });
 

--- a/packages/editor/src/codemirror/image.ts
+++ b/packages/editor/src/codemirror/image.ts
@@ -16,6 +16,7 @@ import {
   type MarkraRendererContext,
   type MarkraSyntaxNode,
 } from "./renderers.ts";
+import { moveToEditableLine } from "./blank-lines.ts";
 import { unescapeMarkdown, unquoteMarkdownTitle } from "./syntax.ts";
 
 export interface MarkraImageSourceContext {
@@ -506,7 +507,7 @@ class ImageWidget extends WidgetType {
         view.state.doc.length,
       );
       hideImageSource(root, state);
-      view.dispatch({ selection: EditorSelection.cursor(anchor) });
+      moveToEditableLine(view, anchor);
       view.focus();
     };
 

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -85,10 +85,10 @@ function renderedLines(view: EditorView) {
   );
 }
 
-function paragraphSeparatorStates(view: EditorView) {
+function layoutSeparatorStates(view: EditorView) {
   return Array.from(
     view.dom.querySelectorAll(".cm-markra-empty-line"),
-    (line) => line.classList.contains("cm-markra-paragraph-separator"),
+    (line) => line.classList.contains("cm-markra-layout-separator"),
   );
 }
 
@@ -507,38 +507,71 @@ describe("liveMarkdown", () => {
 
     expect(renderedLines(view)).toEqual(before);
     const emptyLine = view.dom.querySelector(".cm-markra-empty-line");
-    expect(emptyLine?.hasAttribute("data-markra-empty-source")).toBe(false);
-    expect(paragraphSeparatorStates(view)).toEqual([false]);
+    expect(emptyLine?.getAttribute("data-markra-empty-source")).toBe(
+      "separator",
+    );
+    expect(layoutSeparatorStates(view)).toEqual([true]);
     expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("keeps empty-line rendering stable when the cursor enters a separator", () => {
+  it("keeps one layout separator and additional empty lines stable across recreation", () => {
+    const doc = "Before\n\n\nAfter";
+    const emptyLineStates = (view: EditorView) => Array.from(
+      view.dom.querySelectorAll(".cm-markra-empty-line"),
+      (line) => line.getAttribute("data-markra-empty-source"),
+    );
+    const firstView = createView({ doc, anchor: 0 });
+
+    expect(emptyLineStates(firstView)).toEqual(["separator", null]);
+
+    firstView.dispatch({
+      selection: EditorSelection.cursor("Before\n".length),
+      userEvent: "select.pointer",
+    });
+    expect(emptyLineStates(firstView)).toEqual(["separator", null]);
+
+    const recreatedView = createView({ doc, anchor: doc.length });
+    expect(emptyLineStates(recreatedView)).toEqual(["separator", null]);
+  });
+
+  it("redirects the cursor out of a layout separator without changing layout", () => {
     const doc = "Before\n\nAfter";
     const view = createView({ doc, anchor: doc.length });
     const emptyLine = view.dom.querySelector<HTMLElement>(
       ".cm-markra-empty-line",
     );
 
-    expect(emptyLine?.hasAttribute("data-markra-empty-source")).toBe(false);
-    expect(paragraphSeparatorStates(view)).toEqual([false]);
+    expect(emptyLine?.getAttribute("data-markra-empty-source")).toBe(
+      "separator",
+    );
+    expect(layoutSeparatorStates(view)).toEqual([true]);
     expect(paragraphEndStates(view)).toEqual([false, false]);
 
     view.dispatch({ selection: EditorSelection.cursor("Before\n".length) });
 
     expect(view.state.doc.toString()).toBe(doc);
+    expect(view.state.selection.main.head).toBe("Before\n\n".length);
     const activeEmptyLine = view.dom.querySelector(".cm-markra-empty-line");
-    expect(activeEmptyLine?.hasAttribute("data-markra-empty-source")).toBe(
-      false,
+    expect(activeEmptyLine?.getAttribute("data-markra-empty-source")).toBe(
+      "separator",
     );
-    expect(paragraphSeparatorStates(view)).toEqual([false]);
+    expect(layoutSeparatorStates(view)).toEqual([true]);
     expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("keeps authored blank lines separate from paragraph-end spacing", () => {
+  it("applies paragraph spacing separately from additional editable blank lines", () => {
     const view = createView({ doc: "First\nSecond\n\n\nAfter" });
 
-    expect(paragraphSeparatorStates(view)).toEqual([false, false]);
+    expect(layoutSeparatorStates(view)).toEqual([true, false]);
     expect(paragraphEndStates(view)).toEqual([false, false, false]);
+  });
+
+  it("does not duplicate paragraph spacing when a structural gap exists", () => {
+    const view = createView({ doc: "Before\n\nAfter" });
+
+    expect(layoutSeparatorStates(view)).toEqual([true]);
+    expect(paragraphEndStates(view)).toEqual([false, false]);
+    expect(view.dom.querySelectorAll(".cm-markra-block-gap")).toHaveLength(1);
   });
 
   it("adds paragraph spacing when another block starts directly", () => {
@@ -564,7 +597,7 @@ describe("liveMarkdown", () => {
     expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("keeps an authored blank line stable while text is entered", () => {
+  it("updates paragraph spacing when a layout separator becomes content", () => {
     const doc = "Before\n\nAfter";
     const position = "Before\n".length;
     const view = createView({ doc, anchor: position });

--- a/packages/editor/src/codemirror/markdown-editing.test.ts
+++ b/packages/editor/src/codemirror/markdown-editing.test.ts
@@ -61,6 +61,20 @@ function press(
   );
 }
 
+function expectFullHeightEmptyLines(view: EditorView, count: number) {
+  const emptyLines = Array.from(
+    view.dom.querySelectorAll(
+      ".cm-markra-empty-line:not(.cm-markra-layout-separator)",
+    ),
+  );
+  expect(emptyLines).toHaveLength(count);
+  expect(
+    emptyLines.every((line) =>
+      !line.hasAttribute("data-markra-empty-source")
+    ),
+  ).toBe(true);
+}
+
 afterEach(() => {
   for (const view of views.splice(0)) view.destroy();
   document.body.replaceChildren();
@@ -75,6 +89,154 @@ describe("markdownEditingPlugin", () => {
     expect(press(view, "Enter")).toBe(true);
     expect(view.state.doc.toString()).toBe("MockBefore\nMockAfter");
     expect(view.state.selection.main.head).toBe(position + 1);
+  });
+
+  it("keeps the caret with text when inserting empty lines before it", () => {
+    const doc = "Before\nAfter";
+    const position = "Before\n".length;
+    const view = createView(doc, position);
+    view.focus();
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("Before\n\n\nAfter");
+    expect(view.state.selection.main.head).toBe(position + 2);
+    expectFullHeightEmptyLines(view, 1);
+
+    view.dispatch({
+      changes: { from: position + 2, insert: "Middle" },
+      selection: EditorSelection.cursor(position + 2 + "Middle".length),
+      userEvent: "input.type",
+    });
+
+    expect(view.state.doc.toString()).toBe("Before\n\n\nMiddleAfter");
+    expectFullHeightEmptyLines(view, 1);
+  });
+
+  it("adds one editable blank line when a Markdown separator already exists", () => {
+    const doc = "Before\n\nAfter";
+    const position = "Before\n\n".length;
+    const view = createView(doc, position);
+    view.focus();
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("Before\n\n\nAfter");
+    expect(view.state.selection.main.head).toBe(position + 1);
+    expectFullHeightEmptyLines(view, 1);
+  });
+
+  it("adds one editable blank line after the final character before the next line", () => {
+    const doc = "Before\nAfter";
+    const position = "Before".length;
+    const view = createView(doc, position);
+    view.focus();
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("Before\n\n\nAfter");
+    expect(view.state.selection.main.head).toBe(position + 2);
+    expectFullHeightEmptyLines(view, 1);
+  });
+
+  it("keeps a single native newline at the end of the document", () => {
+    const doc = "Before";
+    const view = createView(doc, doc.length);
+    view.focus();
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("Before\n");
+    expect(view.state.selection.main.head).toBe(doc.length + 1);
+    expectFullHeightEmptyLines(view, 1);
+  });
+
+  it("moves the caret with text across repeated Enter presses", () => {
+    const before = "MockBefore";
+    const after = "MockAfter";
+    const view = createView(`${before}${after}`, before.length);
+    view.focus();
+
+    for (let presses = 1; presses <= 4; presses += 1) {
+      expect(press(view, "Enter")).toBe(true);
+      const lineBreaks = presses === 1 ? 1 : presses + 1;
+      expect(view.state.doc.toString()).toBe(
+        `${before}${"\n".repeat(lineBreaks)}${after}`,
+      );
+      expect(view.state.selection.main.head).toBe(before.length + lineBreaks);
+    }
+
+    expectFullHeightEmptyLines(view, 3);
+
+    const position = view.state.selection.main.head;
+    view.dispatch({
+      changes: { from: position, insert: "Typed" },
+      selection: EditorSelection.cursor(position + "Typed".length),
+      userEvent: "input.type",
+    });
+
+    expect(view.state.doc.toString()).toBe(
+      `${before}\n\n\n\n\nTyped${after}`,
+    );
+    expectFullHeightEmptyLines(view, 3);
+
+    view.dispatch({
+      selection: EditorSelection.cursor(0),
+      userEvent: "select.pointer",
+    });
+    expectFullHeightEmptyLines(view, 3);
+  });
+
+  it("keeps surviving blank lines full height during backward deletion", () => {
+    const before = "MockBefore";
+    const after = "MockAfter";
+    const view = createView(`${before}${after}`, before.length);
+    view.focus();
+
+    for (let presses = 0; presses < 4; presses += 1) {
+      expect(press(view, "Enter")).toBe(true);
+    }
+
+    view.contentDOM.blur();
+    expect(view.hasFocus).toBe(false);
+    expectFullHeightEmptyLines(view, 3);
+
+    view.focus();
+    view.dispatch({
+      selection: EditorSelection.cursor(view.state.doc.line(4).from),
+      userEvent: "select.pointer",
+    });
+    expect(press(view, "Backspace")).toBe(true);
+    expect(view.state.doc.toString()).toBe(`${before}\n\n\n\n${after}`);
+    expectFullHeightEmptyLines(view, 2);
+
+    expect(press(view, "Backspace")).toBe(true);
+    expect(view.state.doc.toString()).toBe(`${before}\n\n\n${after}`);
+    expectFullHeightEmptyLines(view, 1);
+
+    expect(press(view, "Backspace")).toBe(true);
+    expect(view.state.doc.toString()).toBe(`${before}\n\n${after}`);
+    expect(
+      view.dom.querySelector(
+        ".cm-markra-empty-line:not(.cm-markra-layout-separator)",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps multiple inserted empty lines full height", () => {
+    const doc = "One\nTwo";
+    const view = createView(
+      doc,
+      EditorSelection.create([
+        EditorSelection.cursor(0),
+        EditorSelection.cursor("One\n".length),
+      ]),
+    );
+    view.focus();
+
+    expect(press(view, "Enter")).toBe(true);
+    expect(view.state.doc.toString()).toBe("\nOne\n\n\nTwo");
+    expect(view.state.selection.ranges.map((range) => range.head)).toEqual([
+      1,
+      "\nOne\n".length + 2,
+    ]);
+    expectFullHeightEmptyLines(view, 2);
   });
 
   it("keeps the caret associated with text after joining lines backward", () => {

--- a/packages/editor/src/codemirror/markdown-editing.ts
+++ b/packages/editor/src/codemirror/markdown-editing.ts
@@ -9,6 +9,7 @@ import {
 } from "@codemirror/state";
 import { keymap, type EditorView } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
+import { isInsidePreformattedBlock } from "./blank-lines.ts";
 
 const indentation = "  ";
 const listMarkerPattern = /^((?:[\t ]*>[\t ]*)*)([\t ]*)(?:[-+*]|\d+[.)])[\t ]+/u;
@@ -100,7 +101,16 @@ function keepJoinedLineCaretsAfterText(transaction: Transaction) {
 
   const affectedPositions = new Set<number>();
   for (const range of transaction.startState.selection.ranges) {
-    if (!range.empty || range.head === 0) continue;
+    if (!range.empty) continue;
+    if (range.head === 0) {
+      if (
+        transaction.startState.doc.lines > 1 &&
+        transaction.startState.doc.line(1).length === 0
+      ) {
+        affectedPositions.add(0);
+      }
+      continue;
+    }
     const line = transaction.startState.doc.lineAt(range.head);
     if (
       line.from === range.head &&
@@ -142,6 +152,77 @@ function keepJoinedLineCaretsAfterText(transaction: Transaction) {
       sequential: true,
     },
   ];
+}
+
+function removeLeadingEmptyLineBackward(view: EditorView) {
+  if (!isEditable(view)) return false;
+  const { ranges } = view.state.selection;
+  if (
+    ranges.length !== 1 ||
+    !ranges[0]?.empty ||
+    ranges[0].head !== 0 ||
+    view.state.doc.lines === 1 ||
+    view.state.doc.line(1).length !== 0
+  ) {
+    return false;
+  }
+
+  view.dispatch({
+    changes: { from: 0, to: 1 },
+    selection: EditorSelection.cursor(0, 1),
+    userEvent: "delete.backward",
+  });
+  return true;
+}
+
+function insertVisibleBlankLineBeforeText(view: EditorView) {
+  if (!isEditable(view)) return false;
+  const { ranges } = view.state.selection;
+  if (ranges.some((range) => !range.empty)) return false;
+
+  const insertions = ranges.map((range) => {
+    const line = view.state.doc.lineAt(range.head);
+    const previousLine = line.number > 1
+      ? view.state.doc.line(line.number - 1)
+      : null;
+    const nextLine = line.number < view.state.doc.lines
+      ? view.state.doc.line(line.number + 1)
+      : null;
+    const insertsBeforeText =
+      range.head === line.from &&
+      line.length > 0 &&
+      previousLine !== null &&
+      previousLine.text.trim().length > 0 &&
+      !isInsidePreformattedBlock(view.state, line.from) &&
+      !isInsidePreformattedBlock(view.state, previousLine.from);
+    const insertsAfterText =
+      range.head === line.to &&
+      line.length > 0 &&
+      nextLine !== null &&
+      nextLine.text.trim().length > 0 &&
+      !isInsidePreformattedBlock(view.state, line.from) &&
+      !isInsidePreformattedBlock(view.state, nextLine.from);
+    return insertsBeforeText || insertsAfterText ? "\n\n" : "\n";
+  });
+  if (insertions.every((insertion) => insertion.length === 1)) return false;
+
+  const changes = view.state.changes(
+    ranges.map((range, index) => ({
+      from: range.head,
+      insert: insertions[index] ?? "\n",
+    })),
+  );
+  view.dispatch({
+    changes,
+    selection: EditorSelection.create(
+      ranges.map((range) =>
+        EditorSelection.cursor(changes.mapPos(range.head, 1), 1)
+      ),
+      view.state.selection.mainIndex,
+    ),
+    userEvent: "input",
+  });
+  return true;
 }
 
 function confirmIncompleteInlineDestination(view: EditorView) {
@@ -209,7 +290,13 @@ export function markdownEditingPlugin() {
     extension: [
       EditorState.transactionFilter.of(keepJoinedLineCaretsAfterText),
       Prec.high(keymap.of([
-        { key: "Enter", run: confirmIncompleteInlineDestination },
+        { key: "Backspace", run: removeLeadingEmptyLineBackward },
+        {
+          key: "Enter",
+          run: (view) =>
+            confirmIncompleteInlineDestination(view) ||
+            insertVisibleBlankLineBeforeText(view),
+        },
         { key: "Tab", run: handleTab, shift: handleShiftTab },
         { key: "Shift-Enter", run: insertContextualHardBreak },
       ])),

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -30,6 +30,10 @@ import {
 } from "./links.ts";
 import { unescapeMarkdown } from "./syntax.ts";
 import { createTaskDecoration } from "./tasks.ts";
+import {
+  blankLineLayout,
+  isInsidePreformattedBlock,
+} from "./blank-lines.ts";
 
 const HEADING_CLASSES: Readonly<Record<string, string>> = {
   ATXHeading1: "cm-markra-h1",
@@ -94,14 +98,6 @@ const INLINE_WRAPPERS = new Set([
   "Strikethrough",
   "StrongEmphasis",
 ]);
-const PREFORMATTED_BLOCKS = new Set([
-  "BlockMath",
-  "CodeBlock",
-  "FencedCode",
-  "Frontmatter",
-  "HTMLBlock",
-]);
-
 const LIST_ITEM_PATTERN = /^([\t ]*)([-+*]|\d+[.)])[\t ]+(\[[ xX]\](?:[\t ]+|$))?/u;
 const EMPTY_TASK_ITEM_PATTERN =
   /^([\t ]*)([-+*]|\d+[.)])([\t ]+)(\[[ xX]\])[\t ]*$/u;
@@ -209,19 +205,6 @@ function listDepth(node: MarkraSyntaxNode) {
     parent = parent.parent;
   }
   return depth;
-}
-
-function isInsidePreformattedBlock(
-  tree: ReturnType<typeof syntaxTree>,
-  position: number,
-) {
-  let node: ReturnType<typeof tree.resolveInner> | null =
-    tree.resolveInner(position, 1);
-  while (node) {
-    if (PREFORMATTED_BLOCKS.has(node.name)) return true;
-    node = node.parent;
-  }
-  return false;
 }
 
 function hasUnclosedInlineDestination(
@@ -416,11 +399,12 @@ function buildDecorations(
           listDepth(node.node as MarkraSyntaxNode) === 0
         ) {
           const endLine = state.doc.lineAt(node.to - 1).number;
-          // An authored blank line already provides full-height block rhythm.
-          // Extra spacing is only needed when another block starts directly.
+          const nextLine = endLine + 1;
+          // A source blank already owns a stable block-gap widget. Paragraph
+          // padding is only needed for directly adjacent Markdown blocks.
           if (
-            endLine < state.doc.lines &&
-            state.doc.line(endLine + 1).text.trim().length > 0
+            nextLine <= state.doc.lines &&
+            state.doc.line(nextLine).text.trim().length > 0
           ) {
             paragraphEndLine = endLine;
           }
@@ -780,7 +764,7 @@ function buildDecorations(
       if (
         line.length === 0 &&
         !decoratedEmptyLines.has(line.from) &&
-        !isInsidePreformattedBlock(tree, line.from)
+        !isInsidePreformattedBlock(state, line.from)
       ) {
         decoratedEmptyLines.add(line.from);
         ranges.push(
@@ -917,6 +901,7 @@ function previewPlugin(config: LivePreviewConfig): Extension {
 export function livePreview(config: LivePreviewConfig = {}): Extension {
   return [
     sourceDragSelectionExtension,
+    blankLineLayout(),
     previewPlugin(config),
     listMarkerSelectionPlugin,
   ];


### PR DESCRIPTION
## Summary

- derive blank-line layout from Markdown source so it stays stable across focus changes, view recreation, file reopen, and Preview/Source/Split transitions
- render the first internal blank line in each run as a non-editable structural gap, while keeping every additional blank line at the normal editable line height
- use one measured block-gap widget for headings, paragraphs, lists, quotes, tables, rules, code blocks, and Mermaid instead of relying on inconsistent per-block spacing
- keep frontmatter, fenced/indented code, HTML, math, and Mermaid source-internal blank lines out of structural-gap classification
- keep one-press Enter, one-line-at-a-time Backspace, multi-cursor edits, and image-to-next-line navigation aligned with the stable layout
- document repository-wide CodeMirror invariants for deterministic layout, transient state, DOM ownership, geometry CSS, and required regression coverage

## Why

The previous behavior mixed source blank lines, paragraph spacing, and temporary editor state. As a result, the same Markdown could use different line heights after typing, blur, clicking, switching modes, or reopening a file. Collapsing the source line without preserving a separate block gap also made code blocks and other block types touch each other.

The layout is now content-derived: one internal source blank represents Markdown block separation in Preview, additional blanks remain editable rows, and Source mode remains an exact representation of the file. The repository guidelines now preserve these invariants for future CodeMirror work without prohibiting legitimate transient UI state or editor-specific CSS.

## Validation

- `pnpm --filter @markra/editor test` — 34 files, 402 tests passed
- `pnpm --filter @markra/app test` — 130 files, 1480 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `git diff --check` — passed for the text-only `AGENTS.md` follow-up
- actual browser QA: heading/paragraph/quote/list/code/Mermaid/table/rule combinations produced one stable gap per structural separator
- actual browser QA: Mermaid rendered and its internal blank line was not classified as a structural gap
- actual browser QA: four Enter presses produced four editable blank rows; typing stayed on the newest row
- actual browser QA: repeated Backspace removed one editable row at a time, then removed only the structural gap
- actual browser QA: Preview → Source → Split → Preview preserved the same structural and editable blank-line counts

## Risk

- Preview intentionally does not place the caret on the first internal Markdown separator; it remains fully visible and editable in Source mode
- layout classification scans document lines when document or syntax state changes; ordinary documents avoid full-source frontmatter parsing unless their prefix can start frontmatter
- the `AGENTS.md` follow-up changes engineering guidance only and has no runtime effect
- Not run: manual Windows QA

Closes #623 #628
