### PR TITLE
feat(windows): add Explorer context menu integration

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -417,6 +417,75 @@ mod tests {
     }
 
     #[test]
+    fn windows_installers_register_explorer_context_menus() {
+        let config: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
+            .expect("Tauri config should be valid JSON");
+
+        assert_eq!(
+            config
+                .pointer("/bundle/windows/nsis/installerHooks")
+                .and_then(serde_json::Value::as_str),
+            Some("./windows/explorer-menu.nsh")
+        );
+        assert!(
+            config
+                .pointer("/bundle/windows/wix/fragmentPaths")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|paths| {
+                    paths
+                        .iter()
+                        .any(|path| path.as_str() == Some("./windows/explorer-menu.wxs"))
+                }),
+            "WiX should include the Explorer menu registry fragment"
+        );
+        assert!(
+            config
+                .pointer("/bundle/windows/wix/componentRefs")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|components| {
+                    components
+                        .iter()
+                        .any(|component| component.as_str() == Some("MarkraExplorerMenu"))
+                }),
+            "WiX should install the Explorer menu registry component"
+        );
+
+        let windows_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("windows");
+        let nsis_hooks = std::fs::read_to_string(windows_dir.join("explorer-menu.nsh"))
+            .expect("NSIS Explorer menu hooks should exist");
+        assert!(nsis_hooks.contains("NSIS_HOOK_POSTINSTALL"));
+        assert!(nsis_hooks.contains("NSIS_HOOK_PREUNINSTALL"));
+        assert!(nsis_hooks.contains(r"Software\Classes\${OBJECT}\shell\Markra.open"));
+        assert!(nsis_hooks.contains(r#""SystemFileAssociations\.txt""#));
+        assert!(nsis_hooks.contains(r#""Directory""#));
+        assert!(nsis_hooks.contains(r#""Directory\Background""#));
+        assert!(nsis_hooks.contains(r#"$\"${ARGUMENT}$\""#));
+        assert!(nsis_hooks.contains(r#""%1""#));
+        assert!(nsis_hooks.contains(r#""%V""#));
+        assert!(nsis_hooks.contains("ReadRegStr"));
+        assert!(nsis_hooks.contains("DeleteRegKey"));
+
+        let wix_fragment = std::fs::read_to_string(windows_dir.join("explorer-menu.wxs"))
+            .expect("WiX Explorer menu fragment should exist");
+        assert!(wix_fragment.contains("MarkraExplorerMenu"));
+        assert!(wix_fragment.contains(r"SystemFileAssociations\.txt\shell\Markra.open"));
+        assert!(wix_fragment.contains(r"Directory\shell\Markra.open"));
+        assert!(wix_fragment.contains(r"Directory\Background\shell\Markra.open"));
+        assert!(wix_fragment.contains("&quot;%1&quot;"));
+        assert!(wix_fragment.contains("&quot;%V&quot;"));
+        assert_eq!(wix_fragment.matches("<RemoveRegistryKey").count(), 3);
+
+        let mut reader = quick_xml::Reader::from_str(&wix_fragment);
+        loop {
+            match reader.read_event() {
+                Ok(quick_xml::events::Event::Eof) => break,
+                Ok(_) => {}
+                Err(error) => panic!("WiX Explorer menu fragment should be valid XML: {error}"),
+            }
+        }
+    }
+
+    #[test]
     fn desktop_registers_window_state_restore_plugin() {
         let manifest = include_str!("../Cargo.toml");
         assert!(

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -58,6 +58,19 @@
         "role": "Editor"
       }
     ],
+    "windows": {
+      "nsis": {
+        "installerHooks": "./windows/explorer-menu.nsh"
+      },
+      "wix": {
+        "fragmentPaths": [
+          "./windows/explorer-menu.wxs"
+        ],
+        "componentRefs": [
+          "MarkraExplorerMenu"
+        ]
+      }
+    },
     "macOS": {
       "files": {
         "Resources/Assets.car": "icons/generated/Assets.car",

--- a/apps/desktop/src-tauri/windows/explorer-menu.nsh
+++ b/apps/desktop/src-tauri/windows/explorer-menu.nsh
@@ -1,0 +1,30 @@
+!macro MarkraRegisterExplorerMenu OBJECT ARGUMENT
+  WriteRegStr SHCTX "Software\Classes\${OBJECT}\shell\Markra.open" "" "Open with Markra"
+  WriteRegStr SHCTX "Software\Classes\${OBJECT}\shell\Markra.open" "Icon" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\",0"
+  WriteRegStr SHCTX "Software\Classes\${OBJECT}\shell\Markra.open\command" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"${ARGUMENT}$\""
+!macroend
+
+!macro MarkraUnregisterExplorerMenu OBJECT ARGUMENT
+  ReadRegStr $R0 SHCTX "Software\Classes\${OBJECT}\shell\Markra.open\command" ""
+  ; Preserve a verb that another installation may have replaced after this one was installed.
+  ${If} $R0 == "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"${ARGUMENT}$\""
+    DeleteRegKey SHCTX "Software\Classes\${OBJECT}\shell\Markra.open"
+  ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+  ; Markdown associations already provide their own Open with Markra verb.
+  !insertmacro MarkraRegisterExplorerMenu "SystemFileAssociations\.txt" "%1"
+  !insertmacro MarkraRegisterExplorerMenu "Directory" "%1"
+  !insertmacro MarkraRegisterExplorerMenu "Directory\Background" "%V"
+  ; Tell Explorer to refresh its cached file-association data.
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro MarkraUnregisterExplorerMenu "SystemFileAssociations\.txt" "%1"
+  !insertmacro MarkraUnregisterExplorerMenu "Directory" "%1"
+  !insertmacro MarkraUnregisterExplorerMenu "Directory\Background" "%V"
+  ; Tell Explorer to refresh its cached file-association data.
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
+!macroend

--- a/apps/desktop/src-tauri/windows/explorer-menu.wxs
+++ b/apps/desktop/src-tauri/windows/explorer-menu.wxs
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <DirectoryRef Id="INSTALLDIR">
+      <Component
+        Id="MarkraExplorerMenu"
+        Guid="{EE048FC5-8263-4AE0-BE5B-1F4E4F930D13}"
+        Win64="$(var.Win64)"
+      >
+        <!-- Markdown associations already provide their own Open with Markra verb. -->
+        <RegistryValue Root="HKLM" Key="Software\Classes\SystemFileAssociations\.txt\shell\Markra.open" Type="string" Value="Open with Markra" KeyPath="yes" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\SystemFileAssociations\.txt\shell\Markra.open" Name="Icon" Type="string" Value="&quot;[#Path]&quot;,0" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\SystemFileAssociations\.txt\shell\Markra.open\command" Type="string" Value="&quot;[#Path]&quot; &quot;%1&quot;" />
+
+        <RegistryValue Root="HKLM" Key="Software\Classes\Directory\shell\Markra.open" Type="string" Value="Open with Markra" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\Directory\shell\Markra.open" Name="Icon" Type="string" Value="&quot;[#Path]&quot;,0" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\Directory\shell\Markra.open\command" Type="string" Value="&quot;[#Path]&quot; &quot;%1&quot;" />
+
+        <RegistryValue Root="HKLM" Key="Software\Classes\Directory\Background\shell\Markra.open" Type="string" Value="Open with Markra" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\Directory\Background\shell\Markra.open" Name="Icon" Type="string" Value="&quot;[#Path]&quot;,0" />
+        <RegistryValue Root="HKLM" Key="Software\Classes\Directory\Background\shell\Markra.open\command" Type="string" Value="&quot;[#Path]&quot; &quot;%V&quot;" />
+
+        <RemoveRegistryKey Id="RemoveTextMenu" Root="HKLM" Key="Software\Classes\SystemFileAssociations\.txt\shell\Markra.open" Action="uninstall" />
+        <RemoveRegistryKey Id="RemoveDirectoryMenu" Root="HKLM" Key="Software\Classes\Directory\shell\Markra.open" Action="uninstall" />
+        <RemoveRegistryKey Id="RemoveBackgroundMenu" Root="HKLM" Key="Software\Classes\Directory\Background\shell\Markra.open" Action="uninstall" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
## Summary
- add `Open with Markra` Explorer verbs for text files, selected folders, and folder backgrounds
- keep Markdown files on the existing Tauri file-association verb to avoid duplicate menu entries
- register and clean up the verbs for both NSIS and MSI installers
- cover installer configuration, registry targets, argument quoting, cleanup, and WiX XML validity

## Validation
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --locked` — 272 passed
- `pnpm test` — 2,575 passed
- `pnpm typecheck:test` — passed
- `pnpm build` — passed
- `pnpm test:release` — 50 passed
- `pnpm --filter @markra/desktop exec tauri inspect wix-upgrade-code` — Tauri config parsed successfully
- Not run locally: Windows NSIS/MSI packaging and Explorer smoke testing, because the development host is macOS

## Risk
- Windows 11 exposes these legacy static verbs under **Show more options**; native first-level integration would require a separate `IExplorerCommand` extension
- portable builds do not register the menu because they do not run an installer

Closes #659