### PR TITLE
fix(editor): prevent editor control overlap

### DIFF
--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1411,13 +1411,16 @@
   .markdown-paper .cm-markra-table-wrap {
     display: block !important;
     margin: 0 !important;
-    padding: 20px 36px 12px 0 !important;
+    padding: 28px 36px 12px 0 !important;
     overflow: visible !important;
     font-size: 16px !important;
     line-height: 26.4px !important;
   }
 
   .markdown-paper .cm-line:has(> .cm-markra-table-wrap) {
+    /* The source line has zero height, so center block tools inside the
+       reserved 24px table-control row instead of the preceding block. */
+    --markra-block-toolbar-block-offset: 12px;
     font-size: 0 !important;
     line-height: 0 !important;
   }
@@ -1464,8 +1467,8 @@
 
   .markdown-paper[data-editor-theme="github"] .cm-markra-table-wrap,
   .markdown-paper[data-editor-theme="github-dark"] .cm-markra-table-wrap {
-    margin: 16px 0 !important;
-    padding: 0 !important;
+    margin: 0 0 16px !important;
+    padding: 28px 0 0 !important;
   }
 
   .markdown-paper[data-editor-theme="github"] .cm-markra-table th,
@@ -1551,7 +1554,7 @@
     /* Keep block tools anchored to the shared line gutter. List and callout
        padding must move content without pulling controls into the block. */
     position: absolute !important;
-    inset-inline-start: -54px;
+    inset-inline-start: var(--markra-block-toolbar-inline-start, -54px);
     top: calc(0.5lh + var(--markra-block-toolbar-block-offset, 0px));
     z-index: 5;
     display: inline-flex !important;
@@ -2517,13 +2520,16 @@
   }
 
   .markdown-paper .markra-list-toggle-item {
+    /* Reserve the toolbar, its 12px hover bridge, and a 4px gap before the
+       fold button so invisible hit areas cannot cover either control. */
+    --markra-block-toolbar-inline-start: -94px;
     position: relative;
   }
 
   .markdown-paper .markra-list-toggle-button {
     @apply absolute inline-flex size-4 cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 outline-none transition-[opacity,color,background-color] duration-150 ease-out focus-visible:bg-(--bg-hover) focus-visible:outline-none;
     color: color-mix(in srgb, var(--editor-text-secondary) 62%, transparent);
-    left: -2.2em;
+    inset-inline-start: -36px;
     display: inline-flex !important;
     margin: 0 !important;
     padding: 0 !important;
@@ -3238,7 +3244,8 @@
 
   .markdown-paper .markra-table-align-controls {
     @apply absolute left-1.5 z-10 flex items-center gap-0.5;
-    top: -12px !important;
+    height: 24px;
+    top: 0 !important;
   }
 
   .markdown-paper .markra-table-size-controls {

--- a/packages/app/src/styles.test.ts
+++ b/packages/app/src/styles.test.ts
@@ -498,7 +498,7 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .cm-markra-code-header-actions");
     expect(styles).toContain("opacity: 0 !important");
     expect(styles).toContain(".markdown-paper .cm-markra-table-wrap");
-    expect(styles).toContain("padding: 20px 36px 12px 0 !important");
+    expect(styles).toContain("padding: 28px 36px 12px 0 !important");
     expect(styles).toContain(
       ".markdown-paper .cm-line:has(> .cm-markra-table-wrap)",
     );
@@ -587,7 +587,9 @@ describe("editor stylesheet", () => {
     expect(blockLineRule).toContain("position: relative");
     expect(toolbarRuleStart).toBeGreaterThanOrEqual(0);
     expect(toolbarRule).toContain("position: absolute !important");
-    expect(toolbarRule).toContain("inset-inline-start: -54px");
+    expect(toolbarRule).toContain(
+      "inset-inline-start: var(--markra-block-toolbar-inline-start, -54px)",
+    );
     expect(toolbarRule).toContain(
       "top: calc(0.5lh + var(--markra-block-toolbar-block-offset, 0px))",
     );
@@ -603,6 +605,28 @@ describe("editor stylesheet", () => {
     expect(revealRuleStart).toBeGreaterThanOrEqual(0);
     expect(revealRule).toContain("opacity: 0.58 !important");
     expect(revealRule).toContain("pointer-events: auto");
+  });
+
+  it("keeps foldable list controls in separate gutter slots", () => {
+    const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const listItemRuleStart = styles.indexOf(
+      ".markdown-paper .markra-list-toggle-item {",
+    );
+    const listItemRuleEnd = styles.indexOf("\n  }", listItemRuleStart);
+    const listItemRule = styles.slice(listItemRuleStart, listItemRuleEnd);
+    const listButtonRuleStart = styles.indexOf(
+      ".markdown-paper .markra-list-toggle-button {",
+    );
+    const listButtonRuleEnd = styles.indexOf("\n  }", listButtonRuleStart);
+    const listButtonRule = styles.slice(listButtonRuleStart, listButtonRuleEnd);
+
+    expect(listItemRuleStart).toBeGreaterThanOrEqual(0);
+    expect(listItemRule).toContain(
+      "--markra-block-toolbar-inline-start: -94px",
+    );
+    expect(listButtonRuleStart).toBeGreaterThanOrEqual(0);
+    expect(listButtonRule).toContain("inset-inline-start: -36px");
+    expect(listButtonRule).not.toContain("left:");
   });
 
   it("keeps terminal heading tools centered and in separate horizontal slots", () => {
@@ -831,7 +855,7 @@ describe("editor stylesheet", () => {
     const buttonStyles = styles.slice(buttonStart, buttonEnd);
 
     expect(styles).toContain(".markdown-paper .markra-list-toggle-item");
-    expect(buttonStyles).toContain("left: -2.2em");
+    expect(buttonStyles).toContain("inset-inline-start: -36px");
     expect(buttonStyles).toContain("top: calc((1lh - 1rem) / 2);");
     expect(styles).toContain(".markdown-paper .markra-list-toggle-item:hover > .markra-list-toggle-button");
     expect(styles).toContain(".markdown-paper .markra-list-collapsed-content");
@@ -892,6 +916,21 @@ describe("editor stylesheet", () => {
 
   it("keeps table add controls hidden until table hover or focus", () => {
     const styles = readFileSync(`${process.cwd()}/src/styles.css`, "utf8");
+    const tableLineStart = styles.indexOf(
+      ".markdown-paper .cm-line:has(> .cm-markra-table-wrap) {",
+    );
+    const tableLineEnd = styles.indexOf("\n  }", tableLineStart);
+    const tableLineStyles = styles.slice(tableLineStart, tableLineEnd);
+    const tableAlignStart = styles.indexOf(
+      ".markdown-paper .markra-table-align-controls {",
+    );
+    const tableAlignEnd = styles.indexOf("\n  }", tableAlignStart);
+    const tableAlignStyles = styles.slice(tableAlignStart, tableAlignEnd);
+    const githubTableStart = styles.indexOf(
+      '.markdown-paper[data-editor-theme="github"] .cm-markra-table-wrap,',
+    );
+    const githubTableEnd = styles.indexOf("\n  }", githubTableStart);
+    const githubTableStyles = styles.slice(githubTableStart, githubTableEnd);
     const tableControlStart = styles.indexOf(".markdown-paper .markra-table-control {");
     const tableControlEnd = styles.indexOf(".markdown-paper .markra-table-add-column");
     const tableControlStyles = styles.slice(tableControlStart, tableControlEnd);
@@ -905,6 +944,18 @@ describe("editor stylesheet", () => {
     expect(styles).toContain(".markdown-paper .markra-table-add-column");
     expect(styles).toContain(".markdown-paper .markra-table-add-row");
     expect(styles).toContain(".markdown-paper .markra-table-align-controls");
+    expect(tableLineStyles).toContain(
+      "--markra-block-toolbar-block-offset: 12px",
+    );
+    expect(tableAlignStyles).toContain("top: 0 !important");
+    expect(tableAlignStyles).toContain("height: 24px");
+    expect(tableAlignStyles).not.toContain("top: -12px");
+    expect(githubTableStyles).toContain(
+      "padding: 28px 0 0 !important",
+    );
+    expect(githubTableStyles).toContain(
+      "margin: 0 0 16px !important",
+    );
     expect(styles).toContain(".markdown-paper .markra-table-size-controls");
     expect(styles).toContain(".markdown-paper .markra-table-size-button[aria-expanded=\"true\"]");
     expect(styles).toContain(".markdown-paper .markra-table-width-button");


### PR DESCRIPTION
## Summary

- place foldable-list controls and block actions in separate gutter slots so their visible and invisible hit areas do not overlap
- reserve a table-owned 24px control rail so table and block controls stay below preceding content
- preserve the table control rail for the GitHub light and dark editor themes

## Validation

- `pnpm --filter @markra/app test` (132 files, 1508 tests passed)
- `pnpm --filter @markra/app build`
- browser geometry check: list hit areas have a 4px gap and zero overlap
- browser interaction check: the fold button remains clickable and toggles the nested list
- browser geometry check: table controls have zero overlap with the preceding heading and a 4px gap before the table

## Related Issues

Closes #671
