### PR TITLE
fix(editor): align code language selector with themes

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1237,10 +1237,18 @@
     display: flex !important;
     align-items: center;
     gap: 6px;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transform: translateY(-2px);
+    transition: opacity 150ms ease-out, transform 150ms ease-out;
+  }
+
+  .markdown-paper .cm-line.cm-markra-code-header-line[data-code-block-hovered="true"]
+    .cm-markra-code-header-actions,
+  .markdown-paper .cm-markra-code-header-actions:focus-within {
     opacity: 1 !important;
     pointer-events: auto !important;
     transform: none;
-    transition: opacity 150ms ease-out, transform 150ms ease-out;
   }
 
   .markdown-paper .cm-markra-code-header-actions .markra-code-language-control {
@@ -1253,13 +1261,31 @@
   }
 
   .markdown-paper .cm-markra-code-header-actions .markra-code-language-select {
+    -webkit-appearance: none;
+    appearance: none;
     height: 24px !important;
     min-height: 24px !important;
     min-width: 160px !important;
     width: 160px !important;
-    padding: 0 10px !important;
+    padding: 0 28px !important;
     font-size: 13px !important;
     line-height: 1 !important;
+    text-align: center;
+    text-align-last: center;
+  }
+
+  .markdown-paper .cm-markra-code-header-actions .markra-code-language-control::after {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    width: 0;
+    height: 0;
+    border-top: 4px solid currentColor;
+    border-right: 4px solid transparent;
+    border-left: 4px solid transparent;
+    content: "";
+    pointer-events: none;
+    transform: translateY(-25%);
   }
 
   .markdown-paper .cm-markra-code-header-actions .markra-code-copy-button {
@@ -1763,7 +1789,7 @@
     --editor-code-bg: var(--bg-code);
     --editor-code-line-bg: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-code));
     --editor-code-text: var(--text-primary);
-    --editor-code-control-bg: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+    --editor-code-control-bg: color-mix(in srgb, var(--editor-code-bg) 82%, var(--editor-paper-bg));
     --editor-link-color: var(--link-color);
     --editor-hl-keyword: oklch(43% 0.17 283);
     --editor-hl-string: oklch(42% 0.13 151);
@@ -4174,6 +4200,8 @@
 
   .markdown-paper .markra-code-language-select:focus {
     @apply border-(--border-focus) bg-(--bg-primary) text-(--text-primary);
+    background: var(--editor-code-control-bg);
+    color: var(--editor-text-primary);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--border-focus) 18%, transparent);
   }
 

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -283,7 +283,7 @@ describe("editor stylesheet", () => {
     );
   });
 
-  it("overlays code block controls without inserting a blank header line", () => {
+  it("progressively reveals themed code block controls without inserting a blank header line", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
     const headerLineStart = styles.indexOf(
       ".markdown-paper .cm-line.cm-markra-code-header-line {",
@@ -308,6 +308,13 @@ describe("editor stylesheet", () => {
       headerActionsStart,
       headerActionsEnd,
     );
+    const hoveredHeaderSelector =
+      '.markdown-paper .cm-line.cm-markra-code-header-line[data-code-block-hovered="true"]\n' +
+      "    .cm-markra-code-header-actions,";
+    const activeHeaderSelector =
+      '.markdown-paper .cm-line.cm-markra-code-header-line[data-code-block-active="true"]';
+    const focusedHeaderSelector =
+      ".markdown-paper .cm-markra-code-header-actions:focus-within {";
     const closingLineStart = styles.indexOf(
       ".markdown-paper .cm-line.cm-markra-code-closing-line {",
     );
@@ -328,6 +335,17 @@ describe("editor stylesheet", () => {
     const languageSelectRule = styles.slice(
       languageSelectStart,
       languageSelectEnd,
+    );
+    const languageSelectFocusStart = styles.indexOf(
+      ".markdown-paper .markra-code-language-select:focus {",
+    );
+    const languageSelectFocusEnd = styles.indexOf(
+      "\n  }",
+      languageSelectFocusStart,
+    );
+    const languageSelectFocusRule = styles.slice(
+      languageSelectFocusStart,
+      languageSelectFocusEnd,
     );
     const copyButtonStart = styles.indexOf(
       ".markdown-paper .cm-markra-code-header-actions .markra-code-copy-button {",
@@ -374,10 +392,13 @@ describe("editor stylesheet", () => {
     );
     expect(topGapRule).toContain("border-radius: 4px 4px 0 0");
     expect(topGapRule).toContain("background: var(--editor-code-bg)");
-    expect(headerActionsRule).toContain("opacity: 1 !important");
-    expect(headerActionsRule).toContain("pointer-events: auto !important");
-    expect(headerActionsRule).toContain("transform: none");
+    expect(headerActionsRule).toContain("opacity: 0 !important");
+    expect(headerActionsRule).toContain("pointer-events: none !important");
+    expect(headerActionsRule).toContain("transform: translateY(-2px)");
     expect(headerActionsRule).toContain("top: 0");
+    expect(styles).toContain(hoveredHeaderSelector);
+    expect(styles).not.toContain(activeHeaderSelector);
+    expect(styles).toContain(focusedHeaderSelector);
     expect(closingLineRule).toContain("position: relative");
     expect(closingLineRule).toContain("height: 12px");
     expect(closingLineRule).toContain("min-height: 12px");
@@ -389,6 +410,16 @@ describe("editor stylesheet", () => {
     expect(languageSelectRule).toContain("width: 160px !important");
     expect(languageSelectRule).toContain("height: 24px !important");
     expect(languageSelectRule).toContain("min-height: 24px !important");
+    expect(languageSelectRule).toContain("appearance: none");
+    expect(languageSelectRule).toContain("-webkit-appearance: none");
+    expect(languageSelectRule).toContain("text-align: center");
+    expect(languageSelectRule).toContain("text-align-last: center");
+    expect(languageSelectFocusRule).toContain(
+      "background: var(--editor-code-control-bg)",
+    );
+    expect(languageSelectFocusRule).toContain(
+      "color: var(--editor-text-primary)",
+    );
     expect(copyButtonRule).toContain("width: 24px !important");
     expect(copyButtonRule).toContain("height: 24px !important");
     expect(firstContentLineStart).toBeGreaterThanOrEqual(0);
@@ -404,6 +435,9 @@ describe("editor stylesheet", () => {
     expect(closingLineRule).toContain("border-radius: 0 0 4px 4px");
     expect(closingLineRule).toContain(
       "background: var(--editor-code-bg) !important",
+    );
+    expect(styles).toContain(
+      "--editor-code-control-bg: color-mix(in srgb, var(--editor-code-bg)",
     );
     expect(styles).not.toContain(
       ".markdown-paper .cm-line.cm-markra-code-content-line:has(+ .cm-markra-code-closing-line) {\n" +

--- a/packages/editor/src/codemirror/code-block.test.ts
+++ b/packages/editor/src/codemirror/code-block.test.ts
@@ -96,7 +96,52 @@ describe("codeBlockPreviewPlugin", () => {
         .querySelector(".cm-markra-code-closing-line")
         ?.getAttribute("data-code-block-active"),
     ).toBe("true");
+    expect(
+      view.dom
+        .querySelector(".cm-markra-code-header-line")
+        ?.getAttribute("data-code-block-active"),
+    ).toBeNull();
     expect(view.dom.querySelector(".markra-code-language-select")).not.toBeNull();
+  });
+
+  it("marks only the hovered code block for progressive control reveal", () => {
+    const source = [
+      "```sh",
+      "first_command",
+      "```",
+      "",
+      "Between blocks",
+      "",
+      "```python",
+      "second_value = 2",
+      "```",
+    ].join("\n");
+    const view = createView(source);
+    const headers = [
+      ...view.dom.querySelectorAll<HTMLElement>(
+        ".cm-markra-code-header-line",
+      ),
+    ];
+    const secondCodeLine = [
+      ...view.dom.querySelectorAll<HTMLElement>(
+        ".cm-markra-code-content-line",
+      ),
+    ].find((line) => line.textContent?.includes("second_value"));
+    const paragraphLine = [...view.dom.querySelectorAll<HTMLElement>(".cm-line")]
+      .find((line) => line.textContent === "Between blocks");
+
+    secondCodeLine?.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    expect(headers).toHaveLength(2);
+    expect(headers[0]?.dataset.codeBlockHovered).toBeUndefined();
+    expect(headers[1]?.dataset.codeBlockHovered).toBe("true");
+
+    paragraphLine?.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    expect(headers.every((header) =>
+      header.dataset.codeBlockHovered === undefined
+    )).toBe(true);
+    expect(view.state.doc.toString()).toBe(source);
   });
 
   it("uses measured top gaps for consecutive code blocks", () => {

--- a/packages/editor/src/codemirror/code-block.ts
+++ b/packages/editor/src/codemirror/code-block.ts
@@ -1075,6 +1075,69 @@ function fencedCodeAtPosition(state: EditorState, position: number) {
   return null;
 }
 
+function fencedCodeStartingAt(state: EditorState, from: number) {
+  const position = Math.min(state.doc.length, from + 1);
+  const node = fencedCodeAtPosition(state, position);
+  return node?.from === from ? node : null;
+}
+
+interface HoveredCodeBlockState {
+  readonly decorations: DecorationSet;
+  readonly from: number | null;
+}
+
+// Keep hover block-scoped in editor state: a container-level CSS hover would
+// reveal every code toolbar, while this line decoration leaves CM geometry alone.
+const setHoveredCodeBlockEffect = StateEffect.define<number | null>({
+  map(value, changes) {
+    return value === null ? null : changes.mapPos(value, 1);
+  },
+});
+
+function hoveredCodeBlockState(
+  state: EditorState,
+  from: number | null,
+): HoveredCodeBlockState {
+  if (from === null) {
+    return { decorations: Decoration.none, from: null };
+  }
+  const node = fencedCodeStartingAt(state, from);
+  if (!node) return { decorations: Decoration.none, from: null };
+  const firstLine = state.doc.lineAt(node.from);
+  return {
+    decorations: Decoration.set([
+      Decoration.line({
+        attributes: { "data-code-block-hovered": "true" },
+      }).range(firstLine.from),
+    ]),
+    from: node.from,
+  };
+}
+
+const hoveredCodeBlockField = StateField.define<HoveredCodeBlockState>({
+  create(state) {
+    return hoveredCodeBlockState(state, null);
+  },
+  update(previous, transaction) {
+    let from = transaction.docChanged && previous.from !== null
+      ? transaction.changes.mapPos(previous.from, 1)
+      : previous.from;
+    for (const effect of transaction.effects) {
+      if (effect.is(setHoveredCodeBlockEffect)) from = effect.value;
+    }
+    if (
+      !transaction.docChanged &&
+      !syntaxTreeChanged(transaction.startState, transaction.state) &&
+      from === previous.from
+    ) return previous;
+    return hoveredCodeBlockState(transaction.state, from);
+  },
+  provide: (field) => EditorView.decorations.from(
+    field,
+    (value) => value.decorations,
+  ),
+});
+
 function fencedCodeAt(view: CodeMirrorView) {
   return fencedCodeAtPosition(
     view.state,
@@ -1248,7 +1311,53 @@ const codeBlockKeymap = Prec.high(
   ]),
 );
 
+function codeBlockFromPointer(
+  event: MouseEvent,
+  view: CodeMirrorView,
+) {
+  const target = event.target instanceof Element ? event.target : null;
+  const rawFrom = target
+    ?.closest<HTMLElement>("[data-code-block-from]")
+    ?.dataset.codeBlockFrom;
+  const targetFrom = rawFrom === undefined ? null : Number(rawFrom);
+  if (
+    targetFrom !== null &&
+    Number.isInteger(targetFrom) &&
+    fencedCodeStartingAt(view.state, targetFrom)
+  ) {
+    return targetFrom;
+  }
+
+  try {
+    const position = view.posAtCoords({
+      x: event.clientX,
+      y: event.clientY,
+    });
+    return position === null
+      ? null
+      : fencedCodeAtPosition(view.state, position)?.from ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function syncHoveredCodeBlock(
+  view: CodeMirrorView,
+  from: number | null,
+) {
+  if (view.state.field(hoveredCodeBlockField).from === from) return;
+  view.dispatch({ effects: setHoveredCodeBlockEffect.of(from) });
+}
+
 const codeBlockPointerHandlers = EditorView.domEventHandlers({
+  mouseleave(_event, view) {
+    syncHoveredCodeBlock(view, null);
+    return false;
+  },
+  mousemove(event, view) {
+    syncHoveredCodeBlock(view, codeBlockFromPointer(event, view));
+    return false;
+  },
   mousedown(event, view) {
     if (event.button !== 0 || !(event.target instanceof Element)) return false;
     const closingLine = event.target.closest<HTMLElement>(
@@ -1348,6 +1457,7 @@ export function codeBlockPreviewPlugin(
       // pointer-to-caret offset.
       createMermaidPreviewField(labels, renderMermaid),
       createCodeBlockTopGapField(showLineNumbers),
+      hoveredCodeBlockField,
       markraRenderer({
         id: "markra.code-block-preview",
         nodeNames: ["FencedCode"],
@@ -1414,6 +1524,9 @@ export function codeBlockPreviewPlugin(
                   : "cm-markra-code-content-line";
             const codeContentLine = roleClass === "cm-markra-code-content-line";
             if (codeContentLine) codeLineNumber += 1;
+            const codeBlockIdentity = {
+              "data-code-block-from": String(node.from),
+            };
             const lineNumberVisibility = {
               "data-code-line-numbers": String(showLineNumbers),
             };
@@ -1421,6 +1534,7 @@ export function codeBlockPreviewPlugin(
               Decoration.line({
                 attributes: codeContentLine
                   ? {
+                      ...codeBlockIdentity,
                       ...lineNumberVisibility,
                       ...(showLineNumbers
                         ? { "data-code-line-number": String(codeLineNumber) }
@@ -1428,11 +1542,12 @@ export function codeBlockPreviewPlugin(
                     }
                   : roleClass === "cm-markra-code-closing-line"
                     ? {
+                        ...codeBlockIdentity,
                         ...lineNumberVisibility,
                         "data-code-block-active": String(revealed),
                         "data-code-block-end": String(node.to),
                       }
-                    : undefined,
+                    : codeBlockIdentity,
                 class: `cm-markra-code-line ${roleClass}`,
               }).range(line.from),
             );


### PR DESCRIPTION
## Summary

- hide code block controls by default and reveal only the hovered block
- keep controls visible while focused without tying visibility to the cursor position
- center the language label, replace the native select chrome, and derive its background and focus colors from editor theme tokens
- cover per-block hover isolation and progressive reveal styles with regression tests

## Validation

- `pnpm --filter @markra/editor test` — 37 files, 456 tests passed
- `pnpm --filter @markra/app test` — 132 files, 1,507 tests passed
- `pnpm --filter @markra/editor build && pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app build && pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/desktop build` — passed, including 15 vendor chunk imports
- isolated `Markra QA 668.app` desktop build and manual interaction pass — empty and populated blocks, per-block hover isolation, focus persistence, outside-block hit testing, line numbers on/off, and Light/Dark/Sepia themes
- `git diff --check` — passed
- GitHub CI — all reported checks passed

## Risk

The hover marker is transient CodeMirror state. It does not alter the Markdown document or change code block geometry on hover.

Fixes #668
