### PR TITLE
fix(editor): preserve authored blank line height

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -6509,7 +6509,7 @@ describe("Markra workspace", () => {
   });
 
   it("switches between the visual editor and markdown source mode", async () => {
-    renderApp();
+    const { container } = renderApp();
 
     await expectVisibleMarkdownText("Welcome to Markra");
 
@@ -6528,6 +6528,7 @@ describe("Markra workspace", () => {
     expect(await screen.findByRole("heading", { name: "Source edit" })).toBeInTheDocument();
     expect(screen.getByText("Updated from source mode.")).toBeInTheDocument();
     expect(screen.getByLabelText("Markdown editor")).toHaveAttribute("data-editor-engine", "codemirror");
+    expect(container.querySelectorAll(".cm-markra-empty-line")).toHaveLength(1);
   });
 
   it("commits pending visual IME content before source mode mounts", async () => {

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1057,22 +1057,6 @@
     color: var(--editor-text-primary);
   }
 
-  /* Keep the source line in CodeMirror's document model while removing one
-     stable Markdown-only separator from visual layout. */
-  .markdown-paper .cm-line.cm-markra-layout-separator {
-    display: none !important;
-  }
-
-  /* The hidden source separator still represents a Markdown block boundary.
-     Keep its visual rhythm in a non-editable CodeMirror block widget so every
-     block pairing is measured consistently. */
-  .markdown-paper .cm-markra-block-gap {
-    box-sizing: border-box;
-    width: 100% !important;
-    height: var(--editor-paragraph-spacing) !important;
-    pointer-events: none;
-  }
-
   /* Paragraph spacing is extra rhythm after content, not a replacement for
      an authored blank line, which must retain the editor's normal line height. */
   .markdown-paper .cm-line.cm-markra-paragraph-end {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -425,19 +425,9 @@ describe("editor stylesheet", () => {
     expect(styles).not.toContain(emptyLineBreakRule);
   });
 
-  it("keeps editable lines full-height and uses a stable structural gap", () => {
+  it("keeps paragraph spacing separate from authored blank lines", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
 
-    expect(styles).toContain(
-      ".markdown-paper .cm-line.cm-markra-layout-separator {",
-    );
-    expect(styles).toContain("display: none !important;");
-    expect(styles).toContain(
-      ".markdown-paper .cm-markra-block-gap {",
-    );
-    expect(styles).toContain(
-      "height: var(--editor-paragraph-spacing) !important;",
-    );
     expect(styles).not.toContain(
       ".markdown-paper .cm-line.cm-markra-empty-line {",
     );
@@ -450,9 +440,6 @@ describe("editor stylesheet", () => {
     expect(styles).not.toContain("cm-markra-paragraph-separator");
     expect(styles).not.toContain(
       '.cm-markra-empty-line[data-markra-empty-source="hidden"] {',
-    );
-    expect(styles).not.toMatch(
-      /cm-markra-layout-separator[^}]+(?:height|line-height):/su,
     );
   });
 

--- a/packages/editor/src/codemirror/blank-lines.test.ts
+++ b/packages/editor/src/codemirror/blank-lines.test.ts
@@ -23,21 +23,13 @@ function createView(doc: string, anchor = doc.length) {
 
 function renderedLines(view: EditorView) {
   return Array.from(
-    view.dom.querySelectorAll(
-      ".cm-line:not(.cm-markra-layout-separator)",
-    ),
+    view.dom.querySelectorAll(".cm-line"),
     (line) => line.textContent ?? "",
   );
 }
 
 function editableEmptyLines(view: EditorView) {
-  return view.dom.querySelectorAll(
-    ".cm-markra-empty-line:not(.cm-markra-layout-separator)",
-  );
-}
-
-function blockGaps(view: EditorView) {
-  return view.dom.querySelectorAll(".cm-markra-block-gap");
+  return view.dom.querySelectorAll(".cm-markra-empty-line");
 }
 
 afterEach(() => {
@@ -45,37 +37,58 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
-describe("blank line layout", () => {
-  it("does not render a single internal Markdown separator as an editable line", () => {
+describe("blank line rendering", () => {
+  it("renders a single internal Markdown blank as an editable line", () => {
     const doc = "# Synthetic heading\n\n- Synthetic item";
     const view = createView(doc);
 
     expect(renderedLines(view)).toEqual([
       "Synthetic heading",
+      "",
       "Synthetic item",
     ]);
-    expect(
-      view.dom.querySelector(".cm-markra-layout-separator"),
-    ).not.toBeNull();
-    expect(blockGaps(view)).toHaveLength(1);
+    expect(editableEmptyLines(view)).toHaveLength(1);
     expect(view.state.doc.toString()).toBe(doc);
   });
 
-  it("keeps additional internal blank lines at normal editable height", () => {
+  it("keeps every internal blank line at normal editable height", () => {
     const doc = "Synthetic before\n\n\nSynthetic after";
     const view = createView(doc);
 
     expect(renderedLines(view)).toEqual([
       "Synthetic before",
       "",
+      "",
       "Synthetic after",
     ]);
-    expect(editableEmptyLines(view)).toHaveLength(1);
-    expect(blockGaps(view)).toHaveLength(1);
+    expect(editableEmptyLines(view)).toHaveLength(2);
     expect(view.state.doc.toString()).toBe(doc);
   });
 
-  it("uses the same stable gap between different Markdown block types", () => {
+  it("keeps a trailing blank line full height after text is entered below it", () => {
+    const initialDoc = "Synthetic first\n\n";
+    const view = createView(initialDoc);
+
+    view.dispatch({
+      changes: { from: initialDoc.length, insert: "Synthetic second" },
+      selection: EditorSelection.cursor(
+        initialDoc.length + "Synthetic second".length,
+      ),
+      userEvent: "input.type",
+    });
+
+    expect(view.state.doc.toString()).toBe(
+      "Synthetic first\n\nSynthetic second",
+    );
+    expect(renderedLines(view)).toEqual([
+      "Synthetic first",
+      "",
+      "Synthetic second",
+    ]);
+    expect(editableEmptyLines(view)).toHaveLength(1);
+  });
+
+  it("keeps authored blank lines between different Markdown block types", () => {
     const doc = [
       "# Synthetic heading",
       "",
@@ -91,12 +104,7 @@ describe("blank line layout", () => {
     ].join("\n");
     const view = createView(doc);
 
-    expect(blockGaps(view)).toHaveLength(4);
-    expect(
-      Array.from(blockGaps(view)).every((gap) =>
-        gap.getAttribute("aria-hidden") === "true"
-      ),
-    ).toBe(true);
+    expect(editableEmptyLines(view)).toHaveLength(4);
   });
 
   it("keeps leading and trailing blank lines editable", () => {
@@ -107,12 +115,13 @@ describe("blank line layout", () => {
     expect(editableEmptyLines(view)).toHaveLength(2);
   });
 
-  it("collapses whitespace-only Markdown separators without changing source", () => {
+  it("keeps whitespace-only Markdown lines visible without changing source", () => {
     const doc = "Synthetic before\n \t\nSynthetic after";
     const view = createView(doc);
 
     expect(renderedLines(view)).toEqual([
       "Synthetic before",
+      " \t",
       "Synthetic after",
     ]);
     expect(view.state.doc.toString()).toBe(doc);
@@ -135,10 +144,9 @@ describe("blank line layout", () => {
       "synthetic-after",
       "",
     ]);
-    expect(blockGaps(view)).toHaveLength(0);
   });
 
-  it("separates fenced blocks without treating their internal blanks as gaps", () => {
+  it("keeps blank lines around fenced blocks editable", () => {
     const doc = [
       "Synthetic before",
       "",
@@ -154,18 +162,19 @@ describe("blank line layout", () => {
     ].join("\n");
     const view = createView(doc);
 
-    expect(blockGaps(view)).toHaveLength(2);
+    expect(editableEmptyLines(view)).toHaveLength(2);
   });
 
-  it("keeps separator layout stable across selection, focus, and recreation", () => {
+  it("keeps blank rows stable across selection, focus, and recreation", () => {
     const doc = "Synthetic before\n\nSynthetic after";
     const firstView = createView(doc, 0);
 
     expect(renderedLines(firstView)).toEqual([
       "Synthetic before",
+      "",
       "Synthetic after",
     ]);
-    expect(blockGaps(firstView)).toHaveLength(1);
+    expect(editableEmptyLines(firstView)).toHaveLength(1);
     firstView.focus();
     firstView.dispatch({
       selection: EditorSelection.cursor("Synthetic before\n".length),
@@ -174,15 +183,17 @@ describe("blank line layout", () => {
     firstView.contentDOM.blur();
     expect(renderedLines(firstView)).toEqual([
       "Synthetic before",
+      "",
       "Synthetic after",
     ]);
-    expect(blockGaps(firstView)).toHaveLength(1);
+    expect(editableEmptyLines(firstView)).toHaveLength(1);
 
     const recreatedView = createView(doc);
     expect(renderedLines(recreatedView)).toEqual([
       "Synthetic before",
+      "",
       "Synthetic after",
     ]);
-    expect(blockGaps(recreatedView)).toHaveLength(1);
+    expect(editableEmptyLines(recreatedView)).toHaveLength(1);
   });
 });

--- a/packages/editor/src/codemirror/blank-lines.ts
+++ b/packages/editor/src/codemirror/blank-lines.ts
@@ -1,19 +1,6 @@
 import { syntaxTree } from "@codemirror/language";
-import {
-  EditorSelection,
-  EditorState,
-  type Range,
-  StateField,
-  type Extension,
-  type Text,
-  type Transaction,
-} from "@codemirror/state";
-import {
-  Decoration,
-  type DecorationSet,
-  EditorView,
-  WidgetType,
-} from "@codemirror/view";
+import { EditorSelection, EditorState } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
 import { readCodeMirrorFrontmatter } from "./frontmatter-preview.ts";
 
 const PREFORMATTED_BLOCKS = new Set([
@@ -36,28 +23,6 @@ function mayStartWithFrontmatter(state: EditorState) {
   return sourceStart.startsWith("---") ||
     sourceStart.startsWith("+++") ||
     sourceStart.startsWith("{");
-}
-
-interface BlankLineLayout {
-  atomicRanges: DecorationSet;
-  decorations: DecorationSet;
-}
-
-class BlockGapWidget extends WidgetType {
-  eq() {
-    return true;
-  }
-
-  get estimatedHeight() {
-    return 8;
-  }
-
-  toDOM(view: EditorView) {
-    const gap = view.dom.ownerDocument.createElement("div");
-    gap.className = "cm-markra-block-gap";
-    gap.setAttribute("aria-hidden", "true");
-    return gap;
-  }
 }
 
 export function isInsidePreformattedBlock(
@@ -90,169 +55,9 @@ export function isInsidePreformattedBlock(
   return false;
 }
 
-function isCollapsibleBlankLine(
-  state: EditorState,
-  line: ReturnType<Text["line"]>,
-) {
-  return line.text.trim().length === 0 &&
-    !isInsidePreformattedBlock(state, line.from);
-}
-
-function buildBlankLineLayout(state: EditorState): BlankLineLayout {
-  const layoutDecorations: Range<Decoration>[] = [];
-  const atomicRanges: Range<Decoration>[] = [];
-
-  for (let lineNumber = 1; lineNumber <= state.doc.lines;) {
-    const firstBlank = state.doc.line(lineNumber);
-    if (!isCollapsibleBlankLine(state, firstBlank)) {
-      lineNumber += 1;
-      continue;
-    }
-
-    let lastBlankNumber = lineNumber;
-    while (lastBlankNumber < state.doc.lines) {
-      const nextLine = state.doc.line(lastBlankNumber + 1);
-      if (!isCollapsibleBlankLine(state, nextLine)) break;
-      lastBlankNumber += 1;
-    }
-
-    const previousLine = lineNumber > 1
-      ? state.doc.line(lineNumber - 1)
-      : null;
-    const nextLine = lastBlankNumber < state.doc.lines
-      ? state.doc.line(lastBlankNumber + 1)
-      : null;
-    if (
-      previousLine?.text.trim().length &&
-      nextLine?.text.trim().length
-    ) {
-      // Markdown does not preserve whether the first blank source line was
-      // intended as content. Treating one internal line as layout whitespace
-      // gives reopened files a stable, source-only separator while leaving
-      // every additional blank line editable.
-      layoutDecorations.push(
-        Decoration.line({
-          attributes: { "data-markra-empty-source": "separator" },
-          class: "cm-markra-layout-separator",
-        }).range(firstBlank.from),
-      );
-      // The source separator is not an editable row in preview, but it still
-      // represents a block boundary. A measured block widget keeps that
-      // rhythm stable across every block type without changing caret height.
-      layoutDecorations.push(
-        Decoration.widget({
-          block: true,
-          side: -100,
-          widget: new BlockGapWidget(),
-        }).range(firstBlank.from),
-      );
-      atomicRanges.push(
-        Decoration.mark({}).range(previousLine.to, firstBlank.to),
-      );
-    }
-
-    lineNumber = lastBlankNumber + 1;
-  }
-
-  return {
-    atomicRanges: Decoration.set(atomicRanges, true),
-    decorations: Decoration.set(layoutDecorations, true),
-  };
-}
-
-function layoutSeparatorExit(state: EditorState, position: number) {
-  const line = state.doc.lineAt(position);
-  if (line.number === 1 || !isCollapsibleBlankLine(state, line)) return null;
-  const previousLine = state.doc.line(line.number - 1);
-  if (previousLine.text.trim().length === 0) return null;
-
-  let lastBlankNumber = line.number;
-  while (lastBlankNumber < state.doc.lines) {
-    const next = state.doc.line(lastBlankNumber + 1);
-    if (!isCollapsibleBlankLine(state, next)) break;
-    lastBlankNumber += 1;
-  }
-
-  if (lastBlankNumber === state.doc.lines) return null;
-  return state.doc.line(line.number + 1).from;
-}
-
 export function moveToEditableLine(view: EditorView, position: number) {
   const boundedPosition = Math.max(0, Math.min(position, view.state.doc.length));
-  const separatorExit = layoutSeparatorExit(view.state, boundedPosition);
-  if (
-    separatorExit !== null &&
-    !view.state.facet(EditorState.readOnly)
-  ) {
-    view.dispatch({
-      changes: { from: boundedPosition, insert: "\n" },
-      selection: EditorSelection.cursor(boundedPosition + 1, 1),
-      userEvent: "input",
-    });
-    return;
-  }
   view.dispatch({
-    selection: EditorSelection.cursor(separatorExit ?? boundedPosition, 1),
+    selection: EditorSelection.cursor(boundedPosition, 1),
   });
-}
-
-function keepSelectionsOutOfLayoutSeparators(transaction: Transaction) {
-  let corrected = false;
-  const selection = EditorSelection.create(
-    transaction.newSelection.ranges.map((range) => {
-      if (!range.empty) return range;
-      const target = layoutSeparatorExit(transaction.state, range.head);
-      if (target === null) return range;
-      corrected = true;
-      return EditorSelection.cursor(
-        target,
-        1,
-        range.bidiLevel ?? undefined,
-        range.goalColumn ?? undefined,
-      );
-    }),
-    transaction.newSelection.mainIndex,
-  );
-  if (!corrected) return transaction;
-  return [transaction, { selection, sequential: true }];
-}
-
-const blankLineLayoutField = StateField.define<BlankLineLayout>({
-  create: buildBlankLineLayout,
-  update(layout, transaction) {
-    if (
-      !transaction.docChanged &&
-      syntaxTree(transaction.startState) === syntaxTree(transaction.state)
-    ) {
-      return layout;
-    }
-    return buildBlankLineLayout(transaction.state);
-  },
-  provide(field) {
-    return [
-      EditorView.decorations.from(field, (layout) => layout.decorations),
-      EditorView.atomicRanges.of((view) =>
-        view.state.field(field).atomicRanges
-      ),
-    ];
-  },
-});
-
-const blankLineLayoutTheme = EditorView.baseTheme({
-  ".cm-markra-layout-separator": {
-    display: "none",
-  },
-  ".cm-markra-block-gap": {
-    height: "var(--editor-paragraph-spacing, 8px)",
-    pointerEvents: "none",
-    width: "100%",
-  },
-});
-
-export function blankLineLayout(): Extension {
-  return [
-    blankLineLayoutField,
-    blankLineLayoutTheme,
-    EditorState.transactionFilter.of(keepSelectionsOutOfLayoutSeparators),
-  ];
 }

--- a/packages/editor/src/codemirror/image-preview.test.ts
+++ b/packages/editor/src/codemirror/image-preview.test.ts
@@ -344,7 +344,7 @@ describe("imagePreviewPlugin", () => {
     expect(view.dom.querySelector(".cm-markra-image")).toBeNull();
   });
 
-  it("moves into the paragraph after an edited image on Enter", () => {
+  it("moves into the blank line after an edited image on Enter", () => {
     const doc = "![Synthetic alt](./assets/mock.png)\n\nEdit";
     const view = createView(doc);
     view.dom.querySelector<HTMLImageElement>(".cm-markra-image")?.dispatchEvent(
@@ -361,10 +361,8 @@ describe("imagePreviewPlugin", () => {
       key: "Enter",
     }));
 
-    expect(view.state.doc.toString()).toBe(
-      "![Synthetic alt](./assets/mock.png)\n\n\nEdit",
-    );
-    expect(view.state.selection.main.head).toBe(doc.indexOf("\n") + 2);
+    expect(view.state.doc.toString()).toBe(doc);
+    expect(view.state.selection.main.head).toBe(doc.indexOf("\n") + 1);
     expect(view.dom.querySelector(".markra-image-node-source")).toBeNull();
   });
 

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -85,13 +85,6 @@ function renderedLines(view: EditorView) {
   );
 }
 
-function layoutSeparatorStates(view: EditorView) {
-  return Array.from(
-    view.dom.querySelectorAll(".cm-markra-empty-line"),
-    (line) => line.classList.contains("cm-markra-layout-separator"),
-  );
-}
-
 function paragraphEndStates(view: EditorView) {
   return Array.from(
     view.dom.querySelectorAll(".cm-markra-paragraph"),
@@ -494,7 +487,7 @@ describe("liveMarkdown", () => {
     );
   });
 
-  it("keeps preview text and empty-line state stable during a range selection", () => {
+  it("keeps preview text and blank rows stable during a range selection", () => {
     const doc = [
       "Before **bold** and [label](https://example.test/long-target) after",
       "",
@@ -506,72 +499,46 @@ describe("liveMarkdown", () => {
     view.dispatch({ selection: EditorSelection.range(0, doc.length) });
 
     expect(renderedLines(view)).toEqual(before);
-    const emptyLine = view.dom.querySelector(".cm-markra-empty-line");
-    expect(emptyLine?.getAttribute("data-markra-empty-source")).toBe(
-      "separator",
-    );
-    expect(layoutSeparatorStates(view)).toEqual([true]);
+    expect(view.dom.querySelectorAll(".cm-markra-empty-line")).toHaveLength(1);
     expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("keeps one layout separator and additional empty lines stable across recreation", () => {
+  it("keeps all empty lines stable across recreation", () => {
     const doc = "Before\n\n\nAfter";
-    const emptyLineStates = (view: EditorView) => Array.from(
-      view.dom.querySelectorAll(".cm-markra-empty-line"),
-      (line) => line.getAttribute("data-markra-empty-source"),
-    );
+    const emptyLineCount = (view: EditorView) =>
+      view.dom.querySelectorAll(".cm-markra-empty-line").length;
     const firstView = createView({ doc, anchor: 0 });
 
-    expect(emptyLineStates(firstView)).toEqual(["separator", null]);
+    expect(emptyLineCount(firstView)).toBe(2);
 
     firstView.dispatch({
       selection: EditorSelection.cursor("Before\n".length),
       userEvent: "select.pointer",
     });
-    expect(emptyLineStates(firstView)).toEqual(["separator", null]);
+    expect(emptyLineCount(firstView)).toBe(2);
 
     const recreatedView = createView({ doc, anchor: doc.length });
-    expect(emptyLineStates(recreatedView)).toEqual(["separator", null]);
+    expect(emptyLineCount(recreatedView)).toBe(2);
   });
 
-  it("redirects the cursor out of a layout separator without changing layout", () => {
+  it("allows the cursor to remain on an internal blank line", () => {
     const doc = "Before\n\nAfter";
     const view = createView({ doc, anchor: doc.length });
-    const emptyLine = view.dom.querySelector<HTMLElement>(
-      ".cm-markra-empty-line",
-    );
-
-    expect(emptyLine?.getAttribute("data-markra-empty-source")).toBe(
-      "separator",
-    );
-    expect(layoutSeparatorStates(view)).toEqual([true]);
     expect(paragraphEndStates(view)).toEqual([false, false]);
 
     view.dispatch({ selection: EditorSelection.cursor("Before\n".length) });
 
     expect(view.state.doc.toString()).toBe(doc);
-    expect(view.state.selection.main.head).toBe("Before\n\n".length);
-    const activeEmptyLine = view.dom.querySelector(".cm-markra-empty-line");
-    expect(activeEmptyLine?.getAttribute("data-markra-empty-source")).toBe(
-      "separator",
-    );
-    expect(layoutSeparatorStates(view)).toEqual([true]);
+    expect(view.state.selection.main.head).toBe("Before\n".length);
+    expect(view.dom.querySelectorAll(".cm-markra-empty-line")).toHaveLength(1);
     expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("applies paragraph spacing separately from additional editable blank lines", () => {
+  it("keeps paragraph spacing separate from authored blank lines", () => {
     const view = createView({ doc: "First\nSecond\n\n\nAfter" });
 
-    expect(layoutSeparatorStates(view)).toEqual([true, false]);
+    expect(view.dom.querySelectorAll(".cm-markra-empty-line")).toHaveLength(2);
     expect(paragraphEndStates(view)).toEqual([false, false, false]);
-  });
-
-  it("does not duplicate paragraph spacing when a structural gap exists", () => {
-    const view = createView({ doc: "Before\n\nAfter" });
-
-    expect(layoutSeparatorStates(view)).toEqual([true]);
-    expect(paragraphEndStates(view)).toEqual([false, false]);
-    expect(view.dom.querySelectorAll(".cm-markra-block-gap")).toHaveLength(1);
   });
 
   it("adds paragraph spacing when another block starts directly", () => {
@@ -597,7 +564,7 @@ describe("liveMarkdown", () => {
     expect(paragraphEndStates(view)).toEqual([false, false]);
   });
 
-  it("updates paragraph spacing when a layout separator becomes content", () => {
+  it("updates paragraph layout when a blank line becomes content", () => {
     const doc = "Before\n\nAfter";
     const position = "Before\n".length;
     const view = createView({ doc, anchor: position });

--- a/packages/editor/src/codemirror/markdown-editing.test.ts
+++ b/packages/editor/src/codemirror/markdown-editing.test.ts
@@ -63,9 +63,7 @@ function press(
 
 function expectFullHeightEmptyLines(view: EditorView, count: number) {
   const emptyLines = Array.from(
-    view.dom.querySelectorAll(
-      ".cm-markra-empty-line:not(.cm-markra-layout-separator)",
-    ),
+    view.dom.querySelectorAll(".cm-markra-empty-line"),
   );
   expect(emptyLines).toHaveLength(count);
   expect(
@@ -91,24 +89,24 @@ describe("markdownEditingPlugin", () => {
     expect(view.state.selection.main.head).toBe(position + 1);
   });
 
-  it("keeps the caret with text when inserting empty lines before it", () => {
+  it("keeps the caret on a new blank line before text", () => {
     const doc = "Before\nAfter";
     const position = "Before\n".length;
     const view = createView(doc, position);
     view.focus();
 
     expect(press(view, "Enter")).toBe(true);
-    expect(view.state.doc.toString()).toBe("Before\n\n\nAfter");
-    expect(view.state.selection.main.head).toBe(position + 2);
+    expect(view.state.doc.toString()).toBe("Before\n\nAfter");
+    expect(view.state.selection.main.head).toBe(position + 1);
     expectFullHeightEmptyLines(view, 1);
 
     view.dispatch({
-      changes: { from: position + 2, insert: "Middle" },
-      selection: EditorSelection.cursor(position + 2 + "Middle".length),
+      changes: { from: position + 1, insert: "Middle" },
+      selection: EditorSelection.cursor(position + 1 + "Middle".length),
       userEvent: "input.type",
     });
 
-    expect(view.state.doc.toString()).toBe("Before\n\n\nMiddleAfter");
+    expect(view.state.doc.toString()).toBe("Before\n\nMiddleAfter");
     expectFullHeightEmptyLines(view, 1);
   });
 
@@ -121,7 +119,7 @@ describe("markdownEditingPlugin", () => {
     expect(press(view, "Enter")).toBe(true);
     expect(view.state.doc.toString()).toBe("Before\n\n\nAfter");
     expect(view.state.selection.main.head).toBe(position + 1);
-    expectFullHeightEmptyLines(view, 1);
+    expectFullHeightEmptyLines(view, 2);
   });
 
   it("adds one editable blank line after the final character before the next line", () => {
@@ -131,8 +129,8 @@ describe("markdownEditingPlugin", () => {
     view.focus();
 
     expect(press(view, "Enter")).toBe(true);
-    expect(view.state.doc.toString()).toBe("Before\n\n\nAfter");
-    expect(view.state.selection.main.head).toBe(position + 2);
+    expect(view.state.doc.toString()).toBe("Before\n\nAfter");
+    expect(view.state.selection.main.head).toBe(position + 1);
     expectFullHeightEmptyLines(view, 1);
   });
 
@@ -155,7 +153,7 @@ describe("markdownEditingPlugin", () => {
 
     for (let presses = 1; presses <= 4; presses += 1) {
       expect(press(view, "Enter")).toBe(true);
-      const lineBreaks = presses === 1 ? 1 : presses + 1;
+      const lineBreaks = presses;
       expect(view.state.doc.toString()).toBe(
         `${before}${"\n".repeat(lineBreaks)}${after}`,
       );
@@ -172,7 +170,7 @@ describe("markdownEditingPlugin", () => {
     });
 
     expect(view.state.doc.toString()).toBe(
-      `${before}\n\n\n\n\nTyped${after}`,
+      `${before}\n\n\n\nTyped${after}`,
     );
     expectFullHeightEmptyLines(view, 3);
 
@@ -203,19 +201,17 @@ describe("markdownEditingPlugin", () => {
       userEvent: "select.pointer",
     });
     expect(press(view, "Backspace")).toBe(true);
-    expect(view.state.doc.toString()).toBe(`${before}\n\n\n\n${after}`);
+    expect(view.state.doc.toString()).toBe(`${before}\n\n\n${after}`);
     expectFullHeightEmptyLines(view, 2);
 
     expect(press(view, "Backspace")).toBe(true);
-    expect(view.state.doc.toString()).toBe(`${before}\n\n\n${after}`);
+    expect(view.state.doc.toString()).toBe(`${before}\n\n${after}`);
     expectFullHeightEmptyLines(view, 1);
 
     expect(press(view, "Backspace")).toBe(true);
-    expect(view.state.doc.toString()).toBe(`${before}\n\n${after}`);
+    expect(view.state.doc.toString()).toBe(`${before}\n${after}`);
     expect(
-      view.dom.querySelector(
-        ".cm-markra-empty-line:not(.cm-markra-layout-separator)",
-      ),
+      view.dom.querySelector(".cm-markra-empty-line"),
     ).toBeNull();
   });
 
@@ -231,10 +227,10 @@ describe("markdownEditingPlugin", () => {
     view.focus();
 
     expect(press(view, "Enter")).toBe(true);
-    expect(view.state.doc.toString()).toBe("\nOne\n\n\nTwo");
+    expect(view.state.doc.toString()).toBe("\nOne\n\nTwo");
     expect(view.state.selection.ranges.map((range) => range.head)).toEqual([
       1,
-      "\nOne\n".length + 2,
+      "\nOne\n".length + 1,
     ]);
     expectFullHeightEmptyLines(view, 2);
   });

--- a/packages/editor/src/codemirror/markdown-editing.ts
+++ b/packages/editor/src/codemirror/markdown-editing.ts
@@ -9,7 +9,6 @@ import {
 } from "@codemirror/state";
 import { keymap, type EditorView } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
-import { isInsidePreformattedBlock } from "./blank-lines.ts";
 
 const indentation = "  ";
 const listMarkerPattern = /^((?:[\t ]*>[\t ]*)*)([\t ]*)(?:[-+*]|\d+[.)])[\t ]+/u;
@@ -175,56 +174,6 @@ function removeLeadingEmptyLineBackward(view: EditorView) {
   return true;
 }
 
-function insertVisibleBlankLineBeforeText(view: EditorView) {
-  if (!isEditable(view)) return false;
-  const { ranges } = view.state.selection;
-  if (ranges.some((range) => !range.empty)) return false;
-
-  const insertions = ranges.map((range) => {
-    const line = view.state.doc.lineAt(range.head);
-    const previousLine = line.number > 1
-      ? view.state.doc.line(line.number - 1)
-      : null;
-    const nextLine = line.number < view.state.doc.lines
-      ? view.state.doc.line(line.number + 1)
-      : null;
-    const insertsBeforeText =
-      range.head === line.from &&
-      line.length > 0 &&
-      previousLine !== null &&
-      previousLine.text.trim().length > 0 &&
-      !isInsidePreformattedBlock(view.state, line.from) &&
-      !isInsidePreformattedBlock(view.state, previousLine.from);
-    const insertsAfterText =
-      range.head === line.to &&
-      line.length > 0 &&
-      nextLine !== null &&
-      nextLine.text.trim().length > 0 &&
-      !isInsidePreformattedBlock(view.state, line.from) &&
-      !isInsidePreformattedBlock(view.state, nextLine.from);
-    return insertsBeforeText || insertsAfterText ? "\n\n" : "\n";
-  });
-  if (insertions.every((insertion) => insertion.length === 1)) return false;
-
-  const changes = view.state.changes(
-    ranges.map((range, index) => ({
-      from: range.head,
-      insert: insertions[index] ?? "\n",
-    })),
-  );
-  view.dispatch({
-    changes,
-    selection: EditorSelection.create(
-      ranges.map((range) =>
-        EditorSelection.cursor(changes.mapPos(range.head, 1), 1)
-      ),
-      view.state.selection.mainIndex,
-    ),
-    userEvent: "input",
-  });
-  return true;
-}
-
 function confirmIncompleteInlineDestination(view: EditorView) {
   if (!isEditable(view)) return false;
   const { ranges } = view.state.selection;
@@ -293,9 +242,7 @@ export function markdownEditingPlugin() {
         { key: "Backspace", run: removeLeadingEmptyLineBackward },
         {
           key: "Enter",
-          run: (view) =>
-            confirmIncompleteInlineDestination(view) ||
-            insertVisibleBlankLineBeforeText(view),
+          run: confirmIncompleteInlineDestination,
         },
         { key: "Tab", run: handleTab, shift: handleShiftTab },
         { key: "Shift-Enter", run: insertContextualHardBreak },

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -30,10 +30,7 @@ import {
 } from "./links.ts";
 import { unescapeMarkdown } from "./syntax.ts";
 import { createTaskDecoration } from "./tasks.ts";
-import {
-  blankLineLayout,
-  isInsidePreformattedBlock,
-} from "./blank-lines.ts";
+import { isInsidePreformattedBlock } from "./blank-lines.ts";
 
 const HEADING_CLASSES: Readonly<Record<string, string>> = {
   ATXHeading1: "cm-markra-h1",
@@ -766,6 +763,8 @@ function buildDecorations(
         !decoratedEmptyLines.has(line.from) &&
         !isInsidePreformattedBlock(state, line.from)
       ) {
+        // Keep every authored blank as a normal CodeMirror row. Folding one
+        // based on surrounding text makes its height change while typing.
         decoratedEmptyLines.add(line.from);
         ranges.push(
           Decoration.line({
@@ -901,7 +900,6 @@ function previewPlugin(config: LivePreviewConfig): Extension {
 export function livePreview(config: LivePreviewConfig = {}): Extension {
   return [
     sourceDragSelectionExtension,
-    blankLineLayout(),
     previewPlugin(config),
     listMarkerSelectionPlugin,
   ];


### PR DESCRIPTION
## Summary
- keep every authored blank source line as a normal editable CodeMirror row
- remove the hidden separator, 8px block-gap widget, atomic selection redirect, and compensating Enter insertion
- align image continuation and Preview/Source recreation tests with source-faithful blank-line behavior

## Why
An empty row at the end of the document was reclassified after text was entered below it. The editor then hid the real row and replaced it with an 8px layout widget, which made content move upward and destabilized caret, IME, focus, reopen, and mode-switch behavior.

## Validation
- `pnpm --filter @markra/editor test` — 413 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app test` — 1484 tests passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed
- Safari/WebKit runtime QA — the authored blank row remained visible after entering text below it

## Risk
- Preview editing now displays every authored source blank line at normal line height, so documents containing many blank lines will appear taller.
- This intentionally does not implement the compact blank-line behavior requested in #628; editable Preview remains source-faithful instead.