### PR TITLE
fix(editor): restore paragraph spacing between blocks

### DIFF
--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -500,7 +500,7 @@ describe("liveMarkdown", () => {
 
     expect(renderedLines(view)).toEqual(before);
     expect(view.dom.querySelectorAll(".cm-markra-empty-line")).toHaveLength(1);
-    expect(paragraphEndStates(view)).toEqual([false, false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
   });
 
   it("keeps all empty lines stable across recreation", () => {
@@ -524,21 +524,21 @@ describe("liveMarkdown", () => {
   it("allows the cursor to remain on an internal blank line", () => {
     const doc = "Before\n\nAfter";
     const view = createView({ doc, anchor: doc.length });
-    expect(paragraphEndStates(view)).toEqual([false, false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
 
     view.dispatch({ selection: EditorSelection.cursor("Before\n".length) });
 
     expect(view.state.doc.toString()).toBe(doc);
     expect(view.state.selection.main.head).toBe("Before\n".length);
     expect(view.dom.querySelectorAll(".cm-markra-empty-line")).toHaveLength(1);
-    expect(paragraphEndStates(view)).toEqual([false, false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
   });
 
-  it("keeps paragraph spacing separate from authored blank lines", () => {
+  it("adds paragraph spacing without resizing authored blank lines", () => {
     const view = createView({ doc: "First\nSecond\n\n\nAfter" });
 
     expect(view.dom.querySelectorAll(".cm-markra-empty-line")).toHaveLength(2);
-    expect(paragraphEndStates(view)).toEqual([false, false, false]);
+    expect(paragraphEndStates(view)).toEqual([false, true, false]);
   });
 
   it("adds paragraph spacing when another block starts directly", () => {
@@ -569,7 +569,7 @@ describe("liveMarkdown", () => {
     const position = "Before\n".length;
     const view = createView({ doc, anchor: position });
 
-    expect(paragraphEndStates(view)).toEqual([false, false]);
+    expect(paragraphEndStates(view)).toEqual([true, false]);
 
     view.dispatch({
       changes: { from: position, insert: "Middle" },

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -397,13 +397,16 @@ function buildDecorations(
           listDepth(node.node as MarkraSyntaxNode) === 0
         ) {
           const endLine = state.doc.lineAt(node.to - 1).number;
-          const nextLine = endLine + 1;
-          // A source blank already owns a stable block-gap widget. Paragraph
-          // padding is only needed for directly adjacent Markdown blocks.
-          if (
-            nextLine <= state.doc.lines &&
-            state.doc.line(nextLine).text.trim().length > 0
+          let nextContentLine = endLine + 1;
+          while (
+            nextContentLine <= state.doc.lines &&
+            state.doc.line(nextContentLine).text.trim().length === 0
           ) {
+            nextContentLine += 1;
+          }
+          // Authored blank lines stay full-height and editable. Add semantic
+          // paragraph rhythm to the content line only when another block follows.
+          if (nextContentLine <= state.doc.lines) {
             paragraphEndLine = endLine;
           }
         }


### PR DESCRIPTION
## Summary
- apply configured paragraph spacing when another Markdown block follows, including across authored blank lines
- keep authored blank lines full-height and editable
- update live preview coverage for selection, cursor, editing, and multi-line paragraph cases

## Why
The blank-line layout widget that previously consumed `--editor-paragraph-spacing` was removed, but live preview still limited paragraph-end padding to directly adjacent blocks. Normal blank-separated Markdown paragraphs therefore ignored the setting.

## Validation
- `pnpm --filter @markra/editor test` — 456 tests passed
- `pnpm --filter @markra/app test -- src/styles.test.ts` — 66 tests passed
- `pnpm --filter @markra/editor build && pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app build && pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- Browser geometry check — an 8px configured spacing produced 8px paragraph-end padding while the authored blank line retained its normal 26.4px height
- Not run: Windows native WebView manual QA

## Screenshots
Not included; the spacing behavior was validated through computed browser geometry.

## Risk
Low. The change only extends paragraph-end decoration across intervening blank lines and does not mutate Markdown text or resize editable blank rows.

Closes #675
