### PR TITLE
fix(editor): refresh deferred Markdown rendering

### DIFF
--- a/packages/editor/src/codemirror/block-drag.ts
+++ b/packages/editor/src/codemirror/block-drag.ts
@@ -16,7 +16,10 @@ import {
 import { readCodeMirrorFrontmatter } from "./frontmatter-preview.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { openMarkraSlashMenu } from "./slash-menu.ts";
-import { updateOnlyInsertsPlainText } from "./changes.ts";
+import {
+  syntaxTreeChanged,
+  updateOnlyInsertsPlainText,
+} from "./changes.ts";
 
 export interface CodeMirrorBlockRange {
   readonly depth?: number;
@@ -740,7 +743,8 @@ class BlockDragViewPlugin {
 
     if (
       update.docChanged ||
-      readOnlyChanged
+      readOnlyChanged ||
+      syntaxTreeChanged(update.startState, update.state)
     ) {
       this.blocks = update.state.facet(EditorState.readOnly)
         ? []

--- a/packages/editor/src/codemirror/changes.ts
+++ b/packages/editor/src/codemirror/changes.ts
@@ -1,4 +1,15 @@
+import { syntaxTree } from "@codemirror/language";
+import type { EditorState } from "@codemirror/state";
 import type { ViewUpdate } from "@codemirror/view";
+
+export function syntaxTreeChanged(
+  startState: EditorState,
+  state: EditorState,
+) {
+  // CodeMirror can advance parsing in a document-neutral transaction. Cached
+  // syntax-derived UI must compare tree identity instead of only docChanged.
+  return syntaxTree(startState) !== syntaxTree(state);
+}
 
 export function updateOnlyInsertsPlainText(update: ViewUpdate) {
   if (

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -1,4 +1,5 @@
 import { EditorSelection, EditorState } from "@codemirror/state";
+import { forceParsing } from "@codemirror/language";
 import { EditorView, runScopeHandlers } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { codeBlockPreviewPlugin, liveMarkdown } from "./index.ts";
@@ -39,6 +40,18 @@ function renderedLines(view: EditorView) {
   return [...view.dom.querySelectorAll(".cm-line")].map(
     (line) => line.textContent ?? "",
   );
+}
+
+function decorationWidgetNames(view: EditorView) {
+  const names: string[] = [];
+  for (const source of view.state.facet(EditorView.decorations)) {
+    if (typeof source === "function") continue;
+    source.between(0, view.state.doc.length, (_from, _to, decoration) => {
+      const name = decoration.spec.widget?.constructor.name;
+      if (name) names.push(name);
+    });
+  }
+  return names;
 }
 
 afterEach(() => {
@@ -106,6 +119,19 @@ describe("codeBlockPreviewPlugin", () => {
       "12px",
       "12px",
     ]);
+    expect(view.state.doc.toString()).toBe(source);
+  });
+
+  it("adds code block top chrome when background parsing catches up", () => {
+    const prefix = Array.from(
+      { length: 400 },
+      (_, index) => `Synthetic paragraph ${index}.`,
+    ).join("\n\n");
+    const source = `${prefix}\n\n\`\`\`text\nSynthetic code\n\`\`\``;
+    const view = createView(source);
+
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).toContain("CodeBlockTopGapWidget");
     expect(view.state.doc.toString()).toBe(source);
   });
 
@@ -501,6 +527,25 @@ describe("codeBlockPreviewPlugin", () => {
 
     expect(view.dom.querySelector(".markra-mermaid-render")).toBeNull();
     expect(renderedLines(view)).toContain("```mermaid");
+    expect(view.state.doc.toString()).toBe(source);
+  });
+
+  it("registers Mermaid preview when background parsing catches up", () => {
+    const prefix = Array.from(
+      { length: 400 },
+      (_, index) => `Synthetic paragraph ${index}.`,
+    ).join("\n\n");
+    const source = `${prefix}\n\n\`\`\`mermaid\nflowchart TD\n  A --> B\n\`\`\`\n\nEdit`;
+    const renderMermaid = vi.fn().mockResolvedValue(
+      '<svg aria-label="Synthetic diagram"></svg>',
+    );
+    const view = createView(
+      source,
+      codeBlockPreviewPlugin({ renderMermaid }),
+    );
+
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).toContain("MermaidPreviewWidget");
     expect(view.state.doc.toString()).toBe(source);
   });
 

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -28,6 +28,7 @@ import {
   mermaidThemeFromElement,
   renderMermaidToSvg,
 } from "../mermaid.ts";
+import { syntaxTreeChanged } from "./changes.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import {
   createMediaViewerEnlargeIcon,
@@ -345,9 +346,11 @@ function createCodeBlockTopGapField(showLineNumbers: boolean) {
     update(gaps, transaction) {
       // Background parsing commits a new tree without changing Markdown.
       // Re-scan so blocks discovered after initial load receive their chrome.
-      const syntaxTreeChanged =
-        syntaxTree(transaction.startState) !== syntaxTree(transaction.state);
-      return transaction.docChanged || syntaxTreeChanged
+      const treeChanged = syntaxTreeChanged(
+        transaction.startState,
+        transaction.state,
+      );
+      return transaction.docChanged || treeChanged
         ? codeBlockTopGapDecorations(transaction.state, showLineNumbers)
         : gaps;
     },
@@ -912,14 +915,16 @@ function createMermaidPreviewField(
     update(previous, transaction) {
       // A long document can finish parsing in a later, document-neutral
       // transaction. Rebuild so newly discovered Mermaid fences get previews.
-      const syntaxTreeChanged =
-        syntaxTree(transaction.startState) !== syntaxTree(transaction.state);
+      const treeChanged = syntaxTreeChanged(
+        transaction.startState,
+        transaction.state,
+      );
       const focusEffect = transaction.effects.find((effect) =>
         effect.is(setMermaidPreviewFocusedEffect)
       );
       const focused = focusEffect?.value ?? previous.focused;
       if (!transaction.docChanged) {
-        if (syntaxTreeChanged) {
+        if (treeChanged) {
           return createMermaidPreviewState(
             transaction.state,
             focused,
@@ -953,7 +958,7 @@ function createMermaidPreviewField(
       }
 
       if (
-        syntaxTreeChanged ||
+        treeChanged ||
         changesTouchMermaidBlocks(transaction, previous.blocks) ||
         changesMayAffectMermaidFences(transaction)
       ) {

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -343,7 +343,11 @@ function createCodeBlockTopGapField(showLineNumbers: boolean) {
   return StateField.define<DecorationSet>({
     create: (state) => codeBlockTopGapDecorations(state, showLineNumbers),
     update(gaps, transaction) {
-      return transaction.docChanged
+      // Background parsing commits a new tree without changing Markdown.
+      // Re-scan so blocks discovered after initial load receive their chrome.
+      const syntaxTreeChanged =
+        syntaxTree(transaction.startState) !== syntaxTree(transaction.state);
+      return transaction.docChanged || syntaxTreeChanged
         ? codeBlockTopGapDecorations(transaction.state, showLineNumbers)
         : gaps;
     },
@@ -906,11 +910,23 @@ function createMermaidPreviewField(
       );
     },
     update(previous, transaction) {
+      // A long document can finish parsing in a later, document-neutral
+      // transaction. Rebuild so newly discovered Mermaid fences get previews.
+      const syntaxTreeChanged =
+        syntaxTree(transaction.startState) !== syntaxTree(transaction.state);
       const focusEffect = transaction.effects.find((effect) =>
         effect.is(setMermaidPreviewFocusedEffect)
       );
       const focused = focusEffect?.value ?? previous.focused;
       if (!transaction.docChanged) {
+        if (syntaxTreeChanged) {
+          return createMermaidPreviewState(
+            transaction.state,
+            focused,
+            labels,
+            renderMermaid,
+          );
+        }
         const revealChanged =
           revealedMermaidBlocksKey(
             transaction.startState,
@@ -937,6 +953,7 @@ function createMermaidPreviewField(
       }
 
       if (
+        syntaxTreeChanged ||
         changesTouchMermaidBlocks(transaction, previous.blocks) ||
         changesMayAffectMermaidFences(transaction)
       ) {
@@ -972,9 +989,11 @@ function createMermaidPreviewField(
         focused,
       };
     },
-    provide: (mermaidField) => EditorView.decorations.from(
-      mermaidField,
-      (value) => value.decorations,
+    provide: (mermaidField) => Prec.highest(
+      EditorView.decorations.from(
+        mermaidField,
+        (value) => value.decorations,
+      ),
     ),
   });
   const mountedViews = new WeakSet<CodeMirrorView>();
@@ -1001,7 +1020,7 @@ function createMermaidPreviewField(
   };
 
   return [
-    Prec.highest(field),
+    field,
     lifecycle,
     EditorView.domEventHandlers({
       blur(_event, view) {

--- a/packages/editor/src/codemirror/deferred-parsing.test.ts
+++ b/packages/editor/src/codemirror/deferred-parsing.test.ts
@@ -1,0 +1,187 @@
+import { forceParsing } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  blocksPlugin,
+  codeMirrorBlockDragPlugin,
+  codeMirrorSpellcheckPlugin,
+  foldTogglePlugin,
+  footnotePreviewPlugin,
+  getCodeMirrorSpellcheckState,
+  liveMarkdown,
+  markraLanguage,
+  mathPreviewPlugin,
+  rawHtmlPreviewPlugin,
+  readCodeMirrorBlockRanges,
+  tableFragmentMergePlugin,
+  type MarkraPlugin,
+} from "./index.ts";
+import "./dom.test-support.ts";
+
+const views: EditorView[] = [];
+const prefix = Array.from(
+  { length: 400 },
+  (_, index) => `Synthetic paragraph ${index}.`,
+).join("\n\n");
+
+function createView(doc: string, plugin: MarkraPlugin, anchor = doc.length) {
+  const parent = document.createElement("div");
+  document.body.append(parent);
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({
+      doc,
+      extensions: [liveMarkdown({ plugins: [plugin] })],
+      selection: { anchor },
+    }),
+  });
+  view.focus();
+  view.dispatch({ selection: view.state.selection });
+  views.push(view);
+  return view;
+}
+
+function decorationWidgetNames(view: EditorView) {
+  const names: string[] = [];
+  for (const source of view.state.facet(EditorView.decorations)) {
+    const decorations = typeof source === "function" ? source(view) : source;
+    decorations.between(0, view.state.doc.length, (_from, _to, decoration) => {
+      const name = decoration.spec.widget?.constructor.name;
+      if (name) names.push(name);
+    });
+  }
+  return names;
+}
+
+function widgetCount(view: EditorView, name: string) {
+  return decorationWidgetNames(view).filter((candidate) => candidate === name)
+    .length;
+}
+
+afterEach(() => {
+  for (const view of views.splice(0)) view.destroy();
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("deferred Markdown parsing", () => {
+  it("renders raw HTML when background parsing catches up", () => {
+    const source = `${prefix}\n\n<div>Synthetic HTML</div>\n\nEdit`;
+    const view = createView(source, rawHtmlPreviewPlugin());
+
+    expect(decorationWidgetNames(view)).not.toContain("RawHtmlWidget");
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).toContain("RawHtmlWidget");
+  });
+
+  it("removes math preview from a deferred code fence", () => {
+    const source = `${prefix}\n\n\`\`\`text\n$synthetic$\n\`\`\`\n\nEdit`;
+    const view = createView(source, mathPreviewPlugin());
+
+    expect(decorationWidgetNames(view)).toContain("MathWidget");
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).not.toContain("MathWidget");
+  });
+
+  it("removes footnote preview from a deferred code fence", () => {
+    const source = `${prefix}\n\n\`\`\`text\nAlpha[^one]\n\n[^one]: Synthetic detail.\n\`\`\`\n\nEdit`;
+    const view = createView(source, footnotePreviewPlugin());
+
+    expect(decorationWidgetNames(view)).toContain("FootnoteReferenceWidget");
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).not.toContain(
+      "FootnoteReferenceWidget",
+    );
+  });
+
+  it("adds block toolbars when background parsing catches up", () => {
+    const source = `${prefix}\n\nFinal synthetic paragraph.`;
+    const view = createView(source, codeMirrorBlockDragPlugin());
+    const initialCount = widgetCount(view, "BlockToolbarWidget");
+
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(widgetCount(view, "BlockToolbarWidget")).toBeGreaterThan(
+      initialCount,
+    );
+    expect(widgetCount(view, "BlockToolbarWidget")).toBe(
+      readCodeMirrorBlockRanges(view.state).length,
+    );
+  });
+
+  it("offers table fragment merging when background parsing catches up", () => {
+    const table = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Alpha | 1 |",
+      "",
+      "| Beta | 2 |",
+    ].join("\n");
+    const source = `${prefix}\n\n${table}\n\nEdit`;
+    const view = createView(source, tableFragmentMergePlugin());
+
+    expect(decorationWidgetNames(view)).not.toContain(
+      "TableFragmentMergeWidget",
+    );
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).toContain("TableFragmentMergeWidget");
+  });
+
+  it("adds fold toggles when background parsing catches up", () => {
+    const source = `${prefix}\n\n# Final heading\n\nSynthetic body.`;
+    const view = createView(source, foldTogglePlugin());
+
+    expect(decorationWidgetNames(view)).not.toContain("FoldToggleWidget");
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).toContain("FoldToggleWidget");
+  });
+
+  it("shows active heading controls when background parsing catches up", () => {
+    const heading = "# Final heading";
+    const source = `${prefix}\n\n${heading}`;
+    const view = createView(
+      source,
+      blocksPlugin(),
+      source.length - heading.length + 3,
+    );
+
+    expect(decorationWidgetNames(view)).not.toContain("HeadingLevelWidget");
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    expect(decorationWidgetNames(view)).toContain("HeadingLevelWidget");
+  });
+
+  it("rechecks stale spellcheck matches from deferred code fences", () => {
+    vi.useFakeTimers();
+    const source = `${prefix}\n\n\`\`\`text\nmisspeled\n\`\`\``;
+    const parent = document.createElement("div");
+    document.body.append(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: source,
+        extensions: [
+          markraLanguage,
+          codeMirrorSpellcheckPlugin({
+            enabled: true,
+            spellchecker: {
+              check: (word) => word !== "misspeled",
+              suggest: () => [],
+            },
+          }),
+        ],
+      }),
+    });
+    views.push(view);
+
+    vi.advanceTimersByTime(160);
+    expect(
+      getCodeMirrorSpellcheckState(view.state).matches.map((match) => match.word),
+    ).toContain("misspeled");
+
+    expect(forceParsing(view, source.length, 1_000)).toBe(true);
+    vi.advanceTimersByTime(160);
+    expect(
+      getCodeMirrorSpellcheckState(view.state).matches.map((match) => match.word),
+    ).not.toContain("misspeled");
+  });
+});

--- a/packages/editor/src/codemirror/fold-toggle.ts
+++ b/packages/editor/src/codemirror/fold-toggle.ts
@@ -15,6 +15,7 @@ import {
   type EditorView as CodeMirrorView,
   type ViewUpdate,
 } from "@codemirror/view";
+import { syntaxTreeChanged } from "./changes.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 
 export interface FoldToggleLabels {
@@ -193,7 +194,8 @@ class FoldToggleViewPlugin {
   update(update: ViewUpdate) {
     if (
       update.docChanged ||
-      update.transactions.some((transaction) => transaction.effects.length > 0)
+      update.transactions.some((transaction) => transaction.effects.length > 0) ||
+      syntaxTreeChanged(update.startState, update.state)
     ) {
       this.decorations = toggleDecorations(update.state, this.labels);
     }

--- a/packages/editor/src/codemirror/footnote-preview.ts
+++ b/packages/editor/src/codemirror/footnote-preview.ts
@@ -11,7 +11,7 @@ import {
 } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
-import { updateChangesStayAfter } from "./changes.ts";
+import { syntaxTreeChanged, updateChangesStayAfter } from "./changes.ts";
 
 interface FootnoteDefinition {
   readonly content: string;
@@ -368,7 +368,8 @@ export function footnotePreviewPlugin() {
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
-              update.viewportChanged
+              update.viewportChanged ||
+              syntaxTreeChanged(update.startState, update.state)
             ) {
               const state = buildFootnoteDecorations(update.view);
               this.decorations = state.decorations;

--- a/packages/editor/src/codemirror/heading-level.ts
+++ b/packages/editor/src/codemirror/heading-level.ts
@@ -9,6 +9,7 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import type { BlockLabels } from "./blocks.ts";
+import { syntaxTreeChanged } from "./changes.ts";
 import { runMarkraCommand } from "./plugin.ts";
 
 interface ActiveHeading {
@@ -223,7 +224,8 @@ class HeadingLevelViewPlugin {
       update.docChanged ||
       update.selectionSet ||
       update.focusChanged ||
-      update.transactions.some((transaction) => transaction.effects.length > 0)
+      update.transactions.some((transaction) => transaction.effects.length > 0) ||
+      syntaxTreeChanged(update.startState, update.state)
     ) {
       this.decorations = headingDecorations(
         update.view,

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -18,7 +18,7 @@ import {
 } from "../math-render.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
-import { updateChangesStayAfter } from "./changes.ts";
+import { syntaxTreeChanged, updateChangesStayAfter } from "./changes.ts";
 
 export interface CodeMirrorMathRange {
   readonly from: number;
@@ -443,7 +443,8 @@ export function mathPreviewPlugin() {
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
-              update.viewportChanged
+              update.viewportChanged ||
+              syntaxTreeChanged(update.startState, update.state)
             ) {
               const state = buildMathDecorations(update.view);
               this.decorations = state.decorations;

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -31,7 +31,7 @@ import {
 import { unescapeMarkdown } from "./syntax.ts";
 import { createTaskDecoration } from "./tasks.ts";
 import { isInsidePreformattedBlock } from "./blank-lines.ts";
-import { updateOnlyInsertsPlainText } from "./changes.ts";
+import { syntaxTreeChanged, updateOnlyInsertsPlainText } from "./changes.ts";
 
 const HEADING_CLASSES: Readonly<Record<string, string>> = {
   ATXHeading1: "cm-markra-h1",
@@ -887,10 +887,10 @@ function previewPlugin(config: LivePreviewConfig): Extension {
         const reconfigured = update.transactions.some(
           (transaction) => transaction.reconfigured,
         );
-        const syntaxTreeChanged =
+        const treeChanged =
           !update.selectionSet &&
           update.transactions.length > 0 &&
-          syntaxTree(update.startState) !== syntaxTree(update.state);
+          syntaxTreeChanged(update.startState, update.state);
 
         if (
           compositionEnded ||
@@ -899,7 +899,7 @@ function previewPlugin(config: LivePreviewConfig): Extension {
           update.focusChanged ||
           update.viewportChanged ||
           reconfigured ||
-          syntaxTreeChanged
+          treeChanged
         ) {
           this.decorations = buildDecorations(
             update.view,

--- a/packages/editor/src/codemirror/raw-html-preview.ts
+++ b/packages/editor/src/codemirror/raw-html-preview.ts
@@ -15,7 +15,7 @@ import {
 } from "../raw-html-sanitize.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
-import { updateChangesStayAfter } from "./changes.ts";
+import { syntaxTreeChanged, updateChangesStayAfter } from "./changes.ts";
 
 export interface RawHtmlPreviewPluginOptions {
   resolveImageSrc?: ResolveRawHtmlSrc;
@@ -352,7 +352,8 @@ export function rawHtmlPreviewPlugin(
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
-              update.viewportChanged
+              update.viewportChanged ||
+              syntaxTreeChanged(update.startState, update.state)
             ) {
               const state = buildRawHtmlDecorations(update.view, options);
               this.decorations = state.decorations;

--- a/packages/editor/src/codemirror/spellcheck.ts
+++ b/packages/editor/src/codemirror/spellcheck.ts
@@ -20,6 +20,7 @@ import {
   type SpellcheckOptions,
   type Spellchecker,
 } from "../spellcheck.ts";
+import { syntaxTreeChanged } from "./changes.ts";
 
 export interface CodeMirrorSpellcheckState {
   readonly decorations: DecorationSet;
@@ -298,7 +299,8 @@ const spellcheckView = ViewPlugin.fromClass(
         update.docChanged ||
         configChanged ||
         state.enabled !== previous.enabled ||
-        state.ignoredWords !== previous.ignoredWords
+        state.ignoredWords !== previous.ignoredWords ||
+        syntaxTreeChanged(update.startState, update.state)
       ) {
         this.schedule();
       }

--- a/packages/editor/src/codemirror/table-fragment-merge.ts
+++ b/packages/editor/src/codemirror/table-fragment-merge.ts
@@ -10,6 +10,7 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import { parseGfmTableFragment } from "@markra/markdown";
+import { syntaxTreeChanged } from "./changes.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { readCodeMirrorTableShape } from "./table.ts";
 
@@ -206,7 +207,8 @@ class TableFragmentMergeViewPlugin {
   update(update: ViewUpdate) {
     if (
       update.docChanged ||
-      update.startState.readOnly !== update.state.readOnly
+      update.startState.readOnly !== update.state.readOnly ||
+      syntaxTreeChanged(update.startState, update.state)
     ) {
       this.decorations = mergeDecorations(update.state, this.label);
     }


### PR DESCRIPTION
## Summary

- refresh parser-dependent UI when CodeMirror background parsing advances without changing Markdown
- cover code block chrome, Mermaid, raw HTML, math and footnote exclusions, block toolbars, fold controls, table merge controls, heading controls, and spellcheck
- centralize syntax-tree identity checks while preserving existing plain-text input fast paths
- add synthetic long-document regression coverage for all deferred parsing paths

## Why

CodeMirror initially parses only part of a long document. Several state fields and view plugins cached results from that partial syntax tree but refreshed only after document edits or other UI events. This could leave later Mermaid and raw HTML source unrendered, clip code block chrome, show math or footnotes inside code fences, omit block controls, or retain spellcheck matches inside code.

## Validation

- `pnpm --filter @markra/editor test` — 36 files and 440 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app test -- src/components/CodeMirrorPaperSurface.test.tsx src/styles.test.ts` — 2 files and 99 tests passed
- `pnpm --filter @markra/app build` — passed
- `pnpm --filter @markra/app typecheck:test` — passed
- local browser QA with a 46 KB Markdown document confirmed deferred Mermaid SVG rendering and complete rounded code block chrome

## Risk

- low: refreshes are limited to syntax-tree identity changes, ordinary typing keeps the existing mapping fast paths, and spellcheck keeps its existing debounce
