### PR TITLE
feat(search): add regular expression replacements

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -7719,7 +7719,15 @@ describe("Markra workspace", () => {
     expect(searchInput).toHaveAttribute("autocorrect", "off");
     expect(searchInput).toHaveAttribute("spellcheck", "false");
     expect(screen.getByRole("button", { name: "Case sensitive" })).not.toHaveAttribute("title");
+    const regularExpressionButton = screen.getByRole("button", { name: "Use regular expression" });
+    expect(regularExpressionButton).toHaveAttribute("aria-pressed", "false");
     expect(container.querySelector(".editor-content-slot")).toHaveAttribute("data-document-search-open", "true");
+
+    fireEvent.click(regularExpressionButton);
+    fireEvent.change(searchInput, { target: { value: "[" } });
+
+    expect(searchInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent("Invalid regular expression");
   });
 
   it("opens document replace from the native Windows Ctrl+H keyboard shortcut", async () => {
@@ -8064,6 +8072,64 @@ describe("Markra workspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Replace" }));
 
     expect(readMarkdownSource(sourceEditor)).toContain("# Hello to Markra");
+  });
+
+  it("uses regular expressions and capture groups in source-mode document replace", async () => {
+    renderApp();
+
+    await expectVisibleMarkdownText("Welcome to Markra");
+
+    fireEvent.keyDown(window, { key: "s", altKey: true, metaKey: true });
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+
+    fireEvent.keyDown(window, { key: "f", altKey: true, metaKey: true });
+    fireEvent.click(screen.getByRole("button", { name: "Use regular expression" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Find in document" }), {
+      target: { value: "Welcome (to) (Markra)" }
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "Replace" }), {
+      target: { value: "$2 says hello $1" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+
+    expect(readMarkdownSource(sourceEditor)).toContain("# Markra says hello to");
+  });
+
+  it("replaces the selected visual-mode regular expression match", async () => {
+    const content = [
+      "`alpha-1`",
+      "`beta-2`",
+      "`gamma-3`",
+      "`delta-4`",
+      "`epsilon-5`",
+      "`zeta-6`",
+      "`eta-7`",
+      "`theta-8`",
+      "`item-123`"
+    ].join("\n\n");
+    mockOpenMarkdownFile({ content, name: "regex.md", path: mockNativePath });
+    const { container } = renderApp();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Markdown or Folder" }));
+    await expectVisibleCodeMirrorText(container, "item-123");
+
+    fireEvent.keyDown(window, { key: "f", altKey: true, metaKey: true });
+    fireEvent.click(screen.getByRole("button", { name: "Use regular expression" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Find in document" }), {
+      target: { value: "(\\w+)-(\\d+)" }
+    });
+
+    await waitFor(() => expect(screen.getByText("1/9")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Previous match" }));
+    expect(screen.getByText("9/9")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Replace" }), {
+      target: { value: "a" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+
+    await expectVisibleCodeMirrorText(container, "`a`");
+    await expectVisibleMarkdownWithout("item-123");
   });
 
   it("toggles read-only mode from the keyboard shortcut and marks the status area", async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -97,6 +97,7 @@ import {
   markdownImageDragPayloadForFile,
   markdownImageDragSrcForDocument,
   pathNameFromPath,
+  resolveSearchReplacement,
   t,
   type AppLanguage,
   type I18nKey
@@ -989,6 +990,8 @@ function WorkspaceApp() {
     openReplace: openDocumentReplace,
     openSearch: openDocumentSearch,
     query: documentSearchQuery,
+    queryValid: documentSearchQueryValid,
+    regularExpression: documentSearchRegularExpression,
     replacement: documentSearchReplacement,
     replaceOpen: documentSearchReplaceOpen,
     resetActiveIndex: resetDocumentSearchActiveIndex,
@@ -998,6 +1001,7 @@ function WorkspaceApp() {
     setReplacement: setDocumentSearchReplacement,
     setReplaceOpen: setDocumentSearchReplaceOpen,
     setQuery: setDocumentSearchQuery,
+    setRegularExpression: setDocumentSearchRegularExpression,
     setVisualMatches: setVisualDocumentSearchMatches,
     visibleSourceMatches: visibleSourceDocumentSearchMatches,
     visualMatches: visualDocumentSearchMatches
@@ -3437,6 +3441,9 @@ function WorkspaceApp() {
   const handleDocumentSearchCaseSensitiveChange = useCallback((caseSensitive: boolean) => {
     setDocumentSearchCaseSensitive(caseSensitive);
   }, [setDocumentSearchCaseSensitive]);
+  const handleDocumentSearchRegularExpressionChange = useCallback((regularExpression: boolean) => {
+    setDocumentSearchRegularExpression(regularExpression);
+  }, [setDocumentSearchRegularExpression]);
   const handleDocumentSearchNext = useCallback(() => {
     navigateDocumentSearch(1);
   }, [navigateDocumentSearch]);
@@ -3444,17 +3451,42 @@ function WorkspaceApp() {
     navigateDocumentSearch(-1);
   }, [navigateDocumentSearch]);
   const handleDocumentReplace = useCallback(() => {
-    if (readOnlyMode || !activeDocumentSearchMatch) return;
+    if (readOnlyMode || !documentSearchQueryValid || !activeDocumentSearchMatch) return;
 
     if (documentSearchSurface === "source") {
-      handleSourceMarkdownChange(replaceTextRange(document.content, activeDocumentSearchMatch, documentSearchReplacement));
+      handleSourceMarkdownChange(replaceTextRange(
+        document.content,
+        activeDocumentSearchMatch,
+        resolveSearchReplacement(
+          document.content,
+          activeDocumentSearchMatch,
+          documentSearchQuery,
+          documentSearchReplacement,
+          {
+            caseSensitive: documentSearchCaseSensitive,
+            regularExpression: documentSearchRegularExpression
+          }
+        )
+      ));
       return;
     }
 
-    replaceEditorSearchMatch(activeDocumentSearchMatch, documentSearchReplacement);
+    replaceEditorSearchMatch(
+      activeDocumentSearchMatch,
+      documentSearchReplacement,
+      documentSearchQuery,
+      {
+        caseSensitive: documentSearchCaseSensitive,
+        regularExpression: documentSearchRegularExpression
+      }
+    );
   }, [
     activeDocumentSearchMatch,
     document.content,
+    documentSearchCaseSensitive,
+    documentSearchQuery,
+    documentSearchQueryValid,
+    documentSearchRegularExpression,
     documentSearchReplacement,
     documentSearchSurface,
     handleSourceMarkdownChange,
@@ -3462,19 +3494,44 @@ function WorkspaceApp() {
     readOnlyMode
   ]);
   const handleDocumentReplaceAll = useCallback(() => {
-    if (readOnlyMode || documentSearchMatches.length === 0) return;
+    if (readOnlyMode || !documentSearchQueryValid || documentSearchMatches.length === 0) return;
 
     if (documentSearchSurface === "source") {
-      handleSourceMarkdownChange(replaceTextRanges(document.content, documentSearchMatches, documentSearchReplacement));
+      handleSourceMarkdownChange(replaceTextRanges(
+        document.content,
+        documentSearchMatches,
+        (match) => resolveSearchReplacement(
+          document.content,
+          match,
+          documentSearchQuery,
+          documentSearchReplacement,
+          {
+            caseSensitive: documentSearchCaseSensitive,
+            regularExpression: documentSearchRegularExpression
+          }
+        )
+      ));
       resetDocumentSearchActiveIndex();
       return;
     }
 
-    replaceAllEditorSearchMatches(documentSearchMatches, documentSearchReplacement);
+    replaceAllEditorSearchMatches(
+      documentSearchMatches,
+      documentSearchReplacement,
+      documentSearchQuery,
+      {
+        caseSensitive: documentSearchCaseSensitive,
+        regularExpression: documentSearchRegularExpression
+      }
+    );
     resetDocumentSearchActiveIndex();
   }, [
     document.content,
+    documentSearchCaseSensitive,
     documentSearchMatches,
+    documentSearchQuery,
+    documentSearchQueryValid,
+    documentSearchRegularExpression,
     documentSearchReplacement,
     documentSearchSurface,
     handleSourceMarkdownChange,
@@ -3490,7 +3547,8 @@ function WorkspaceApp() {
 
     setVisualDocumentSearchMatches(
       findEditorSearchMatches(documentSearchQuery, {
-        caseSensitive: documentSearchCaseSensitive
+        caseSensitive: documentSearchCaseSensitive,
+        regularExpression: documentSearchRegularExpression
       })
     );
   }, [
@@ -3500,6 +3558,7 @@ function WorkspaceApp() {
     documentSearchCaseSensitive,
     documentSearchOpen,
     documentSearchQuery,
+    documentSearchRegularExpression,
     documentSearchSurface,
     findEditorSearchMatches,
     visualEditorReadySequence
@@ -4655,7 +4714,9 @@ function WorkspaceApp() {
                   language={appLanguage.language}
                   matchCount={documentSearchMatchCount}
                   query={documentSearchQuery}
+                  queryValid={documentSearchQueryValid}
                   readOnly={readOnlyMode}
+                  regularExpression={documentSearchRegularExpression}
                   replaceOpen={documentSearchReplaceOpen}
                   replacement={documentSearchReplacement}
                   onCaseSensitiveChange={handleDocumentSearchCaseSensitiveChange}
@@ -4663,6 +4724,7 @@ function WorkspaceApp() {
                   onNext={handleDocumentSearchNext}
                   onPrevious={handleDocumentSearchPrevious}
                   onQueryChange={handleDocumentSearchQueryChange}
+                  onRegularExpressionChange={handleDocumentSearchRegularExpressionChange}
                   onReplace={handleDocumentReplace}
                   onReplaceAll={handleDocumentReplaceAll}
                   onReplaceOpenChange={setDocumentSearchReplaceOpen}

--- a/packages/app/src/app/workspace-model.ts
+++ b/packages/app/src/app/workspace-model.ts
@@ -85,10 +85,21 @@ export function replaceTextRange(content: string, range: SearchRange, replacemen
   return `${content.slice(0, range.from)}${replacement}${content.slice(range.to)}`;
 }
 
-export function replaceTextRanges(content: string, ranges: SearchRange[], replacement: string) {
+export function replaceTextRanges(
+  content: string,
+  ranges: SearchRange[],
+  replacement: string | ((range: SearchRange) => string)
+) {
   return [...ranges]
     .sort((left, right) => right.from - left.from)
-    .reduce((nextContent, range) => replaceTextRange(nextContent, range, replacement), content);
+    .reduce(
+      (nextContent, range) => replaceTextRange(
+        nextContent,
+        range,
+        typeof replacement === "function" ? replacement(range) : replacement
+      ),
+      content
+    );
 }
 
 export function restoreElementScrollTop(element: HTMLElement, scrollTop: number) {

--- a/packages/app/src/components/DocumentSearchBar.test.tsx
+++ b/packages/app/src/components/DocumentSearchBar.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { DocumentSearchBar } from "./DocumentSearchBar";
+
+describe("DocumentSearchBar", () => {
+  it("disables navigation and replacement while a regular expression is invalid", () => {
+    const next = vi.fn();
+    const previous = vi.fn();
+    const replace = vi.fn();
+    render(
+      <DocumentSearchBar
+        activeIndex={0}
+        caseSensitive={false}
+        matchCount={1}
+        query="["
+        queryValid={false}
+        regularExpression
+        replaceOpen
+        replacement="synthetic"
+        onCaseSensitiveChange={() => {}}
+        onClose={() => {}}
+        onNext={next}
+        onPrevious={previous}
+        onQueryChange={() => {}}
+        onRegularExpressionChange={() => {}}
+        onReplace={replace}
+        onReplaceAll={() => {}}
+        onReplaceOpenChange={() => {}}
+        onReplacementChange={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Previous match" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next match" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Replace" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "All" })).toBeDisabled();
+
+    fireEvent.keyDown(screen.getByRole("searchbox", { name: "Find in document" }), { key: "Enter" });
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Replace" }), { key: "Enter" });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(previous).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/components/DocumentSearchBar.tsx
+++ b/packages/app/src/components/DocumentSearchBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, type KeyboardEvent } from "react";
-import { CaseSensitive, ChevronDown, ChevronUp, Replace, Search, X } from "lucide-react";
+import { CaseSensitive, ChevronDown, ChevronUp, Regex, Replace, Search, X } from "lucide-react";
 import { t, type AppLanguage } from "@markra/shared";
 import { Tooltip } from "@markra/ui";
 
@@ -9,7 +9,9 @@ type DocumentSearchBarProps = {
   language?: AppLanguage;
   matchCount: number;
   query: string;
+  queryValid: boolean;
   readOnly?: boolean;
+  regularExpression: boolean;
   replaceOpen: boolean;
   replacement: string;
   onCaseSensitiveChange: (caseSensitive: boolean) => unknown;
@@ -17,6 +19,7 @@ type DocumentSearchBarProps = {
   onNext: () => unknown;
   onPrevious: () => unknown;
   onQueryChange: (query: string) => unknown;
+  onRegularExpressionChange: (regularExpression: boolean) => unknown;
   onReplace: () => unknown;
   onReplaceAll: () => unknown;
   onReplaceOpenChange: (open: boolean) => unknown;
@@ -27,44 +30,52 @@ const labels: Record<string, {
   caseSensitive: string;
   close: string;
   findInDocument: string;
+  invalidRegularExpression: string;
   next: string;
   previous: string;
   replace: string;
   replaceAll: string;
   replacePlaceholder: string;
+  regularExpression: string;
   toggleReplace: string;
 }> = {
   en: {
     caseSensitive: "Case sensitive",
     close: "Close search",
     findInDocument: "Find in document",
+    invalidRegularExpression: "Invalid regular expression",
     next: "Next match",
     previous: "Previous match",
     replace: "Replace",
     replaceAll: "All",
     replacePlaceholder: "Replace",
+    regularExpression: "Use regular expression",
     toggleReplace: "Show replace"
   },
   "zh-CN": {
     caseSensitive: "区分大小写",
     close: "关闭搜索",
     findInDocument: "文档内搜索",
+    invalidRegularExpression: "无效的正则表达式",
     next: "下一个匹配",
     previous: "上一个匹配",
     replace: "替换",
     replaceAll: "全部",
     replacePlaceholder: "替换为",
+    regularExpression: "使用正则表达式",
     toggleReplace: "显示替换"
   },
   "zh-TW": {
     caseSensitive: "區分大小寫",
     close: "關閉搜尋",
     findInDocument: "文件內搜尋",
+    invalidRegularExpression: "無效的規則運算式",
     next: "下一個相符項目",
     previous: "上一個相符項目",
     replace: "取代",
     replaceAll: "全部",
     replacePlaceholder: "取代為",
+    regularExpression: "使用規則運算式",
     toggleReplace: "顯示取代"
   }
 };
@@ -79,7 +90,9 @@ export function DocumentSearchBar({
   language = "en",
   matchCount,
   query,
+  queryValid,
   readOnly = false,
+  regularExpression,
   replaceOpen,
   replacement,
   onCaseSensitiveChange,
@@ -87,6 +100,7 @@ export function DocumentSearchBar({
   onNext,
   onPrevious,
   onQueryChange,
+  onRegularExpressionChange,
   onReplace,
   onReplaceAll,
   onReplaceOpenChange,
@@ -111,6 +125,7 @@ export function DocumentSearchBar({
     if (event.key !== "Enter") return;
 
     event.preventDefault();
+    if (!queryValid) return;
     if (event.shiftKey) {
       onPrevious();
     } else {
@@ -128,11 +143,12 @@ export function DocumentSearchBar({
     if (event.key !== "Enter") return;
 
     event.preventDefault();
+    if (!queryValid) return;
     onReplace();
   };
 
-  const navigationDisabled = matchCount === 0;
-  const replaceDisabled = readOnly || matchCount === 0;
+  const navigationDisabled = !queryValid || matchCount === 0;
+  const replaceDisabled = !queryValid || readOnly || matchCount === 0;
 
   return (
     <div
@@ -144,6 +160,8 @@ export function DocumentSearchBar({
         <Search aria-hidden="true" className="shrink-0 text-(--text-secondary)" size={14} />
         <input
           className="h-8 min-w-0 flex-1 rounded-sm border border-(--border-default) bg-(--bg-primary) px-2 text-[12px] text-(--text-heading) outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-(--text-secondary) focus:border-(--accent) focus:shadow-[0_0_0_2px_var(--accent-soft)]"
+          aria-describedby={!queryValid ? "document-search-query-error" : undefined}
+          aria-invalid={!queryValid || undefined}
           aria-label={label.findInDocument}
           autoCapitalize="none"
           autoComplete="off"
@@ -186,6 +204,17 @@ export function DocumentSearchBar({
             <CaseSensitive aria-hidden="true" size={14} />
           </button>
         </Tooltip>
+        <Tooltip content={label.regularExpression}>
+          <button
+            className="document-search-icon-button"
+            aria-label={label.regularExpression}
+            aria-pressed={regularExpression}
+            type="button"
+            onClick={() => onRegularExpressionChange(!regularExpression)}
+          >
+            <Regex aria-hidden="true" size={14} />
+          </button>
+        </Tooltip>
         <button
           className="document-search-icon-button"
           aria-label={label.toggleReplace}
@@ -204,6 +233,15 @@ export function DocumentSearchBar({
           <X aria-hidden="true" size={14} />
         </button>
       </div>
+      {!queryValid ? (
+        <p
+          className="pl-5 text-[11px] text-(--danger)"
+          id="document-search-query-error"
+          role="alert"
+        >
+          {label.invalidRegularExpression}
+        </p>
+      ) : null}
       {replaceOpen ? (
         <div className="flex min-w-0 items-center gap-1.5 pl-5">
           <input

--- a/packages/app/src/components/MarkdownSourceEditor.test.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.test.tsx
@@ -492,6 +492,24 @@ describe("MarkdownSourceEditor", () => {
     });
   });
 
+  it("renders and selects zero-width search matches in source mode", async () => {
+    const { container } = render(
+      <MarkdownSourceEditor
+        content="alpha\nbeta"
+        searchMatches={[{ from: 6, to: 6 }]}
+        searchActiveIndex={0}
+        onChange={() => {}}
+      />
+    );
+    const view = getMarkdownSourceView(container);
+
+    await waitFor(() => {
+      expect(view.state.selection.main.from).toBe(6);
+      expect(view.state.selection.main.to).toBe(6);
+      expect(container.querySelector(".markra-cm-source-search-zero-width")).toBeInTheDocument();
+    });
+  });
+
   it("updates the selected source search match when active index changes", async () => {
     const { container, rerender } = render(
       <MarkdownSourceEditor

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, type CSSProperties, type Ref, type UIEvent } from "react";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { Annotation, Compartment, EditorSelection, EditorState, Prec, Transaction, type Extension } from "@codemirror/state";
-import { Decoration, EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { Decoration, EditorView, keymap, lineNumbers, WidgetType } from "@codemirror/view";
 import { minimalSetup } from "codemirror";
 import { t, type AppLanguage, type SearchRange } from "@markra/shared";
 import {
@@ -113,11 +113,41 @@ function clampSearchRange(match: SearchRange, documentLength: number) {
   return { from, to };
 }
 
+class ZeroWidthSourceSearchMatchWidget extends WidgetType {
+  constructor(readonly active: boolean) {
+    super();
+  }
+
+  eq(other: ZeroWidthSourceSearchMatchWidget) {
+    return other.active === this.active;
+  }
+
+  toDOM() {
+    const marker = document.createElement("span");
+    marker.className = this.active
+      ? "markra-cm-source-search-zero-width markra-cm-source-search-match-current"
+      : "markra-cm-source-search-zero-width";
+    marker.setAttribute("aria-hidden", "true");
+    return marker;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
 function markdownSourceSearchExtension(matches: SearchRange[] = [], activeIndex = -1): Extension {
   return EditorView.decorations.compute(["doc"], (state) => {
     const decorations = matches.flatMap((match, index) => {
       const { from, to } = clampSearchRange(match, state.doc.length);
-      if (to <= from) return [];
+      if (to < from) return [];
+
+      if (from === to) {
+        return Decoration.widget({
+          side: 1,
+          widget: new ZeroWidthSourceSearchMatchWidget(index === activeIndex)
+        }).range(from);
+      }
 
       return Decoration.mark({
         class: `markra-cm-source-search-match ${

--- a/packages/app/src/hooks/useCodeMirrorEditorController.ts
+++ b/packages/app/src/hooks/useCodeMirrorEditorController.ts
@@ -31,6 +31,7 @@ import {
   showCodeMirrorAiPreview,
   showCodeMirrorAiSelectionHold,
   type AiEditorPreviewLabels,
+  type CodeMirrorSearchOptions,
   type CodeMirrorMarkdownImageReference,
   type CodeMirrorMarkdownLinkReference,
   type ReplaceCodeMirrorMarkdownOptions,
@@ -307,7 +308,7 @@ export function useCodeMirrorEditorController() {
   );
 
   const findSearchMatches = useCallback(
-    (query: string, options: { caseSensitive?: boolean } = {}) => {
+    (query: string, options: CodeMirrorSearchOptions = {}) => {
       const view = viewRef.current;
       return view ? findCodeMirrorSearchMatches(view.state, query, options) : [];
     },
@@ -335,20 +336,36 @@ export function useCodeMirrorEditorController() {
   );
 
   const replaceSearchMatch = useCallback(
-    (match: SearchRange | null | undefined, replacement: string) => {
+    (
+      match: SearchRange | null | undefined,
+      replacement: string,
+      query = "",
+      options: CodeMirrorSearchOptions = {},
+    ) => {
       const view = viewRef.current;
       return view
-        ? replaceCodeMirrorSearchMatch(view, match, replacement)
+        ? replaceCodeMirrorSearchMatch(view, match, replacement, query, options)
         : false;
     },
     [],
   );
 
   const replaceAllSearchMatches = useCallback(
-    (matches: SearchRange[], replacement: string) => {
+    (
+      matches: SearchRange[],
+      replacement: string,
+      query = "",
+      options: CodeMirrorSearchOptions = {},
+    ) => {
       const view = viewRef.current;
       return view
-        ? replaceAllCodeMirrorSearchMatches(view, matches, replacement)
+        ? replaceAllCodeMirrorSearchMatches(
+            view,
+            matches,
+            replacement,
+            query,
+            options,
+          )
         : false;
     },
     [],

--- a/packages/app/src/hooks/useDocumentSearchState.test.tsx
+++ b/packages/app/src/hooks/useDocumentSearchState.test.tsx
@@ -52,6 +52,29 @@ describe("useDocumentSearchState", () => {
     expect(result.current.activeMatch).toEqual({ from: 7, to: 13 });
   });
 
+  it("tracks regular expression mode and invalid patterns", () => {
+    const { result } = renderHook(() => useDocumentSearchState({
+      available: true,
+      sourceContent: "alpha-12 beta-345",
+      surface: "source"
+    }));
+
+    act(() => {
+      result.current.openSearch();
+      result.current.setQuery("alpha-\\d+");
+      result.current.setRegularExpression(true);
+    });
+
+    expect(result.current.regularExpression).toBe(true);
+    expect(result.current.queryValid).toBe(true);
+    expect(result.current.matches).toEqual([{ from: 0, to: 8 }]);
+
+    act(() => result.current.setQuery("["));
+
+    expect(result.current.queryValid).toBe(false);
+    expect(result.current.matches).toEqual([]);
+  });
+
   it("switches between source and visual matches", () => {
     const { result, rerender } = renderHook(
       ({ surface }) => useDocumentSearchState({
@@ -75,6 +98,57 @@ describe("useDocumentSearchState", () => {
 
     expect(result.current.matches).toEqual([{ from: 100, to: 105 }]);
     expect(result.current.visibleSourceMatches).toEqual([]);
+  });
+
+  it("starts a newly populated visual search at the first match", () => {
+    const { result } = renderHook(() => useDocumentSearchState({
+      available: true,
+      sourceContent: "item-1 item-2 item-3",
+      surface: "visual"
+    }));
+
+    act(() => {
+      result.current.openReplace();
+      result.current.setRegularExpression(true);
+      result.current.setQuery("(\\w+)-(\\d+)");
+    });
+
+    act(() => {
+      result.current.setVisualMatches([
+        { from: 0, to: 6 },
+        { from: 7, to: 13 },
+        { from: 14, to: 20 }
+      ]);
+    });
+
+    expect(result.current.activeIndex).toBe(0);
+    expect(result.current.activeMatch).toEqual({ from: 0, to: 6 });
+  });
+
+  it("does not expose visual matches from an earlier regular expression", () => {
+    const { result } = renderHook(() => useDocumentSearchState({
+      available: true,
+      sourceContent: "item-1 other-2",
+      surface: "visual"
+    }));
+
+    act(() => {
+      result.current.openReplace();
+      result.current.setRegularExpression(true);
+      result.current.setQuery("item-(\\d+)");
+    });
+    act(() => {
+      result.current.setVisualMatches([{ from: 0, to: 6 }]);
+    });
+
+    expect(result.current.matchCount).toBe(1);
+
+    act(() => {
+      result.current.setQuery("other-(\\d+)");
+    });
+
+    expect(result.current.matches).toEqual([]);
+    expect(result.current.activeMatch).toBeNull();
   });
 
   it("normalizes navigation and tracks reveal revisions", () => {

--- a/packages/app/src/hooks/useDocumentSearchState.ts
+++ b/packages/app/src/hooks/useDocumentSearchState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   findSearchRanges,
+  isValidSearchQuery,
   normalizeSearchIndex,
   type SearchRange
 } from "@markra/shared";
@@ -23,16 +24,18 @@ export function useDocumentSearchState({
   const [query, setQueryState] = useState("");
   const [replacement, setReplacement] = useState("");
   const [caseSensitive, setCaseSensitiveState] = useState(false);
+  const [regularExpression, setRegularExpressionState] = useState(false);
   const [activeIndexState, setActiveIndexState] = useState(0);
   const [revealRevision, setRevealRevision] = useState(0);
   const [visualMatches, setVisualMatches] = useState<SearchRange[]>([]);
+  const queryValid = isValidSearchQuery(query, { caseSensitive, regularExpression });
 
   const sourceMatches = useMemo(
     () =>
       open && surface === "source"
-        ? findSearchRanges(sourceContent, query, { caseSensitive })
+        ? findSearchRanges(sourceContent, query, { caseSensitive, regularExpression })
         : [],
-    [caseSensitive, open, query, sourceContent, surface]
+    [caseSensitive, open, query, regularExpression, sourceContent, surface]
   );
   const matches = surface === "source" ? sourceMatches : visualMatches;
   const matchCount = matches.length;
@@ -45,6 +48,7 @@ export function useDocumentSearchState({
 
     setOpen(true);
     setReplaceOpen(false);
+    setVisualMatches([]);
     setActiveIndexState(0);
   }, [available]);
 
@@ -53,6 +57,7 @@ export function useDocumentSearchState({
 
     setOpen(true);
     setReplaceOpen(true);
+    setVisualMatches([]);
     setActiveIndexState(0);
   }, [available]);
 
@@ -68,11 +73,20 @@ export function useDocumentSearchState({
 
   const setQuery = useCallback((nextQuery: string) => {
     setQueryState(nextQuery);
+    // Visual matches refresh after render; invalidate them now so Replace cannot use the previous pattern's ranges.
+    setVisualMatches([]);
     setActiveIndexState(0);
   }, []);
 
   const setCaseSensitive = useCallback((nextCaseSensitive: boolean) => {
     setCaseSensitiveState(nextCaseSensitive);
+    setVisualMatches([]);
+    setActiveIndexState(0);
+  }, []);
+
+  const setRegularExpression = useCallback((nextRegularExpression: boolean) => {
+    setRegularExpressionState(nextRegularExpression);
+    setVisualMatches([]);
     setActiveIndexState(0);
   }, []);
 
@@ -102,7 +116,10 @@ export function useDocumentSearchState({
   }, [available]);
 
   useEffect(() => {
-    const nextIndex = normalizeSearchIndex(activeIndexState, matchCount);
+    // Keep the stored index at the first result while visual matches recompute; -1 would wrap to the last result.
+    const nextIndex = matchCount <= 0
+      ? 0
+      : normalizeSearchIndex(activeIndexState, matchCount);
     if (nextIndex !== activeIndexState) setActiveIndexState(nextIndex);
   }, [activeIndexState, matchCount]);
 
@@ -119,6 +136,8 @@ export function useDocumentSearchState({
     openReplace,
     openSearch,
     query,
+    queryValid,
+    regularExpression,
     replacement,
     replaceOpen,
     resetActiveIndex,
@@ -128,6 +147,7 @@ export function useDocumentSearchState({
     setReplacement,
     setReplaceOpen,
     setQuery,
+    setRegularExpression,
     setVisualMatches,
     visibleSourceMatches,
     visualMatches

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1686,6 +1686,14 @@
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
   }
 
+  .markra-cm-source-search-zero-width {
+    display: inline-block;
+    height: 1em;
+    margin-left: -1px;
+    border-left: 2px solid color-mix(in srgb, var(--accent) 72%, transparent);
+    vertical-align: text-bottom;
+  }
+
   .markra-spellcheck-error {
     text-decoration-line: underline;
     text-decoration-style: wavy;

--- a/packages/editor/src/codemirror/controller.test.ts
+++ b/packages/editor/src/codemirror/controller.test.ts
@@ -269,6 +269,40 @@ describe("CodeMirror editor controller", () => {
     expect(view.state.doc.toString()).toBe("A B A beta");
   });
 
+  it("finds regular expressions and expands capture groups while replacing", () => {
+    const view = createView("first:last next:item");
+    const query = "(?<first>\\w+):(?<last>\\w+)";
+    const options = { caseSensitive: true, regularExpression: true };
+    const matches = findCodeMirrorSearchMatches(view.state, query, options);
+
+    expect(matches).toEqual([
+      { from: 0, to: 10 },
+      { from: 11, to: 20 },
+    ]);
+    expect(replaceAllCodeMirrorSearchMatches(
+      view,
+      matches,
+      "$<last>-$1",
+      query,
+      options,
+    )).toBe(true);
+    expect(view.state.doc.toString()).toBe("last-first item-next");
+  });
+
+  it("replaces zero-width regular expression matches", () => {
+    const view = createView("alpha\nbeta");
+    const query = "^";
+    const options = { caseSensitive: true, regularExpression: true };
+    const matches = findCodeMirrorSearchMatches(view.state, query, options);
+
+    expect(matches).toEqual([
+      { from: 0, to: 0 },
+      { from: 6, to: 6 },
+    ]);
+    expect(replaceAllCodeMirrorSearchMatches(view, matches, "> ", query, options)).toBe(true);
+    expect(view.state.doc.toString()).toBe("> alpha\n> beta");
+  });
+
   it("does not expose hidden display-math source as visual search text", () => {
     const doc = ["# Visible c", "", "$$", String.raw`z &= csa`, "$$"].join("\n");
     const view = createView(doc);

--- a/packages/editor/src/codemirror/controller.ts
+++ b/packages/editor/src/codemirror/controller.ts
@@ -14,7 +14,10 @@ import type {
 } from "@markra/ai";
 import { getMarkdownOutline } from "@markra/markdown";
 import {
+  findSearchRanges,
   normalizedExternalAutolinkUrl,
+  resolveSearchReplacement,
+  type SearchOptions,
   type SearchRange,
 } from "@markra/shared";
 import { findCodeMirrorMathRanges } from "./math-preview.ts";
@@ -28,9 +31,7 @@ export interface ReplaceCodeMirrorMarkdownOptions {
   historyBaselineMarkdown?: string;
 }
 
-export interface CodeMirrorSearchOptions {
-  caseSensitive?: boolean;
-}
+export type CodeMirrorSearchOptions = Omit<SearchOptions, "maxMatches">;
 
 export interface CodeMirrorMarkdownImageReference {
   alt: string;
@@ -362,16 +363,6 @@ export function readCodeMirrorTableAnchors(
   return anchors;
 }
 
-function searchTextMatches(
-  candidate: string,
-  query: string,
-  caseSensitive: boolean,
-) {
-  return caseSensitive
-    ? candidate === query
-    : candidate.toLocaleLowerCase() === query.toLocaleLowerCase();
-}
-
 export function findCodeMirrorSearchMatches(
   state: EditorState,
   query: string,
@@ -383,26 +374,13 @@ export function findCodeMirrorSearchMatches(
   const hiddenDisplayMath = findCodeMirrorMathRanges(state).filter(
     (range) => range.kind === "display",
   );
-  const matches: SearchRange[] = [];
-  let position = 0;
-
-  while (position + query.length <= document.length) {
-    const candidate = document.slice(position, position + query.length);
-    const hidden = hiddenDisplayMath.some(
-      (range) => position < range.to && position + query.length > range.from,
-    );
-    if (
-      !hidden &&
-      searchTextMatches(candidate, query, options.caseSensitive ?? false)
-    ) {
-      matches.push({ from: position, to: position + query.length });
-      position += query.length;
-      continue;
-    }
-    position += 1;
-  }
-
-  return matches;
+  return findSearchRanges(document, query, options).filter((match) =>
+    !hiddenDisplayMath.some((range) =>
+      match.from === match.to
+        ? match.from > range.from && match.from < range.to
+        : match.from < range.to && match.to > range.from,
+    )
+  );
 }
 
 function validSearchRange(
@@ -414,7 +392,7 @@ function validSearchRange(
       Number.isInteger(match.from) &&
       Number.isInteger(match.to) &&
       match.from >= 0 &&
-      match.from < match.to &&
+      match.from <= match.to &&
       match.to <= documentLength,
   );
 }
@@ -423,6 +401,8 @@ export function replaceCodeMirrorSearchMatch(
   view: EditorView,
   match: SearchRange | null | undefined,
   replacement: string,
+  query = "",
+  options: CodeMirrorSearchOptions = {},
 ) {
   if (
     view.state.facet(EditorState.readOnly) ||
@@ -431,8 +411,13 @@ export function replaceCodeMirrorSearchMatch(
     return false;
   }
 
+  const document = view.state.doc.toString();
   view.dispatch({
-    changes: { from: match.from, insert: replacement, to: match.to },
+    changes: {
+      from: match.from,
+      insert: resolveSearchReplacement(document, match, query, replacement, options),
+      to: match.to,
+    },
     scrollIntoView: true,
   });
   return true;
@@ -442,6 +427,8 @@ export function replaceAllCodeMirrorSearchMatches(
   view: EditorView,
   matches: readonly SearchRange[],
   replacement: string,
+  query = "",
+  options: CodeMirrorSearchOptions = {},
 ) {
   if (view.state.facet(EditorState.readOnly)) return false;
 
@@ -457,10 +444,11 @@ export function replaceAllCodeMirrorSearchMatches(
     nonOverlapping.push(match);
   }
 
+  const document = view.state.doc.toString();
   view.dispatch({
     changes: nonOverlapping.map((match) => ({
       from: match.from,
-      insert: replacement,
+      insert: resolveSearchReplacement(document, match, query, replacement, options),
       to: match.to,
     })),
     scrollIntoView: true,

--- a/packages/editor/src/codemirror/search.test.ts
+++ b/packages/editor/src/codemirror/search.test.ts
@@ -56,6 +56,26 @@ describe("CodeMirror search decorations", () => {
     });
   });
 
+  it("renders zero-width regular expression matches", () => {
+    const view = createView("alpha\nbeta");
+
+    updateCodeMirrorSearchDecorations(
+      view,
+      [
+        { from: 0, to: 0 },
+        { from: 6, to: 6 },
+      ],
+      1,
+    );
+
+    expect(view.dom.querySelectorAll(".cm-markra-search-zero-width")).toHaveLength(2);
+    expect(view.dom.querySelectorAll(".cm-markra-search-match-current")).toHaveLength(1);
+    expect(getCodeMirrorSearchState(view.state).matches).toEqual([
+      { from: 0, to: 0 },
+      { from: 6, to: 6 },
+    ]);
+  });
+
   it("drops invalid ranges and clears stale results after document edits", () => {
     const view = createView();
 
@@ -81,6 +101,9 @@ describe("CodeMirror search decorations", () => {
     const view = createView();
 
     expect(scrollCodeMirrorSearchMatchIntoView(view, { from: 11, to: 16 })).toBe(
+      true,
+    );
+    expect(scrollCodeMirrorSearchMatchIntoView(view, { from: 6, to: 6 })).toBe(
       true,
     );
     expect(scrollCodeMirrorSearchMatchIntoView(view, { from: 20, to: 30 })).toBe(

--- a/packages/editor/src/codemirror/search.ts
+++ b/packages/editor/src/codemirror/search.ts
@@ -8,6 +8,7 @@ import {
   Decoration,
   EditorView,
   type DecorationSet,
+  WidgetType,
 } from "@codemirror/view";
 import type { SearchRange } from "@markra/shared";
 
@@ -29,6 +30,29 @@ const emptySearchState: CodeMirrorSearchState = {
 };
 const setSearchEffect = StateEffect.define<SearchUpdate>();
 
+class ZeroWidthSearchMatchWidget extends WidgetType {
+  constructor(readonly active: boolean) {
+    super();
+  }
+
+  eq(other: ZeroWidthSearchMatchWidget) {
+    return other.active === this.active;
+  }
+
+  toDOM() {
+    const marker = document.createElement("span");
+    marker.className = this.active
+      ? "cm-markra-search-zero-width cm-markra-search-match-current"
+      : "cm-markra-search-zero-width";
+    marker.setAttribute("aria-hidden", "true");
+    return marker;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
 function validMatches(
   matches: readonly SearchRange[],
   documentLength: number,
@@ -40,7 +64,7 @@ function validMatches(
         Number.isInteger(match.from) &&
         Number.isInteger(match.to) &&
         match.from >= 0 &&
-        match.from < match.to &&
+        match.from <= match.to &&
         match.to <= documentLength,
     )
     .sort((left, right) => left.from - right.from || left.to - right.to);
@@ -55,14 +79,19 @@ function createSearchState(
     (match) => match.originalIndex === update.activeIndex,
   );
   const decorations = Decoration.set(
-    matches.map((match, index) =>
-      Decoration.mark({
-        class:
-          index === activeIndex
-            ? "cm-markra-search-match cm-markra-search-match-current"
-            : "cm-markra-search-match",
-      }).range(match.from, match.to),
-    ),
+    matches.map((match, index) => {
+      const active = index === activeIndex;
+      return match.from === match.to
+        ? Decoration.widget({
+            side: 1,
+            widget: new ZeroWidthSearchMatchWidget(active),
+          }).range(match.from)
+        : Decoration.mark({
+            class: active
+              ? "cm-markra-search-match cm-markra-search-match-current"
+              : "cm-markra-search-match",
+          }).range(match.from, match.to);
+    }),
     true,
   );
 
@@ -99,6 +128,13 @@ const searchTheme = EditorView.baseTheme({
     backgroundColor: "color-mix(in srgb, #f59e0b 58%, transparent)",
     boxShadow: "0 0 0 1px color-mix(in srgb, #d97706 72%, transparent)",
   },
+  ".cm-markra-search-zero-width": {
+    borderLeft: "2px solid color-mix(in srgb, #f59e0b 76%, transparent)",
+    display: "inline-block",
+    height: "1em",
+    marginLeft: "-1px",
+    verticalAlign: "text-bottom",
+  },
 });
 
 export function codeMirrorSearchPlugin(): Extension {
@@ -128,7 +164,7 @@ function validScrollMatch(
       Number.isInteger(match.from) &&
       Number.isInteger(match.to) &&
       match.from >= 0 &&
-      match.from < match.to &&
+      match.from <= match.to &&
       match.to <= documentLength,
   );
 }

--- a/packages/shared/src/search.test.ts
+++ b/packages/shared/src/search.test.ts
@@ -1,4 +1,8 @@
-import { findSearchRanges } from "./search";
+import {
+  findSearchRanges,
+  isValidSearchQuery,
+  resolveSearchReplacement
+} from "./search";
 
 describe("document search", () => {
   it("matches punctuation exactly without width normalization", () => {
@@ -31,5 +35,47 @@ describe("document search", () => {
       { from: 0, to: 5 },
       { from: 11, to: 16 }
     ]);
+  });
+
+  it("matches regular expressions with multiline and case-sensitive options", () => {
+    const text = "Alpha-12\nalpha-345\nbeta-9";
+
+    expect(findSearchRanges(text, "^alpha-\\d+$", { regularExpression: true })).toEqual([
+      { from: 0, to: 8 },
+      { from: 9, to: 18 }
+    ]);
+    expect(findSearchRanges(text, "^alpha-\\d+$", {
+      caseSensitive: true,
+      regularExpression: true
+    })).toEqual([{ from: 9, to: 18 }]);
+  });
+
+  it("handles zero-width regular expression matches without looping", () => {
+    expect(findSearchRanges("alpha\nbeta", "^", { regularExpression: true })).toEqual([
+      { from: 0, to: 0 },
+      { from: 6, to: 6 }
+    ]);
+  });
+
+  it("reports invalid regular expressions without affecting literal queries", () => {
+    expect(isValidSearchQuery("[", { regularExpression: true })).toBe(false);
+    expect(isValidSearchQuery("[", { regularExpression: false })).toBe(true);
+    expect(findSearchRanges("[", "[", { regularExpression: true })).toEqual([]);
+  });
+
+  it("expands numbered and named capture groups in replacements", () => {
+    const text = "first:last";
+    const [range] = findSearchRanges(text, "(?<first>\\w+):(?<last>\\w+)", {
+      caseSensitive: true,
+      regularExpression: true
+    });
+
+    expect(resolveSearchReplacement(
+      text,
+      range,
+      "(?<first>\\w+):(?<last>\\w+)",
+      "$<last>, $1 ($$)",
+      { caseSensitive: true, regularExpression: true }
+    )).toBe("last, first ($)");
   });
 });

--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -3,10 +3,69 @@ export type SearchRange = {
   to: number;
 };
 
-type SearchOptions = {
+export type SearchOptions = {
   caseSensitive?: boolean;
   maxMatches?: number;
+  regularExpression?: boolean;
 };
+
+type RegularExpressionMode = "global" | "sticky";
+
+function regularExpressionFlags(options: SearchOptions, mode: RegularExpressionMode) {
+  return `${mode === "global" ? "g" : ""}${options.caseSensitive ? "" : "i"}mu${mode === "sticky" ? "y" : ""}`;
+}
+
+function createRegularExpression(
+  query: string,
+  options: SearchOptions,
+  mode: RegularExpressionMode
+) {
+  try {
+    return new RegExp(query, regularExpressionFlags(options, mode));
+  } catch {
+    return null;
+  }
+}
+
+function nextStringIndex(text: string, index: number) {
+  if (index >= text.length) return text.length + 1;
+
+  return index + (text.codePointAt(index)! > 0xffff ? 2 : 1);
+}
+
+export function isValidSearchQuery(query: string, options: SearchOptions = {}) {
+  return !options.regularExpression || createRegularExpression(query, options, "global") !== null;
+}
+
+function findRegularExpressionRanges(
+  text: string,
+  query: string,
+  options: SearchOptions,
+  maxMatches: number
+) {
+  const expression = createRegularExpression(query, options, "global");
+  if (!expression) return [];
+
+  const ranges: SearchRange[] = [];
+  let match = expression.exec(text);
+
+  while (match) {
+    ranges.push({
+      from: match.index,
+      to: match.index + match[0].length
+    });
+    if (ranges.length >= maxMatches) return ranges;
+
+    if (match[0].length === 0) {
+      // RegExp.exec does not advance after an empty match, so move by one
+      // Unicode code point to keep anchors and lookarounds from looping.
+      expression.lastIndex = nextStringIndex(text, match.index);
+    }
+    match = expression.exec(text);
+  }
+
+  return ranges;
+}
 
 export function findSearchRanges(text: string, query: string, options: SearchOptions = {}): SearchRange[] {
   if (!query) return [];
@@ -14,6 +73,9 @@ export function findSearchRanges(text: string, query: string, options: SearchOpt
   const ranges: SearchRange[] = [];
   const maxMatches = Math.max(0, options.maxMatches ?? Number.POSITIVE_INFINITY);
   if (maxMatches === 0) return ranges;
+  if (options.regularExpression) {
+    return findRegularExpressionRanges(text, query, options, maxMatches);
+  }
 
   const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
   let from = 0;
@@ -38,6 +100,36 @@ export function findSearchRanges(text: string, query: string, options: SearchOpt
   }
 
   return ranges;
+}
+
+export function resolveSearchReplacement(
+  text: string,
+  range: SearchRange,
+  query: string,
+  replacement: string,
+  options: SearchOptions = {}
+) {
+  if (!options.regularExpression) return replacement;
+
+  // Keep the full input available so lookbehind and JavaScript replacement
+  // tokens such as $`, $', $1, and $<name> retain their native semantics.
+  const expression = createRegularExpression(query, options, "sticky");
+  if (!expression) return replacement;
+
+  expression.lastIndex = range.from;
+  const match = expression.exec(text);
+  if (
+    !match
+    || match.index !== range.from
+    || match.index + match[0].length !== range.to
+  ) {
+    return replacement;
+  }
+
+  expression.lastIndex = range.from;
+  const replacedText = text.replace(expression, replacement);
+  const suffixLength = text.length - range.to;
+  return replacedText.slice(range.from, replacedText.length - suffixLength);
 }
 
 export function normalizeSearchIndex(index: number, count: number) {


### PR DESCRIPTION
## Summary
- add a regular-expression toggle to document search with invalid-pattern feedback
- support numbered and named capture groups for current and all replacements in source and visual modes
- render zero-width matches and keep visual search results aligned with the active query
- reset new searches to the first match and invalidate stale visual match ranges before replacement

## Why
Document search previously supported literal matching only. The initial regular-expression path also exposed an asynchronous visual-search state issue where a new query could start on the last result or reuse ranges from the previous pattern.

## Validation
- `pnpm --filter @markra/shared test` — 66 tests passed
- `pnpm --filter @markra/editor test` — 450 tests passed
- `pnpm --filter @markra/app test` — 1496 tests passed
- `pnpm --filter @markra/shared build` and `typecheck:test` passed
- `pnpm --filter @markra/editor build` and `typecheck:test` passed
- `pnpm --filter @markra/app build` and `typecheck:test` passed
- runtime browser QA: `(\\w+)-(\\d+)` found nine matches, replacing the ninth `item-123` with `a` succeeded, and replace-all expanded `$2-$1` capture groups
- `git diff --check origin/v2...HEAD` passed

## Risk
- regular expressions follow JavaScript Unicode and multiline semantics; invalid patterns are rejected and replacement controls are disabled
- no data or configuration migration is required
