### PR TITLE
fix(editor): stabilize visual table line breaks

### DIFF
--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -1080,13 +1080,118 @@ describe("tablePreviewPlugin", () => {
       key: "Enter",
     });
 
-    cell?.dispatchEvent(event);
+    cell?.focus();
+    cell?.closest("table")?.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(true);
     expect(view.dom.querySelector(".cm-markra-table")).not.toBeNull();
   });
 
-  it("inserts an HTML line break with Shift+Enter in a visual table cell", async () => {
+  it.each([
+    {
+      afterInput: "<br>NextAlpha",
+      afterLineBreak: "<br>Alpha",
+      caretOffset: 0,
+      eventTarget: "table",
+      position: "start",
+    },
+    {
+      afterInput: "Al<br>Nextpha",
+      afterLineBreak: "Al<br>pha",
+      caretOffset: 2,
+      eventTarget: "table",
+      position: "middle",
+    },
+    {
+      afterInput: "Alpha<br>Next",
+      afterLineBreak: "Alpha<br>",
+      caretOffset: 5,
+      eventTarget: "table",
+      position: "end",
+    },
+    {
+      afterInput: "Al<br>Nextpha",
+      afterLineBreak: "Al<br>pha",
+      caretOffset: 2,
+      eventTarget: "cell",
+      position: "middle",
+    },
+  ])("keeps a line break at the $position when Enter targets the $eventTarget", async ({
+    afterInput,
+    afterLineBreak,
+    caretOffset,
+    eventTarget,
+  }) => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+    const text = cell?.firstChild;
+
+    cell?.focus();
+    if (text) {
+      const selection = document.getSelection();
+      const range = document.createRange();
+      range.setStart(text, caretOffset);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+      shiftKey: true,
+    });
+    const keydownTarget = eventTarget === "table"
+      ? cell?.closest("table")
+      : cell;
+    keydownTarget?.dispatchEvent(event);
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+    expect(event.defaultPrevented).toBe(true);
+    expect(view.state.doc.toString()).toContain(`| ${afterLineBreak} | 1 |`);
+    const lineBreak = updatedCell?.querySelector("br");
+    expect(lineBreak).not.toBeNull();
+    expect(document.activeElement).toBe(updatedCell);
+    expect(document.getSelection()?.anchorNode?.parentNode).toBe(
+      lineBreak?.nextSibling,
+    );
+    expect(document.getSelection()?.anchorOffset).toBe(1);
+
+    const nativeLineBreak = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      inputType: "insertLineBreak",
+    });
+    updatedCell?.closest("table")?.dispatchEvent(nativeLineBreak);
+    expect(nativeLineBreak.defaultPrevented).toBe(true);
+    expect(view.state.doc.toString()).toContain(`| ${afterLineBreak} | 1 |`);
+
+    const caretText = document.getSelection()?.anchorNode;
+    if (caretText) caretText.textContent = "\u200bNext";
+    updatedCell?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      data: "Next",
+      inputType: "insertText",
+    }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain(`| ${afterInput} | 1 |`);
+    expect(view.state.doc.toString()).not.toContain("\u200b");
+  });
+
+  it("keeps composed text on the new visual table line", async () => {
     const doc = [
       "| Name | Value |",
       "| --- | --- |",
@@ -1109,38 +1214,37 @@ describe("tablePreviewPlugin", () => {
       selection?.removeAllRanges();
       selection?.addRange(range);
     }
-    const event = new KeyboardEvent("keydown", {
+    cell?.closest("table")?.dispatchEvent(new KeyboardEvent("keydown", {
       bubbles: true,
       cancelable: true,
       key: "Enter",
       shiftKey: true,
-    });
-    cell?.dispatchEvent(event);
+    }));
     await Promise.resolve();
 
     const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
       ".cm-markra-table tbody td",
     );
-    expect(event.defaultPrevented).toBe(true);
-    expect(view.state.doc.toString()).toContain("| Al<br>pha | 1 |");
-    const lineBreak = updatedCell?.querySelector("br");
-    expect(lineBreak).not.toBeNull();
-    expect(document.activeElement).toBe(updatedCell);
-    expect(document.getSelection()?.anchorNode?.parentNode).toBe(
-      lineBreak?.nextSibling,
-    );
-    expect(document.getSelection()?.anchorOffset).toBe(1);
-
-    const caretText = document.getSelection()?.anchorNode;
-    if (caretText) caretText.textContent = "\u200bNext";
-    updatedCell?.dispatchEvent(new InputEvent("input", {
+    const table = updatedCell?.closest("table");
+    table?.dispatchEvent(new CompositionEvent("compositionstart", {
       bubbles: true,
-      data: "Next",
-      inputType: "insertText",
+      data: "Mock",
+    }));
+    const caretText = document.getSelection()?.anchorNode;
+    if (caretText) caretText.textContent = "\u200bMock";
+    table?.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      data: "Mock",
+      inputType: "insertCompositionText",
+      isComposing: true,
+    }));
+    table?.dispatchEvent(new CompositionEvent("compositionend", {
+      bubbles: true,
+      data: "Mock",
     }));
     await Promise.resolve();
 
-    expect(view.state.doc.toString()).toContain("| Al<br>Nextpha | 1 |");
+    expect(view.state.doc.toString()).toContain("| Al<br>Mockpha | 1 |");
     expect(view.state.doc.toString()).not.toContain("\u200b");
   });
 

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -855,6 +855,45 @@ function insertVisualTableCellLineBreak(
   }
 }
 
+function handleVisualTableCellEnter(
+  view: CodeMirrorView,
+  preview: TablePreview,
+  cell: HTMLTableCellElement,
+  event: KeyboardEvent,
+  rowIndex: number,
+  columnIndex: number,
+  header: boolean,
+  images: ImagePreviewPluginOptions | undefined,
+  links: LinksPluginOptions | undefined,
+) {
+  event.preventDefault();
+  event.stopPropagation();
+  if (event.shiftKey) {
+    insertVisualTableCellLineBreak(
+      view,
+      preview,
+      cell,
+      rowIndex,
+      columnIndex,
+      header,
+    );
+    return;
+  }
+
+  const session = tableEditingSessions.get(view);
+  tableEditingSessions.delete(view);
+  if (session?.inlineSourceVisible) {
+    renderVisualTableCell(
+      view,
+      cell,
+      visualTableCellSource(cell),
+      images,
+      links,
+    );
+  }
+  view.focus();
+}
+
 function syncVisualTableCell(
   view: CodeMirrorView,
   preview: TablePreview,
@@ -1066,34 +1105,18 @@ function appendCell(
     }, 0);
   });
   cell.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" && event.shiftKey) {
-      event.preventDefault();
-      event.stopPropagation();
-      insertVisualTableCellLineBreak(
+    if (event.key === "Enter") {
+      handleVisualTableCellEnter(
         view,
         preview,
         cell,
+        event,
         rowIndex,
         columnIndex,
         header,
+        images,
+        links,
       );
-      return;
-    }
-    if (event.key === "Enter") {
-      event.preventDefault();
-      event.stopPropagation();
-      const session = tableEditingSessions.get(view);
-      tableEditingSessions.delete(view);
-      if (session?.inlineSourceVisible) {
-        renderVisualTableCell(
-          view,
-          cell,
-          visualTableCellSource(cell),
-          images,
-          links,
-        );
-      }
-      view.focus();
       return;
     }
     if (event.key !== "Escape") return;
@@ -1347,6 +1370,30 @@ class TableWidget extends WidgetType {
     table.dataset.widthMode = widthMode;
     table.classList.toggle("markra-table-width-auto", widthMode === "auto");
     table.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        const cell = activeVisualTableCell(view, table);
+        if (!cell) return;
+        const rowIndex = Number(cell.dataset.tableRow);
+        const columnIndex = Number(cell.dataset.tableColumn);
+        const header = cell.dataset.tableHeader === "true";
+        if (!Number.isInteger(rowIndex) || !Number.isInteger(columnIndex)) {
+          return;
+        }
+        // Safari targets keyboard events at the shared contenteditable table
+        // instead of the focused cell, so route both targets through one path.
+        handleVisualTableCellEnter(
+          view,
+          this.preview,
+          cell,
+          event,
+          rowIndex,
+          columnIndex,
+          header,
+          this.images,
+          this.links,
+        );
+        return;
+      }
       if (
         event.key !== "Tab" ||
         event.altKey ||
@@ -1364,6 +1411,18 @@ class TableWidget extends WidgetType {
     // Browsers target editing events at the shared contenteditable table host,
     // so cell-level listeners miss real input even though the cell DOM changes.
     table.addEventListener("beforeinput", (event) => {
+      if (
+        event instanceof InputEvent &&
+        (event.inputType === "insertLineBreak" ||
+          event.inputType === "insertParagraph")
+      ) {
+        // Enter is handled by the controlled keydown path. WebKit may still
+        // deliver this native event after keydown was canceled, which would
+        // otherwise rewrite the controlled <br> or add a second break.
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       if (event instanceof InputEvent && event.isComposing) return;
       repairVisualTableCellSelection(view, table);
     });


### PR DESCRIPTION
## Summary

- route Enter and Shift+Enter from both visual table cells and Safari’s shared contenteditable table through one controlled path
- suppress WebKit’s follow-up native line-break event so it cannot rewrite the persisted <br> or move the caret back
- cover line breaks at the start, middle, and end of a cell, Chromium-style cell event targeting, Safari-style table event targeting, and composition input

## Why

Safari targets keyboard events at the shared contenteditable table, while Chromium can target the focused cell. The original #632 implementation listened for Enter only on each cell, so Safari fell through to native editing behavior: middle breaks became spaces, boundary breaks could appear briefly, and subsequent input jumped back to the original line.

## Validation

- pnpm --filter @markra/editor test — 34 files, 408 tests passed
- pnpm --filter @markra/editor test -- table.test.ts — 53 tests passed
- pnpm --filter @markra/editor build — passed
- pnpm --filter @markra/editor typecheck:test — passed
- pnpm --filter @markra/app test -- styles.test.ts MarkdownExportDocument.test.tsx — 72 tests passed
- Safari QA: generated <br>NextAlpha, Al<br>Nextpha, and Alpha<br>Next for start, middle, and end insertion respectively
- git diff --check — passed

An initial concurrent full-suite run had one unrelated block-drag test failure; the isolated test and the subsequent serial full suite both passed.

## Risk

- Not run: manual Windows QA; both known browser event-target paths are covered by tests.

Refs #632