### PR TITLE
feat(ai): add bulk model selection

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2988,6 +2988,16 @@ describe("Markra workspace", () => {
     expect(screen.getAllByText("GPT Image 1").length).toBeGreaterThan(0);
     await waitFor(() => expect(document.querySelector(".app-toast")).toHaveTextContent("Model list updated."));
 
+    fireEvent.click(screen.getByRole("button", { name: "Deselect all models" }));
+    expect(screen.getByRole("switch", { name: "GPT-5" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("switch", { name: "GPT Image 1" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("switch", { name: "GPT-5.5 Thinking Updated" })).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all models" }));
+    expect(screen.getByRole("switch", { name: "GPT-5" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("switch", { name: "GPT Image 1" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("switch", { name: "GPT-5.5 Thinking Updated" })).toHaveAttribute("aria-checked", "true");
+
     fireEvent.click(screen.getByRole("button", { name: "Save AI providers" }));
 
     await waitFor(() =>

--- a/packages/app/src/components/AiProviderModelsSection.tsx
+++ b/packages/app/src/components/AiProviderModelsSection.tsx
@@ -66,6 +66,11 @@ export function AiProviderModelsSection({
   setModelDraft: Dispatch<SetStateAction<AiProviderModelDraft>>;
   updateSelectedProvider: (updater: (provider: AiProviderConfig) => AiProviderConfig) => unknown;
 }) {
+  const allModelsEnabled = modelOptions.length > 0 && modelOptions.every((model) => model.enabled);
+  const toggleAllModelsLabel = translate(
+    allModelsEnabled ? "settings.ai.deselectAllModels" : "settings.ai.selectAllModels"
+  );
+
   return (
     <AiSettingsSection label={translate("settings.sections.aiModels")}>
       <div className="grid gap-4 py-2">
@@ -95,7 +100,23 @@ export function AiProviderModelsSection({
             <p className="m-0 text-[12px] leading-5 font-bold text-(--text-secondary)">
               {translate("settings.ai.availableModels")}
             </p>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <AiSettingsActionButton
+                label={toggleAllModelsLabel}
+                disabled={modelOptions.length === 0}
+                onClick={() =>
+                  updateSelectedProvider((provider) => {
+                    const enabled = !provider.models.every((model) => model.enabled);
+
+                    return {
+                      ...provider,
+                      models: provider.models.map((model) => ({ ...model, enabled }))
+                    };
+                  })
+                }
+              >
+                {toggleAllModelsLabel}
+              </AiSettingsActionButton>
               <AiSettingsActionButton label={translate("settings.ai.addModel")} onClick={onStartAddModel}>
                 <Plus aria-hidden="true" size={14} />
                 {translate("settings.ai.addModel")}

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "Anbieter gelöscht.",
   "settings.ai.addModel": "Modell hinzufügen",
   "settings.ai.addModelToProvider": "Zum Anbieter hinzufügen",
+  "settings.ai.selectAllModels": "Alle Modelle auswählen",
+  "settings.ai.deselectAllModels": "Auswahl aller Modelle aufheben",
   "settings.ai.cancelAddModel": "Abbrechen",
   "settings.ai.editModel": "Modell bearbeiten",
   "settings.ai.cancelEditModel": "Abbrechen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -463,6 +463,8 @@ const messages: BaseLocaleMessages = {
   "settings.ai.providerDeleted": "Provider deleted.",
   "settings.ai.addModel": "Add model",
   "settings.ai.addModelToProvider": "Add model to provider",
+  "settings.ai.selectAllModels": "Select all models",
+  "settings.ai.deselectAllModels": "Deselect all models",
   "settings.ai.cancelAddModel": "Cancel",
   "settings.ai.editModel": "Edit model",
   "settings.ai.cancelEditModel": "Cancel",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "Proveedor eliminado.",
   "settings.ai.addModel": "Añadir modelo",
   "settings.ai.addModelToProvider": "Añadir al proveedor",
+  "settings.ai.selectAllModels": "Seleccionar todos los modelos",
+  "settings.ai.deselectAllModels": "Deseleccionar todos los modelos",
   "settings.ai.cancelAddModel": "Cancelar",
   "settings.ai.editModel": "Editar modelo",
   "settings.ai.cancelEditModel": "Cancelar",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "Fournisseur supprimé.",
   "settings.ai.addModel": "Ajouter un modèle",
   "settings.ai.addModelToProvider": "Ajouter au fournisseur",
+  "settings.ai.selectAllModels": "Sélectionner tous les modèles",
+  "settings.ai.deselectAllModels": "Désélectionner tous les modèles",
   "settings.ai.cancelAddModel": "Annuler",
   "settings.ai.editModel": "Modifier le modèle",
   "settings.ai.cancelEditModel": "Annuler",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "Provider eliminato.",
   "settings.ai.addModel": "Aggiungi modello",
   "settings.ai.addModelToProvider": "Aggiungi al provider",
+  "settings.ai.selectAllModels": "Seleziona tutti i modelli",
+  "settings.ai.deselectAllModels": "Deseleziona tutti i modelli",
   "settings.ai.cancelAddModel": "Annulla",
   "settings.ai.editModel": "Modifica modello",
   "settings.ai.cancelEditModel": "Annulla",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -126,6 +126,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "プロバイダーを削除しました。",
   "settings.ai.addModel": "モデルを追加",
   "settings.ai.addModelToProvider": "プロバイダーに追加",
+  "settings.ai.selectAllModels": "すべてのモデルを選択",
+  "settings.ai.deselectAllModels": "すべてのモデルの選択を解除",
   "settings.ai.cancelAddModel": "キャンセル",
   "settings.ai.editModel": "モデルを編集",
   "settings.ai.cancelEditModel": "キャンセル",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "제공자를 삭제했습니다.",
   "settings.ai.addModel": "모델 추가",
   "settings.ai.addModelToProvider": "제공자에 추가",
+  "settings.ai.selectAllModels": "모든 모델 선택",
+  "settings.ai.deselectAllModels": "모든 모델 선택 해제",
   "settings.ai.cancelAddModel": "취소",
   "settings.ai.editModel": "모델 편집",
   "settings.ai.cancelEditModel": "취소",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "Provedor excluído.",
   "settings.ai.addModel": "Adicionar modelo",
   "settings.ai.addModelToProvider": "Adicionar ao provedor",
+  "settings.ai.selectAllModels": "Selecionar todos os modelos",
+  "settings.ai.deselectAllModels": "Desmarcar todos os modelos",
   "settings.ai.cancelAddModel": "Cancelar",
   "settings.ai.editModel": "Editar modelo",
   "settings.ai.cancelEditModel": "Cancelar",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -118,6 +118,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "Провайдер удалён.",
   "settings.ai.addModel": "Добавить модель",
   "settings.ai.addModelToProvider": "Добавить к провайдеру",
+  "settings.ai.selectAllModels": "Выбрать все модели",
+  "settings.ai.deselectAllModels": "Снять выбор со всех моделей",
   "settings.ai.cancelAddModel": "Отмена",
   "settings.ai.editModel": "Редактировать модель",
   "settings.ai.cancelEditModel": "Отмена",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -474,6 +474,8 @@ export type I18nKey =
   | "settings.ai.providerDeleted"
   | "settings.ai.addModel"
   | "settings.ai.addModelToProvider"
+  | "settings.ai.selectAllModels"
+  | "settings.ai.deselectAllModels"
   | "settings.ai.cancelAddModel"
   | "settings.ai.editModel"
   | "settings.ai.cancelEditModel"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -463,6 +463,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "服务商已删除。",
   "settings.ai.addModel": "添加模型",
   "settings.ai.addModelToProvider": "添加到服务商",
+  "settings.ai.selectAllModels": "全选模型",
+  "settings.ai.deselectAllModels": "取消全选模型",
   "settings.ai.cancelAddModel": "取消",
   "settings.ai.editModel": "编辑模型",
   "settings.ai.cancelEditModel": "取消",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -126,6 +126,8 @@ const messages: LocaleMessages = {
   "settings.ai.providerDeleted": "服務商已刪除。",
   "settings.ai.addModel": "新增模型",
   "settings.ai.addModelToProvider": "新增到服務商",
+  "settings.ai.selectAllModels": "全選模型",
+  "settings.ai.deselectAllModels": "取消全選模型",
   "settings.ai.cancelAddModel": "取消",
   "settings.ai.editModel": "編輯模型",
   "settings.ai.cancelEditModel": "取消",


### PR DESCRIPTION
## Summary
- add a bulk action that switches between selecting and deselecting every model for the current AI provider
- derive the action from the current model state and disable it when the provider has no models
- localize the new labels for every supported language and cover both directions with the settings integration test

## Validation
- `pnpm --filter @markra/app test` — 132 files and 1501 tests passed
- `pnpm --filter @markra/shared test` — 7 files and 62 tests passed
- `pnpm --filter @markra/app typecheck:test`
- `pnpm --filter @markra/app build`
- `pnpm --filter @markra/shared build`
- `git diff --check`
- Not run: manual screenshot or desktop UI QA; the settings interaction is covered by the integration test

## Risk
- Low. The change only updates existing model `enabled` flags and does not alter persisted settings schemas.

Closes #651