### PR TITLE
fix(app): keep deferred outline visible while editing

### DIFF
--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -905,6 +905,107 @@ describe("useMarkdownDocument", () => {
     expect(result.current.wordCount).toBe(4);
   });
 
+  it("keeps the previous deferred summary visible while refreshing an edited document", async () => {
+    const initialContent = "# Synthetic guide\n\nInitial content.";
+    const initialOutlineItems = [{ level: 1, title: "Synthetic guide" }];
+    const editedContent = "# Refreshed guide\n\nInitial content.\n\nEdited content.";
+    const refreshedOutlineItems = [{ level: 1, title: "Refreshed guide" }];
+    mockedReadNativeMarkdownFile.mockResolvedValueOnce({
+      content: initialContent,
+      name: "synthetic-guide.md",
+      path: "/mock-files/synthetic-guide.md",
+      sizeBytes: 300_000
+    } as Awaited<ReturnType<typeof readNativeMarkdownFile>>);
+    markdownHelperMocks.getMarkdownOutline.mockReturnValue(initialOutlineItems);
+    markdownHelperMocks.getWordCount.mockReturnValue(4);
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "synthetic-guide.md",
+        path: "/mock-files/synthetic-guide.md",
+        relativePath: "synthetic-guide.md"
+      });
+    });
+    await waitFor(() => expect(result.current.outlineItems).toEqual(initialOutlineItems));
+
+    markdownHelperMocks.getMarkdownOutline.mockReturnValue(refreshedOutlineItems);
+    markdownHelperMocks.getWordCount.mockReturnValue(6);
+
+    act(() => {
+      result.current.handleMarkdownChange(editedContent);
+    });
+
+    expect(result.current.outlineItems).toEqual(initialOutlineItems);
+    expect(result.current.wordCount).toBe(4);
+
+    await waitFor(() => expect(result.current.outlineItems).toEqual(refreshedOutlineItems));
+    expect(markdownHelperMocks.getMarkdownOutline).toHaveBeenCalledWith(editedContent);
+    expect(result.current.wordCount).toBe(6);
+  });
+
+  it("does not reuse a deferred summary after switching documents", async () => {
+    const firstContent = "# First synthetic guide";
+    const secondContent = "# Second synthetic guide";
+    const firstOutlineItems = [{ level: 1, title: "First synthetic guide" }];
+    const secondOutlineItems = [{ level: 1, title: "Second synthetic guide" }];
+    mockedReadNativeMarkdownFile
+      .mockResolvedValueOnce({
+        content: firstContent,
+        name: "first-synthetic-guide.md",
+        path: "/mock-files/first-synthetic-guide.md",
+        sizeBytes: 300_000
+      } as Awaited<ReturnType<typeof readNativeMarkdownFile>>)
+      .mockResolvedValueOnce({
+        content: secondContent,
+        name: "second-synthetic-guide.md",
+        path: "/mock-files/second-synthetic-guide.md",
+        sizeBytes: 300_000
+      } as Awaited<ReturnType<typeof readNativeMarkdownFile>>);
+    markdownHelperMocks.getMarkdownOutline.mockReturnValue(firstOutlineItems);
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        documentTabsEnabled: true,
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "first-synthetic-guide.md",
+        path: "/mock-files/first-synthetic-guide.md",
+        relativePath: "first-synthetic-guide.md"
+      });
+    });
+    await waitFor(() => expect(result.current.outlineItems).toEqual(firstOutlineItems));
+
+    markdownHelperMocks.getMarkdownOutline.mockReturnValue(secondOutlineItems);
+
+    await act(async () => {
+      await result.current.openTreeMarkdownFile({
+        name: "second-synthetic-guide.md",
+        path: "/mock-files/second-synthetic-guide.md",
+        relativePath: "second-synthetic-guide.md"
+      });
+    });
+
+    expect(result.current.outlineItems).toEqual([]);
+
+    await waitFor(() => expect(result.current.outlineItems).toEqual(secondOutlineItems));
+  });
+
   it("restores historical content into the active document as an unsaved edit", async () => {
     mockedReadNativeMarkdownFile.mockResolvedValueOnce({
       content: "# Guide\n\nCurrent",

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -119,23 +119,15 @@ export type ActiveDiskFileContentChange = {
 };
 
 type MarkdownDocumentSummary = {
-  key: string;
+  documentKey: string;
   outlineItems: MarkdownOutlineItem[];
   wordCount: number;
 };
 
-const emptyMarkdownDocumentSummary: Omit<MarkdownDocumentSummary, "key"> = {
+const emptyMarkdownDocumentSummary: Omit<MarkdownDocumentSummary, "documentKey"> = {
   outlineItems: [],
   wordCount: 0
 };
-
-function markdownDocumentSummaryKey(document: DocumentState) {
-  return [
-    document.revision,
-    document.content.length,
-    document.sizeBytes ?? "unknown-size"
-  ].join(":");
-}
 
 function isMissingMarkdownFileReadError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
@@ -145,7 +137,7 @@ function isMissingMarkdownFileReadError(error: unknown) {
 function calculateMarkdownDocumentSummary(
   content: string,
   detail: Record<string, unknown>
-): Omit<MarkdownDocumentSummary, "key"> {
+): Omit<MarkdownDocumentSummary, "documentKey"> {
   return measureAppPerformance("markdown-summary", () => ({
     outlineItems: getMarkdownOutline(content),
     wordCount: getWordCount(content)
@@ -308,11 +300,7 @@ export function useMarkdownDocument({
       shouldDeferMarkdownSummary(document.content, { sizeBytes: document.sizeBytes }),
     [document.content, document.sizeBytes, largeDocumentSummariesBlocked]
   );
-  const markdownSummaryKey = useMemo(() => markdownDocumentSummaryKey(document), [
-    document.content.length,
-    document.revision,
-    document.sizeBytes
-  ]);
+  const markdownSummaryDocumentKey = `${activeTabId ?? "no-active-tab"}:${document.revision}`;
   const immediateMarkdownSummary = useMemo(
     () =>
       largeDocumentSummariesBlocked || markdownSummaryDeferred
@@ -333,8 +321,12 @@ export function useMarkdownDocument({
       markdownSummaryDeferred
     ]
   );
+  // Keep the last completed summary visible while the same document refreshes
+  // in the background; clearing it here makes the outline collapse on every edit.
   const currentDeferredMarkdownSummary =
-    deferredMarkdownSummary?.key === markdownSummaryKey ? deferredMarkdownSummary : null;
+    deferredMarkdownSummary?.documentKey === markdownSummaryDocumentKey
+      ? deferredMarkdownSummary
+      : null;
   const outlineItems = markdownSummaryDeferred
     ? currentDeferredMarkdownSummary?.outlineItems ?? emptyMarkdownDocumentSummary.outlineItems
     : immediateMarkdownSummary.outlineItems;
@@ -348,7 +340,7 @@ export function useMarkdownDocument({
 
     let active = true;
     const summaryContent = document.content;
-    const summaryKey = markdownSummaryKey;
+    const summaryDocumentKey = markdownSummaryDocumentKey;
     const cancel = scheduleMarkdownSummaryIdle(() => {
       if (!active) return;
 
@@ -362,7 +354,7 @@ export function useMarkdownDocument({
       if (!active) return;
 
       setDeferredMarkdownSummary({
-        key: summaryKey,
+        documentKey: summaryDocumentKey,
         ...summary
       });
     });
@@ -377,7 +369,7 @@ export function useMarkdownDocument({
     document.path,
     document.sizeBytes,
     markdownSummaryDeferred,
-    markdownSummaryKey
+    markdownSummaryDocumentKey
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep the last completed outline and word count visible while a deferred summary refreshes
- scope cached summaries to the active document so switching tabs cannot reuse stale outline data
- add regression coverage for edits and cross-document isolation

## Why
The lower deferred-summary threshold introduced in #638 exposed an existing behavior where every content-length change temporarily replaced the outline with an empty result. This caused the outline to flash “No headings” on each keystroke in #639.

## Validation
- `pnpm --filter @markra/app test` — 1488 tests passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/app test -- src/hooks/useMarkdownDocument.test.tsx` — 88 tests passed
- `git diff --check` — passed

## Risk
Low. Initial deferred document loads still wait for their first summary, while edits retain only the last summary from the same document revision. Switching documents continues to clear stale summary data.

Not run: Windows desktop QA. The regression is covered at the hook level with synthetic data.

Closes #639