### PR TITLE
fix(editor): preserve rich HTML paste formatting

### DIFF
--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -1,3 +1,12 @@
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClipboardContent {
+    html: Option<String>,
+    text: Option<String>,
+}
+
 fn clipboard_text_from_result(
     result: Result<String, arboard::Error>,
 ) -> Result<Option<String>, String> {
@@ -5,6 +14,28 @@ fn clipboard_text_from_result(
         Ok(text) => Ok(Some(text)),
         Err(arboard::Error::ContentNotAvailable) => Ok(None),
         Err(error) => Err(format!("Could not read clipboard text: {error}")),
+    }
+}
+
+fn clipboard_content_from_results(
+    text_result: Result<String, arboard::Error>,
+    html_result: Result<String, arboard::Error>,
+) -> Result<Option<ClipboardContent>, String> {
+    let text = clipboard_text_from_result(text_result);
+    let html = clipboard_text_from_result(html_result);
+    match (text, html) {
+        (Ok(text), Ok(html)) => {
+            Ok((text.is_some() || html.is_some()).then_some(ClipboardContent { html, text }))
+        }
+        (Ok(Some(text)), Err(_)) => Ok(Some(ClipboardContent {
+            html: None,
+            text: Some(text),
+        })),
+        (Err(_), Ok(Some(html))) => Ok(Some(ClipboardContent {
+            html: Some(html),
+            text: None,
+        })),
+        (Err(error), Ok(None)) | (Ok(None), Err(error)) | (Err(error), Err(_)) => Err(error),
     }
 }
 
@@ -16,9 +47,19 @@ pub(crate) fn read_clipboard_text() -> Result<Option<String>, String> {
     clipboard_text_from_result(clipboard.get_text())
 }
 
+#[tauri::command]
+pub(crate) fn read_clipboard_content() -> Result<Option<ClipboardContent>, String> {
+    let mut clipboard = arboard::Clipboard::new()
+        .map_err(|error| format!("Could not access clipboard: {error}"))?;
+    let text = clipboard.get().text();
+    let html = clipboard.get().html();
+
+    clipboard_content_from_results(text, html)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::clipboard_text_from_result;
+    use super::{clipboard_content_from_results, clipboard_text_from_result, ClipboardContent};
 
     #[test]
     fn returns_none_when_clipboard_text_is_unavailable() {
@@ -33,6 +74,34 @@ mod tests {
         assert_eq!(
             clipboard_text_from_result(Ok("mock clipboard".to_string())),
             Ok(Some("mock clipboard".to_string()))
+        );
+    }
+
+    #[test]
+    fn returns_rich_clipboard_content() {
+        assert_eq!(
+            clipboard_content_from_results(
+                Ok("mock text".to_string()),
+                Ok("<p><strong>mock text</strong></p>".to_string()),
+            ),
+            Ok(Some(ClipboardContent {
+                html: Some("<p><strong>mock text</strong></p>".to_string()),
+                text: Some("mock text".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn keeps_plain_text_when_html_is_unavailable() {
+        assert_eq!(
+            clipboard_content_from_results(
+                Ok("mock text".to_string()),
+                Err(arboard::Error::ContentNotAvailable),
+            ),
+            Ok(Some(ClipboardContent {
+                html: None,
+                text: Some("mock text".to_string()),
+            }))
         );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -36,7 +36,7 @@ use ai_http::{request_ai_provider_json, request_native_chat, request_native_chat
 use app_exit::handle_app_exit_requested;
 use app_logs::open_log_folder;
 use backup::backup_markdown_folder;
-use clipboard::read_clipboard_text;
+use clipboard::{read_clipboard_content, read_clipboard_text};
 use external_urls::open_external_url;
 use fonts::list_system_font_families;
 use image_upload::{upload_picgo_image, upload_s3_image, upload_webdav_image};
@@ -297,6 +297,7 @@ pub fn run() {
             delete_markdown_template_file,
             save_clipboard_attachment,
             save_clipboard_image,
+            read_clipboard_content,
             read_clipboard_text,
             minimize_current_window,
             open_blank_editor_window,

--- a/apps/desktop/src/runtime/index.ts
+++ b/apps/desktop/src/runtime/index.ts
@@ -151,6 +151,7 @@ export const desktopRuntime = {
     installApplicationMenu: menu.installNativeApplicationMenu,
     installEditorContextMenu: menu.installNativeEditorContextMenu,
     listenApplicationMenuCommands: menu.listenNativeApplicationMenuCommands,
+    readClipboardContent: menu.readNativeClipboardContent,
     readClipboardText: menu.readNativeClipboardText,
     showMarkdownFileTreeContextMenu: menu.showNativeMarkdownFileTreeContextMenu
   },

--- a/apps/desktop/src/runtime/tauri/menu.test.ts
+++ b/apps/desktop/src/runtime/tauri/menu.test.ts
@@ -379,7 +379,7 @@ describe("native menu", () => {
     expect(domMenuItemById("markra:context:table").textContent).toContain("Cmd/Ctrl+Shift+T");
   });
 
-  it("uses the native clipboard command for editor context menu paste", async () => {
+  it("uses the native rich clipboard command for editor context menu paste", async () => {
     const target = document.createElement("main");
     const paper = document.createElement("article");
     const execCommand = vi.fn((command: string) => command !== "paste");
@@ -397,7 +397,12 @@ describe("native menu", () => {
       }
     });
     mockedInvoke.mockImplementation(async (command) => {
-      if (command === "read_clipboard_text") return "native clipboard text";
+      if (command === "read_clipboard_content") {
+        return {
+          html: "<p><strong>native clipboard text</strong></p>",
+          text: "native clipboard text"
+        };
+      }
 
       return undefined;
     });
@@ -409,7 +414,7 @@ describe("native menu", () => {
     await flushNativeMenuPopup();
     await flushNativeMenuPopup();
 
-    expect(mockedInvoke).toHaveBeenCalledWith("read_clipboard_text");
+    expect(mockedInvoke).toHaveBeenCalledWith("read_clipboard_content");
     expect(browserReadText).not.toHaveBeenCalled();
     expect(execCommand).toHaveBeenCalledTimes(1);
     expect(execCommand).toHaveBeenNthCalledWith(1, "insertText", false, "native clipboard text");
@@ -439,7 +444,12 @@ describe("native menu", () => {
       value: execCommand
     });
     mockedInvoke.mockImplementation(async (command) => {
-      if (command === "read_clipboard_text") return "side clipboard text";
+      if (command === "read_clipboard_content") {
+        return {
+          html: "<p><strong>side clipboard text</strong></p>",
+          text: "side clipboard text"
+        };
+      }
 
       return undefined;
     });
@@ -451,6 +461,13 @@ describe("native menu", () => {
     await vi.waitFor(() => expect(sidePaste).toHaveBeenCalledTimes(1));
 
     expect(mainPaste).not.toHaveBeenCalled();
+    const clipboardEvent = sidePaste.mock.calls[0]?.[0] as ClipboardEvent;
+    expect(clipboardEvent.clipboardData?.getData("text/html")).toBe(
+      "<p><strong>side clipboard text</strong></p>"
+    );
+    expect(clipboardEvent.clipboardData?.getData("text/plain")).toBe(
+      "side clipboard text"
+    );
     expect(execCommand).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/runtime/tauri/menu.ts
+++ b/apps/desktop/src/runtime/tauri/menu.ts
@@ -10,6 +10,8 @@ import {
   showContextMenu,
   type ContextMenuEntry,
   type ContextMenuIdPrefixes,
+  type NativeClipboardContent,
+  type NativeClipboardContentReader,
   type RecentMarkdownFile
 } from "@markra/app/runtime";
 import type { MarkdownShortcutMap } from "@markra/editor";
@@ -44,12 +46,14 @@ export type NativeClipboardTextReader = () => string | null | undefined | Promis
 export type NativeEditorContextMenuOptions = {
   getAiCommandsAvailable?: () => boolean;
   markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardContent?: NativeClipboardContentReader;
   readClipboardText?: NativeClipboardTextReader;
 };
 
 export type NativeEditorContextMenuEntryOptions = {
   aiCommandsAvailable?: boolean;
   markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardContent?: NativeClipboardContentReader;
   readClipboardText?: NativeClipboardTextReader;
 };
 
@@ -191,10 +195,28 @@ export async function readNativeClipboardText() {
   }
 }
 
-function withNativeClipboardText<TOptions extends { readClipboardText?: NativeClipboardTextReader }>(options: TOptions) {
+export async function readNativeClipboardContent() {
+  try {
+    const content = await invokeNative<NativeClipboardContent | null>(
+      "read_clipboard_content"
+    );
+    if (!content || (typeof content.html !== "string" && typeof content.text !== "string")) {
+      return null;
+    }
+
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+function withNativeClipboardContent<
+  TOptions extends { readClipboardContent?: NativeClipboardContentReader }
+>(options: TOptions) {
   return {
     ...options,
-    readClipboardText: options.readClipboardText ?? readNativeClipboardText
+    readClipboardContent:
+      options.readClipboardContent ?? readNativeClipboardContent
   };
 }
 
@@ -203,7 +225,7 @@ export function createNativeEditorContextMenuItems(
   language: AppLanguage = "en",
   options: NativeEditorContextMenuEntryOptions = {}
 ): ContextMenuEntry[] {
-  return createEditorContextMenuEntries(handlers, language, withNativeClipboardText(options), desktopContextMenuIdPrefixes);
+  return createEditorContextMenuEntries(handlers, language, withNativeClipboardContent(options), desktopContextMenuIdPrefixes);
 }
 
 export async function installNativeEditorContextMenu(
@@ -226,7 +248,7 @@ export async function installNativeEditorContextMenu(
       entries: createEditorContextMenuEntriesFromOptions(
         handlers,
         language,
-        withNativeClipboardText(options),
+        withNativeClipboardContent(options),
         desktopContextMenuIdPrefixes,
         element
       ),

--- a/packages/app/src/lib/tauri/menu.ts
+++ b/packages/app/src/lib/tauri/menu.ts
@@ -28,15 +28,28 @@ export type NativeMarkdownFileTreeContextMenuHandlers = {
 
 export type NativeClipboardTextReader = () => string | null | undefined | Promise<string | null | undefined>;
 
+export type NativeClipboardContent = {
+  html?: string | null;
+  text?: string | null;
+};
+
+export type NativeClipboardContentReader = () =>
+  | NativeClipboardContent
+  | null
+  | undefined
+  | Promise<NativeClipboardContent | null | undefined>;
+
 export type NativeEditorContextMenuOptions = {
   getAiCommandsAvailable?: () => boolean;
   markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardContent?: NativeClipboardContentReader;
   readClipboardText?: NativeClipboardTextReader;
 };
 
 export type NativeEditorContextMenuEntryOptions = {
   aiCommandsAvailable?: boolean;
   markdownShortcuts?: MarkdownShortcutMap;
+  readClipboardContent?: NativeClipboardContentReader;
   readClipboardText?: NativeClipboardTextReader;
 };
 

--- a/packages/app/src/runtime/context-menu-items.test.ts
+++ b/packages/app/src/runtime/context-menu-items.test.ts
@@ -1,7 +1,10 @@
 import { EditorSelection, EditorState, type Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { history, undo } from "@codemirror/commands";
-import { liveMarkdown } from "@markra/editor/codemirror";
+import {
+  codeMirrorClipboardAssetsPlugin,
+  liveMarkdown
+} from "@markra/editor/codemirror";
 import {
   createEditorContextMenuEntries,
   createEditorContextMenuEntriesFromOptions,
@@ -51,6 +54,22 @@ function clipboardPasteItem(target: Element, text: string) {
   );
 }
 
+function clipboardContentPasteItem(
+  target: Element,
+  content: { html: string; text: string }
+) {
+  return menuItemById(
+    createEditorContextMenuEntriesFromOptions(
+      {},
+      "en",
+      { readClipboardContent: () => content },
+      {},
+      target
+    ),
+    "markra:context:paste"
+  );
+}
+
 describe("editor context menu entries", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -90,6 +109,41 @@ describe("editor context menu entries", () => {
     expect(editor.view.state.selection.main.head).toBe("- Alpha\n- Pasted item".length);
     expect(undo(editor.view)).toBe(true);
     expect(editor.view.state.doc.toString()).toBe(doc);
+  });
+
+  it("preserves native rich clipboard content through the editor paste pipeline", async () => {
+    const editor = createEditor(
+      "",
+      EditorSelection.cursor(0),
+      [
+        liveMarkdown({
+          plugins: [codeMirrorClipboardAssetsPlugin()]
+        })
+      ]
+    );
+
+    await Promise.resolve(clipboardContentPasteItem(editor.paper, {
+      html: [
+        "<p>Mock summary</p>",
+        "<ol><li>First <code>choice</code></li><li>Second choice</li></ol>",
+        '<p>See <a href="https://example.test/mock-docs">mock docs</a>.</p>'
+      ].join(""),
+      text: [
+        "Mock summary",
+        "First choice",
+        "Second choice",
+        "See [mock docs](https://example.test/mock-docs)."
+      ].join("\n")
+    }).onSelect?.());
+
+    expect(editor.view.state.doc.toString()).toBe([
+      "Mock summary",
+      "",
+      "1.  First `choice`",
+      "2.  Second choice",
+      "",
+      "See [mock docs](https://example.test/mock-docs)."
+    ].join("\n"));
   });
 
   it("does not change a read-only editor", async () => {

--- a/packages/app/src/runtime/context-menu-items.ts
+++ b/packages/app/src/runtime/context-menu-items.ts
@@ -14,6 +14,7 @@ import {
   type ContextMenuEntry
 } from "../components/ContextMenu";
 import type {
+  NativeClipboardContent,
   NativeEditorContextMenuEntryOptions,
   NativeEditorContextMenuOptions,
   NativeMarkdownFileTreeContextMenuHandlers,
@@ -25,8 +26,12 @@ import type { NativeMarkdownFolderFile } from "../lib/tauri/file";
 type BrowserEditCommand = "copy" | "cut" | "paste" | "selectAll";
 
 type ClipboardTextInserter = (text: string) => boolean | Promise<boolean>;
+type ClipboardContentInserter = (
+  content: NativeClipboardContent
+) => boolean | Promise<boolean>;
 
 type EditorContextMenuEntryOptions = NativeEditorContextMenuEntryOptions & {
+  insertClipboardContent?: ClipboardContentInserter;
   insertClipboardText?: ClipboardTextInserter;
 };
 
@@ -120,21 +125,32 @@ async function readBrowserClipboardText(documentTarget: Document) {
   return readText.call(clipboard);
 }
 
-function clipboardTextData(text: string) {
+function clipboardContentData(content: NativeClipboardContent) {
+  const html = typeof content.html === "string" ? content.html : "";
+  const text = typeof content.text === "string" ? content.text : "";
   return {
     files: Object.assign([], {
       item: () => null
     }),
-    getData: (type: string) => type === "text/plain" ? text : ""
+    getData: (type: string) => {
+      if (type === "text/html") return html;
+      if (type === "text/plain") return text;
+
+      return "";
+    },
+    types: [
+      ...(html ? ["text/html"] : []),
+      ...(text ? ["text/plain"] : [])
+    ]
   };
 }
 
-function createClipboardTextInserter(target: Element) {
+function createClipboardContentInserter(target: Element) {
   const paper = target.closest(".markdown-paper");
   const content = paper?.querySelector<HTMLElement>(".cm-content");
   if (!content) return undefined;
 
-  return (text: string) => {
+  return (clipboardContent: NativeClipboardContent) => {
     // Native clipboard reads are asynchronous. If the originating editor was
     // removed meanwhile, consume the paste instead of retargeting another tab.
     if (!content.isConnected) return true;
@@ -145,11 +161,44 @@ function createClipboardTextInserter(target: Element) {
       cancelable: true
     });
     Object.defineProperty(event, "clipboardData", {
-      value: clipboardTextData(text)
+      value: clipboardContentData(clipboardContent)
     });
     content.dispatchEvent(event);
     return true;
   };
+}
+
+function createClipboardTextInserter(
+  insertContent: ClipboardContentInserter | undefined
+) {
+  return insertContent ? (text: string) => insertContent({ text }) : undefined;
+}
+
+function normalizeClipboardContent(
+  content: NativeClipboardContent | null | undefined
+) {
+  const html = typeof content?.html === "string" ? content.html : "";
+  const text = typeof content?.text === "string" ? content.text : "";
+  return html || text ? { html, text } : null;
+}
+
+async function pasteClipboardContent(
+  documentTarget: Document,
+  readClipboardContent: NonNullable<NativeEditorContextMenuOptions["readClipboardContent"]>,
+  insertClipboardContent?: ClipboardContentInserter
+) {
+  try {
+    const content = normalizeClipboardContent(await readClipboardContent());
+    if (!content) return false;
+    if (insertClipboardContent && await insertClipboardContent(content)) {
+      return true;
+    }
+    if (!content.text) return false;
+
+    return runDocumentEditCommand(documentTarget, "insertText", false, content.text);
+  } catch {
+    return false;
+  }
 }
 
 async function pasteClipboardText(
@@ -158,18 +207,21 @@ async function pasteClipboardText(
   insertClipboardText?: ClipboardTextInserter
 ) {
   const readText = readClipboardText ?? (() => readBrowserClipboardText(documentTarget));
+  // Keep the fallback on the editor pipeline because live preview can hide
+  // Markdown markers that make direct DOM insertion target the wrong offset.
+  return pasteClipboardContent(
+    documentTarget,
+    async () => {
+      const text = await readText();
 
-  try {
-    const text = await readText();
-    if (!text) return false;
-    // Live preview replaces Markdown markers in the DOM, so DOM insertion can
-    // map pasted text before a hidden list marker instead of after it.
-    if (insertClipboardText && await insertClipboardText(text)) return true;
-
-    return runDocumentEditCommand(documentTarget, "insertText", false, text);
-  } catch {
-    return false;
-  }
+      return text ? { text } : null;
+    },
+    insertClipboardText
+      ? (content) => content.text
+        ? insertClipboardText(content.text)
+        : false
+      : undefined
+  );
 }
 
 async function runInjectedClipboardPasteCommand(
@@ -185,10 +237,24 @@ async function runInjectedClipboardPasteCommand(
 
 function runBrowserEditCommand(
   command: BrowserEditCommand,
-  options: Pick<EditorContextMenuEntryOptions, "insertClipboardText" | "readClipboardText"> = {}
+  options: Pick<
+    EditorContextMenuEntryOptions,
+    | "insertClipboardContent"
+    | "insertClipboardText"
+    | "readClipboardContent"
+    | "readClipboardText"
+  > = {}
 ) {
   const documentTarget = typeof document === "undefined" ? null : document;
   if (!documentTarget) return false;
+
+  if (command === "paste" && options.readClipboardContent) {
+    return pasteClipboardContent(
+      documentTarget,
+      options.readClipboardContent,
+      options.insertClipboardContent
+    ).then((handled) => handled || runDocumentEditCommand(documentTarget, "paste"));
+  }
 
   if (command === "paste" && options.readClipboardText) {
     return runInjectedClipboardPasteCommand(
@@ -209,7 +275,13 @@ function browserItem(
   label: string,
   accelerator: string,
   command: BrowserEditCommand,
-  options: Pick<EditorContextMenuEntryOptions, "insertClipboardText" | "readClipboardText"> = {}
+  options: Pick<
+    EditorContextMenuEntryOptions,
+    | "insertClipboardContent"
+    | "insertClipboardText"
+    | "readClipboardContent"
+    | "readClipboardText"
+  > = {}
 ) {
   return contextMenuItem(id, label, accelerator, () => runBrowserEditCommand(command, options), false);
 }
@@ -310,13 +382,18 @@ export function createEditorContextMenuEntriesFromOptions(
   idPrefixes?: Partial<ContextMenuIdPrefixes>,
   target?: Element
 ) {
+  const insertClipboardContent = target
+    ? createClipboardContentInserter(target)
+    : undefined;
   return createEditorContextMenuEntries(
     handlers,
     language,
     {
       aiCommandsAvailable: readAiCommandsAvailable(options),
-      insertClipboardText: target ? createClipboardTextInserter(target) : undefined,
+      insertClipboardContent,
+      insertClipboardText: createClipboardTextInserter(insertClipboardContent),
       markdownShortcuts: options.markdownShortcuts,
+      readClipboardContent: options.readClipboardContent,
       readClipboardText: options.readClipboardText
     },
     idPrefixes

--- a/packages/app/src/runtime/index.ts
+++ b/packages/app/src/runtime/index.ts
@@ -63,6 +63,7 @@ import type {
   WriteNativeWebDavTextFileInput
 } from "../lib/tauri/file";
 import type {
+  NativeClipboardContent,
   NativeEditorContextMenuEntryOptions,
   NativeEditorContextMenuOptions,
   NativeMarkdownFileTreeContextMenuHandlers,
@@ -271,6 +272,7 @@ export type AppMenuRuntime = {
     options?: NativeEditorContextMenuOptions
   ) => Promise<RuntimeCleanup>;
   listenApplicationMenuCommands: (handlers: NativeMenuHandlers) => Promise<RuntimeCleanup>;
+  readClipboardContent: () => Promise<NativeClipboardContent | null>;
   readClipboardText: () => Promise<string | null>;
   showMarkdownFileTreeContextMenu: (
     handlers: NativeMarkdownFileTreeContextMenuHandlers,
@@ -574,6 +576,11 @@ export function createDefaultAppRuntime(): AppRuntime {
       installApplicationMenu: async () => () => undefined,
       installEditorContextMenu: async () => () => undefined,
       listenApplicationMenuCommands: async () => () => undefined,
+      readClipboardContent: async () => {
+        const text = await readBrowserClipboardText();
+
+        return text ? { text } : null;
+      },
       readClipboardText: readBrowserClipboardText,
       showMarkdownFileTreeContextMenu: async () => undefined
     },
@@ -732,6 +739,8 @@ export {
   type ContextMenuIdPrefixes
 } from "./context-menu-items";
 export type {
+  NativeClipboardContent,
+  NativeClipboardContentReader,
   NativeEditorContextMenuOptions,
   NativeMarkdownFileTreeContextMenuHandlers,
   NativeMenuCommand,

--- a/packages/editor/src/codemirror/clipboard-assets.test.ts
+++ b/packages/editor/src/codemirror/clipboard-assets.test.ts
@@ -224,6 +224,35 @@ describe("codeMirrorClipboardAssetsPlugin", () => {
     ].join("\n"));
   });
 
+  it("keeps styled file badges as inline links", () => {
+    const view = createView("");
+    const expected = [
+      "Mock changes: ",
+      "[example-a.ts (line 108)](/mock-project/src/example-a.ts:108), ",
+      "[example-b.ts (line 438)](/mock-project/src/example-b.ts:438).",
+    ].join("");
+
+    const event = paste(view, {
+      html: [
+        "<p>Mock changes: ",
+        '<a href="/mock-project/src/example-a.ts:108">',
+        '<div style="font-family: Menlo, monospace; white-space: pre-wrap">',
+        "example-a.ts (line 108)",
+        "</div>",
+        "</a>, ",
+        '<a href="/mock-project/src/example-b.ts:438">',
+        '<div style="font-family: Menlo, monospace; white-space: pre-wrap">',
+        "example-b.ts (line 438)",
+        "</div>",
+        "</a>.</p>",
+      ].join(""),
+      text: expected,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(view.state.doc.toString()).toBe(expected);
+  });
+
   it("preserves Markdown-looking lines inside a styled mixed-content code block", () => {
     const view = createView("");
     const code = [

--- a/packages/editor/src/codemirror/clipboard-assets.test.ts
+++ b/packages/editor/src/codemirror/clipboard-assets.test.ts
@@ -229,7 +229,8 @@ describe("codeMirrorClipboardAssetsPlugin", () => {
     const expected = [
       "Mock changes: ",
       "[example-a.ts (line 108)](/mock-project/src/example-a.ts:108), ",
-      "[example-b.ts (line 438)](/mock-project/src/example-b.ts:438).",
+      "[example-b.ts (line 438)](C:/mock-project/src/example-b.ts:438), ",
+      "[example-c.ts (line 7)](https://example.test/mock-file#L7).",
     ].join("");
 
     const event = paste(view, {
@@ -240,10 +241,13 @@ describe("codeMirrorClipboardAssetsPlugin", () => {
         "example-a.ts (line 108)",
         "</div>",
         "</a>, ",
-        '<a href="/mock-project/src/example-b.ts:438">',
-        '<div style="font-family: Menlo, monospace; white-space: pre-wrap">',
-        "example-b.ts (line 438)",
-        "</div>",
+        '<a href="C:/mock-project/src/example-b.ts:438" ',
+        'style="font-family: Menlo, monospace; white-space: pre-wrap">',
+        "<div>example-b.ts</div>",
+        "<div>(line 438)</div>",
+        "</a>, ",
+        '<a href="https://example.test/mock-file#L7">',
+        '<p style="font-family: Menlo, monospace">example-c.ts (line 7)</p>',
         "</a>.</p>",
       ].join(""),
       text: expected,
@@ -251,6 +255,52 @@ describe("codeMirrorClipboardAssetsPlugin", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(view.state.doc.toString()).toBe(expected);
+  });
+
+  it("does not merge ordinary linked card blocks", () => {
+    const view = createView("");
+    const href = "https://example.test/mock-card";
+
+    paste(view, {
+      html: [
+        '<p>See <a href="https://example.test/mock-card">',
+        "<div>Mock title</div>",
+        "<div>Mock subtitle</div>",
+        "</a>.</p>",
+      ].join(""),
+      text: "See Mock title Mock subtitle.",
+    });
+
+    const markdown = view.state.doc.toString();
+    expect(markdown).toContain(`[Mock title](${href})`);
+    expect(markdown).toContain(`[Mock subtitle](${href})`);
+    expect(markdown).not.toContain("Mock titleMock subtitle");
+  });
+
+  it("does not flatten semantic or multiline linked code", () => {
+    const semanticView = createView("");
+    const multilineView = createView("");
+
+    paste(semanticView, {
+      html: [
+        '<p>See <a href="https://example.test/mock-code">',
+        '<pre style="font-family: Menlo, monospace"><code>const mock = 1;</code></pre>',
+        "</a>.</p>",
+      ].join(""),
+      text: "See const mock = 1;.",
+    });
+    paste(multilineView, {
+      html: [
+        '<p>See <a href="https://example.test/mock-lines">',
+        '<div style="font-family: Menlo, monospace; white-space: pre-wrap">',
+        "Mock line one<br>Mock line two",
+        "</div></a>.</p>",
+      ].join(""),
+      text: "See Mock line one\nMock line two.",
+    });
+
+    expect(semanticView.state.doc.toString()).toContain("```\nconst mock = 1;\n```");
+    expect(multilineView.state.doc.toString()).toContain("```\nMock line one\nMock line two\n```");
   });
 
   it("preserves Markdown-looking lines inside a styled mixed-content code block", () => {

--- a/packages/editor/src/codemirror/clipboard-assets.test.ts
+++ b/packages/editor/src/codemirror/clipboard-assets.test.ts
@@ -196,6 +196,129 @@ describe("codeMirrorClipboardAssetsPlugin", () => {
     expect(view.state.doc.toString()).toContain("Outro");
   });
 
+  it("prefers structured rich HTML over Markdown-looking fallback text", () => {
+    const view = createView("");
+
+    const event = paste(view, {
+      html: [
+        "<p>Mock summary</p>",
+        "<ol><li>First <code>choice</code></li><li>Second choice</li></ol>",
+        '<p>See <a href="https://example.test/mock-docs">mock docs</a>.</p>',
+      ].join(""),
+      text: [
+        "Mock summary",
+        "First choice",
+        "Second choice",
+        "See [mock docs](https://example.test/mock-docs).",
+      ].join("\n"),
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(view.state.doc.toString()).toBe([
+      "Mock summary",
+      "",
+      "1.  First `choice`",
+      "2.  Second choice",
+      "",
+      "See [mock docs](https://example.test/mock-docs).",
+    ].join("\n"));
+  });
+
+  it("preserves Markdown-looking lines inside a styled mixed-content code block", () => {
+    const view = createView("");
+    const code = [
+      "# Mock score",
+      "=",
+      "+ reward × 100",
+      "",
+      "- resource cost",
+    ].join("\n");
+
+    const event = paste(view, {
+      html: [
+        "<h2>Mock formula</h2>",
+        "<ul><li>First constraint</li><li>Second constraint</li></ul>",
+        "<p>Use this synthetic model:</p>",
+        '<div style="font-family: Menlo, monospace; white-space: pre-wrap">',
+        "<div># Mock score</div>",
+        "<div>=</div>",
+        "<div>+ reward × 100</div>",
+        "<div><br></div>",
+        "<div>- resource cost</div>",
+        "</div>",
+      ].join(""),
+      text: [
+        "Mock formula",
+        "First constraint",
+        "Second constraint",
+        "Use this synthetic model:",
+        code,
+      ].join("\n"),
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(view.state.doc.toString()).toBe([
+      "## Mock formula",
+      "",
+      "-   First constraint",
+      "-   Second constraint",
+      "",
+      "Use this synthetic model:",
+      "",
+      "```",
+      code,
+      "```",
+    ].join("\n"));
+  });
+
+  it("preserves language metadata from a styled mixed-content code block", () => {
+    const code = "print('mock value')";
+    const view = createView("");
+
+    paste(view, {
+      html: [
+        "<p>Mock introduction</p>",
+        '<div style="font-family: Menlo, monospace; white-space: pre-wrap">',
+        `<code class="language-python">${code}</code>`,
+        "</div>",
+        "<p>Mock conclusion</p>",
+      ].join(""),
+      text: ["Mock introduction", code, "Mock conclusion"].join("\n"),
+    });
+
+    expect(view.state.doc.toString()).toBe([
+      "Mock introduction",
+      "",
+      "```python",
+      code,
+      "```",
+      "",
+      "Mock conclusion",
+    ].join("\n"));
+  });
+
+  it("keeps Markdown source from a non-semantic editor clipboard", () => {
+    const source = [
+      "# Mock heading",
+      "",
+      "- First item",
+      "- Second item",
+    ].join("\n");
+    const view = createView("");
+
+    paste(view, {
+      html: [
+        '<div class="mock-editor-line"><span># Mock heading</span></div>',
+        '<div class="mock-editor-line"><br></div>',
+        '<div class="mock-editor-line"><span>- First item</span></div>',
+        '<div class="mock-editor-line"><span>- Second item</span></div>',
+      ].join(""),
+      text: source,
+    });
+
+    expect(view.state.doc.toString()).toBe(source);
+  });
+
   it("wraps code copied with syntax-highlighted HTML in a fenced block", () => {
     const code = [
       "const mock_value = items[0];",

--- a/packages/editor/src/codemirror/clipboard-assets.ts
+++ b/packages/editor/src/codemirror/clipboard-assets.ts
@@ -431,9 +431,11 @@ function insertHtmlPaste(
   const html = event.clipboardData?.getData("text/html") ?? "";
   if (!html) return false;
   const plainText = event.clipboardData?.getData("text/plain") ?? "";
-  if (looksLikeMarkdownSource(plainText)) return false;
   const converted = convertCodeMirrorClipboardHtml(html, plainText);
   if (!converted) return false;
+  // Rendered rich text can contain an incidental Markdown-looking fragment.
+  // Only preserve the raw source when the HTML has no authored document structure.
+  if (looksLikeMarkdownSource(plainText) && !converted.structured) return false;
 
   const { from, to } = view.state.selection.main;
   const replacements = saveRemoteImage

--- a/packages/editor/src/codemirror/html-paste.ts
+++ b/packages/editor/src/codemirror/html-paste.ts
@@ -34,6 +34,8 @@ const richTextSelector = [
   "ul",
 ].join(",");
 const preformattedBlockNames = new Set(["DIV", "P", "PRE"]);
+const anchorMarkupPattern = /<a\b(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/a\s*>/giu;
+const anchorBlockPattern = /<(\/?)(?:div|p|pre)\b((?:[^>"']|"[^"]*"|'[^']*')*)>/giu;
 
 function preformattedStyle(element: Element) {
   const style = element.getAttribute("style") ?? "";
@@ -43,6 +45,17 @@ function preformattedStyle(element: Element) {
 function preformattedElements(document: Document) {
   return Array.from(document.querySelectorAll<HTMLElement>("pre, [style]"))
     .filter((element) => element.tagName === "PRE" || preformattedStyle(element));
+}
+
+function normalizeAnchorBlockMarkup(html: string) {
+  // A block wrapper inside a paragraph link makes the HTML parser split one
+  // authored anchor into empty and duplicate links before Turndown sees it.
+  return html.replace(anchorMarkupPattern, (anchor) =>
+    anchor.replace(
+      anchorBlockPattern,
+      (_tag, closing: string, attributes: string) => `<${closing}span${attributes}>`,
+    )
+  );
 }
 
 function meaningfulBodyNodes(document: Document) {
@@ -202,7 +215,10 @@ export function convertCodeMirrorClipboardHtml(
   plainText = "",
 ): CodeMirrorHtmlPaste | null {
   if (!html.trim() || typeof DOMParser === "undefined") return null;
-  const document = new DOMParser().parseFromString(html, "text/html");
+  const document = new DOMParser().parseFromString(
+    normalizeAnchorBlockMarkup(html),
+    "text/html",
+  );
   const service = createTurndownService();
   const structured = hasStructuredHtml(document);
   const code = syntaxHighlightedPlainText(document, plainText);

--- a/packages/editor/src/codemirror/html-paste.ts
+++ b/packages/editor/src/codemirror/html-paste.ts
@@ -4,29 +4,128 @@ import type { RemoteClipboardImage } from "../clipboard-asset-types.ts";
 export interface CodeMirrorHtmlPaste {
   readonly markdown: string;
   readonly remoteImages: readonly RemoteClipboardImage[];
+  readonly structured: boolean;
 }
 
 const codeFontPattern = /(?:monospace|menlo|monaco|consolas|courier|sfmono|fira code|jetbrains mono|cascadia code|source code pro)/iu;
 const preformattedWhitespacePattern = /white-space\s*:\s*(?:pre|pre-wrap|break-spaces)/iu;
+const richTextSelector = [
+  "a[href]",
+  "b",
+  "blockquote",
+  "del",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "i",
+  "img",
+  "ol",
+  "s",
+  "strike",
+  "strong",
+  "sub",
+  "sup",
+  "table",
+  "ul",
+].join(",");
+const preformattedBlockNames = new Set(["DIV", "P", "PRE"]);
+
+function preformattedStyle(element: Element) {
+  const style = element.getAttribute("style") ?? "";
+  return codeFontPattern.test(style) || preformattedWhitespacePattern.test(style);
+}
+
+function preformattedElements(document: Document) {
+  return Array.from(document.querySelectorAll<HTMLElement>("pre, [style]"))
+    .filter((element) => element.tagName === "PRE" || preformattedStyle(element));
+}
+
+function meaningfulBodyNodes(document: Document) {
+  return Array.from(document.body.childNodes).filter(
+    (node) => node.nodeType === 1 ||
+      (node.nodeType === 3 && Boolean(node.textContent?.trim())),
+  );
+}
+
+function hasMixedPreformattedContent(document: Document) {
+  const bodyNodes = meaningfulBodyNodes(document);
+  return preformattedElements(document).some(
+    (element) => bodyNodes.some(
+      (node) => node !== element && !element.contains(node),
+    ),
+  );
+}
+
+function hasStructuredHtml(document: Document) {
+  return document.querySelector(richTextSelector) !== null ||
+    hasMixedPreformattedContent(document);
+}
 
 function syntaxHighlightedPlainText(
   document: Document,
   plainText: string,
 ) {
   if (!plainText || document.querySelector("pre > code")) return null;
-  const preformatted = document.querySelector("pre") !== null ||
-    Array.from(document.querySelectorAll<HTMLElement>("[style]")).some(
-      (element) => {
-        const style = element.getAttribute("style") ?? "";
-        return codeFontPattern.test(style) ||
-          preformattedWhitespacePattern.test(style);
-      },
-    );
-  if (!preformatted) return null;
+  if (preformattedElements(document).length === 0 || hasStructuredHtml(document)) {
+    return null;
+  }
 
   // Syntax-highlighted clipboard HTML represents punctuation as ordinary text.
   // Turndown would escape it as Markdown, so preserve the accompanying source.
   return plainText.replace(/\r\n?/gu, "\n");
+}
+
+function preformattedNodeText(node: Node): string {
+  if (node.nodeType === 3) return node.textContent ?? "";
+  if (node.nodeType !== 1) return "";
+  const element = node as Element;
+  if (element.tagName === "BR") return "\n";
+
+  const text = Array.from(element.childNodes)
+    .map((child) => preformattedNodeText(child))
+    .join("");
+  if (!preformattedBlockNames.has(element.tagName)) return text;
+  return `${text.replace(/\n+$/u, "")}\n`;
+}
+
+function codeLanguageClass(element: Element) {
+  const candidates = [element, ...Array.from(element.querySelectorAll("[class]"))];
+  for (const candidate of candidates) {
+    for (const className of candidate.classList) {
+      const match = /^(?:lang(?:uage)?)-(.+)$/iu.exec(className);
+      if (match?.[1]) return `language-${match[1]}`;
+    }
+  }
+
+  return "";
+}
+
+function normalizeStyledCodeBlocks(document: Document) {
+  for (const element of preformattedElements(document)) {
+    if (!preformattedBlockNames.has(element.tagName)) continue;
+    if (element.tagName === "PRE" && element.querySelector(":scope > code")) {
+      continue;
+    }
+    const parent = element.parentElement;
+    if (parent && preformattedStyle(parent)) continue;
+
+    const codeText = preformattedNodeText(element)
+      .replace(/\r\n?/gu, "\n")
+      .replace(/\n+$/u, "");
+    if (!codeText) continue;
+    const pre = document.createElement("pre");
+    const code = document.createElement("code");
+    const languageClass = codeLanguageClass(element);
+    if (languageClass) code.classList.add(languageClass);
+    code.textContent = codeText;
+    pre.append(code);
+    element.replaceWith(pre);
+  }
 }
 
 function normalizedCellMarkdown(service: TurndownService, cell: Element) {
@@ -105,7 +204,11 @@ export function convertCodeMirrorClipboardHtml(
   if (!html.trim() || typeof DOMParser === "undefined") return null;
   const document = new DOMParser().parseFromString(html, "text/html");
   const service = createTurndownService();
+  const structured = hasStructuredHtml(document);
   const code = syntaxHighlightedPlainText(document, plainText);
+  // Turndown collapses whitespace in ordinary styled elements before applying
+  // rules, so semanticize code containers while their authored line breaks remain.
+  if (!code) normalizeStyledCodeBlocks(document);
   const markdown = code ?? service
     .turndown(document.body.innerHTML)
     .replace(/\r\n?/gu, "\n")
@@ -119,5 +222,6 @@ export function convertCodeMirrorClipboardHtml(
       const remote = remoteImage(image);
       return remote ? [remote] : [];
     }),
+    structured,
   };
 }

--- a/packages/editor/src/codemirror/html-paste.ts
+++ b/packages/editor/src/codemirror/html-paste.ts
@@ -35,7 +35,6 @@ const richTextSelector = [
 ].join(",");
 const preformattedBlockNames = new Set(["DIV", "P", "PRE"]);
 const anchorMarkupPattern = /<a\b(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?<\/a\s*>/giu;
-const anchorBlockPattern = /<(\/?)(?:div|p|pre)\b((?:[^>"']|"[^"]*"|'[^']*')*)>/giu;
 
 function preformattedStyle(element: Element) {
   const style = element.getAttribute("style") ?? "";
@@ -47,15 +46,48 @@ function preformattedElements(document: Document) {
     .filter((element) => element.tagName === "PRE" || preformattedStyle(element));
 }
 
-function normalizeAnchorBlockMarkup(html: string) {
+function styledInlineLinkMarkup(link: HTMLAnchorElement) {
+  const blocks = Array.from(link.querySelectorAll<HTMLElement>("div, p"));
+  // Only flatten compact preformatted wrappers; semantic or multiline content
+  // must stay on the normal code/link conversion path.
+  if (blocks.length === 0 ||
+    link.querySelector("br, code, pre") !== null ||
+    /[\r\n]/u.test(link.textContent ?? "") ||
+    ![link, ...Array.from(link.querySelectorAll<HTMLElement>("[style]"))]
+      .some((element) => preformattedStyle(element))) {
+    return null;
+  }
+
+  const blockSet = new Set(blocks);
+  const blocksWithFollowingBlock = new Set(blocks.filter(
+    (block) => Boolean(
+      block.nextElementSibling && blockSet.has(block.nextElementSibling as HTMLElement),
+    ),
+  ));
+  for (const block of blocks.reverse()) {
+    const span = link.ownerDocument.createElement("span");
+    for (const attribute of Array.from(block.attributes)) {
+      span.setAttribute(attribute.name, attribute.value);
+    }
+    span.append(...Array.from(block.childNodes));
+    block.replaceWith(span);
+    if (blocksWithFollowingBlock.has(block)) span.after(" ");
+  }
+
+  return link.outerHTML;
+}
+
+function normalizeAnchorBlockMarkup(html: string, parser: DOMParser) {
   // A block wrapper inside a paragraph link makes the HTML parser split one
   // authored anchor into empty and duplicate links before Turndown sees it.
-  return html.replace(anchorMarkupPattern, (anchor) =>
-    anchor.replace(
-      anchorBlockPattern,
-      (_tag, closing: string, attributes: string) => `<${closing}span${attributes}>`,
-    )
-  );
+  return html.replace(anchorMarkupPattern, (anchor) => {
+    if (!codeFontPattern.test(anchor) && !preformattedWhitespacePattern.test(anchor)) {
+      return anchor;
+    }
+    const fragment = parser.parseFromString(anchor, "text/html");
+    const link = fragment.body.querySelector<HTMLAnchorElement>("a[href]");
+    return link ? styledInlineLinkMarkup(link) ?? anchor : anchor;
+  });
 }
 
 function meaningfulBodyNodes(document: Document) {
@@ -215,8 +247,9 @@ export function convertCodeMirrorClipboardHtml(
   plainText = "",
 ): CodeMirrorHtmlPaste | null {
   if (!html.trim() || typeof DOMParser === "undefined") return null;
-  const document = new DOMParser().parseFromString(
-    normalizeAnchorBlockMarkup(html),
+  const parser = new DOMParser();
+  const document = parser.parseFromString(
+    normalizeAnchorBlockMarkup(html, parser),
     "text/html",
   );
   const service = createTurndownService();


### PR DESCRIPTION
## Summary

- prefer authored structured HTML over Markdown-looking clipboard fallback text
- normalize styled preformatted regions into fenced code blocks while preserving line breaks and language metadata
- preserve compact Codex-style file badges as inline Markdown links
- limit badge normalization to single-line preformatted `div/p` wrappers without semantic code content
- pass both HTML and plain text through the desktop context-menu paste path
- add regression coverage for ChatGPT/Codex-style mixed rich content and native clipboard handling

## Why

Rich content copied from ChatGPT, Codex, and similar sources can include incidental Markdown-looking text alongside valid HTML. The editor previously selected the plain-text fallback or flattened the whole payload when it encountered a styled code region. Block-styled file badges inside anchors could also be parsed as empty links plus detached code blocks. Desktop right-click paste discarded HTML entirely.

## Validation

- `pnpm --filter @markra/editor test` — 447 tests passed
- `pnpm --filter @markra/app test -- context-menu-items.test.ts` — 14 tests passed
- `pnpm --filter @markra/app test` — 1,489 tests passed
- `pnpm --filter @markra/desktop test` — 149 tests passed
- `cargo test` in `apps/desktop/src-tauri` — 271 tests passed
- editor, app, and desktop builds passed
- editor, app, and desktop test typechecks passed
- `cargo fmt --check` passed
- `git diff --check` passed

## Risk

The change is scoped to clipboard HTML conversion and native context-menu paste. Plain text and raw Markdown fallback behavior remains covered. Styled link normalization requires a compact single-line `div/p` wrapper with monospace or preformatted whitespace evidence. Ordinary linked cards, semantic `pre/code` content, multiline links, and code blocks outside links remain on their existing conversion paths. Proprietary class-only rich text without semantic markup or inline preformatted styles remains best-effort.

## Related Issues

Refs #631
