### PR TITLE
perf(editor): reduce live preview typing latency

### DIFF
--- a/packages/app/src/components/CodeMirrorPaperSurface.tsx
+++ b/packages/app/src/components/CodeMirrorPaperSurface.tsx
@@ -35,6 +35,7 @@ import {
   tableFragmentMergePlugin,
   tablePreviewPlugin,
   trailingSpacePlugin,
+  updateCodeMirrorHeadingAnchors,
   updateCodeMirrorSpellcheckOptions,
   type MarkraPlugin,
 } from "@markra/editor/codemirror";
@@ -510,6 +511,9 @@ export function CodeMirrorPaperSurface({
     const container = containerRef.current;
     if (!container || viewRef.current) return;
 
+    let headingAnchors: ReturnType<typeof readCodeMirrorHeadingAnchors> | null =
+      null;
+
     const view = new EditorView({
       parent: container,
       state: EditorState.create({
@@ -605,9 +609,18 @@ export function CodeMirrorPaperSurface({
                 );
               }
 
-              const headings = readCodeMirrorHeadingAnchors(update.state);
+              if (headingAnchors === null) {
+                headingAnchors = readCodeMirrorHeadingAnchors(update.state);
+              } else if (update.docChanged) {
+                headingAnchors = updateCodeMirrorHeadingAnchors(
+                  headingAnchors,
+                  update.startState,
+                  update.state,
+                  update.changes,
+                );
+              }
               let activeOutlineIndex: number | null = null;
-              for (const [index, heading] of headings.entries()) {
+              for (const [index, heading] of headingAnchors.entries()) {
                 if (heading.from > selection.head) break;
                 activeOutlineIndex = index;
               }

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -636,6 +636,45 @@ describe("useMarkdownDocument", () => {
     expect(confirmDiscardUnsavedChanges).toHaveBeenCalledWith(expect.objectContaining({ name: "source.md" }));
   });
 
+  it("skips live editor equivalence checks after the document is already dirty", async () => {
+    const isCurrentMarkdownEquivalent = vi.fn(() => false);
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: "Original clean source.",
+      name: "performance.md",
+      path: "/mock-files/performance.md"
+    });
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        isCurrentMarkdownEquivalent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "performance.md",
+        path: "/mock-files/performance.md",
+        relativePath: "performance.md"
+      });
+    });
+
+    act(() => {
+      result.current.handleMarkdownChange("First user edit.", { surface: "source" });
+    });
+    expect(result.current.document.dirty).toBe(true);
+    isCurrentMarkdownEquivalent.mockClear();
+
+    act(() => {
+      result.current.handleMarkdownChange("Second user edit.", { surface: "source" });
+    });
+
+    expect(isCurrentMarkdownEquivalent).not.toHaveBeenCalled();
+  });
+
   it("does not ask to discard a clean file when the visual editor tightens callout list spacing", async () => {
     let closeRequestHandler: ((event: MockWindowCloseRequestEvent) => unknown | Promise<unknown>) | null = null;
     let editorMarkdown = [
@@ -3104,6 +3143,50 @@ describe("useMarkdownDocument", () => {
         }
       ]
     });
+  });
+
+  it("coalesces repeated persistence after a document is already dirty", async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() =>
+        useMarkdownDocument({
+          getCurrentMarkdown: (fallbackContent) => fallbackContent,
+          onTreeRootFromFilePath: vi.fn(),
+          onTreeRootFromFolderPath: vi.fn(),
+          preferencesReady: false,
+          restoreWorkspaceOnStartup: false,
+        })
+      );
+
+      act(() => {
+        result.current.handleMarkdownChange("First edit");
+      });
+      expect(result.current.document.dirty).toBe(true);
+      mockedSaveStoredWorkspaceState.mockClear();
+
+      act(() => {
+        result.current.handleMarkdownChange("Second edit");
+      });
+      act(() => {
+        result.current.handleMarkdownChange("Latest edit");
+      });
+
+      expect(mockedSaveStoredWorkspaceState).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledTimes(1);
+      expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledWith({
+        activeDraftId: "untitled:0",
+        draftTabs: [
+          expect.objectContaining({ content: "Latest edit" }),
+        ],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps an untitled edit visible when save starts before the tab state flushes", async () => {

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -195,6 +195,7 @@ type OpenMarkdownFileOptions = {
 };
 
 let pendingWorkspaceStateSave: Promise<unknown> | null = null;
+const DRAFT_WORKSPACE_PERSIST_DELAY_MS = 250;
 
 function persistWorkspaceState(patch: Parameters<typeof saveStoredWorkspaceState>[0]) {
   // Workspace writes are read-modify-write operations; keep draft snapshots ordered.
@@ -293,6 +294,7 @@ export function useMarkdownDocument({
   const nativeWindowCloseAllowedRef = useRef(false);
   const nativeWindowCloseScheduledRef = useRef(false);
   const dirtyFileSavePromiseRef = useRef<Promise<unknown> | null>(null);
+  const draftWorkspacePersistTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const editorSyncStateRef = useRef<EditorSyncState | null>(null);
   if (editorSyncStateRef.current === null) editorSyncStateRef.current = createEditorSyncState();
   const editorSyncState = editorSyncStateRef.current;
@@ -482,6 +484,24 @@ export function useMarkdownDocument({
     });
   }, []);
 
+  const scheduleDraftWorkspacePersistence = useCallback(() => {
+    if (draftWorkspacePersistTimeoutRef.current !== null) {
+      clearTimeout(draftWorkspacePersistTimeoutRef.current);
+    }
+
+    draftWorkspacePersistTimeoutRef.current = setTimeout(() => {
+      draftWorkspacePersistTimeoutRef.current = null;
+      persistWorkspaceState(draftWorkspacePatchFromTabs(tabsRef.current, activeTabIdRef.current));
+    }, DRAFT_WORKSPACE_PERSIST_DELAY_MS);
+  }, []);
+
+  useEffect(() => () => {
+    if (draftWorkspacePersistTimeoutRef.current === null) return;
+
+    clearTimeout(draftWorkspacePersistTimeoutRef.current);
+    draftWorkspacePersistTimeoutRef.current = null;
+  }, []);
+
   const setActiveTabState = useCallback((nextTabs: MarkdownDocumentTab[], nextActiveTabId: string | null) => {
     const activeTab = nextTabs.find((tab) => tab.id === nextActiveTabId) ?? null;
     const nextDocument = activeTab
@@ -646,7 +666,9 @@ export function useMarkdownDocument({
       return;
     }
     const canKeepEquivalentMarkdownClean = options.surface !== "source";
-    const editorContentEquivalent = isActiveEditorMarkdownEquivalent(current.content);
+    const editorContentEquivalent = current.dirty
+      ? undefined
+      : isActiveEditorMarkdownEquivalent(current.content);
     if (
       !current.dirty &&
       options.surface === "visual" &&
@@ -671,11 +693,18 @@ export function useMarkdownDocument({
       ? tabsRef.current.map((tab) => tab.id === currentActiveTabId ? createDocumentTab(nextDocument, tab.id) : tab)
       : tabsRef.current;
     setActiveDocument(nextDocument);
-    persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, currentActiveTabId));
+    // Persist the first dirty snapshot immediately for recovery, then coalesce
+    // continuous typing so desktop storage I/O does not compete with keystrokes.
+    if (current.dirty) {
+      scheduleDraftWorkspacePersistence();
+    } else {
+      persistWorkspaceState(draftWorkspacePatchFromTabs(nextTabs, currentActiveTabId));
+    }
   }, [
     editorSyncState,
     editorReady,
     isActiveEditorMarkdownEquivalent,
+    scheduleDraftWorkspacePersistence,
     setActiveDocument
   ]);
 

--- a/packages/app/src/lib/markdown-summary.test.ts
+++ b/packages/app/src/lib/markdown-summary.test.ts
@@ -6,8 +6,8 @@ import {
 
 describe("markdown summary scheduling", () => {
   it("defers summaries for medium documents below the visual rendering limit", () => {
-    expect(markdownSummaryDeferredLimitBytes).toBe(256_000);
-    expect(markdownSummaryDeferredLimitChars).toBe(256_000);
+    expect(markdownSummaryDeferredLimitBytes).toBe(64_000);
+    expect(markdownSummaryDeferredLimitChars).toBe(64_000);
     expect(shouldDeferMarkdownSummary("# Small", {
       sizeBytes: markdownSummaryDeferredLimitBytes - 1
     })).toBe(false);
@@ -15,6 +15,9 @@ describe("markdown summary scheduling", () => {
       sizeBytes: markdownSummaryDeferredLimitBytes
     })).toBe(true);
     expect(shouldDeferMarkdownSummary("x".repeat(markdownSummaryDeferredLimitChars))).toBe(true);
+    expect(shouldDeferMarkdownSummary("# Synthetic issue", {
+      sizeBytes: 254_775
+    })).toBe(true);
   });
 
   it("does not defer summaries for documents blocked from visual rendering", () => {

--- a/packages/app/src/lib/markdown-summary.ts
+++ b/packages/app/src/lib/markdown-summary.ts
@@ -1,7 +1,9 @@
 import { shouldBlockLargeMarkdownVisual } from "./large-markdown";
 
-export const markdownSummaryDeferredLimitBytes = 256_000;
-export const markdownSummaryDeferredLimitChars = 256_000;
+// Outline parsing and Unicode word counting run synchronously. Keep them off
+// the input path once a document is large enough to consume a visible frame.
+export const markdownSummaryDeferredLimitBytes = 64_000;
+export const markdownSummaryDeferredLimitChars = 64_000;
 
 type MarkdownSummaryMetadata = {
   sizeBytes?: number | null;

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -4217,6 +4217,9 @@
     background: transparent;
     border-color: transparent;
     box-shadow: none;
+    contain: layout paint style;
+    transform: translateZ(0);
+    will-change: transform;
   }
 
   .markdown-paper .cm-markra-code-top-gap:has(+ .cm-line .markra-code-block[data-mermaid-mode="preview"]) {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -1358,6 +1358,9 @@ describe("editor stylesheet", () => {
     expect(mermaidFoldStyles).toContain("display: none");
     expect(mermaidFoldStyles).toContain("background: transparent");
     expect(mermaidFoldStyles).toContain("border-color: transparent");
+    expect(mermaidFoldStyles).toContain("contain: layout paint style");
+    expect(mermaidFoldStyles).toContain("will-change: transform");
+    expect(mermaidFoldStyles).toContain("transform: translateZ(0)");
     expect(mermaidFoldStyles).toContain(".markra-code-language-control");
     expect(styles).toContain(
       ".markdown-paper .cm-markra-code-top-gap:has(+ .cm-line .markra-code-block[data-mermaid-mode=\"preview\"]) {\n" +

--- a/packages/editor/src/code-support.test.ts
+++ b/packages/editor/src/code-support.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { highlightMarkraCode } from "./code-support.ts";
 
 describe("code highlighting", () => {
-  it("treats missing and unsupported languages as plain text", () => {
+  it("auto-detects missing and unsupported languages", () => {
     const source = "const syntheticValue = 42;";
 
-    expect(highlightMarkraCode("", source)).toEqual([]);
-    expect(highlightMarkraCode("synthetic-unknown-language", source)).toEqual(
-      [],
-    );
+    expect(highlightMarkraCode("", source)).not.toEqual([]);
+    expect(
+      highlightMarkraCode("synthetic-unknown-language", source),
+    ).not.toEqual([]);
   });
 
   it("highlights explicitly supported languages", () => {

--- a/packages/editor/src/code-support.test.ts
+++ b/packages/editor/src/code-support.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { highlightMarkraCode } from "./code-support.ts";
+
+describe("code highlighting", () => {
+  it("treats missing and unsupported languages as plain text", () => {
+    const source = "const syntheticValue = 42;";
+
+    expect(highlightMarkraCode("", source)).toEqual([]);
+    expect(highlightMarkraCode("synthetic-unknown-language", source)).toEqual(
+      [],
+    );
+  });
+
+  it("highlights explicitly supported languages", () => {
+    expect(highlightMarkraCode("javascript", "const value = 42;")).not.toEqual(
+      [],
+    );
+  });
+});

--- a/packages/editor/src/code-support.ts
+++ b/packages/editor/src/code-support.ts
@@ -105,11 +105,12 @@ function collectHighlightRanges(
 export function highlightMarkraCode(language: string, code: string) {
   if (!code.trim()) return [];
 
+  const normalizedLanguage = normalizeMarkraCodeLanguage(language);
+  if (!normalizedLanguage || !lowlight.registered(normalizedLanguage)) return [];
+
   const ranges: MarkraCodeHighlightSpan[] = [];
   try {
-    const tree = language && lowlight.registered(language)
-      ? lowlight.highlight(language, code)
-      : lowlight.highlightAuto(code);
+    const tree = lowlight.highlight(normalizedLanguage, code);
     collectHighlightRanges(tree as HighlightAstNode, 0, [], ranges);
   } catch {
     return [];

--- a/packages/editor/src/code-support.ts
+++ b/packages/editor/src/code-support.ts
@@ -106,11 +106,11 @@ export function highlightMarkraCode(language: string, code: string) {
   if (!code.trim()) return [];
 
   const normalizedLanguage = normalizeMarkraCodeLanguage(language);
-  if (!normalizedLanguage || !lowlight.registered(normalizedLanguage)) return [];
-
   const ranges: MarkraCodeHighlightSpan[] = [];
   try {
-    const tree = lowlight.highlight(normalizedLanguage, code);
+    const tree = normalizedLanguage && lowlight.registered(normalizedLanguage)
+      ? lowlight.highlight(normalizedLanguage, code)
+      : lowlight.highlightAuto(code);
     collectHighlightRanges(tree as HighlightAstNode, 0, [], ranges);
   } catch {
     return [];

--- a/packages/editor/src/codemirror/block-drag.test.ts
+++ b/packages/editor/src/codemirror/block-drag.test.ts
@@ -455,6 +455,31 @@ describe("codeMirrorBlockDragPlugin", () => {
     expect(view.dom.querySelectorAll(".markra-block-add-button")).toHaveLength(4);
   });
 
+  it("keeps later block controls mounted while typing plain text before them", () => {
+    const doc = "Edit here\n\n## Later block";
+    const view = createView(doc);
+    const laterFrom = doc.indexOf("## Later block");
+    const laterToolbar = view.dom.querySelector<HTMLElement>(
+      `[data-block-from="${laterFrom}"]`,
+    );
+
+    view.dispatch({
+      changes: { from: "Edit here".length, insert: "字" },
+      selection: EditorSelection.cursor("Edit here字".length),
+      userEvent: "input.type",
+    });
+
+    const nextLaterFrom = laterFrom + 1;
+    expect(
+      view.dom.querySelector(`[data-block-from="${nextLaterFrom}"]`),
+    ).toBe(laterToolbar);
+    expect(
+      view.dom.querySelector(
+        `.cm-line[data-markra-block-from="${nextLaterFrom}"]`,
+      ),
+    ).not.toBeNull();
+  });
+
   it("does not render mutation controls in a read-only editor", () => {
     const view = createView("First\n\nSecond", true);
 

--- a/packages/editor/src/codemirror/block-drag.ts
+++ b/packages/editor/src/codemirror/block-drag.ts
@@ -16,6 +16,7 @@ import {
 import { readCodeMirrorFrontmatter } from "./frontmatter-preview.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { openMarkraSlashMenu } from "./slash-menu.ts";
+import { updateOnlyInsertsPlainText } from "./changes.ts";
 
 export interface CodeMirrorBlockRange {
   readonly depth?: number;
@@ -390,17 +391,38 @@ function blockControl(
   return button;
 }
 
+interface BlockToolbarRuntime {
+  blockFrom: number;
+  toolbar: HTMLElement | null;
+}
+
 class BlockToolbarWidget extends WidgetType {
+  private runtime: BlockToolbarRuntime;
+  private readonly labelsKey: string;
+
   constructor(
-    readonly blockFrom: number,
+    blockFrom: number,
     readonly labels: CodeMirrorBlockDragLabels,
   ) {
     super();
+    this.labelsKey = JSON.stringify(labels);
+    this.runtime = { blockFrom, toolbar: null };
+  }
+
+  private get blockFrom() {
+    return this.runtime.blockFrom;
   }
 
   eq(other: BlockToolbarWidget) {
-    return this.blockFrom === other.blockFrom &&
-      JSON.stringify(this.labels) === JSON.stringify(other.labels);
+    if (this.labelsKey !== other.labelsKey) return false;
+
+    const nextBlockFrom = other.blockFrom;
+    other.runtime = this.runtime;
+    this.runtime.blockFrom = nextBlockFrom;
+    if (this.runtime.toolbar) {
+      this.runtime.toolbar.dataset.blockFrom = String(nextBlockFrom);
+    }
+    return true;
   }
 
   ignoreEvent() {
@@ -422,6 +444,7 @@ class BlockToolbarWidget extends WidgetType {
     );
     toolbar.className = "cm-markra-block-toolbar markra-block-toolbar";
     toolbar.dataset.blockFrom = String(this.blockFrom);
+    this.runtime.toolbar = toolbar;
     for (let index = 0; index < 6; index += 1) {
       const dot = document.createElement("span");
       dot.className = "markra-block-drag-dot";
@@ -453,12 +476,11 @@ class BlockToolbarWidget extends WidgetType {
   }
 }
 
-function blockDecorations(
-  state: CodeMirrorState,
+function blockDecorationsFromRanges(
+  blocks: readonly CodeMirrorBlockRange[],
   labels: CodeMirrorBlockDragLabels,
-): DecorationSet {
-  if (state.facet(EditorState.readOnly)) return Decoration.none;
-  const decorations = readCodeMirrorBlockRanges(state).flatMap((block) => [
+) {
+  const decorations = blocks.flatMap((block) => [
     Decoration.line({
       attributes: { "data-markra-block-from": String(block.from) },
     }).range(block.from),
@@ -471,6 +493,34 @@ function blockDecorations(
     }).range(block.from),
   ]);
   return Decoration.set(decorations, true);
+}
+
+function plainTextInputStaysInsideBlocks(
+  update: ViewUpdate,
+  blocks: readonly CodeMirrorBlockRange[],
+) {
+  if (!updateOnlyInsertsPlainText(update)) return false;
+
+  let insideExistingBlock = true;
+  update.changes.iterChangedRanges((fromA, toA) => {
+    insideExistingBlock &&= fromA === toA && blocks.some((block) =>
+      block.name === "Paragraph" &&
+      fromA >= block.from &&
+      fromA <= block.to
+    );
+  });
+  return insideExistingBlock;
+}
+
+function mapBlockRanges(
+  blocks: readonly CodeMirrorBlockRange[],
+  update: ViewUpdate,
+) {
+  return blocks.map((block) => ({
+    ...block,
+    from: update.changes.mapPos(block.from, -1),
+    to: update.changes.mapPos(block.to, 1),
+  }));
 }
 
 function eventElement(event: Event) {
@@ -666,18 +716,36 @@ function draggedBlockFrom(event: DragEvent) {
 }
 
 class BlockDragViewPlugin {
+  blocks: readonly CodeMirrorBlockRange[];
   decorations: DecorationSet;
 
   constructor(view: CodeMirrorView, readonly labels: CodeMirrorBlockDragLabels) {
-    this.decorations = blockDecorations(view.state, labels);
+    this.blocks = view.state.facet(EditorState.readOnly)
+      ? []
+      : readCodeMirrorBlockRanges(view.state);
+    this.decorations = blockDecorationsFromRanges(this.blocks, labels);
   }
 
   update(update: ViewUpdate) {
+    const readOnlyChanged =
+      update.startState.readOnly !== update.state.readOnly;
+    if (
+      !readOnlyChanged &&
+      plainTextInputStaysInsideBlocks(update, this.blocks)
+    ) {
+      this.blocks = mapBlockRanges(this.blocks, update);
+      this.decorations = blockDecorationsFromRanges(this.blocks, this.labels);
+      return;
+    }
+
     if (
       update.docChanged ||
-      update.startState.readOnly !== update.state.readOnly
+      readOnlyChanged
     ) {
-      this.decorations = blockDecorations(update.state, this.labels);
+      this.blocks = update.state.facet(EditorState.readOnly)
+        ? []
+        : readCodeMirrorBlockRanges(update.state);
+      this.decorations = blockDecorationsFromRanges(this.blocks, this.labels);
     }
   }
 }

--- a/packages/editor/src/codemirror/changes.ts
+++ b/packages/editor/src/codemirror/changes.ts
@@ -1,0 +1,53 @@
+import type { ViewUpdate } from "@codemirror/view";
+
+export function updateOnlyInsertsPlainText(update: ViewUpdate) {
+  if (
+    !update.docChanged ||
+    update.focusChanged ||
+    update.transactions.some((transaction) => transaction.reconfigured) ||
+    update.transactions.some((transaction) =>
+      transaction.docChanged && !transaction.isUserEvent("input")
+    )
+  ) {
+    return false;
+  }
+
+  let plainInsertion = true;
+  update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+    if (
+      fromA !== toA ||
+      !/^[\p{L}\p{M}\p{N}]+$/u.test(inserted.toString())
+    ) {
+      plainInsertion = false;
+    }
+  });
+  return plainInsertion;
+}
+
+export function updateChangesStayAfter(
+  update: ViewUpdate,
+  position: number,
+  insertedMayAffectSyntax: (source: string) => boolean,
+) {
+  if (!update.docChanged || update.focusChanged) return false;
+  if (
+    [...update.startState.selection.ranges, ...update.state.selection.ranges]
+      .some((range) => range.from <= position)
+  ) {
+    return false;
+  }
+
+  let staysAfter = true;
+  update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+    // Removing delimiters can expose syntax that was previously inside code,
+    // so both deleted and inserted source participate in invalidation.
+    if (
+      fromA <= position ||
+      insertedMayAffectSyntax(update.startState.sliceDoc(fromA, toA)) ||
+      insertedMayAffectSyntax(inserted.toString())
+    ) {
+      staysAfter = false;
+    }
+  });
+  return staysAfter;
+}

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -297,7 +297,7 @@ describe("codeBlockPreviewPlugin", () => {
     )).toBe("const answer = 42;\nreturn answer;");
   });
 
-  it("accepts a cached host highlighter without bundling one", () => {
+  it("reuses cached highlighting when editing outside the code block", () => {
     const highlight = vi.fn(({ code, language }) => {
       expect(language).toBe("ts");
       expect(code).toContain("const answer");
@@ -316,6 +316,13 @@ describe("codeBlockPreviewPlugin", () => {
     expect(highlight).toHaveBeenCalledOnce();
 
     view.dispatch({ selection: { anchor: codeDocument.length - 2 } });
+    expect(highlight).toHaveBeenCalledOnce();
+
+    view.dispatch({
+      changes: { from: codeDocument.length, insert: "!" },
+      selection: { anchor: codeDocument.length + 1 },
+      userEvent: "input",
+    });
     expect(highlight).toHaveBeenCalledOnce();
   });
 
@@ -495,6 +502,91 @@ describe("codeBlockPreviewPlugin", () => {
     expect(view.dom.querySelector(".markra-mermaid-render")).toBeNull();
     expect(renderedLines(view)).toContain("```mermaid");
     expect(view.state.doc.toString()).toBe(source);
+  });
+
+  it("removes empty zero-size Mermaid label nodes", async () => {
+    const source = "```mermaid\nflowchart TD\n  A --> B\n```\n\nEdit";
+    const view = createView(
+      source,
+      codeBlockPreviewPlugin({
+        renderMermaid: async () => [
+          "<svg>",
+          '<g class="label"><foreignObject width="0" height="0"></foreignObject></g>',
+          '<g class="label"><foreignObject width="32" height="24"><div>Visible</div></foreignObject></g>',
+          "</svg>",
+        ].join(""),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(view.dom.querySelector(".markra-mermaid-render svg")).not.toBeNull();
+    });
+
+    expect(
+      view.dom.querySelector(
+        '.markra-mermaid-render foreignObject[width="0"][height="0"]',
+      ),
+    ).toBeNull();
+    expect(view.dom.querySelector(".markra-mermaid-render")?.textContent)
+      .toContain("Visible");
+  });
+
+  it("keeps an unchanged Mermaid preview mounted when editing after it", async () => {
+    const source = "```mermaid\nflowchart TD\n  A --> B\n```\n\nEdit";
+    const renderMermaid = vi.fn().mockResolvedValue(
+      '<svg aria-label="Synthetic diagram"></svg>',
+    );
+    const view = createView(
+      source,
+      codeBlockPreviewPlugin({ renderMermaid }),
+    );
+
+    await vi.waitFor(() => {
+      expect(view.dom.querySelector(".markra-mermaid-render svg")).not.toBeNull();
+    });
+    const preview = view.dom.querySelector(".markra-mermaid-render");
+    expect(renderMermaid).toHaveBeenCalledOnce();
+
+    view.dispatch({
+      changes: { from: source.length, insert: "!" },
+      selection: { anchor: source.length + 1 },
+      userEvent: "input",
+    });
+
+    await Promise.resolve();
+    expect(renderMermaid).toHaveBeenCalledOnce();
+    expect(view.dom.querySelector(".markra-mermaid-render")).toBe(preview);
+  });
+
+  it("keeps an unchanged Mermaid preview mounted when editing before it", async () => {
+    const source = "Before\n\n```mermaid\nflowchart TD\n  A --> B\n```\n\nAfter";
+    const renderMermaid = vi.fn().mockResolvedValue(
+      '<svg aria-label="Synthetic diagram"></svg>',
+    );
+    const view = createView(
+      source,
+      codeBlockPreviewPlugin({ renderMermaid }),
+    );
+
+    await vi.waitFor(() => {
+      expect(view.dom.querySelector(".markra-mermaid-render svg")).not.toBeNull();
+    });
+    const preview = view.dom.querySelector(".markra-mermaid-render");
+    expect(renderMermaid).toHaveBeenCalledOnce();
+
+    const inserted = "Expanded synthetic prefix. ";
+    view.dispatch({
+      changes: { from: 0, insert: inserted },
+      selection: { anchor: inserted.length },
+      userEvent: "input",
+    });
+
+    await Promise.resolve();
+    expect(renderMermaid).toHaveBeenCalledOnce();
+    expect(view.dom.querySelector(".markra-mermaid-render")).toBe(preview);
+
+    view.dom.querySelector<HTMLElement>(".markra-mermaid-render")?.click();
+    expect(view.dom.querySelector(".markra-mermaid-render")).toBeNull();
   });
 
   it("returns active Mermaid source to preview mode with Escape", async () => {

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -2,15 +2,17 @@ import { syntaxTree } from "@codemirror/language";
 import {
   EditorSelection,
   Prec,
+  StateEffect,
   StateField,
   type Range,
   type EditorState,
-  type Text,
+  type Transaction,
 } from "@codemirror/state";
 import {
   Decoration,
   EditorView,
   keymap,
+  ViewPlugin,
   WidgetType,
   type DecorationSet,
   type EditorView as CodeMirrorView,
@@ -259,9 +261,8 @@ const codeBlockTheme = EditorView.baseTheme({
     position: "relative",
     textAlign: "center",
   },
-  // This widget is emitted through a view plugin, so CodeMirror requires an
-  // inline replacement. An inline-block avoids the empty line boxes produced
-  // by placing a block element between CodeMirror's inline widget buffers.
+  // An inline-block avoids the empty line boxes WebKit can produce around
+  // CodeMirror's widget buffers while still letting the preview fill the row.
   ".markra-code-block[data-mermaid-mode='preview']": {
     boxSizing: "border-box",
     display: "inline-block",
@@ -279,9 +280,6 @@ const codeBlockTheme = EditorView.baseTheme({
   ".markra-mermaid-render svg": {
     height: "auto",
     maxWidth: "100%",
-  },
-  ".cm-markra-mermaid-hidden-line": {
-    display: "none",
   },
 });
 
@@ -322,6 +320,11 @@ function codeBlockTopGapDecorations(
       const firstLine = state.doc.lineAt(node.from);
       const lastLine = state.doc.lineAt(node.to);
       if (firstLine.number === lastLine.number) return;
+      const fencedLanguage = /^\s*(?:`{3,}|~{3,})\s*([^\s`]*)/u
+        .exec(firstLine.text)?.[1] ?? "";
+      if (isMermaidLanguage(normalizeMarkraCodeLanguage(fencedLanguage))) {
+        return;
+      }
       // Fenced code may be indented by up to three spaces. Block widgets
       // anchored after that indentation split the folded header in WebKit.
       gaps.push(
@@ -520,13 +523,37 @@ class CodeBlockExitWidget extends WidgetType {
   }
 }
 
-class MermaidPreviewWidget extends WidgetType {
-  private observer: MutationObserver | null = null;
-  private renderToken = 0;
-  private mediaViewer: MediaViewerHandle | null = null;
+interface MermaidPreviewRuntime {
+  mediaViewer: MediaViewerHandle | null;
+  observer: MutationObserver | null;
+  renderToken: number;
+}
 
+const mermaidPreviewRuntimes = new WeakMap<
+  HTMLElement,
+  MermaidPreviewRuntime
+>();
+
+function removeEmptyMermaidLabels(preview: HTMLElement) {
+  for (const emptyLabel of preview.querySelectorAll(
+    'foreignObject[width="0"][height="0"]',
+  )) {
+    const label = emptyLabel.parentElement;
+    if (
+      label?.classList.contains("label") &&
+      label.childElementCount === 1 &&
+      !label.textContent?.trim()
+    ) {
+      label.remove();
+      continue;
+    }
+    emptyLabel.remove();
+  }
+}
+
+class MermaidPreviewWidget extends WidgetType {
   constructor(
-    readonly from: number,
+    readonly sourceOffset: number,
     readonly labels: CodeBlockPreviewLabels,
     readonly renderMermaid: NonNullable<CodeBlockPreviewPluginOptions["renderMermaid"]>,
     readonly source: string,
@@ -535,27 +562,31 @@ class MermaidPreviewWidget extends WidgetType {
   }
 
   eq(other: MermaidPreviewWidget) {
-    return this.from === other.from && this.source === other.source;
+    return (
+      this.source === other.source &&
+      this.sourceOffset === other.sourceOffset
+    );
   }
 
   ignoreEvent() {
     return true;
   }
 
-  private closeViewer() {
-    this.mediaViewer?.close({ restoreFocus: false });
-    this.mediaViewer = null;
+  private closeViewer(runtime: MermaidPreviewRuntime) {
+    runtime.mediaViewer?.close({ restoreFocus: false });
+    runtime.mediaViewer = null;
   }
 
   private openZoom(
+    runtime: MermaidPreviewRuntime,
     view: CodeMirrorView,
     preview: HTMLElement,
     trigger: HTMLButtonElement,
   ) {
     const sourceSvg = preview.querySelector("svg");
     if (!sourceSvg) return;
-    this.closeViewer();
-    this.mediaViewer = openMediaViewer({
+    this.closeViewer(runtime);
+    runtime.mediaViewer = openMediaViewer({
       labels: {
         close: "Close enlarged Mermaid diagram",
         dialog: "Enlarged Mermaid diagram",
@@ -573,6 +604,7 @@ class MermaidPreviewWidget extends WidgetType {
   }
 
   private appendZoomButton(
+    runtime: MermaidPreviewRuntime,
     view: CodeMirrorView,
     preview: HTMLElement,
     wrapper: HTMLElement,
@@ -592,7 +624,7 @@ class MermaidPreviewWidget extends WidgetType {
     button.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
-      this.openZoom(view, preview, button);
+      this.openZoom(runtime, view, preview, button);
     });
     wrapper.append(button);
   }
@@ -601,6 +633,12 @@ class MermaidPreviewWidget extends WidgetType {
     const document = view.dom.ownerDocument;
     const wrapper = document.createElement("div");
     const preview = document.createElement("div");
+    const runtime: MermaidPreviewRuntime = {
+      mediaViewer: null,
+      observer: null,
+      renderToken: 0,
+    };
+    mermaidPreviewRuntimes.set(wrapper, runtime);
     wrapper.className = "markra-code-block";
     wrapper.dataset.mermaidMode = "preview";
     preview.className = "markra-mermaid-render";
@@ -611,9 +649,17 @@ class MermaidPreviewWidget extends WidgetType {
     const revealSource = (event: Event) => {
       event.preventDefault();
       event.stopPropagation();
+      let anchor = this.sourceOffset;
+      try {
+        // The widget may move when text is inserted before an unchanged
+        // diagram. Resolve its current document position from the reused DOM.
+        anchor = view.posAtDOM(wrapper) + this.sourceOffset;
+      } catch {
+        // Fall back to the creation position if the DOM was already detached.
+      }
       view.dispatch({
         scrollIntoView: true,
-        selection: { anchor: this.from },
+        selection: { anchor },
       });
       view.focus();
     };
@@ -623,20 +669,21 @@ class MermaidPreviewWidget extends WidgetType {
     });
 
     const render = () => {
-      this.renderToken += 1;
-      const token = this.renderToken;
+      runtime.renderToken += 1;
+      const token = runtime.renderToken;
       const theme = mermaidThemeFromElement(preview);
       preview.setAttribute("aria-busy", "true");
       this.renderMermaid({ source: this.source, theme, view })
         .then((svg) => {
-          if (token !== this.renderToken) return;
-          this.closeViewer();
+          if (token !== runtime.renderToken) return;
+          this.closeViewer(runtime);
           preview.innerHTML = svg;
-          this.appendZoomButton(view, preview, wrapper);
+          removeEmptyMermaidLabels(preview);
+          this.appendZoomButton(runtime, view, preview, wrapper);
           preview.setAttribute("aria-busy", "false");
         })
         .catch(() => {
-          if (token !== this.renderToken) return;
+          if (token !== runtime.renderToken) return;
           preview.textContent = this.labels.mermaidError;
           preview.dataset.error = "true";
           preview.setAttribute("aria-busy", "false");
@@ -646,24 +693,28 @@ class MermaidPreviewWidget extends WidgetType {
 
     const MutationObserverConstructor = document.defaultView?.MutationObserver;
     if (MutationObserverConstructor) {
-      this.observer = new MutationObserverConstructor(render);
+      runtime.observer = new MutationObserverConstructor(render);
       const options = {
         attributeFilter: ["data-editor-theme", "data-theme"],
         attributes: true,
       };
       const paper = view.dom.closest(".markdown-paper");
-      if (paper) this.observer.observe(paper, options);
-      this.observer.observe(document.documentElement, options);
+      if (paper) runtime.observer.observe(paper, options);
+      runtime.observer.observe(document.documentElement, options);
     }
     wrapper.append(preview);
     return wrapper;
   }
 
-  destroy() {
-    this.renderToken += 1;
-    this.closeViewer();
-    this.observer?.disconnect();
-    this.observer = null;
+  destroy(dom: HTMLElement) {
+    const runtime = mermaidPreviewRuntimes.get(dom);
+    if (!runtime) return;
+
+    runtime.renderToken += 1;
+    this.closeViewer(runtime);
+    runtime.observer?.disconnect();
+    runtime.observer = null;
+    mermaidPreviewRuntimes.delete(dom);
   }
 }
 
@@ -687,6 +738,280 @@ function codeBlockParts(
     languageTo: infoNode ? infoNode.from + rawLanguage.length : openingMark?.to ?? node.from,
     openingMarkTo: openingMark?.to ?? node.from,
   };
+}
+
+const setMermaidPreviewFocusedEffect = StateEffect.define<boolean>();
+
+interface MermaidPreviewState {
+  readonly blocks: readonly MermaidPreviewBlock[];
+  readonly decorations: DecorationSet;
+  readonly focused: boolean;
+}
+
+interface MermaidPreviewBlock {
+  readonly from: number;
+  readonly source: string;
+  readonly sourceOffset: number;
+  readonly to: number;
+}
+
+function mermaidSourceRevealed(
+  state: EditorState,
+  from: number,
+  to: number,
+  focused: boolean,
+) {
+  if (!focused) return false;
+  return state.selection.ranges.some((selection) =>
+    selection.empty
+      ? selection.head > from && selection.head <= to
+      : selection.anchor > from && selection.anchor <= to
+  );
+}
+
+function readMermaidPreviewBlocks(state: EditorState) {
+  const blocks: MermaidPreviewBlock[] = [];
+  syntaxTree(state).iterate({
+    enter(node) {
+      if (node.type.name !== "FencedCode") return;
+      const parts = codeBlockParts(state, node.node as MarkraSyntaxNode);
+      if (
+        !parts.codeNode ||
+        !parts.code.trim() ||
+        !isMermaidLanguage(parts.language)
+      ) {
+        return;
+      }
+      blocks.push({
+        from: node.from,
+        source: parts.code,
+        sourceOffset: parts.codeNode.from - node.from,
+        to: node.to,
+      });
+    },
+  });
+  return blocks;
+}
+
+function mermaidPreviewDecorationsFromBlocks(
+  state: EditorState,
+  focused: boolean,
+  blocks: readonly MermaidPreviewBlock[],
+  labels: CodeBlockPreviewLabels,
+  renderMermaid: NonNullable<CodeBlockPreviewPluginOptions["renderMermaid"]>,
+) {
+  const previews: Range<Decoration>[] = [];
+  for (const block of blocks) {
+    if (mermaidSourceRevealed(state, block.from, block.to, focused)) continue;
+    // Replace the complete fence with one block widget. Splitting the preview
+    // across a first-line widget and hidden source lines makes CodeMirror
+    // remount the expensive SVG while it reconciles the block's height map.
+    previews.push(
+      Decoration.replace({
+        block: true,
+        widget: new MermaidPreviewWidget(
+          block.sourceOffset,
+          labels,
+          renderMermaid,
+          block.source,
+        ),
+      }).range(block.from, block.to),
+    );
+  }
+  return Decoration.set(previews, true);
+}
+
+function createMermaidPreviewState(
+  state: EditorState,
+  focused: boolean,
+  labels: CodeBlockPreviewLabels,
+  renderMermaid: NonNullable<CodeBlockPreviewPluginOptions["renderMermaid"]>,
+): MermaidPreviewState {
+  const blocks = readMermaidPreviewBlocks(state);
+  return {
+    blocks,
+    decorations: mermaidPreviewDecorationsFromBlocks(
+      state,
+      focused,
+      blocks,
+      labels,
+      renderMermaid,
+    ),
+    focused,
+  };
+}
+
+function mapMermaidPreviewBlocks(
+  blocks: readonly MermaidPreviewBlock[],
+  transaction: Transaction,
+) {
+  return blocks.map((block) => ({
+    ...block,
+    from: transaction.changes.mapPos(block.from, 1),
+    to: transaction.changes.mapPos(block.to, -1),
+  }));
+}
+
+function changesTouchMermaidBlocks(
+  transaction: Transaction,
+  blocks: readonly MermaidPreviewBlock[],
+) {
+  let touched = false;
+  transaction.changes.iterChangedRanges((fromA, toA) => {
+    touched ||= blocks.some((block) =>
+      fromA === toA
+        ? fromA > block.from && fromA < block.to
+        : fromA < block.to && toA > block.from
+    );
+  });
+  return touched;
+}
+
+function changesMayAffectMermaidFences(transaction: Transaction) {
+  let mayAffect = false;
+  transaction.changes.iterChanges(
+    (fromA, toA, fromB, _toB, inserted) => {
+      if (fromA < toA || /[`~\r\n]/u.test(inserted.toString())) {
+        mayAffect = true;
+        return;
+      }
+      const line = transaction.state.doc.lineAt(fromB);
+      mayAffect ||= /^\s*(?:`{3,}|~{3,})/u.test(line.text);
+    },
+  );
+  return mayAffect;
+}
+
+function revealedMermaidBlocksKey(
+  state: EditorState,
+  focused: boolean,
+  blocks: readonly MermaidPreviewBlock[],
+) {
+  return blocks.map((block) =>
+    mermaidSourceRevealed(state, block.from, block.to, focused) ? "1" : "0"
+  ).join("");
+}
+
+function createMermaidPreviewField(
+  labels: CodeBlockPreviewLabels,
+  renderMermaid: NonNullable<CodeBlockPreviewPluginOptions["renderMermaid"]>,
+) {
+  const field = StateField.define<MermaidPreviewState>({
+    create(state) {
+      return createMermaidPreviewState(
+        state,
+        true,
+        labels,
+        renderMermaid,
+      );
+    },
+    update(previous, transaction) {
+      const focusEffect = transaction.effects.find((effect) =>
+        effect.is(setMermaidPreviewFocusedEffect)
+      );
+      const focused = focusEffect?.value ?? previous.focused;
+      if (!transaction.docChanged) {
+        const revealChanged =
+          revealedMermaidBlocksKey(
+            transaction.startState,
+            previous.focused,
+            previous.blocks,
+          ) !== revealedMermaidBlocksKey(
+            transaction.state,
+            focused,
+            previous.blocks,
+          );
+        return {
+          ...previous,
+          decorations: revealChanged
+            ? mermaidPreviewDecorationsFromBlocks(
+                transaction.state,
+                focused,
+                previous.blocks,
+                labels,
+                renderMermaid,
+              )
+            : previous.decorations,
+          focused,
+        };
+      }
+
+      if (
+        changesTouchMermaidBlocks(transaction, previous.blocks) ||
+        changesMayAffectMermaidFences(transaction)
+      ) {
+        return createMermaidPreviewState(
+          transaction.state,
+          focused,
+          labels,
+          renderMermaid,
+        );
+      }
+
+      const blocks = mapMermaidPreviewBlocks(previous.blocks, transaction);
+      const revealChanged = revealedMermaidBlocksKey(
+        transaction.startState,
+        previous.focused,
+        previous.blocks,
+      ) !== revealedMermaidBlocksKey(
+        transaction.state,
+        focused,
+        blocks,
+      );
+      return {
+        blocks,
+        decorations: revealChanged
+          ? mermaidPreviewDecorationsFromBlocks(
+              transaction.state,
+              focused,
+              blocks,
+              labels,
+              renderMermaid,
+            )
+          : previous.decorations.map(transaction.changes),
+        focused,
+      };
+    },
+    provide: (mermaidField) => EditorView.decorations.from(
+      mermaidField,
+      (value) => value.decorations,
+    ),
+  });
+  const mountedViews = new WeakSet<CodeMirrorView>();
+  const lifecycle = ViewPlugin.define((view) => {
+    mountedViews.add(view);
+    return {
+      destroy() {
+        mountedViews.delete(view);
+      },
+    };
+  });
+
+  const syncFocusedState = (view: CodeMirrorView) => {
+    // Focus events can fire inside toolbar and widget handlers that already
+    // dispatch a transaction. Defer this independent UI state update so it
+    // cannot interrupt the originating command or its React subscribers.
+    queueMicrotask(() => {
+      if (!mountedViews.has(view)) return;
+      const focused = view.hasFocus;
+      const previewState = view.state.field(field, false);
+      if (!previewState || previewState.focused === focused) return;
+      view.dispatch({ effects: setMermaidPreviewFocusedEffect.of(focused) });
+    });
+  };
+
+  return [
+    Prec.highest(field),
+    lifecycle,
+    EditorView.domEventHandlers({
+      blur(_event, view) {
+        syncFocusedState(view);
+      },
+      focus(_event, view) {
+        syncFocusedState(view);
+      },
+    }),
+  ];
 }
 
 function normalizeHighlights(
@@ -931,24 +1256,30 @@ export function codeBlockPreviewPlugin(
       idPrefix: "markra-codemirror-mermaid",
       theme: context.theme,
     }));
-  const highlightCache = new WeakMap<
-    Text,
-    Map<string, readonly CodeBlockHighlightSpan[]>
-  >();
+  const highlightCache: Array<{
+    code: string;
+    highlighted: readonly CodeBlockHighlightSpan[];
+    language: string;
+  }> = [];
+  let cachedCodeCharacters = 0;
+  const maxCachedCodeBlocks = 16;
+  const maxCachedCodeCharacters = 1_000_000;
 
   const highlightsFor = (
     context: MarkraRendererContext,
     parts: CodeBlockParts,
   ) => {
     if (!parts.codeNode) return [];
-    let documentCache = highlightCache.get(context.state.doc);
-    if (!documentCache) {
-      documentCache = new Map();
-      highlightCache.set(context.state.doc, documentCache);
+    const cachedIndex = highlightCache.findIndex(
+      (entry) =>
+        entry.language === parts.language && entry.code === parts.code,
+    );
+    const cached = highlightCache[cachedIndex];
+    if (cached) {
+      highlightCache.splice(cachedIndex, 1);
+      highlightCache.push(cached);
+      return cached.highlighted;
     }
-    const key = `${context.node.from}:${context.node.to}:${parts.language}`;
-    const cached = documentCache.get(key);
-    if (cached) return cached;
 
     let highlighted: readonly CodeBlockHighlightSpan[] = [];
     try {
@@ -964,7 +1295,23 @@ export function codeBlockPreviewPlugin(
     } catch {
       highlighted = [];
     }
-    documentCache.set(key, highlighted);
+
+    // Edits outside a fenced block create a new EditorState while leaving its
+    // source unchanged. Cache by the actual highlighter inputs so that common
+    // typing does not synchronously re-highlight untouched blocks.
+    highlightCache.push({
+      code: parts.code,
+      highlighted,
+      language: parts.language,
+    });
+    cachedCodeCharacters += parts.code.length;
+    while (
+      highlightCache.length > maxCachedCodeBlocks ||
+      cachedCodeCharacters > maxCachedCodeCharacters
+    ) {
+      const removed = highlightCache.shift();
+      cachedCodeCharacters -= removed?.code.length ?? 0;
+    }
     return highlighted;
   };
 
@@ -975,6 +1322,7 @@ export function codeBlockPreviewPlugin(
       // CodeMirror's height map in every WebView. State-field block widgets
       // are measured explicitly, so repeated blocks cannot accumulate a
       // pointer-to-caret offset.
+      createMermaidPreviewField(labels, renderMermaid),
       createCodeBlockTopGapField(showLineNumbers),
       markraRenderer({
         id: "markra.code-block-preview",
@@ -1015,29 +1363,6 @@ export function codeBlockPreviewPlugin(
             parts.code.trim() &&
             isMermaidLanguage(parts.language)
           ) {
-            const firstLine = state.doc.lineAt(node.from);
-            const lastLine = state.doc.lineAt(node.to);
-            context.add(
-              Decoration.replace({
-                widget: new MermaidPreviewWidget(
-                  parts.codeNode.from,
-                  labels,
-                  renderMermaid,
-                  parts.code,
-                ),
-              }).range(firstLine.from, firstLine.to),
-            );
-            for (
-              let lineNumber = firstLine.number + 1;
-              lineNumber <= lastLine.number;
-              lineNumber += 1
-            ) {
-              context.add(
-                Decoration.line({
-                  class: "cm-markra-mermaid-hidden-line",
-                }).range(state.doc.line(lineNumber).from),
-              );
-            }
             return false;
           }
           const visibleFrom = Math.max(node.from, visibleRange.from);

--- a/packages/editor/src/codemirror/controller.test.ts
+++ b/packages/editor/src/codemirror/controller.test.ts
@@ -18,6 +18,7 @@ import {
   replaceAllCodeMirrorSearchMatches,
   replaceCodeMirrorMarkdown,
   replaceCodeMirrorSearchMatch,
+  updateCodeMirrorHeadingAnchors,
 } from "./controller.ts";
 import { markraLanguage } from "./index.ts";
 import "./dom.test-support.ts";
@@ -188,6 +189,46 @@ describe("CodeMirror editor controller", () => {
       },
     ]);
     expect(sections[0]?.text).toBe(doc.slice(0, doc.indexOf("# Three")));
+  });
+
+  it("reuses heading anchors when an edit cannot affect headings", () => {
+    const doc = "# Synthetic heading\n\nBody";
+    const view = createView(doc);
+    const anchors = readCodeMirrorHeadingAnchors(view.state);
+    const transaction = view.state.update({
+      changes: { from: doc.length, insert: " text" },
+    });
+
+    const updated = updateCodeMirrorHeadingAnchors(
+      anchors,
+      transaction.startState,
+      transaction.state,
+      transaction.changes,
+    );
+
+    expect(updated).toEqual(anchors);
+    expect(updated[0]).toBe(anchors[0]);
+  });
+
+  it("refreshes heading anchors when heading source changes", () => {
+    const doc = "# Before\n\nBody";
+    const view = createView(doc);
+    const anchors = readCodeMirrorHeadingAnchors(view.state);
+    const titleFrom = "# ".length;
+    const transaction = view.state.update({
+      changes: { from: titleFrom, to: "# Before".length, insert: "After" },
+    });
+
+    expect(
+      updateCodeMirrorHeadingAnchors(
+        anchors,
+        transaction.startState,
+        transaction.state,
+        transaction.changes,
+      ),
+    ).toEqual([
+      { from: 0, level: 1, title: "After", to: "# After".length },
+    ]);
   });
 
   it("extracts GFM table anchors under their current heading", () => {

--- a/packages/editor/src/codemirror/controller.ts
+++ b/packages/editor/src/codemirror/controller.ts
@@ -1,5 +1,6 @@
 import { syntaxTree } from "@codemirror/language";
 import {
+  type ChangeSet,
   EditorSelection,
   EditorState,
   Transaction,
@@ -214,6 +215,62 @@ export function readCodeMirrorHeadingAnchors(
   });
 
   return headings;
+}
+
+const atxHeadingLinePattern = /^[\t ]{0,3}#{1,6}(?:[\t ]+|$)/u;
+const setextHeadingLinePattern = /^[\t ]{0,3}(?:=+|-+)[\t ]*$/u;
+
+function lineNeighborhoodMayContainHeading(
+  state: EditorState,
+  from: number,
+  to: number,
+) {
+  const boundedFrom = Math.max(0, Math.min(from, state.doc.length));
+  const boundedTo = Math.max(0, Math.min(to, state.doc.length));
+  // Setext headings are owned jointly by a title line and its underline, so
+  // edits must inspect one neighboring line on either side.
+  const firstLine = Math.max(1, state.doc.lineAt(boundedFrom).number - 1);
+  const lastLine = Math.min(
+    state.doc.lines,
+    state.doc.lineAt(boundedTo).number + 1,
+  );
+
+  for (let lineNumber = firstLine; lineNumber <= lastLine; lineNumber += 1) {
+    const source = state.doc.line(lineNumber).text;
+    if (
+      atxHeadingLinePattern.test(source) ||
+      setextHeadingLinePattern.test(source)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function updateCodeMirrorHeadingAnchors(
+  headings: readonly AiHeadingAnchor[],
+  startState: EditorState,
+  state: EditorState,
+  changes: ChangeSet,
+): AiHeadingAnchor[] {
+  let refresh = false;
+  changes.iterChangedRanges((fromA, toA, fromB, toB) => {
+    if (
+      lineNeighborhoodMayContainHeading(startState, fromA, toA) ||
+      lineNeighborhoodMayContainHeading(state, fromB, toB)
+    ) {
+      refresh = true;
+    }
+  });
+  if (refresh) return readCodeMirrorHeadingAnchors(state);
+
+  return headings.map((heading) => {
+    const from = changes.mapPos(heading.from, 1);
+    const to = changes.mapPos(heading.to, -1);
+    return from === heading.from && to === heading.to
+      ? heading
+      : { ...heading, from, to };
+  });
 }
 
 export function readCodeMirrorSectionAnchors(

--- a/packages/editor/src/codemirror/footnote-preview.test.ts
+++ b/packages/editor/src/codemirror/footnote-preview.test.ts
@@ -1,8 +1,32 @@
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { footnotePreviewPlugin, liveMarkdown } from "./index.ts";
 import "./dom.test-support.ts";
+
+const syntaxTreeIterations = vi.hoisted(
+  (): Array<{ from: number | undefined; to: number | undefined }> => [],
+);
+
+vi.mock("@codemirror/language", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codemirror/language")>();
+
+  return {
+    ...actual,
+    syntaxTree(state: Parameters<typeof actual.syntaxTree>[0]) {
+      const tree = actual.syntaxTree(state);
+      return new Proxy(tree, {
+        get(target, property, receiver) {
+          if (property !== "iterate") return Reflect.get(target, property, receiver);
+          return (spec: Parameters<typeof tree.iterate>[0]) => {
+            syntaxTreeIterations.push({ from: spec.from, to: spec.to });
+            return target.iterate(spec);
+          };
+        },
+      });
+    },
+  };
+});
 
 const views: EditorView[] = [];
 
@@ -29,6 +53,40 @@ afterEach(() => {
 });
 
 describe("footnotePreviewPlugin", () => {
+  it("does not rescan footnotes when plain text changes after them", () => {
+    const doc = "Alpha[^one]\n\n[^one]: Synthetic detail.\n\nEdit";
+    const view = createView(doc);
+    syntaxTreeIterations.splice(0);
+
+    view.dispatch({
+      changes: { from: doc.length, insert: "!" },
+      selection: { anchor: doc.length + 1 },
+      userEvent: "input",
+    });
+
+    expect(
+      syntaxTreeIterations.filter(
+        ({ from, to }) => from === undefined && to === undefined,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("rescans when removing a code fence exposes footnote syntax", () => {
+    const doc = "```\nAlpha[^one]\n\n[^one]: Synthetic detail.\n```\n\nEdit";
+    const view = createView(doc);
+    const closingFenceFrom = doc.lastIndexOf("```");
+
+    expect(view.dom.querySelector(".cm-markra-footnote-reference")).toBeNull();
+    view.dispatch({
+      changes: [
+        { from: 0, to: "```\n".length },
+        { from: closingFenceFrom, to: closingFenceFrom + "```\n".length },
+      ],
+    });
+
+    expect(view.dom.querySelector(".cm-markra-footnote-reference")).not.toBeNull();
+  });
+
   it("renders references and definition labels without changing Markdown", () => {
     const doc = "Alpha[^one]\n\n[^one]: Synthetic detail.\n\nEdit";
     const view = createView(doc);

--- a/packages/editor/src/codemirror/footnote-preview.ts
+++ b/packages/editor/src/codemirror/footnote-preview.ts
@@ -11,6 +11,7 @@ import {
 } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
+import { updateChangesStayAfter } from "./changes.ts";
 
 interface FootnoteDefinition {
   readonly content: string;
@@ -245,7 +246,12 @@ class FootnoteDefinitionLabelWidget extends WidgetType {
   }
 }
 
-function buildFootnoteDecorations(view: CodeMirrorView) {
+interface FootnoteDecorationState {
+  readonly decorations: DecorationSet;
+  readonly lastRangeTo: number;
+}
+
+function buildFootnoteDecorations(view: CodeMirrorView): FootnoteDecorationState {
   const ranges: Range<Decoration>[] = [];
   const definitions = readFootnoteDefinitions(view.state);
   const references = readFootnoteReferences(view.state, definitions);
@@ -278,7 +284,14 @@ function buildFootnoteDecorations(view: CodeMirrorView) {
     );
   }
 
-  return Decoration.set(ranges, true);
+  return {
+    decorations: Decoration.set(ranges, true),
+    lastRangeTo: Math.max(
+      -1,
+      ...definitions.map((definition) => definition.to),
+      ...references.map((reference) => reference.to),
+    ),
+  };
 }
 
 const footnoteTheme = EditorView.baseTheme({
@@ -332,19 +345,34 @@ export function footnotePreviewPlugin() {
       ViewPlugin.fromClass(
         class {
           decorations: DecorationSet;
+          lastRangeTo: number;
 
           constructor(view: CodeMirrorView) {
-            this.decorations = buildFootnoteDecorations(view);
+            const state = buildFootnoteDecorations(view);
+            this.decorations = state.decorations;
+            this.lastRangeTo = state.lastRangeTo;
           }
 
           update(update: ViewUpdate) {
+            if (
+              updateChangesStayAfter(
+                update,
+                this.lastRangeTo,
+                (source) => /[\[\]^:`~\n]/u.test(source),
+              )
+            ) {
+              this.decorations = this.decorations.map(update.changes);
+              return;
+            }
             if (
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
               update.viewportChanged
             ) {
-              this.decorations = buildFootnoteDecorations(update.view);
+              const state = buildFootnoteDecorations(update.view);
+              this.decorations = state.decorations;
+              this.lastRangeTo = state.lastRangeTo;
             }
           }
         },

--- a/packages/editor/src/codemirror/index.ts
+++ b/packages/editor/src/codemirror/index.ts
@@ -96,6 +96,7 @@ export {
   replaceCodeMirrorSearchMatch,
   serializeCodeMirrorMarkdownImage,
   serializeCodeMirrorMarkdownLink,
+  updateCodeMirrorHeadingAnchors,
 } from "./controller.ts";
 export type {
   DocumentLinksPluginOptions,

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -593,6 +593,39 @@ describe("liveMarkdown", () => {
     expect(syntaxTreeIterations).toHaveLength(0);
   });
 
+  it("maps existing preview decorations while typing plain text", () => {
+    const doc = [
+      "# Synthetic heading",
+      "",
+      "- Synthetic list item",
+      "",
+      "Edit here",
+    ].join("\n");
+    const view = createView({ doc, anchor: doc.length });
+
+    syntaxTreeIterations.splice(0);
+    view.dispatch({
+      changes: { from: doc.length, insert: "字" },
+      selection: EditorSelection.cursor(doc.length + 1),
+      userEvent: "input.type",
+    });
+
+    expect(syntaxTreeIterations).toHaveLength(0);
+    expect(view.dom.querySelector(".cm-markra-h1")?.textContent).toBe(
+      "Synthetic heading",
+    );
+    expect(renderedLines(view).at(-1)).toBe("Edit here字");
+
+    syntaxTreeIterations.splice(0);
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: "*" },
+      selection: EditorSelection.cursor(view.state.doc.length + 1),
+      userEvent: "input.type",
+    });
+
+    expect(syntaxTreeIterations.length).toBeGreaterThan(0);
+  });
+
   it("reveals heading source at every heading cursor in a multi-selection", () => {
     const doc = "# One\n\n# Two\n\nRest";
     const selection = EditorSelection.create([

--- a/packages/editor/src/codemirror/math-preview.test.ts
+++ b/packages/editor/src/codemirror/math-preview.test.ts
@@ -1,8 +1,32 @@
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { liveMarkdown, mathPreviewPlugin } from "./index.ts";
 import "./dom.test-support.ts";
+
+const syntaxTreeIterations = vi.hoisted(
+  (): Array<{ from: number | undefined; to: number | undefined }> => [],
+);
+
+vi.mock("@codemirror/language", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codemirror/language")>();
+
+  return {
+    ...actual,
+    syntaxTree(state: Parameters<typeof actual.syntaxTree>[0]) {
+      const tree = actual.syntaxTree(state);
+      return new Proxy(tree, {
+        get(target, property, receiver) {
+          if (property !== "iterate") return Reflect.get(target, property, receiver);
+          return (spec: Parameters<typeof tree.iterate>[0]) => {
+            syntaxTreeIterations.push({ from: spec.from, to: spec.to });
+            return target.iterate(spec);
+          };
+        },
+      });
+    },
+  };
+});
 
 const views: EditorView[] = [];
 
@@ -29,6 +53,40 @@ afterEach(() => {
 });
 
 describe("mathPreviewPlugin", () => {
+  it("does not rescan math when plain text changes after it", () => {
+    const doc = "Before $x + y$ after\n\nEdit";
+    const view = createView(doc);
+    syntaxTreeIterations.splice(0);
+
+    view.dispatch({
+      changes: { from: doc.length, insert: "!" },
+      selection: { anchor: doc.length + 1 },
+      userEvent: "input",
+    });
+
+    expect(
+      syntaxTreeIterations.filter(
+        ({ from, to }) => from === undefined && to === undefined,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("rescans when removing a code fence exposes math syntax", () => {
+    const doc = "```\n$x + y$\n```\n\nEdit";
+    const view = createView(doc);
+    const closingFenceFrom = doc.lastIndexOf("```");
+
+    expect(view.dom.querySelector(".markra-math-render")).toBeNull();
+    view.dispatch({
+      changes: [
+        { from: 0, to: "```\n".length },
+        { from: closingFenceFrom, to: closingFenceFrom + "```\n".length },
+      ],
+    });
+
+    expect(view.dom.querySelector(".markra-math-render")).not.toBeNull();
+  });
+
   it("renders dollar and Hugo math with KaTeX without changing Markdown", () => {
     const doc = [
       "Where $a^2 + b^2 = c^2$.",

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -18,6 +18,7 @@ import {
 } from "../math-render.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
+import { updateChangesStayAfter } from "./changes.ts";
 
 export interface CodeMirrorMathRange {
   readonly from: number;
@@ -332,11 +333,17 @@ function renderMath(
   return renderMarkraMathToString(range.tex, range.kind, macros);
 }
 
-function buildMathDecorations(view: CodeMirrorView) {
+interface MathDecorationState {
+  readonly decorations: DecorationSet;
+  readonly lastRangeTo: number;
+}
+
+function buildMathDecorations(view: CodeMirrorView): MathDecorationState {
   const ranges: Range<Decoration>[] = [];
   const macros = createMarkraMathMacros();
+  const mathRanges = findCodeMirrorMathRanges(view.state);
 
-  for (const range of findCodeMirrorMathRanges(view.state)) {
+  for (const range of mathRanges) {
     const macroDefinitionOnly =
       range.kind === "display" && isMarkraMathMacroDefinitionSource(range.tex);
     const active = cursorInsideRange(view, range.from, range.to);
@@ -382,7 +389,10 @@ function buildMathDecorations(view: CodeMirrorView) {
     }
   }
 
-  return Decoration.set(ranges, true);
+  return {
+    decorations: Decoration.set(ranges, true),
+    lastRangeTo: Math.max(-1, ...mathRanges.map((range) => range.to)),
+  };
 }
 
 const mathTheme = EditorView.baseTheme({
@@ -410,19 +420,34 @@ export function mathPreviewPlugin() {
       ViewPlugin.fromClass(
         class {
           decorations: DecorationSet;
+          lastRangeTo: number;
 
           constructor(view: CodeMirrorView) {
-            this.decorations = buildMathDecorations(view);
+            const state = buildMathDecorations(view);
+            this.decorations = state.decorations;
+            this.lastRangeTo = state.lastRangeTo;
           }
 
           update(update: ViewUpdate) {
+            if (
+              updateChangesStayAfter(
+                update,
+                this.lastRangeTo,
+                (source) => /[$\\`~\n]/u.test(source),
+              )
+            ) {
+              this.decorations = this.decorations.map(update.changes);
+              return;
+            }
             if (
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
               update.viewportChanged
             ) {
-              this.decorations = buildMathDecorations(update.view);
+              const state = buildMathDecorations(update.view);
+              this.decorations = state.decorations;
+              this.lastRangeTo = state.lastRangeTo;
             }
           }
         },

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -31,6 +31,7 @@ import {
 import { unescapeMarkdown } from "./syntax.ts";
 import { createTaskDecoration } from "./tasks.ts";
 import { isInsidePreformattedBlock } from "./blank-lines.ts";
+import { updateOnlyInsertsPlainText } from "./changes.ts";
 
 const HEADING_CLASSES: Readonly<Record<string, string>> = {
   ATXHeading1: "cm-markra-h1",
@@ -801,6 +802,32 @@ function previewPlugin(config: LivePreviewConfig): Extension {
     }
   }
 
+  function cursorInTopLevelParagraph(
+    state: ViewUpdate["state"],
+    position: number,
+  ) {
+    const node = syntaxTree(state).resolveInner(position, -1);
+    return node.parent?.name === "Document" && node.name === "Paragraph";
+  }
+
+  function plainTextInputCanMapDecorations(update: ViewUpdate) {
+    const before = update.startState.selection.main;
+    const after = update.state.selection.main;
+    if (
+      !updateOnlyInsertsPlainText(update) ||
+      update.startState.selection.ranges.length !== 1 ||
+      update.state.selection.ranges.length !== 1 ||
+      !before.empty ||
+      !after.empty ||
+      getMarkraRenderers(update.state, "Paragraph").length > 0
+    ) {
+      return false;
+    }
+
+    return cursorInTopLevelParagraph(update.startState, before.head) &&
+      cursorInTopLevelParagraph(update.state, after.head);
+  }
+
   return ViewPlugin.fromClass(
     class {
       decorations: DecorationSet;
@@ -845,6 +872,14 @@ function previewPlugin(config: LivePreviewConfig): Extension {
         if (this.composing) {
           // Mapping preserves the current DOM while the platform owns the
           // composition range. A full rebuild at this point can cancel IME.
+          this.decorations = this.decorations.map(update.changes);
+          return;
+        }
+
+        if (plainTextInputCanMapDecorations(update)) {
+          // Plain letters and numbers cannot create Markdown structure in a
+          // top-level paragraph. Mapping retains every unchanged preview DOM
+          // instead of walking the full visible syntax tree per keystroke.
           this.decorations = this.decorations.map(update.changes);
           return;
         }

--- a/packages/editor/src/codemirror/raw-html-preview.test.ts
+++ b/packages/editor/src/codemirror/raw-html-preview.test.ts
@@ -4,6 +4,29 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { liveMarkdown, rawHtmlPreviewPlugin } from "./index.ts";
 import "./dom.test-support.ts";
 
+const syntaxTreeIterations = vi.hoisted(() => [] as Array<unknown>);
+
+vi.mock("@codemirror/language", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codemirror/language")>();
+  return {
+    ...actual,
+    syntaxTree(state: Parameters<typeof actual.syntaxTree>[0]) {
+      const tree = actual.syntaxTree(state);
+      return new Proxy(tree, {
+        get(target, property, receiver) {
+          if (property !== "iterate") {
+            return Reflect.get(target, property, receiver);
+          }
+          return (spec: Parameters<typeof tree.iterate>[0]) => {
+            syntaxTreeIterations.push(spec);
+            return target.iterate(spec);
+          };
+        },
+      });
+    },
+  };
+});
+
 const views: EditorView[] = [];
 
 function createView(
@@ -49,6 +72,29 @@ describe("rawHtmlPreviewPlugin", () => {
     expect(preview?.firstElementChild?.hasAttribute("onclick")).toBe(false);
     expect(preview?.querySelector("script")).toBeNull();
     expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("maps rendered HTML when plain text is typed after its last range", () => {
+    const doc = [
+      "<div>",
+      "Synthetic HTML",
+      "</div>",
+      "",
+      "Edit here",
+    ].join("\n");
+    const view = createView(doc);
+
+    syntaxTreeIterations.splice(0);
+    view.dispatch({
+      changes: { from: doc.length, insert: "字" },
+      selection: EditorSelection.cursor(doc.length + 1),
+      userEvent: "input.type",
+    });
+
+    expect(syntaxTreeIterations).toHaveLength(0);
+    expect(view.dom.querySelector(".markra-html-node")?.textContent).toContain(
+      "Synthetic HTML",
+    );
   });
 
   it("renders inline HTML and reveals its source when activated", () => {

--- a/packages/editor/src/codemirror/raw-html-preview.ts
+++ b/packages/editor/src/codemirror/raw-html-preview.ts
@@ -15,6 +15,7 @@ import {
 } from "../raw-html-sanitize.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
+import { updateChangesStayAfter } from "./changes.ts";
 
 export interface RawHtmlPreviewPluginOptions {
   resolveImageSrc?: ResolveRawHtmlSrc;
@@ -277,7 +278,29 @@ function buildRawHtmlDecorations(
     }
   }
 
-  return Decoration.set(ranges, true);
+  return {
+    decorations: Decoration.set(ranges, true),
+    lastRangeTo: Math.max(-1, ...htmlRanges.map((range) => range.to)),
+  };
+}
+
+function changedLinesMayContainRawHtml(update: ViewUpdate) {
+  let mayContainHtml = false;
+  update.changes.iterChangedRanges((_fromA, _toA, fromB, toB) => {
+    const firstLine = update.state.doc.lineAt(fromB).number;
+    const lastLine = update.state.doc.lineAt(toB).number;
+    for (
+      let lineNumber = firstLine;
+      lineNumber <= lastLine;
+      lineNumber += 1
+    ) {
+      if (/[<>]/u.test(update.state.doc.line(lineNumber).text)) {
+        mayContainHtml = true;
+        return;
+      }
+    }
+  });
+  return mayContainHtml;
 }
 
 const rawHtmlTheme = EditorView.baseTheme({
@@ -305,19 +328,35 @@ export function rawHtmlPreviewPlugin(
       ViewPlugin.fromClass(
         class {
           decorations: DecorationSet;
+          lastRangeTo: number;
 
           constructor(view: CodeMirrorView) {
-            this.decorations = buildRawHtmlDecorations(view, options);
+            const state = buildRawHtmlDecorations(view, options);
+            this.decorations = state.decorations;
+            this.lastRangeTo = state.lastRangeTo;
           }
 
           update(update: ViewUpdate) {
+            if (
+              !changedLinesMayContainRawHtml(update) &&
+              updateChangesStayAfter(
+                update,
+                this.lastRangeTo,
+                (source) => /[<>\n]/u.test(source),
+              )
+            ) {
+              this.decorations = this.decorations.map(update.changes);
+              return;
+            }
             if (
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
               update.viewportChanged
             ) {
-              this.decorations = buildRawHtmlDecorations(update.view, options);
+              const state = buildRawHtmlDecorations(update.view, options);
+              this.decorations = state.decorations;
+              this.lastRangeTo = state.lastRangeTo;
             }
           }
         },

--- a/packages/editor/src/codemirror/renderer.test.ts
+++ b/packages/editor/src/codemirror/renderer.test.ts
@@ -53,6 +53,50 @@ describe("Markra renderers", () => {
     );
   });
 
+  it("reruns a contributed paragraph renderer when its text changes", () => {
+    const render = vi.fn();
+    const view = createView([
+      liveMarkdown(),
+      markraRenderer({
+        id: "synthetic.paragraph",
+        nodeNames: ["Paragraph"],
+        render,
+      }),
+    ]);
+    render.mockClear();
+
+    view.dispatch({
+      changes: { from: syntheticDocument.length, insert: "字" },
+      selection: { anchor: syntheticDocument.length + 1 },
+      userEvent: "input.type",
+    });
+
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("reruns a contributed inline renderer when typing inside its node", () => {
+    const render = vi.fn();
+    const view = createView([
+      liveMarkdown(),
+      markraRenderer({
+        id: "synthetic.strong-update",
+        nodeNames: ["StrongEmphasis"],
+        render,
+      }),
+    ]);
+    const insertionPosition = syntheticDocument.indexOf("synthetic") + 3;
+    view.dispatch({ selection: { anchor: insertionPosition } });
+    render.mockClear();
+
+    view.dispatch({
+      changes: { from: insertionPosition, insert: "字" },
+      selection: { anchor: insertionPosition + 1 },
+      userEvent: "input.type",
+    });
+
+    expect(render).toHaveBeenCalled();
+  });
+
   it("rejects duplicate renderer identifiers", () => {
     const renderer = {
       id: "synthetic.duplicate",

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -37,6 +37,41 @@ afterEach(() => {
 });
 
 describe("tablePreviewPlugin", () => {
+  it("keeps an unchanged visual table mounted when editing before it", async () => {
+    const doc = [
+      "Before",
+      "",
+      "| Name | Value |",
+      "| --- | ---: |",
+      "| Alpha | 1 |",
+      "",
+      "After",
+    ].join("\n");
+    const view = createView(doc);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+
+    expect(table).not.toBeNull();
+
+    const inserted = "Expanded synthetic prefix. ";
+    view.dispatch({
+      changes: { from: 0, insert: inserted },
+      selection: { anchor: inserted.length },
+      userEvent: "input",
+    });
+
+    expect(view.dom.querySelector(".cm-markra-table")).toBe(table);
+    expect(table?.closest<HTMLElement>(".cm-markra-table-wrap")?.dataset.tableFrom)
+      .toBe(String(inserted.length + doc.indexOf("| Name")));
+
+    view.dom
+      .querySelector<HTMLButtonElement>('[aria-label="Add row below"]')
+      ?.click();
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain(`${inserted}Before`);
+    expect(view.state.doc.toString()).toContain("|  |  |\n\nAfter");
+  });
+
   it("renders a GFM table without changing its Markdown source", () => {
     const doc = [
       "| Name | Value |",

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -1143,12 +1143,28 @@ function appendCell(
   row.append(cell);
 }
 
+interface TableWidgetRuntime {
+  documentMouseDownHandler: ((event: MouseEvent) => void) | null;
+  preview: TablePreview;
+  sizeButton: HTMLButtonElement | null;
+  sizePopover: HTMLElement | null;
+}
+
+function tablePreviewContentKey(preview: TablePreview) {
+  return JSON.stringify({
+    alignments: preview.alignments,
+    header: preview.header.map((cell) => cell.source),
+    rows: preview.rows.map((row) => row.map((cell) => cell.source)),
+  });
+}
+
 class TableWidget extends WidgetType {
-  private sizeButton: HTMLButtonElement | null = null;
-  private sizePopover: HTMLElement | null = null;
+  private readonly contentKey: string;
+  private readonly labelsKey: string;
+  private runtime: TableWidgetRuntime;
 
   constructor(
-    readonly preview: TablePreview,
+    preview: TablePreview,
     readonly labels: TablePreviewLabels,
     readonly defaultWidthMode: CodeMirrorTableWidthMode,
     readonly getDocumentKey: () => string | null | undefined,
@@ -1156,16 +1172,56 @@ class TableWidget extends WidgetType {
     readonly links: LinksPluginOptions | undefined,
   ) {
     super();
+    this.contentKey = tablePreviewContentKey(preview);
+    this.labelsKey = JSON.stringify(labels);
+    this.runtime = {
+      documentMouseDownHandler: null,
+      preview,
+      sizeButton: null,
+      sizePopover: null,
+    };
+  }
+
+  private get preview() {
+    return this.runtime.preview;
+  }
+
+  private hasSameContent(other: TableWidget) {
+    return (
+      this.contentKey === other.contentKey &&
+      this.defaultWidthMode === other.defaultWidthMode &&
+      this.getDocumentKey === other.getDocumentKey &&
+      this.images === other.images &&
+      this.links === other.links &&
+      this.labelsKey === other.labelsKey
+    );
   }
 
   eq(other: TableWidget) {
-    return (
-      JSON.stringify(this.preview) === JSON.stringify(other.preview) &&
-      this.defaultWidthMode === other.defaultWidthMode &&
-      this.images === other.images &&
-      this.links === other.links &&
-      JSON.stringify(this.labels) === JSON.stringify(other.labels)
-    );
+    if (!this.hasSameContent(other)) return false;
+    if (
+      this.preview.from !== other.preview.from ||
+      this.preview.to !== other.preview.to
+    ) {
+      return false;
+    }
+
+    const nextPreview = other.preview;
+    other.runtime = this.runtime;
+    this.runtime.preview = nextPreview;
+    return true;
+  }
+
+  updateDOM(dom: HTMLElement, _view: CodeMirrorView, from: this) {
+    if (!this.hasSameContent(from)) return false;
+
+    const nextPreview = this.preview;
+    // Reused DOM listeners close over the previous widget, so both widget
+    // generations must share the latest document positions and popup state.
+    this.runtime = from.runtime;
+    this.runtime.preview = nextPreview;
+    dom.dataset.tableFrom = String(nextPreview.from);
+    return true;
   }
 
   ignoreEvent() {
@@ -1173,22 +1229,26 @@ class TableWidget extends WidgetType {
   }
 
   private closeSizePicker = () => {
-    const document = this.sizePopover?.ownerDocument;
-    this.sizePopover?.remove();
-    this.sizePopover = null;
-    if (this.sizeButton) this.sizeButton.ariaExpanded = "false";
-    document?.removeEventListener(
-      "mousedown",
-      this.handleDocumentMouseDown,
-      true,
-    );
+    const document = this.runtime.sizePopover?.ownerDocument;
+    this.runtime.sizePopover?.remove();
+    this.runtime.sizePopover = null;
+    if (this.runtime.sizeButton) this.runtime.sizeButton.ariaExpanded = "false";
+    if (this.runtime.documentMouseDownHandler) {
+      document?.removeEventListener(
+        "mousedown",
+        this.runtime.documentMouseDownHandler,
+        true,
+      );
+      this.runtime.documentMouseDownHandler = null;
+    }
   };
 
   private handleDocumentMouseDown = (event: MouseEvent) => {
     const target = event.target;
     if (
       target instanceof Node &&
-      (this.sizeButton?.contains(target) || this.sizePopover?.contains(target))
+      (this.runtime.sizeButton?.contains(target) ||
+        this.runtime.sizePopover?.contains(target))
     ) {
       return;
     }
@@ -1199,7 +1259,7 @@ class TableWidget extends WidgetType {
     view: CodeMirrorView,
     anchor: HTMLButtonElement,
   ) {
-    if (this.sizePopover) {
+    if (this.runtime.sizePopover) {
       this.closeSizePicker();
       return;
     }
@@ -1319,16 +1379,16 @@ class TableWidget extends WidgetType {
     popover.style.position = "fixed";
     popover.style.top = `${position.top}px`;
     anchor.ariaExpanded = "true";
-    document.addEventListener("mousedown", this.handleDocumentMouseDown, true);
-    this.sizePopover = popover;
-  }
-
-  destroy(dom: HTMLElement) {
-    dom.ownerDocument.removeEventListener(
+    this.runtime.documentMouseDownHandler = this.handleDocumentMouseDown;
+    document.addEventListener(
       "mousedown",
-      this.handleDocumentMouseDown,
+      this.runtime.documentMouseDownHandler,
       true,
     );
+    this.runtime.sizePopover = popover;
+  }
+
+  destroy() {
     this.closeSizePicker();
   }
 
@@ -1463,7 +1523,7 @@ class TableWidget extends WidgetType {
       event.stopPropagation();
       this.openSizePicker(view, sizeButton);
     });
-    this.sizeButton = sizeButton;
+    this.runtime.sizeButton = sizeButton;
 
     const alignButtons = (["left", "center", "right"] as const).map(
       (alignment) => {


### PR DESCRIPTION
## Summary
- keep unchanged Mermaid and table previews mounted while editing elsewhere in the document
- incrementally map live-preview, block-control, math, footnote, raw HTML, heading, and code-highlight state for safe non-structural edits
- preserve automatic syntax highlighting for code blocks without a recognized language while caching unchanged highlight results
- persist the first dirty draft immediately, then coalesce continuous workspace writes; defer document summaries from 64 KB

## Why
Issue #636 reports severe typing lag in Markdown documents. Profiling also reproduced the problem in small documents when expensive preview blocks were located after the caret. The input path was rebuilding preview state and, on desktop, queueing a settings-store read/write/save for every character.

## Validation
- `pnpm --filter @markra/editor exec vitest run --environment jsdom --globals --maxWorkers=1 --no-file-parallelism` — 35 files, 430 tests passed after the compatibility adjustment
- `pnpm --filter @markra/app exec vitest run --environment jsdom --globals --maxWorkers=1 --no-file-parallelism` — 130 files, 1486 tests passed
- `pnpm --filter @markra/editor build && pnpm --filter @markra/editor typecheck:test` — passed after the compatibility adjustment
- `pnpm --filter @markra/app build && pnpm --filter @markra/app typecheck:test` — passed
- desktop runtime check with the supplied small Mermaid document: a 20-character batch took 48.4 ms above the diagram, 50.9 ms below it, and 51.3 ms with the diagram removed

## Risk
- incremental mapping is restricted to edits that cannot create Markdown structure; structural edits and custom renderer nodes fall back to rebuilding decorations
- code blocks without a recognized language retain the existing automatic language detection behavior
- the first dirty draft is still persisted immediately, limiting the coalescing window to later continuous input

Closes #636