### PR TITLE
fix(editor): preserve selection across view modes

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -116,6 +116,17 @@ import { configureAppRuntime, createDefaultAppRuntime, resetAppRuntimeForTests }
 import { showAppToast } from "./lib/app-toast";
 import { createShardedTest } from "./test/shard";
 
+const scheduleMarkdownSourceEditorPreloadMock = vi.hoisted(() => vi.fn(() => vi.fn()));
+
+vi.mock("./components/LazyMarkdownSourceEditor", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./components/LazyMarkdownSourceEditor")>();
+
+  return {
+    ...actual,
+    scheduleMarkdownSourceEditorPreload: scheduleMarkdownSourceEditorPreloadMock
+  };
+});
+
 installAppTestHarness();
 
 // Vitest shards files only, so CI needs a local registration boundary to split this monolithic suite by test title.
@@ -615,6 +626,15 @@ describe("Markra workspace", () => {
     expect(shell).toHaveClass("bg-(--bg-primary)");
     expect(shell).toHaveClass("grid-rows-[minmax(0,1fr)]");
     expect(shell).toHaveClass("overscroll-none");
+  });
+
+  it("schedules source editor preloading after the visual editor is ready", async () => {
+    scheduleMarkdownSourceEditorPreloadMock.mockClear();
+
+    const { container } = renderApp();
+
+    await waitFor(() => expect(container.querySelector(".cm-editor")).toBeInTheDocument());
+    await waitFor(() => expect(scheduleMarkdownSourceEditorPreloadMock).toHaveBeenCalled());
   });
 
   it("imports local images through the native file menu without replacing manual image insertion", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -6531,6 +6531,53 @@ describe("Markra workspace", () => {
     expect(container.querySelectorAll(".cm-markra-empty-line")).toHaveLength(1);
   });
 
+  it("preserves the active selection and editor focus across visual and source modes", async () => {
+    const syntheticContent = "# Synthetic cursor\n\nalpha beta gamma\n\nomega";
+    mockOpenMarkdownFile({
+      content: syntheticContent,
+      name: "synthetic.md",
+      path: mockNativePath
+    });
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    await expectVisibleMarkdownText("Synthetic cursor");
+
+    const visualEditor = screen.getByRole("textbox", { name: "Markdown document" });
+    const visualView = getMarkdownSourceView(visualEditor);
+    const visualCursor = syntheticContent.indexOf("beta") + 2;
+    const visualSelection = EditorSelection.single(visualCursor, syntheticContent.indexOf("alpha"));
+    act(() => {
+      visualView.dispatch({ selection: visualSelection });
+    });
+
+    await selectEditorViewMode("Source code");
+
+    const sourceEditor = await screen.findByRole("textbox", { name: "Markdown source" });
+    const sourceView = getMarkdownSourceView(sourceEditor);
+    await waitFor(() => {
+      expect(sourceView.state.selection.eq(visualSelection)).toBe(true);
+      expect(sourceEditor).toHaveFocus();
+    });
+
+    const sourceCursor = syntheticContent.indexOf("omega") + 3;
+    const sourceSelection = EditorSelection.single(sourceCursor, syntheticContent.indexOf("gamma"));
+    act(() => {
+      sourceView.dispatch({ selection: sourceSelection });
+    });
+    const requestMeasureSpy = vi.spyOn(visualView, "requestMeasure");
+    requestMeasureSpy.mockClear();
+
+    await selectEditorViewMode("Preview");
+
+    await waitFor(() => {
+      expect(visualView.state.selection.eq(sourceSelection)).toBe(true);
+      expect(visualEditor).toHaveFocus();
+      expect(requestMeasureSpy).toHaveBeenCalled();
+    });
+    requestMeasureSpy.mockRestore();
+  });
+
   it("commits pending visual IME content before source mode mounts", async () => {
     renderApp();
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -90,6 +90,7 @@ import {
   useSettingsWindowShortcut
 } from "./hooks/useNativeBindings";
 import type { EditorView } from "@codemirror/view";
+import { EditorSelection } from "@codemirror/state";
 import {
   aiTranslationLanguageName,
   clampNumber,
@@ -289,7 +290,15 @@ export async function refreshImportedAttachmentTree(refreshTree: () => Promise<u
 type AiQuickActionIntent = Exclude<AiEditIntent, "custom">;
 type EditorMode = "source" | "split" | "visual";
 type EditorSurface = "source" | "visual";
+type EditorSelectionSnapshot = {
+  mainIndex: number;
+  ranges: Array<{
+    anchor: number;
+    head: number;
+  }>;
+};
 type DocumentTabViewState = {
+  selection?: EditorSelectionSnapshot;
   sourceScrollTop?: number;
   visualScrollTop?: number;
 };
@@ -298,6 +307,29 @@ type PendingEditorModeScroll = {
   tabId: string;
   targetSurface: EditorSurface;
 };
+type PendingEditorModeSelection = {
+  selection: EditorSelectionSnapshot;
+  tabId: string;
+  targetSurface: EditorSurface;
+};
+
+function boundedEditorSelection(selection: EditorSelectionSnapshot, documentLength: number) {
+  const ranges = selection.ranges.length > 0
+    ? selection.ranges.map((range) => EditorSelection.range(
+        Math.max(0, Math.min(documentLength, range.anchor)),
+        Math.max(0, Math.min(documentLength, range.head))
+      ))
+    : [EditorSelection.cursor(0)];
+
+  return EditorSelection.create(ranges, Math.max(0, Math.min(ranges.length - 1, selection.mainIndex)));
+}
+
+function editorSelectionSnapshot(selection: EditorSelection): EditorSelectionSnapshot {
+  return {
+    mainIndex: selection.mainIndex,
+    ranges: selection.ranges.map(({ anchor, head }) => ({ anchor, head }))
+  };
+}
 
 export { runEditorLinkCommand } from "./app/editor-link-command";
 export { globalSearchDebounceMs } from "./hooks/useWorkspaceSearch";
@@ -481,6 +513,7 @@ function WorkspaceApp() {
   const [splitVisualPanePercent, setSplitVisualPanePercent] = useState(defaultSplitVisualPanePercent);
   const [sideDocumentMainPanePercent, setSideDocumentMainPanePercent] = useState(defaultSideDocumentMainPanePercent);
   const [editorTabDropTargetActive, setEditorTabDropTargetActive] = useState(false);
+  const [sourceEditorReadySequence, setSourceEditorReadySequence] = useState(0);
   const [visualEditorReadySequence, setVisualEditorReadySequence] = useState(0);
   const [exportSnapshot, setExportSnapshot] = useState<MarkdownExportSnapshot | null>(null);
   const sourceMode = editorMode === "source";
@@ -505,10 +538,12 @@ function WorkspaceApp() {
   });
   const largeMarkdownVisualBlockedRef = useRef(false);
   const mainDocumentPaneRef = useRef<HTMLDivElement | null>(null);
+  const sourceEditorRef = useRef<EditorView | null>(null);
   const sourceScrollRef = useRef<HTMLElement | null>(null);
   const visualScrollRef = useRef<HTMLElement | null>(null);
   const mainVisualEditorsRef = useRef(new Map<string, EditorView>());
   const documentTabViewStatesRef = useRef(new Map<string, DocumentTabViewState>());
+  const pendingEditorModeSelectionRef = useRef<PendingEditorModeSelection | null>(null);
   const pendingEditorModeScrollRef = useRef<PendingEditorModeScroll | null>(null);
   const splitSurfaceRef = useRef<HTMLDivElement | null>(null);
   const sideDocumentSurfaceRef = useRef<HTMLDivElement | null>(null);
@@ -902,6 +937,14 @@ function WorkspaceApp() {
     handleVisualEditorReady,
     rememberMarkdownTabVisualBaseline
   ]);
+  const handleSourceEditorReady = useCallback((readyEditor: EditorView | null, disposedEditor?: EditorView) => {
+    if (readyEditor) {
+      sourceEditorRef.current = readyEditor;
+      setSourceEditorReadySequence((current) => current + 1);
+    } else if (sourceEditorRef.current === disposedEditor) {
+      sourceEditorRef.current = null;
+    }
+  }, []);
   useEffect(() => {
     if (!activeTabId) {
       handleVisualEditorReady(null);
@@ -1285,6 +1328,16 @@ function WorkspaceApp() {
     if (activeImageFile || !activeTabId) return;
 
     const nextState: DocumentTabViewState = {};
+    const activeEditor = editorMode === "source"
+      ? sourceEditorRef.current
+      : editorMode === "visual"
+        ? mainVisualEditorsRef.current.get(activeTabId) ?? null
+        : activeEditorSurface === "source"
+          ? sourceEditorRef.current
+          : mainVisualEditorsRef.current.get(activeTabId) ?? null;
+    if (activeEditor) {
+      nextState.selection = editorSelectionSnapshot(activeEditor.state.selection);
+    }
     if (editorMode === "visual" && visualScrollRef.current) {
       nextState.visualScrollTop = visualScrollRef.current.scrollTop;
     } else if (editorMode === "source" && sourceScrollRef.current) {
@@ -1297,7 +1350,20 @@ function WorkspaceApp() {
       }
     }
     if (Object.keys(nextState).length > 0) saveDocumentTabViewState(activeTabId, nextState);
+    return nextState.selection;
   }, [activeEditorSurface, activeImageFile, activeTabId, editorMode, saveDocumentTabViewState]);
+  const queueEditorModeSelection = useCallback((
+    targetSurface: EditorSurface,
+    selection: EditorSelectionSnapshot | undefined
+  ) => {
+    if (!activeTabId || !selection) return;
+
+    pendingEditorModeSelectionRef.current = {
+      selection,
+      tabId: activeTabId,
+      targetSurface
+    };
+  }, [activeTabId]);
   const queueEditorModeScroll = useCallback((targetSurface: EditorSurface) => {
     if (!activeTabId) return;
 
@@ -3568,7 +3634,7 @@ function WorkspaceApp() {
     if (!sourceModeAvailable) return;
     if (nextMode === editorMode) return;
 
-    captureActiveDocumentViewState();
+    const selection = captureActiveDocumentViewState();
     // IME changes can still be pending in the visual surface when source mode
     // mounts, so snapshot the originating editor before changing surfaces.
     commitActiveVisualMarkdown();
@@ -3576,6 +3642,7 @@ function WorkspaceApp() {
     if (nextMode === "visual") {
       if (sourceMode) syncSourceEditsToVisualHistory();
       queueEditorModeScroll("visual");
+      queueEditorModeSelection("visual", selection);
       setEditorMode("visual");
       setActiveEditorSurface("visual");
       return;
@@ -3585,6 +3652,7 @@ function WorkspaceApp() {
       updateActiveAiSelection(null);
       handleAiCommandClose();
       queueEditorModeScroll("source");
+      queueEditorModeSelection("source", selection);
       setEditorMode("source");
       setActiveEditorSurface("source");
       return;
@@ -3593,6 +3661,7 @@ function WorkspaceApp() {
     updateActiveAiSelection(null);
     handleAiCommandClose();
     if (sideDocumentGroup) clearSideDocumentGroup();
+    queueEditorModeSelection(sourceMode ? "source" : "visual", selection);
     setEditorMode("split");
     setActiveEditorSurface(sourceMode ? "source" : "visual");
   }, [
@@ -3602,6 +3671,7 @@ function WorkspaceApp() {
     editorMode,
     handleAiCommandClose,
     queueEditorModeScroll,
+    queueEditorModeSelection,
     sideDocumentGroup,
     sourceMode,
     sourceModeAvailable,
@@ -3827,6 +3897,23 @@ function WorkspaceApp() {
       )) {
         pendingEditorModeScrollRef.current = null;
       }
+
+      const pendingSelection = pendingEditorModeSelectionRef.current;
+      const targetSurface = editorMode === "split" ? activeEditorSurface : editorMode;
+      if (pendingSelection?.tabId === activeTabId && pendingSelection.targetSurface === targetSurface) {
+        const targetEditor = targetSurface === "source"
+          ? sourceEditorRef.current
+          : mainVisualEditorsRef.current.get(activeTabId) ?? null;
+        if (targetEditor) {
+          const selection = boundedEditorSelection(pendingSelection.selection, targetEditor.state.doc.length);
+          // CodeMirror may measure while its visual surface is hidden; refresh it only after React reveals the target.
+          targetEditor.requestMeasure();
+          targetEditor.dispatch({ selection, scrollIntoView: true });
+          targetEditor.focus();
+          saveDocumentTabViewState(activeTabId, { selection: editorSelectionSnapshot(selection) });
+          pendingEditorModeSelectionRef.current = null;
+        }
+      }
     });
 
     return () => {
@@ -3834,11 +3921,13 @@ function WorkspaceApp() {
     };
   }, [
     activeImageFile,
+    activeEditorSurface,
     activeTabId,
     document.revision,
     editorMode,
     hasOpenDocument,
     saveDocumentTabViewState,
+    sourceEditorReadySequence,
     visualEditorReadySequence
   ]);
   const aiAgentContext = useMemo(() => ({
@@ -4267,6 +4356,13 @@ function WorkspaceApp() {
     ]
   );
   const mainVisualEditorTabs = documentTabs.filter((tab) => tab.open);
+  const pendingSourceSelection = pendingEditorModeSelectionRef.current;
+  const activeSourceInitialSelection = pendingSourceSelection?.tabId === activeTabId
+    && pendingSourceSelection.targetSurface === "source"
+    ? pendingSourceSelection.selection
+    : activeTabId
+      ? documentTabViewStatesRef.current.get(activeTabId)?.selection
+      : undefined;
   const mainVisualEditors = (
     <>
       {mainVisualEditorTabs.map((tab) => {
@@ -4727,6 +4823,7 @@ function WorkspaceApp() {
                           contentWidthPx={activeEditorContentWidthPx}
                           editorFontFamily={editorPreferences.preferences.editorFontFamily}
                           extendedSyntax={editorPreferences.preferences.extendedSyntax}
+                          initialSelection={activeSourceInitialSelection}
                           language={appLanguage.language}
                           lineHeight={editorPreferences.preferences.lineHeight}
                           onChange={(content) => handleSourceMarkdownTabChange(
@@ -4738,6 +4835,7 @@ function WorkspaceApp() {
                           )}
                           onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
                           onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
+                          onEditorReady={handleSourceEditorReady}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
                           readOnly={readOnlyMode}
@@ -4765,6 +4863,7 @@ function WorkspaceApp() {
                           contentWidthPx={activeEditorContentWidthPx}
                           editorFontFamily={editorPreferences.preferences.editorFontFamily}
                           extendedSyntax={editorPreferences.preferences.extendedSyntax}
+                          initialSelection={activeSourceInitialSelection}
                           language={appLanguage.language}
                           lineHeight={editorPreferences.preferences.lineHeight}
                           onChange={(content) => handleSourceMarkdownTabChange(
@@ -4776,6 +4875,7 @@ function WorkspaceApp() {
                           )}
                           onContentWidthChange={editorWidthResizerVisible ? handleEditorContentWidthChange : undefined}
                           onContentWidthResizeEnd={editorWidthResizerVisible ? handleEditorContentWidthResizeEnd : undefined}
+                          onEditorReady={handleSourceEditorReady}
                           onScroll={handleSourcePaneScroll}
                           onSelectionTextChange={updateSelectedWordCount}
                           readOnly={readOnlyMode}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -28,7 +28,10 @@ import {
   type MarkdownExportSnapshot
 } from "./components/MarkdownExportDocument";
 import { MarkdownPaper } from "./components/MarkdownPaper";
-import { LazyMarkdownSourceEditor } from "./components/LazyMarkdownSourceEditor";
+import {
+  LazyMarkdownSourceEditor,
+  scheduleMarkdownSourceEditorPreload
+} from "./components/LazyMarkdownSourceEditor";
 import {
   MarkdownTabsBar,
   markdownTabDragDataType,
@@ -2997,6 +3000,13 @@ function WorkspaceApp() {
   const titleDocumentKind = activeImageFile ? "image" : hasOpenDocument ? "file" : "folder";
   const sourceModeAvailable = hasOpenDocument && !activeImageFile;
   const supportsAiThinking = selectedInlineAiModel?.capabilities.includes("reasoning") ?? false;
+  useEffect(() => {
+    if (editorMode !== "visual" || !sourceModeAvailable || !activeTabId) return;
+    // Keep visual editor setup on the startup path; warm the source chunk only after it is usable.
+    if (!mainVisualEditorsRef.current.has(activeTabId)) return;
+
+    return scheduleMarkdownSourceEditorPreload();
+  }, [activeTabId, editorMode, sourceModeAvailable, visualEditorReadySequence]);
   useEffect(() => {
     if (activeEditorSurface !== "source") return;
 

--- a/packages/app/src/components/LazyMarkdownSourceEditor.tsx
+++ b/packages/app/src/components/LazyMarkdownSourceEditor.tsx
@@ -56,7 +56,16 @@ function MarkdownSourceEditorFallback({
         className={`markdown-source-paper relative mx-auto min-h-screen w-full max-w-215 px-18 ${markdownSourceTopInsetClassName(topInset)} text-[16px] leading-[1.65] text-(--text-primary) max-[900px]:px-5.25`}
         data-editor-engine="source-loading"
         style={paperStyle}
-      />
+      >
+        <div className="flex flex-col gap-3 pt-1 opacity-70">
+          <span className="h-3 w-2/5 rounded-sm bg-(--bg-active)" data-source-loading-line />
+          <span className="h-3 w-4/5 rounded-sm bg-(--bg-active)" data-source-loading-line />
+          <span className="h-3 w-3/5 rounded-sm bg-(--bg-active)" data-source-loading-line />
+          <span className="h-3 w-5/6 rounded-sm bg-(--bg-active)" data-source-loading-line />
+          <span className="h-3 w-1/2 rounded-sm bg-(--bg-active)" data-source-loading-line />
+          <span className="h-3 w-3/4 rounded-sm bg-(--bg-active)" data-source-loading-line />
+        </div>
+      </article>
     </section>
   );
 }

--- a/packages/app/src/components/LazyMarkdownSourceEditor.tsx
+++ b/packages/app/src/components/LazyMarkdownSourceEditor.tsx
@@ -6,8 +6,61 @@ import {
 import { editorFontFamilyCssValue } from "../lib/editor-font";
 import type { MarkdownSourceEditorProps } from "./MarkdownSourceEditor";
 
+type MarkdownSourceEditorModule = typeof import("./MarkdownSourceEditor");
+type MarkdownSourceEditorPreloadTarget = {
+  cancelIdleCallback?: (handle: number) => unknown;
+  clearTimeout: (handle: number) => unknown;
+  requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+  setTimeout: (callback: () => void, delay: number) => number;
+};
+
+const markdownSourceEditorPreloadIdleTimeoutMs = 1_500;
+const markdownSourceEditorPreloadFallbackDelayMs = 800;
+let markdownSourceEditorModulePromise: Promise<MarkdownSourceEditorModule> | null = null;
+
+function loadMarkdownSourceEditor() {
+  if (markdownSourceEditorModulePromise) return markdownSourceEditorModulePromise;
+
+  const modulePromise = import("./MarkdownSourceEditor");
+  markdownSourceEditorModulePromise = modulePromise;
+  void modulePromise.catch(() => {
+    if (markdownSourceEditorModulePromise === modulePromise) markdownSourceEditorModulePromise = null;
+  });
+
+  return modulePromise;
+}
+
+export function preloadMarkdownSourceEditor() {
+  return loadMarkdownSourceEditor();
+}
+
+export function scheduleMarkdownSourceEditorPreload(
+  target: MarkdownSourceEditorPreloadTarget = window
+): () => void {
+  if (markdownSourceEditorModulePromise) return () => {};
+
+  const startPreload = () => {
+    void preloadMarkdownSourceEditor().catch(() => {});
+  };
+  if (target.requestIdleCallback) {
+    const handle = target.requestIdleCallback(startPreload, {
+      timeout: markdownSourceEditorPreloadIdleTimeoutMs
+    });
+
+    return () => {
+      target.cancelIdleCallback?.(handle);
+    };
+  }
+
+  const handle = target.setTimeout(startPreload, markdownSourceEditorPreloadFallbackDelayMs);
+
+  return () => {
+    target.clearTimeout(handle);
+  };
+}
+
 const MarkdownSourceEditor = lazy(async () => {
-  const module = await import("./MarkdownSourceEditor");
+  const module = await loadMarkdownSourceEditor();
 
   return { default: module.MarkdownSourceEditor };
 });

--- a/packages/app/src/components/MarkdownSourceEditor.tsx
+++ b/packages/app/src/components/MarkdownSourceEditor.tsx
@@ -36,12 +36,20 @@ export type MarkdownSourceEditorProps = {
   contentWidthPx?: number | null;
   editorFontFamily?: EditorFontFamilyPreference;
   extendedSyntax?: ExtendedSyntaxPreferences;
+  initialSelection?: {
+    mainIndex: number;
+    ranges: Array<{
+      anchor: number;
+      head: number;
+    }>;
+  };
   language?: AppLanguage;
   lineHeight?: number;
   onChange: (content: string) => unknown;
   onContentWidthChange?: (width: number) => unknown;
   onContentWidthResizeEnd?: () => unknown;
   onContentWidthResizeStart?: () => unknown;
+  onEditorReady?: (view: EditorView | null, disposedView?: EditorView) => unknown;
   onScroll?: (event: UIEvent<HTMLElement>) => unknown;
   onRedo?: () => unknown;
   onSelectionTextChange?: (text: string | null) => unknown;
@@ -59,6 +67,20 @@ export type MarkdownSourceEditorProps = {
 type MarkdownSourcePaperStyle = CSSProperties & {
   "--source-editor-font-family"?: string;
 };
+
+function boundedInitialSelection(
+  selection: NonNullable<MarkdownSourceEditorProps["initialSelection"]>,
+  documentLength: number
+) {
+  const ranges = selection.ranges.length > 0
+    ? selection.ranges.map((range) => EditorSelection.range(
+        Math.max(0, Math.min(documentLength, range.anchor)),
+        Math.max(0, Math.min(documentLength, range.head))
+      ))
+    : [EditorSelection.cursor(0)];
+
+  return EditorSelection.create(ranges, Math.max(0, Math.min(ranges.length - 1, selection.mainIndex)));
+}
 
 const externalSourceUpdate = Annotation.define<boolean>();
 
@@ -203,12 +225,14 @@ export function MarkdownSourceEditor({
   contentWidthMin = editorCustomContentWidthMin,
   contentWidthPx = null,
   editorFontFamily = { family: null, source: "theme" },
+  initialSelection,
   language = "en",
   lineHeight = 1.65,
   onChange,
   onContentWidthChange,
   onContentWidthResizeEnd,
   onContentWidthResizeStart,
+  onEditorReady,
   onScroll,
   onRedo,
   onSelectionTextChange,
@@ -224,7 +248,9 @@ export function MarkdownSourceEditor({
 }: MarkdownSourceEditorProps) {
   const editorContainerRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef(content);
+  const initialSelectionRef = useRef(initialSelection);
   const onChangeRef = useRef(onChange);
+  const onEditorReadyRef = useRef(onEditorReady);
   const onRedoRef = useRef(onRedo);
   const onSelectionTextChangeRef = useRef(onSelectionTextChange);
   const onUndoRef = useRef(onUndo);
@@ -257,6 +283,10 @@ export function MarkdownSourceEditor({
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  useEffect(() => {
+    onEditorReadyRef.current = onEditorReady;
+  }, [onEditorReady]);
 
   useEffect(() => {
     onRedoRef.current = onRedo;
@@ -329,17 +359,24 @@ export function MarkdownSourceEditor({
       parent: container,
       state: EditorState.create({
         doc: contentRef.current,
-        extensions
+        extensions,
+        ...(initialSelectionRef.current
+          ? {
+              selection: boundedInitialSelection(initialSelectionRef.current, contentRef.current.length)
+            }
+          : {})
       })
     });
 
     viewRef.current = view;
+    onEditorReadyRef.current?.(view);
     if (autoFocus) view.focus();
 
     return () => {
       onSelectionTextChangeRef.current?.(null);
       view.destroy();
       viewRef.current = null;
+      onEditorReadyRef.current?.(null, view);
     };
   }, [extensions]);
 

--- a/packages/app/src/components/SideDocumentPane.lazy.test.tsx
+++ b/packages/app/src/components/SideDocumentPane.lazy.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { scheduleMarkdownSourceEditorPreload } from "./LazyMarkdownSourceEditor";
 import { SideDocumentPane } from "./SideDocumentPane";
 
 const sourceEditorModule = vi.hoisted(() => ({
@@ -39,7 +40,22 @@ describe("SideDocumentPane source editor loading", () => {
     sourceEditorModule.suspend = false;
   });
 
-  it("loads the source editor module only when source mode is rendered", async () => {
+  it("uses a cancellable timeout when idle callbacks are unavailable", () => {
+    const clearTimeout = vi.fn();
+    const setTimeout = vi.fn((_callback: () => void, _delay: number) => 23);
+    const cancelPreload = scheduleMarkdownSourceEditorPreload({
+      clearTimeout,
+      setTimeout
+    });
+
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+
+    cancelPreload();
+
+    expect(clearTimeout).toHaveBeenCalledWith(23);
+  });
+
+  it("preloads the source editor during idle time and reuses it when source mode renders", async () => {
     const props = {
       bodyFontSize: 16,
       content: "# Source",
@@ -57,10 +73,35 @@ describe("SideDocumentPane source editor loading", () => {
     expect(screen.getByTestId("visual-editor")).toBeInTheDocument();
     expect(sourceEditorModule.loads).toBe(0);
 
+    let idleCallback: IdleRequestCallback | null = null;
+    const cancelIdleCallback = vi.fn();
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallback = callback;
+      return 17;
+    });
+    const cancelPreload = scheduleMarkdownSourceEditorPreload({
+      cancelIdleCallback,
+      clearTimeout: vi.fn(),
+      requestIdleCallback,
+      setTimeout: vi.fn((_callback: () => void, _delay: number) => 19)
+    });
+
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: expect.any(Number) });
+    expect(sourceEditorModule.loads).toBe(0);
+
+    await act(async () => {
+      idleCallback?.({ didTimeout: false, timeRemaining: () => 10 });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(sourceEditorModule.loads).toBe(1));
+
     rerender(<SideDocumentPane {...props} mode="source" />);
 
     expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveTextContent("# Source");
     expect(sourceEditorModule.loads).toBe(1);
+
+    cancelPreload();
+    expect(cancelIdleCallback).toHaveBeenCalledWith(17);
   });
 
   it("shows a visible source-shaped placeholder while the editor loads", () => {

--- a/packages/app/src/components/SideDocumentPane.lazy.test.tsx
+++ b/packages/app/src/components/SideDocumentPane.lazy.test.tsx
@@ -2,7 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { SideDocumentPane } from "./SideDocumentPane";
 
 const sourceEditorModule = vi.hoisted(() => ({
-  loads: 0
+  loads: 0,
+  pending: new Promise(() => {}),
+  suspend: false
 }));
 
 vi.mock("./LargeMarkdownNotice", () => ({
@@ -17,18 +19,26 @@ vi.mock("./MarkdownSourceEditor", () => {
   sourceEditorModule.loads += 1;
 
   return {
-    MarkdownSourceEditor: ({ content }: { content: string }) => (
-      <div
-        aria-label="Markdown source"
-        role="textbox"
-      >
-        {content}
-      </div>
-    )
+    MarkdownSourceEditor: ({ content }: { content: string }) => {
+      if (sourceEditorModule.suspend) throw sourceEditorModule.pending;
+
+      return (
+        <div
+          aria-label="Markdown source"
+          role="textbox"
+        >
+          {content}
+        </div>
+      );
+    }
   };
 });
 
 describe("SideDocumentPane source editor loading", () => {
+  beforeEach(() => {
+    sourceEditorModule.suspend = false;
+  });
+
   it("loads the source editor module only when source mode is rendered", async () => {
     const props = {
       bodyFontSize: 16,
@@ -51,5 +61,28 @@ describe("SideDocumentPane source editor loading", () => {
 
     expect(await screen.findByRole("textbox", { name: "Markdown source" })).toHaveTextContent("# Source");
     expect(sourceEditorModule.loads).toBe(1);
+  });
+
+  it("shows a visible source-shaped placeholder while the editor loads", () => {
+    sourceEditorModule.suspend = true;
+
+    const { container } = render(
+      <SideDocumentPane
+        bodyFontSize={16}
+        content="# Synthetic source"
+        contentWidth="default"
+        contentWidthPx={null}
+        editorFontFamily={{ family: null, source: "theme" }}
+        editorTheme="light"
+        lineHeight={1.65}
+        mode="source"
+        onChange={() => {}}
+        revision={0}
+      />
+    );
+
+    const fallback = container.querySelector('[data-editor-engine="source-loading"]');
+    expect(fallback).toBeInTheDocument();
+    expect(fallback?.querySelectorAll("[data-source-loading-line]")).toHaveLength(6);
   });
 });


### PR DESCRIPTION
## Summary
- preserve CodeMirror selections and focus when switching between Preview, Source, and Split modes
- remeasure the revealed editor surface so long documents do not appear blank after a mode switch
- preload the source editor chunk during idle time after the visual editor is ready
- reuse the same module promise for preloading and lazy rendering, with a source-shaped loading placeholder as fallback

## Why
Switching modes recreated the source editor at offset 0 and could leave the visual editor unfocused or measured while hidden. This lost the active cursor position and could make the editing surface appear blank. The first switch also waited for the source editor chunk even when the app had already become idle.

## Validation
- `pnpm --filter @markra/app exec vitest run` — 130 test files and 1493 tests passed
- `pnpm --filter @markra/desktop build` — production build and vendor chunk verification passed
- manual browser QA with an 80-section document across Preview → Source → Split → Preview — cursor continuity, focus restoration, visible rendering, and zero console errors confirmed

## Risk
- preloading starts only after the active visual editor is ready and uses a cancellable idle callback or delayed timeout fallback
- selection offsets are clamped to the current document length before restoration
- no hidden source editor instance, persisted-data change, or configuration migration

Closes #649