### PR TITLE
fix(editor): support line breaks in visual table cells

### DIFF
--- a/packages/editor/src/codemirror/inline-markdown.ts
+++ b/packages/editor/src/codemirror/inline-markdown.ts
@@ -11,6 +11,7 @@ const inlineParser = parser.configure([GFM, markraHighlight]);
 type InlineNode = ReturnType<typeof inlineParser.parse>["topNode"];
 
 const markdownEscape = /\\([\\`*{}\[\]()#+\-.!_|>~])/gu;
+const htmlLineBreak = /^<br\s*\/?>$/iu;
 const markerNodes = new Set([
   "CodeMark",
   "EmphasisMark",
@@ -317,7 +318,21 @@ function renderNode(
       renderAutolink(parent, ownerDocument, source, node, options);
       return;
     case "HardBreak":
-      parent.appendChild(ownerDocument.createElement("br"));
+      {
+        const lineBreak = ownerDocument.createElement("br");
+        lineBreak.dataset.markraSourceBreak = "true";
+        parent.appendChild(lineBreak);
+      }
+      return;
+    case "HTMLBlock":
+    case "HTMLTag":
+      if (htmlLineBreak.test(source.slice(from, to))) {
+        const lineBreak = ownerDocument.createElement("br");
+        lineBreak.dataset.markraSourceBreak = "true";
+        parent.appendChild(lineBreak);
+      } else {
+        appendText(parent, source, from, to);
+      }
       return;
     case "Escape":
       {
@@ -404,6 +419,9 @@ function serializeNode(node: Node): string {
       return node.dataset.markraImageMarkdown ??
         `![${node.getAttribute("alt") ?? ""}](${node.getAttribute("src") ?? ""})`;
     case "SPAN":
+      if (node.dataset.markraTableCaretHost === "true") {
+        return content.replace(/^\u200b/u, "");
+      }
       if (
         node.dataset.markraEscapeMarkdown &&
         node.textContent === node.dataset.markraEscapeText

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -1062,7 +1062,7 @@ describe("tablePreviewPlugin", () => {
     expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
   });
 
-  it("keeps line breaks out of visual table cells", () => {
+  it("uses Enter to finish editing a visual table cell", () => {
     const doc = [
       "| Name | Value |",
       "| --- | --- |",
@@ -1084,6 +1084,87 @@ describe("tablePreviewPlugin", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
+  });
+
+  it("inserts an HTML line break with Shift+Enter in a visual table cell", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+    const text = cell?.firstChild;
+
+    cell?.focus();
+    if (text) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(text, 2);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+      shiftKey: true,
+    });
+    cell?.dispatchEvent(event);
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+    expect(event.defaultPrevented).toBe(true);
+    expect(view.state.doc.toString()).toContain("| Al<br>pha | 1 |");
+    const lineBreak = updatedCell?.querySelector("br");
+    expect(lineBreak).not.toBeNull();
+    expect(document.activeElement).toBe(updatedCell);
+    expect(document.getSelection()?.anchorNode?.parentNode).toBe(
+      lineBreak?.nextSibling,
+    );
+    expect(document.getSelection()?.anchorOffset).toBe(1);
+
+    const caretText = document.getSelection()?.anchorNode;
+    if (caretText) caretText.textContent = "\u200bNext";
+    updatedCell?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      data: "Next",
+      inputType: "insertText",
+    }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain("| Al<br>Nextpha | 1 |");
+    expect(view.state.doc.toString()).not.toContain("\u200b");
+  });
+
+  it("does not mistake a persisted line break for an empty-cell placeholder", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| <br> | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+
+    expect(
+      cell?.querySelector('br[data-markra-source-break="true"]'),
+    ).not.toBeNull();
+    cell?.focus();
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe(doc);
   });
 
   it("adds rows and columns and keeps editing in the new visual cells", async () => {

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -58,6 +58,16 @@ interface TableCellPreview {
   readonly to: number;
 }
 
+const TABLE_CARET_PLACEHOLDER = "\u200b";
+
+function createVisualTableCaretHost(ownerDocument: Document) {
+  const host = ownerDocument.createElement("span");
+  host.dataset.markraTableCaretHost = "true";
+  const text = ownerDocument.createTextNode(TABLE_CARET_PLACEHOLDER);
+  host.append(text);
+  return { host, text };
+}
+
 interface TablePreview {
   readonly alignments: readonly CodeMirrorTableAlignment[];
   readonly from: number;
@@ -587,13 +597,15 @@ function applyWidthModeToTableControls(
 function visualTableCellHasPlaceholderBreak(cell: HTMLTableCellElement) {
   return (
     cell.childNodes.length === 1 &&
-    cell.firstElementChild?.tagName === "BR"
+    cell.firstElementChild?.tagName === "BR" &&
+    cell.firstElementChild.getAttribute("data-markra-source-break") !== "true"
   );
 }
 
 function visualTableCellSource(cell: HTMLTableCellElement) {
   // Browsers keep a lone <br> as the caret placeholder after the last
-  // character is deleted; visual table cells do not allow real line breaks.
+  // character is deleted. Persisted line breaks are tagged during rendering,
+  // so only the browser-owned placeholder represents an empty cell.
   if (visualTableCellHasPlaceholderBreak(cell)) return "";
   return serializeInlineMarkdown(cell);
 }
@@ -640,7 +652,7 @@ function tableCellCaretOffset(cell: HTMLTableCellElement) {
   const range = cell.ownerDocument.createRange();
   range.selectNodeContents(cell);
   range.setEnd(anchorNode, selection.anchorOffset);
-  return range.toString().length;
+  return range.toString().replaceAll(TABLE_CARET_PLACEHOLDER, "").length;
 }
 
 function activeVisualTableCell(
@@ -756,6 +768,7 @@ export function focusVisualTableCell(
   columnIndex: number,
   header: boolean,
   caretOffset: number,
+  lineBreakIndex?: number,
 ) {
   queueMicrotask(() => {
     if (!view.dom.isConnected) return;
@@ -766,8 +779,80 @@ export function focusVisualTableCell(
     );
     if (!cell) return;
 
-    placeVisualTableCellCaret(cell, caretOffset);
+    const lineBreak = lineBreakIndex === undefined
+      ? undefined
+      : cell.querySelectorAll<HTMLBRElement>(
+          'br[data-markra-source-break="true"]',
+        )[lineBreakIndex];
+    if (!lineBreak) {
+      placeVisualTableCellCaret(cell, caretOffset);
+      return;
+    }
+
+    cell.focus();
+    const caretHost = createVisualTableCaretHost(cell.ownerDocument);
+    lineBreak.after(caretHost.host);
+    const selection = cell.ownerDocument.getSelection();
+    if (!selection) return;
+    const range = cell.ownerDocument.createRange();
+    range.setStart(caretHost.text, TABLE_CARET_PLACEHOLDER.length);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
   });
+}
+
+function insertVisualTableCellLineBreak(
+  view: CodeMirrorView,
+  preview: TablePreview,
+  cell: HTMLTableCellElement,
+  rowIndex: number,
+  columnIndex: number,
+  header: boolean,
+) {
+  const selection = cell.ownerDocument.getSelection();
+  let range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+  if (!range || !cell.contains(range.commonAncestorContainer)) {
+    placeVisualTableCellCaret(cell, tableCellCaretOffset(cell));
+    range = selection?.rangeCount ? selection.getRangeAt(0) : null;
+  }
+  if (!selection || !range) return;
+
+  range.deleteContents();
+  const lineBreak = cell.ownerDocument.createElement("br");
+  lineBreak.dataset.markraSourceBreak = "true";
+  range.insertNode(lineBreak);
+  const caretHost = createVisualTableCaretHost(cell.ownerDocument);
+  lineBreak.after(caretHost.host);
+  range.setStart(caretHost.text, TABLE_CARET_PLACEHOLDER.length);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  const lineBreakIndex = Array.from(
+    cell.querySelectorAll<HTMLBRElement>(
+      'br[data-markra-source-break="true"]',
+    ),
+  ).indexOf(lineBreak);
+  const changed = replaceVisualTableCell(
+    view,
+    preview,
+    rowIndex,
+    columnIndex,
+    header,
+    visualTableCellSource(cell),
+  );
+  if (changed) {
+    focusVisualTableCell(
+      view,
+      preview.from,
+      rowIndex,
+      columnIndex,
+      header,
+      0,
+      lineBreakIndex,
+    );
+  }
 }
 
 function syncVisualTableCell(
@@ -981,6 +1066,19 @@ function appendCell(
     }, 0);
   });
   cell.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" && event.shiftKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      insertVisualTableCellLineBreak(
+        view,
+        preview,
+        cell,
+        rowIndex,
+        columnIndex,
+        header,
+      );
+      return;
+    }
     if (event.key === "Enter") {
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
## Summary
- let `Shift+Enter` insert a persisted `<br>` in visual table cells while keeping focus on the new visual line
- preserve the existing plain `Enter` behavior that finishes cell editing
- distinguish authored line breaks from browser-owned empty-cell placeholders, including a cell whose only content is `<br>`

## Why
Visual table cells handled every Enter keypress as a request to leave editing, so the existing source-mode `Shift+Enter` behavior was unavailable in preview mode. This predates and is independent of #630.

## Validation
- `pnpm --filter @markra/editor test` — 33 files, 387 tests passed
- `pnpm --filter @markra/app test -- MarkdownExportDocument.test.tsx` — 9 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `git diff --check` — passed
- browser QA: inserted a line break, continued typing on the next visual line, and confirmed the source became `First<br>Second`

## Risk
- scoped to Enter handling and exact `<br>` rendering/serialization inside visual table cells
- non-break HTML remains literal, and plain Enter behavior is unchanged