### PR TITLE
fix(editor): remove excess Mermaid preview spacing

### DIFF
--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -378,6 +378,17 @@ describe("codeBlockPreviewPlugin", () => {
     await vi.waitFor(() => {
       expect(view.dom.querySelector(".markra-mermaid-render svg")).not.toBeNull();
     });
+    const preview = view.dom.querySelector<HTMLElement>(
+      ".markra-mermaid-render",
+    );
+    const wrapper = preview?.closest<HTMLElement>(".markra-code-block");
+    expect(getComputedStyle(wrapper!).display).toBe("inline-block");
+    expect(getComputedStyle(wrapper!).marginTop).toBe("0px");
+    expect(getComputedStyle(wrapper!).marginBottom).toBe("0px");
+    expect(getComputedStyle(preview!).marginTop).toBe("0px");
+    expect(getComputedStyle(preview!).marginBottom).toBe("0px");
+    expect(getComputedStyle(preview!).paddingTop).toBe("0px");
+    expect(getComputedStyle(preview!).paddingBottom).toBe("0px");
     expect(renderMermaid).toHaveBeenCalledWith(
       expect.objectContaining({
         source: "flowchart TD\n  A --> B",

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -258,6 +258,23 @@ const codeBlockTheme = EditorView.baseTheme({
     position: "relative",
     textAlign: "center",
   },
+  // This widget is emitted through a view plugin, so CodeMirror requires an
+  // inline replacement. An inline-block avoids the empty line boxes produced
+  // by placing a block element between CodeMirror's inline widget buffers.
+  ".markra-code-block[data-mermaid-mode='preview']": {
+    boxSizing: "border-box",
+    display: "inline-block",
+    margin: "0",
+    maxWidth: "100%",
+    verticalAlign: "top",
+    width: "100%",
+  },
+  ".markra-code-block[data-mermaid-mode='preview'] .markra-mermaid-render": {
+    background: "transparent",
+    border: "0",
+    margin: "0",
+    padding: "0",
+  },
   ".markra-mermaid-render svg": {
     height: "auto",
     maxWidth: "100%",


### PR DESCRIPTION
## Summary
- render the Mermaid preview replacement as one full-width inline block instead of a block element that creates extra CodeMirror line boxes
- remove preview-only wrapper and render spacing while preserving the loading minimum height
- add a regression test for the computed preview layout

## Why
The Mermaid widget is emitted as an inline replacement, but its wrapper was laid out as a block. CodeMirror then kept an empty line box before and after the diagram. The app-level preview overrides also live in a cascade layer, so the unlayered CodeMirror base theme kept the generic Mermaid margin and padding.

This behavior exists on the current `v2` baseline and is independent of #630 and #632.

## Validation
- `pnpm --filter @markra/editor test` — 33 files, 385 tests passed
- `pnpm --filter @markra/editor test -- code-block.test.ts` — 22 tests passed after the final change
- `pnpm --filter @markra/app test -- styles.test.ts` — 63 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `git diff --check` — passed
- browser QA: reproduced the oversized `.cm-line`, then confirmed the full-width preview no longer has the large blank area around the SVG

## Risk
- scoped to the Mermaid preview state; ordinary code block source layout is unchanged
- existing Mermaid activation, source reveal, and zoom tests remain passing