### PR TITLE
fix(editor): stabilize math preview scrolling

### DIFF
--- a/packages/editor/src/codemirror/changes.ts
+++ b/packages/editor/src/codemirror/changes.ts
@@ -1,5 +1,5 @@
 import { syntaxTree } from "@codemirror/language";
-import type { EditorState } from "@codemirror/state";
+import type { EditorState, Transaction } from "@codemirror/state";
 import type { ViewUpdate } from "@codemirror/view";
 
 export function syntaxTreeChanged(
@@ -35,30 +35,57 @@ export function updateOnlyInsertsPlainText(update: ViewUpdate) {
   return plainInsertion;
 }
 
-export function updateChangesStayAfter(
-  update: ViewUpdate,
+function changesStayAfter(
+  change: Pick<
+    Transaction,
+    "changes" | "docChanged" | "startState" | "state"
+  >,
   position: number,
   insertedMayAffectSyntax: (source: string) => boolean,
 ) {
-  if (!update.docChanged || update.focusChanged) return false;
+  if (!change.docChanged) return false;
   if (
-    [...update.startState.selection.ranges, ...update.state.selection.ranges]
+    [...change.startState.selection.ranges, ...change.state.selection.ranges]
       .some((range) => range.from <= position)
   ) {
     return false;
   }
 
   let staysAfter = true;
-  update.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+  change.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
     // Removing delimiters can expose syntax that was previously inside code,
     // so both deleted and inserted source participate in invalidation.
     if (
       fromA <= position ||
-      insertedMayAffectSyntax(update.startState.sliceDoc(fromA, toA)) ||
+      insertedMayAffectSyntax(change.startState.sliceDoc(fromA, toA)) ||
       insertedMayAffectSyntax(inserted.toString())
     ) {
       staysAfter = false;
     }
   });
   return staysAfter;
+}
+
+export function transactionChangesStayAfter(
+  transaction: Transaction,
+  position: number,
+  insertedMayAffectSyntax: (source: string) => boolean,
+) {
+  return changesStayAfter(
+    transaction,
+    position,
+    insertedMayAffectSyntax,
+  );
+}
+
+export function updateChangesStayAfter(
+  update: ViewUpdate,
+  position: number,
+  insertedMayAffectSyntax: (source: string) => boolean,
+) {
+  return !update.focusChanged && changesStayAfter(
+    update,
+    position,
+    insertedMayAffectSyntax,
+  );
 }

--- a/packages/editor/src/codemirror/math-preview.test.ts
+++ b/packages/editor/src/codemirror/math-preview.test.ts
@@ -2,12 +2,14 @@ import { EditorSelection, EditorState, type Extension } from "@codemirror/state"
 import { EditorView, ViewUpdate, type PluginValue, type ViewPlugin } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { liveMarkdown, mathPreviewPlugin } from "./index.ts";
+import { codeMirrorVimModeChangedEffect } from "./vim.ts";
 import "./dom.test-support.ts";
 
 const syntaxTreeIterations = vi.hoisted(
   (): Array<{ from: number | undefined; to: number | undefined }> => [],
 );
 const syntaxTreeProxies = vi.hoisted(() => new WeakMap<object, object>());
+const mathRenderCalls = vi.hoisted((): string[] => []);
 
 vi.mock("@codemirror/language", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codemirror/language")>();
@@ -34,7 +36,42 @@ vi.mock("@codemirror/language", async (importOriginal) => {
   };
 });
 
+vi.mock("../math-render.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../math-render.ts")>();
+  return {
+    ...actual,
+    renderMarkraMathToString(
+      ...args: Parameters<typeof actual.renderMarkraMathToString>
+    ) {
+      mathRenderCalls.push(args[0]);
+      return actual.renderMarkraMathToString(...args);
+    },
+  };
+});
+
 const views: EditorView[] = [];
+
+function decorationRanges(view: EditorView, widgetName: string) {
+  const ranges: Array<{
+    block: boolean;
+    estimatedHeight: number;
+    from: number;
+    to: number;
+  }> = [];
+  for (const source of view.state.facet(EditorView.decorations)) {
+    if (typeof source === "function") continue;
+    source.between(0, view.state.doc.length, (from, to, decoration) => {
+      if (decoration.spec.widget?.constructor.name !== widgetName) return;
+      ranges.push({
+        block: decoration.spec.block === true,
+        estimatedHeight: decoration.spec.widget.estimatedHeight,
+        from,
+        to,
+      });
+    });
+  }
+  return ranges;
+}
 
 function createView(
   doc: string,
@@ -59,10 +96,34 @@ function createView(
 
 afterEach(() => {
   for (const view of views.splice(0)) view.destroy();
+  mathRenderCalls.splice(0);
   document.body.replaceChildren();
 });
 
 describe("mathPreviewPlugin", () => {
+  it("replaces multiline display math with one block decoration", () => {
+    const source = [
+      "Before",
+      "",
+      "$$",
+      String.raw`\frac{x + y}{z}`,
+      "$$",
+      "",
+      "After",
+    ].join("\n");
+    const mathFrom = source.indexOf("$$");
+    const mathTo = source.lastIndexOf("$$") + 2;
+    const view = createView(source);
+
+    expect(decorationRanges(view, "MathWidget")).toContainEqual({
+      block: true,
+      estimatedHeight: 78,
+      from: mathFrom,
+      to: mathTo,
+    });
+    expect(view.dom.querySelector(".cm-markra-math-hidden-line")).toBeNull();
+  });
+
   it("does not rebuild every math decoration for viewport-only updates", () => {
     const doc = Array.from(
       { length: 200 },
@@ -90,6 +151,20 @@ describe("mathPreviewPlugin", () => {
         ({ from, to }) => from === undefined && to === undefined,
       ),
     ).toHaveLength(0);
+  });
+
+  it("reuses rendered formulas for selection-only reveal updates", () => {
+    const doc = Array.from(
+      { length: 200 },
+      (_, index) => `Synthetic formula ${index}: $x_${index}$.`,
+    ).join("\n\n");
+    const firstFormula = doc.indexOf("$x_0$") + 1;
+    const view = createView(doc);
+    mathRenderCalls.splice(0);
+
+    view.dispatch({ selection: EditorSelection.cursor(firstFormula) });
+
+    expect(mathRenderCalls).toHaveLength(0);
   });
 
   it("does not rescan math when plain text changes after it", () => {
@@ -172,7 +247,10 @@ describe("mathPreviewPlugin", () => {
     const view = createView(doc);
 
     view.scrollDOM.classList.add("cm-vimMode");
-    view.dispatch({ selection: EditorSelection.cursor(0) });
+    view.dispatch({
+      effects: codeMirrorVimModeChangedEffect.of(true),
+      selection: EditorSelection.cursor(0),
+    });
 
     expect(view.dom.querySelector(".markra-math-render-inline")).toBeNull();
     expect(view.dom.textContent).toContain(doc);
@@ -184,6 +262,7 @@ describe("mathPreviewPlugin", () => {
 
     view.scrollDOM.classList.add("cm-vimMode");
     view.dispatch({
+      effects: codeMirrorVimModeChangedEffect.of(true),
       selection: EditorSelection.cursor(doc.indexOf(" tail")),
     });
 

--- a/packages/editor/src/codemirror/math-preview.test.ts
+++ b/packages/editor/src/codemirror/math-preview.test.ts
@@ -1,5 +1,5 @@
-import { EditorSelection, EditorState } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
+import { EditorSelection, EditorState, type Extension } from "@codemirror/state";
+import { EditorView, ViewUpdate, type PluginValue, type ViewPlugin } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { liveMarkdown, mathPreviewPlugin } from "./index.ts";
 import "./dom.test-support.ts";
@@ -7,6 +7,7 @@ import "./dom.test-support.ts";
 const syntaxTreeIterations = vi.hoisted(
   (): Array<{ from: number | undefined; to: number | undefined }> => [],
 );
+const syntaxTreeProxies = vi.hoisted(() => new WeakMap<object, object>());
 
 vi.mock("@codemirror/language", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codemirror/language")>();
@@ -15,7 +16,10 @@ vi.mock("@codemirror/language", async (importOriginal) => {
     ...actual,
     syntaxTree(state: Parameters<typeof actual.syntaxTree>[0]) {
       const tree = actual.syntaxTree(state);
-      return new Proxy(tree, {
+      const cached = syntaxTreeProxies.get(tree);
+      if (cached) return cached as typeof tree;
+
+      const proxy = new Proxy(tree, {
         get(target, property, receiver) {
           if (property !== "iterate") return Reflect.get(target, property, receiver);
           return (spec: Parameters<typeof tree.iterate>[0]) => {
@@ -24,20 +28,26 @@ vi.mock("@codemirror/language", async (importOriginal) => {
           };
         },
       });
+      syntaxTreeProxies.set(tree, proxy);
+      return proxy;
     },
   };
 });
 
 const views: EditorView[] = [];
 
-function createView(doc: string, anchor = doc.length) {
+function createView(
+  doc: string,
+  anchor = doc.length,
+  plugin = mathPreviewPlugin(),
+) {
   const parent = document.createElement("div");
   document.body.append(parent);
   const view = new EditorView({
     parent,
     state: EditorState.create({
       doc,
-      extensions: [liveMarkdown({ plugins: [mathPreviewPlugin()] })],
+      extensions: [liveMarkdown({ plugins: [plugin] })],
       selection: EditorSelection.cursor(anchor),
     }),
   });
@@ -53,6 +63,35 @@ afterEach(() => {
 });
 
 describe("mathPreviewPlugin", () => {
+  it("does not rebuild every math decoration for viewport-only updates", () => {
+    const doc = Array.from(
+      { length: 200 },
+      (_, index) => `Synthetic formula ${index}: $x_${index}$.`,
+    ).join("\n\n");
+    const plugin = mathPreviewPlugin();
+    const view = createView(doc, doc.length, plugin);
+    const [viewPlugin] = plugin.extension as readonly Extension[];
+    const pluginValue = view.plugin(
+      viewPlugin as ViewPlugin<PluginValue & { update(update: ViewUpdate): unknown }>,
+    );
+    const ViewUpdateConstructor = ViewUpdate as unknown as new (
+      view: EditorView,
+      state: EditorState,
+      transactions: readonly [],
+    ) => ViewUpdate;
+    const viewportUpdate = new ViewUpdateConstructor(view, view.state, []);
+    (viewportUpdate as unknown as { flags: number }).flags = 4;
+    syntaxTreeIterations.splice(0);
+
+    pluginValue?.update(viewportUpdate);
+
+    expect(
+      syntaxTreeIterations.filter(
+        ({ from, to }) => from === undefined && to === undefined,
+      ),
+    ).toHaveLength(0);
+  });
+
   it("does not rescan math when plain text changes after it", () => {
     const doc = "Before $x + y$ after\n\nEdit";
     const view = createView(doc);

--- a/packages/editor/src/codemirror/math-preview.test.ts
+++ b/packages/editor/src/codemirror/math-preview.test.ts
@@ -1,5 +1,5 @@
-import { EditorSelection, EditorState, type Extension } from "@codemirror/state";
-import { EditorView, ViewUpdate, type PluginValue, type ViewPlugin } from "@codemirror/view";
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { liveMarkdown, mathPreviewPlugin } from "./index.ts";
 import { codeMirrorVimModeChangedEffect } from "./vim.ts";
@@ -124,28 +124,19 @@ describe("mathPreviewPlugin", () => {
     expect(view.dom.querySelector(".cm-markra-math-hidden-line")).toBeNull();
   });
 
-  it("does not rebuild every math decoration for viewport-only updates", () => {
+  it("does not rebuild every math decoration when the viewport scrolls", async () => {
     const doc = Array.from(
       { length: 200 },
       (_, index) => `Synthetic formula ${index}: $x_${index}$.`,
     ).join("\n\n");
-    const plugin = mathPreviewPlugin();
-    const view = createView(doc, doc.length, plugin);
-    const [viewPlugin] = plugin.extension as readonly Extension[];
-    const pluginValue = view.plugin(
-      viewPlugin as ViewPlugin<PluginValue & { update(update: ViewUpdate): unknown }>,
-    );
-    const ViewUpdateConstructor = ViewUpdate as unknown as new (
-      view: EditorView,
-      state: EditorState,
-      transactions: readonly [],
-    ) => ViewUpdate;
-    const viewportUpdate = new ViewUpdateConstructor(view, view.state, []);
-    (viewportUpdate as unknown as { flags: number }).flags = 4;
+    const view = createView(doc);
+    mathRenderCalls.splice(0);
     syntaxTreeIterations.splice(0);
 
-    pluginValue?.update(viewportUpdate);
+    view.scrollDOM.dispatchEvent(new Event("scroll"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
+    expect(mathRenderCalls).toHaveLength(0);
     expect(
       syntaxTreeIterations.filter(
         ({ from, to }) => from === undefined && to === undefined,

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -1,5 +1,10 @@
 import { syntaxTree } from "@codemirror/language";
-import type { EditorState, Range } from "@codemirror/state";
+import {
+  StateEffect,
+  StateField,
+  type EditorState,
+  type Range,
+} from "@codemirror/state";
 import {
   Decoration,
   EditorView,
@@ -17,8 +22,12 @@ import {
   type MarkraMathMacros,
 } from "../math-render.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
-import { cursorInsideRange, selectionChangeAffectsReveal } from "./policy.ts";
-import { syntaxTreeChanged, updateChangesStayAfter } from "./changes.ts";
+import { selectionRevealsRange } from "./policy.ts";
+import {
+  syntaxTreeChanged,
+  transactionChangesStayAfter,
+} from "./changes.ts";
+import { codeMirrorVimModeChangedEffect } from "./vim.ts";
 
 export interface CodeMirrorMathRange {
   readonly from: number;
@@ -231,6 +240,8 @@ function activateMath(view: CodeMirrorView, range: CodeMirrorMathRange) {
   view.focus();
 }
 
+const estimatedEditorLineHeight = 26;
+
 class MathWidget extends WidgetType {
   constructor(
     readonly range: CodeMirrorMathRange,
@@ -245,6 +256,16 @@ class MathWidget extends WidgetType {
       other.range.source === this.range.source &&
       other.html === this.html &&
       other.className === this.className
+    );
+  }
+
+  get estimatedHeight() {
+    if (this.range.kind !== "display") return -1;
+    // Preserve roughly the source block's footprint until CodeMirror measures
+    // the rendered formula, limiting scroll jumps for offscreen replacements.
+    return Math.max(
+      48,
+      this.range.source.split("\n").length * estimatedEditorLineHeight,
     );
   }
 
@@ -281,6 +302,10 @@ class MacroFoldWidget extends WidgetType {
     return other.range.source === this.range.source;
   }
 
+  get estimatedHeight() {
+    return this.range.source.includes("\n") ? 32 : -1;
+  }
+
   ignoreEvent() {
     return false;
   }
@@ -299,31 +324,17 @@ class MacroFoldWidget extends WidgetType {
   }
 }
 
-function addMultilineReplacement(
-  state: EditorState,
+function addMathReplacement(
   ranges: Range<Decoration>[],
   range: CodeMirrorMathRange,
   widget: WidgetType,
 ) {
-  const firstLine = state.doc.lineAt(range.from);
-  const lastLine = state.doc.lineAt(range.to);
-  const firstTo = Math.min(firstLine.to, range.to);
-  ranges.push(Decoration.replace({ widget }).range(range.from, firstTo));
-
-  for (let lineNumber = firstLine.number + 1; lineNumber <= lastLine.number; lineNumber += 1) {
-    const line = state.doc.line(lineNumber);
-    const segmentFrom = line.from;
-    const segmentTo = Math.min(line.to, range.to);
-    if (segmentFrom >= segmentTo) continue;
-
-    if (segmentFrom === line.from && segmentTo === line.to) {
-      ranges.push(
-        Decoration.line({ class: "cm-markra-math-hidden-line" }).range(line.from),
-      );
-    } else {
-      ranges.push(Decoration.replace({}).range(segmentFrom, segmentTo));
-    }
-  }
+  ranges.push(
+    Decoration.replace({
+      block: range.source.includes("\n"),
+      widget,
+    }).range(range.from, range.to),
+  );
 }
 
 function renderMath(
@@ -333,26 +344,53 @@ function renderMath(
   return renderMarkraMathToString(range.tex, range.kind, macros);
 }
 
+interface MathRenderEntry {
+  readonly html: string;
+  readonly macroDefinitionOnly: boolean;
+  readonly range: CodeMirrorMathRange;
+}
+
+interface MathPreviewContext {
+  readonly focused: boolean;
+  readonly vimNormalMode: boolean;
+}
+
 interface MathDecorationState {
   readonly decorations: DecorationSet;
+  readonly entries: readonly MathRenderEntry[];
+  readonly context: MathPreviewContext;
   readonly lastRangeTo: number;
 }
 
-function buildMathDecorations(view: CodeMirrorView): MathDecorationState {
-  const ranges: Range<Decoration>[] = [];
+function buildMathRenderEntries(state: EditorState) {
   const macros = createMarkraMathMacros();
-  const mathRanges = findCodeMirrorMathRanges(view.state);
+  return findCodeMirrorMathRanges(state).map((range): MathRenderEntry => ({
+    html: renderMath(range, macros),
+    macroDefinitionOnly:
+      range.kind === "display" && isMarkraMathMacroDefinitionSource(range.tex),
+    range,
+  }));
+}
 
-  for (const range of mathRanges) {
-    const macroDefinitionOnly =
-      range.kind === "display" && isMarkraMathMacroDefinitionSource(range.tex);
-    const active = cursorInsideRange(view, range.from, range.to);
+function buildMathDecorations(
+  state: EditorState,
+  entries: readonly MathRenderEntry[],
+  context: MathPreviewContext,
+) {
+  const ranges: Range<Decoration>[] = [];
+
+  for (const { html, macroDefinitionOnly, range } of entries) {
+    const active = selectionRevealsRange(
+      state,
+      context.focused,
+      context.vimNormalMode,
+      range.from,
+      range.to,
+    );
 
     if (macroDefinitionOnly) {
-      renderMath(range, macros);
       if (active) continue;
-      addMultilineReplacement(
-        view.state,
+      addMathReplacement(
         ranges,
         range,
         new MacroFoldWidget(range),
@@ -360,11 +398,11 @@ function buildMathDecorations(view: CodeMirrorView): MathDecorationState {
       continue;
     }
 
-    const html = renderMath(range, macros);
     if (active) {
       if (range.kind === "display") {
         ranges.push(
           Decoration.widget({
+            block: range.source.includes("\n"),
             side: 1,
             widget: new MathWidget(
               range,
@@ -377,28 +415,50 @@ function buildMathDecorations(view: CodeMirrorView): MathDecorationState {
       continue;
     }
 
-    const widget = new MathWidget(
+    addMathReplacement(
+      ranges,
       range,
-      html,
-      `markra-math-render markra-math-render-${range.kind}`,
+      new MathWidget(
+        range,
+        html,
+        `markra-math-render markra-math-render-${range.kind}`,
+      ),
     );
-    if (range.source.includes("\n")) {
-      addMultilineReplacement(view.state, ranges, range, widget);
-    } else {
-      ranges.push(Decoration.replace({ widget }).range(range.from, range.to));
-    }
   }
 
+  return Decoration.set(ranges, true);
+}
+
+function createMathDecorationState(
+  state: EditorState,
+  context: MathPreviewContext,
+): MathDecorationState {
+  const entries = buildMathRenderEntries(state);
   return {
-    decorations: Decoration.set(ranges, true),
-    lastRangeTo: Math.max(-1, ...mathRanges.map((range) => range.to)),
+    context,
+    decorations: buildMathDecorations(state, entries, context),
+    entries,
+    lastRangeTo: Math.max(-1, ...entries.map(({ range }) => range.to)),
   };
 }
 
+function revealedMathRangesKey(
+  state: EditorState,
+  context: MathPreviewContext,
+  entries: readonly MathRenderEntry[],
+) {
+  return entries.map(({ range }) =>
+    selectionRevealsRange(
+      state,
+      context.focused,
+      context.vimNormalMode,
+      range.from,
+      range.to,
+    ) ? "1" : "0"
+  ).join("");
+}
+
 const mathTheme = EditorView.baseTheme({
-  ".cm-markra-math-hidden-line": {
-    display: "none",
-  },
   ".markra-math-render": {
     cursor: "text",
   },
@@ -413,53 +473,127 @@ const mathTheme = EditorView.baseTheme({
   },
 });
 
+const setMathPreviewFocusedEffect = StateEffect.define<boolean>();
+
+function createMathPreviewExtension() {
+  const initialContext: MathPreviewContext = {
+    focused: true,
+    vimNormalMode: false,
+  };
+  const field = StateField.define<MathDecorationState>({
+    create(state) {
+      return createMathDecorationState(state, initialContext);
+    },
+    update(previous, transaction) {
+      const focusEffect = transaction.effects.find((effect) =>
+        effect.is(setMathPreviewFocusedEffect)
+      );
+      const vimEffect = transaction.effects.find((effect) =>
+        effect.is(codeMirrorVimModeChangedEffect)
+      );
+      const context = {
+        focused: focusEffect?.value ?? previous.context.focused,
+        vimNormalMode: vimEffect?.value ?? previous.context.vimNormalMode,
+      };
+      const contextChanged =
+        context.focused !== previous.context.focused ||
+        context.vimNormalMode !== previous.context.vimNormalMode;
+
+      if (
+        !contextChanged &&
+        transactionChangesStayAfter(
+          transaction,
+          previous.lastRangeTo,
+          (source) => /[$\\`~\n]/u.test(source),
+        )
+      ) {
+        return {
+          ...previous,
+          decorations: previous.decorations.map(transaction.changes),
+        };
+      }
+
+      if (
+        transaction.docChanged ||
+        syntaxTreeChanged(transaction.startState, transaction.state)
+      ) {
+        return createMathDecorationState(transaction.state, context);
+      }
+
+      const revealChanged =
+        revealedMathRangesKey(
+          transaction.startState,
+          previous.context,
+          previous.entries,
+        ) !== revealedMathRangesKey(
+          transaction.state,
+          context,
+          previous.entries,
+        );
+      if (!contextChanged && !revealChanged) return previous;
+
+      return {
+        ...previous,
+        context,
+        decorations: buildMathDecorations(
+          transaction.state,
+          previous.entries,
+          context,
+        ),
+      };
+    },
+    // Layout-changing block replacements must come directly from editor state
+    // so CodeMirror can keep its virtualized height map synchronized.
+    provide: (mathField) => EditorView.decorations.from(
+      mathField,
+      (value) => value.decorations,
+    ),
+  });
+  const mountedViews = new WeakSet<CodeMirrorView>();
+  const syncFocusedState = (view: CodeMirrorView) => {
+    queueMicrotask(() => {
+      if (!mountedViews.has(view)) return;
+      const previewState = view.state.field(field, false);
+      if (!previewState || previewState.context.focused === view.hasFocus) return;
+      view.dispatch({ effects: setMathPreviewFocusedEffect.of(view.hasFocus) });
+    });
+  };
+  const lifecycle = ViewPlugin.fromClass(
+    class {
+      constructor(readonly view: CodeMirrorView) {
+        mountedViews.add(view);
+        syncFocusedState(view);
+      }
+
+      update(update: ViewUpdate) {
+        if (update.focusChanged) syncFocusedState(update.view);
+      }
+
+      destroy() {
+        mountedViews.delete(this.view);
+      }
+    },
+  );
+
+  return [
+    lifecycle,
+    field,
+    EditorView.domEventHandlers({
+      blur(_event, view) {
+        syncFocusedState(view);
+      },
+      focus(_event, view) {
+        syncFocusedState(view);
+      },
+    }),
+  ];
+}
+
 export function mathPreviewPlugin() {
   return defineMarkraPlugin({
     id: "markra.math-preview",
     extension: [
-      ViewPlugin.fromClass(
-        class {
-          decorations: DecorationSet;
-          lastRangeTo: number;
-
-          constructor(view: CodeMirrorView) {
-            const state = buildMathDecorations(view);
-            this.decorations = state.decorations;
-            this.lastRangeTo = state.lastRangeTo;
-          }
-
-          update(update: ViewUpdate) {
-            if (
-              updateChangesStayAfter(
-                update,
-                this.lastRangeTo,
-                (source) => /[$\\`~\n]/u.test(source),
-              )
-            ) {
-              this.decorations = this.decorations.map(update.changes);
-              return;
-            }
-            const treeChanged = syntaxTreeChanged(
-              update.startState,
-              update.state,
-            );
-            // Math decorations already cover the entire document. Rebuilding
-            // them for viewport-only updates would rerender every formula on
-            // each scroll frame; deferred parser progress is covered below.
-            if (
-              update.docChanged ||
-              selectionChangeAffectsReveal(update) ||
-              update.focusChanged ||
-              treeChanged
-            ) {
-              const state = buildMathDecorations(update.view);
-              this.decorations = state.decorations;
-              this.lastRangeTo = state.lastRangeTo;
-            }
-          }
-        },
-        { decorations: (plugin) => plugin.decorations },
-      ),
+      ...createMathPreviewExtension(),
       mathTheme,
     ],
   });

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -12,7 +12,6 @@ import {
   WidgetType,
   type DecorationSet,
   type EditorView as CodeMirrorView,
-  type ViewUpdate,
 } from "@codemirror/view";
 import {
   createMarkraMathMacros,
@@ -236,8 +235,8 @@ function activateMath(view: CodeMirrorView, range: CodeMirrorMathRange) {
   const offset = range.source.startsWith("$$") || range.source.startsWith(String.raw`\[`)
     ? 2
     : 1;
-  view.dispatch({ selection: { anchor: Math.min(range.to - 1, range.from + offset) } });
   view.focus();
+  view.dispatch({ selection: { anchor: Math.min(range.to - 1, range.from + offset) } });
 }
 
 const estimatedEditorLineHeight = 26;
@@ -550,40 +549,38 @@ function createMathPreviewExtension() {
     ),
   });
   const mountedViews = new WeakSet<CodeMirrorView>();
-  const syncFocusedState = (view: CodeMirrorView) => {
-    queueMicrotask(() => {
-      if (!mountedViews.has(view)) return;
-      const previewState = view.state.field(field, false);
-      if (!previewState || previewState.context.focused === view.hasFocus) return;
-      view.dispatch({ effects: setMathPreviewFocusedEffect.of(view.hasFocus) });
-    });
+  const syncFocusedState = (view: CodeMirrorView, focused: boolean) => {
+    // Focus can move while an IME owns the editable DOM. Rebuilding block
+    // decorations then can interrupt the active composition.
+    if (!mountedViews.has(view) || view.compositionStarted) return;
+    const previewState = view.state.field(field, false);
+    if (!previewState || previewState.context.focused === focused) return;
+    view.dispatch({ effects: setMathPreviewFocusedEffect.of(focused) });
   };
-  const lifecycle = ViewPlugin.fromClass(
-    class {
-      constructor(readonly view: CodeMirrorView) {
-        mountedViews.add(view);
-        syncFocusedState(view);
-      }
-
-      update(update: ViewUpdate) {
-        if (update.focusChanged) syncFocusedState(update.view);
-      }
-
+  const initializeFocus = ViewPlugin.define((view) => {
+    mountedViews.add(view);
+    queueMicrotask(() => {
+      if (!view.hasFocus) syncFocusedState(view, false);
+    });
+    return {
       destroy() {
-        mountedViews.delete(this.view);
-      }
-    },
-  );
+        mountedViews.delete(view);
+      },
+    };
+  });
 
   return [
-    lifecycle,
     field,
+    initializeFocus,
     EditorView.domEventHandlers({
       blur(_event, view) {
-        syncFocusedState(view);
+        syncFocusedState(view, false);
       },
       focus(_event, view) {
-        syncFocusedState(view);
+        syncFocusedState(view, true);
+      },
+      compositionend(_event, view) {
+        syncFocusedState(view, view.hasFocus);
       },
     }),
   ];

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -439,12 +439,18 @@ export function mathPreviewPlugin() {
               this.decorations = this.decorations.map(update.changes);
               return;
             }
+            const treeChanged = syntaxTreeChanged(
+              update.startState,
+              update.state,
+            );
+            // Math decorations already cover the entire document. Rebuilding
+            // them for viewport-only updates would rerender every formula on
+            // each scroll frame; deferred parser progress is covered below.
             if (
               update.docChanged ||
               selectionChangeAffectsReveal(update) ||
               update.focusChanged ||
-              update.viewportChanged ||
-              syntaxTreeChanged(update.startState, update.state)
+              treeChanged
             ) {
               const state = buildMathDecorations(update.view);
               this.decorations = state.decorations;

--- a/packages/editor/src/codemirror/policy.ts
+++ b/packages/editor/src/codemirror/policy.ts
@@ -87,16 +87,31 @@ export function cursorInsideRange(
   from: number,
   to: number,
 ) {
-  const includeCursorBoundaries = codeMirrorVimNormalModeActive(view);
+  return selectionRevealsRange(
+    view.state,
+    view.hasFocus,
+    codeMirrorVimNormalModeActive(view),
+    from,
+    to,
+  );
+}
+
+export function selectionRevealsRange(
+  state: EditorState,
+  focused: boolean,
+  includeCursorBoundaries: boolean,
+  from: number,
+  to: number,
+) {
   return (
-    view.hasFocus &&
-    view.state.selection.ranges.some(
+    focused &&
+    state.selection.ranges.some(
       (selection) =>
         selection.empty
           ? includeCursorBoundaries
             ? selection.head >= from && selection.head < to
             : selection.head > from && selection.head < to
-          : sourceDragStartedInsideRange(view.state, from, to),
+          : sourceDragStartedInsideRange(state, from, to),
     )
   );
 }

--- a/packages/editor/src/codemirror/vim.ts
+++ b/packages/editor/src/codemirror/vim.ts
@@ -26,7 +26,7 @@ let vimModulePromise:
   | Promise<typeof import("@replit/codemirror-vim")>
   | null = null;
 
-export const codeMirrorVimModeChangedEffect = StateEffect.define<null>();
+export const codeMirrorVimModeChangedEffect = StateEffect.define<boolean>();
 
 function isVimWordCharacter(character: string) {
   return /[\p{L}\p{N}_]/u.test(character);
@@ -210,7 +210,11 @@ export function codeMirrorVimNormalModeActive(view: EditorView) {
 function notifyCodeMirrorVimModeChanged(view: EditorView) {
   // Vim applies its Normal-mode class while the compartment settles. Preview
   // plugins need a follow-up transaction so they read the final mode.
-  view.dispatch({ effects: codeMirrorVimModeChangedEffect.of(null) });
+  view.dispatch({
+    effects: codeMirrorVimModeChangedEffect.of(
+      codeMirrorVimNormalModeActive(view),
+    ),
+  });
 }
 
 export function reconfigureCodeMirrorVimMode(


### PR DESCRIPTION
## Summary
- stop rebuilding all math decorations during viewport-only scroll updates
- replace multiline formulas with a single state-backed CodeMirror block replacement
- remove the `.cm-line` `display: none` layout workaround
- cache rendered KaTeX across selection, focus, and Vim reveal-only updates
- estimate offscreen formula height from the original source footprint
- keep math focus synchronization out of active IME composition

## Why
The issue attachment has roughly 929 math ranges. Viewport updates previously rescanned and rerendered all of them, while multiline formulas hid individual editor lines outside CodeMirror’s block height model. Together these could make large scroll jumps expensive and leave WebKit with stale document geometry.

Moving block decorations into editor state fixed the height model, but the first CI run also exposed a focus-sync transaction racing controlled Chinese IME input. Focus changes are now applied synchronously before composition, deferred while composition owns the editable DOM, and reconciled after composition ends.

## Validation
- `pnpm --filter @markra/app test` — 1,494 tests passed, including the controlled IME/image regression
- `pnpm --filter @markra/editor test` — 450 tests passed
- `pnpm --filter @markra/app build` and `typecheck:test` — passed
- `pnpm --filter @markra/editor build` and `typecheck:test` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- clean Chromium session with the issue attachment — a 14,000px jump reached section 7.2 with 15 visible lines, 4 display formulas, 0 hidden math lines, stable `160079px` height at 150ms/850ms, and no error toast

## Risk
- Tauri dev launched successfully, but the Mac was locked so the WebKit window could not be operated for the final smoke test. The PR remains draft until that target-specific check is completed.
- Parallel local stress runs exposed existing deferred-parser timing flakes in unrelated preview tests. The affected files passed in isolation, and the sequential editor suite passed 450/450.

Refs #654