### PR TITLE
fix(editor): preserve line breaks after whole-line selection

### DIFF
--- a/packages/editor/src/codemirror/markdown-editing.test.ts
+++ b/packages/editor/src/codemirror/markdown-editing.test.ts
@@ -79,6 +79,49 @@ afterEach(() => {
 });
 
 describe("markdownEditingPlugin", () => {
+  it("keeps the trailing line break when replacing a triple-clicked line", () => {
+    const firstLine = "Mock selected line";
+    const secondLine = "Mock next line";
+    const view = createView(`${firstLine}\n${secondLine}`, 0);
+    view.focus();
+
+    view.contentDOM.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+      detail: 3,
+    }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(view.state.selection.main.from).toBe(0);
+    expect(view.state.selection.main.to).toBe(firstLine.length);
+
+    view.dispatch(
+      view.state.replaceSelection("Replacement"),
+      { userEvent: "input.type" },
+    );
+
+    expect(view.state.doc.toString()).toBe(`Replacement\n${secondLine}`);
+  });
+
+  it("keeps CodeMirror's double-click word selection behavior", () => {
+    const view = createView("Mock selected line\nMock next line", 0);
+    view.focus();
+
+    view.contentDOM.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+      detail: 2,
+    }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(view.state.selection.main.from).toBe(0);
+    expect(view.state.selection.main.to).toBe("Mock".length);
+  });
+
   it("keeps CodeMirror's native Enter behavior in a paragraph", () => {
     const doc = "MockBeforeMockAfter";
     const position = "MockBefore".length;

--- a/packages/editor/src/codemirror/markdown-editing.test.ts
+++ b/packages/editor/src/codemirror/markdown-editing.test.ts
@@ -79,10 +79,56 @@ afterEach(() => {
 });
 
 describe("markdownEditingPlugin", () => {
-  it("keeps the trailing line break when replacing a triple-clicked line", () => {
+  it.each([3, 4])(
+    "keeps the trailing line break when replacing a line after click count %s",
+    (detail) => {
+      const firstLine = "Mock selected line";
+      const secondLine = "Mock next line";
+      const view = createView(`${firstLine}\n${secondLine}`, 0);
+      view.focus();
+
+      view.contentDOM.dispatchEvent(new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        clientX: 0,
+        clientY: 0,
+        detail,
+      }));
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      expect(view.state.selection.main.from).toBe(0);
+      expect(view.state.selection.main.to).toBe(firstLine.length);
+
+      view.dispatch(
+        view.state.replaceSelection("Replacement"),
+        { userEvent: "input.type" },
+      );
+
+      expect(view.state.doc.toString()).toBe(`Replacement\n${secondLine}`);
+    },
+  );
+
+  it("keeps the trailing line break when replacing a keyboard-selected line", () => {
     const firstLine = "Mock selected line";
     const secondLine = "Mock next line";
     const view = createView(`${firstLine}\n${secondLine}`, 0);
+    view.focus();
+
+    expect(press(view, "l", { altKey: true })).toBe(true);
+    expect(view.state.selection.main.from).toBe(0);
+    expect(view.state.selection.main.to).toBe(firstLine.length);
+
+    view.dispatch(
+      view.state.replaceSelection("Replacement"),
+      { userEvent: "input.type" },
+    );
+
+    expect(view.state.doc.toString()).toBe(`Replacement\n${secondLine}`);
+  });
+
+  it("inserts into a triple-clicked empty line without removing it", () => {
+    const secondLine = "Mock next line";
+    const view = createView(`\n${secondLine}`, 0);
     view.focus();
 
     view.contentDOM.dispatchEvent(new MouseEvent("mousedown", {
@@ -94,15 +140,70 @@ describe("markdownEditingPlugin", () => {
     }));
     document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
-    expect(view.state.selection.main.from).toBe(0);
-    expect(view.state.selection.main.to).toBe(firstLine.length);
-
+    expect(view.state.selection.main.empty).toBe(true);
     view.dispatch(
       view.state.replaceSelection("Replacement"),
       { userEvent: "input.type" },
     );
 
     expect(view.state.doc.toString()).toBe(`Replacement\n${secondLine}`);
+  });
+
+  it("keeps internal line breaks in a keyboard-selected line range", () => {
+    const firstLine = "Mock first line";
+    const secondLine = "Mock second line";
+    const thirdLine = "Mock third line";
+    const doc = `${firstLine}\n${secondLine}\n${thirdLine}`;
+    const view = createView(
+      doc,
+      EditorSelection.create([
+        EditorSelection.range(2, firstLine.length + 1 + 4),
+      ]),
+    );
+
+    expect(press(view, "l", { altKey: true })).toBe(true);
+    expect(view.state.selection.main.from).toBe(0);
+    expect(view.state.selection.main.to).toBe(
+      firstLine.length + 1 + secondLine.length,
+    );
+
+    view.dispatch(
+      view.state.replaceSelection("Replacement"),
+      { userEvent: "input.type" },
+    );
+
+    expect(view.state.doc.toString()).toBe(`Replacement\n${thirdLine}`);
+  });
+
+  it("selects multiple complete lines without their trailing breaks", () => {
+    const firstLine = "Mock first line";
+    const middleLine = "Mock middle line";
+    const lastLine = "Mock last line";
+    const doc = `${firstLine}\n${middleLine}\n${lastLine}`;
+    const lastLineFrom = firstLine.length + 1 + middleLine.length + 1;
+    const view = createView(
+      doc,
+      EditorSelection.create([
+        EditorSelection.cursor(2),
+        EditorSelection.cursor(lastLineFrom + 2),
+      ]),
+    );
+
+    expect(press(view, "l", { altKey: true })).toBe(true);
+    expect(view.state.selection.ranges.map(({ from, to }) => ({ from, to })))
+      .toEqual([
+        { from: 0, to: firstLine.length },
+        { from: lastLineFrom, to: doc.length },
+      ]);
+
+    view.dispatch(
+      view.state.replaceSelection("Replacement"),
+      { userEvent: "input.type" },
+    );
+
+    expect(view.state.doc.toString()).toBe(
+      `Replacement\n${middleLine}\nReplacement`,
+    );
   });
 
   it("keeps CodeMirror's double-click word selection behavior", () => {

--- a/packages/editor/src/codemirror/markdown-editing.ts
+++ b/packages/editor/src/codemirror/markdown-editing.ts
@@ -7,7 +7,7 @@ import {
   type SelectionRange,
   type Transaction,
 } from "@codemirror/state";
-import { keymap, type EditorView } from "@codemirror/view";
+import { EditorView, keymap, type ViewUpdate } from "@codemirror/view";
 import { defineMarkraPlugin } from "./plugin.ts";
 
 const indentation = "  ";
@@ -91,6 +91,45 @@ function handleTab(view: EditorView) {
 
 function handleShiftTab(view: EditorView) {
   return indentList(view, true);
+}
+
+function selectTripleClickedLine(view: EditorView, event: MouseEvent) {
+  if (event.button !== 0 || event.detail !== 3) return null;
+
+  const clickedPosition = view.posAtCoords({
+    x: event.clientX,
+    y: event.clientY,
+  });
+  if (clickedPosition === null) return null;
+  let start = clickedPosition;
+  let startSelection = view.state.selection;
+
+  return {
+    get(currentEvent: MouseEvent, extend: boolean, multiple: boolean) {
+      const head = view.posAtCoords({
+        x: currentEvent.clientX,
+        y: currentEvent.clientY,
+      });
+      if (head === null) return startSelection;
+
+      const anchor = extend ? startSelection.main.anchor : start;
+      const anchorLine = view.state.doc.lineAt(anchor);
+      const headLine = view.state.doc.lineAt(head);
+      // CodeMirror includes the trailing line break in triple-click selections.
+      // Leave it outside the visual-editor selection so replacement cannot
+      // merge lines.
+      const range = head >= anchor
+        ? EditorSelection.range(anchorLine.from, headLine.to)
+        : EditorSelection.range(anchorLine.to, headLine.from);
+      return multiple
+        ? startSelection.addRange(range)
+        : EditorSelection.create([range]);
+    },
+    update(update: ViewUpdate) {
+      start = update.changes.mapPos(start);
+      startSelection = startSelection.map(update.changes);
+    },
+  };
 }
 
 function keepJoinedLineCaretsAfterText(transaction: Transaction) {
@@ -237,6 +276,7 @@ export function markdownEditingPlugin() {
   return defineMarkraPlugin({
     id: "markra.markdown-editing",
     extension: [
+      EditorView.mouseSelectionStyle.of(selectTripleClickedLine),
       EditorState.transactionFilter.of(keepJoinedLineCaretsAfterText),
       Prec.high(keymap.of([
         { key: "Backspace", run: removeLeadingEmptyLineBackward },

--- a/packages/editor/src/codemirror/markdown-editing.ts
+++ b/packages/editor/src/codemirror/markdown-editing.ts
@@ -94,7 +94,7 @@ function handleShiftTab(view: EditorView) {
 }
 
 function selectTripleClickedLine(view: EditorView, event: MouseEvent) {
-  if (event.button !== 0 || event.detail !== 3) return null;
+  if (event.button !== 0 || event.detail < 3) return null;
 
   const clickedPosition = view.posAtCoords({
     x: event.clientX,
@@ -130,6 +130,37 @@ function selectTripleClickedLine(view: EditorView, event: MouseEvent) {
       startSelection = startSelection.map(update.changes);
     },
   };
+}
+
+function selectLinesWithoutTrailingBreak(view: EditorView) {
+  const blocks: Array<{ from: number; to: number }> = [];
+  let coveredThroughLine = -1;
+
+  for (const range of view.state.selection.ranges) {
+    const startLine = view.state.doc.lineAt(range.from);
+    let endLine = view.state.doc.lineAt(range.to);
+    if (!range.empty && range.to === endLine.from) {
+      endLine = view.state.doc.lineAt(range.to - 1);
+    }
+
+    if (coveredThroughLine >= startLine.number) {
+      // Adjacent line selections would touch across their shared line break,
+      // so keep them in one valid CodeMirror selection range.
+      const previous = blocks[blocks.length - 1];
+      if (previous) previous.to = Math.max(previous.to, endLine.to);
+    } else {
+      blocks.push({ from: startLine.from, to: endLine.to });
+    }
+    coveredThroughLine = Math.max(coveredThroughLine, endLine.number + 1);
+  }
+
+  view.dispatch({
+    selection: EditorSelection.create(
+      blocks.map(({ from, to }) => EditorSelection.range(from, to)),
+    ),
+    userEvent: "select",
+  });
+  return true;
 }
 
 function keepJoinedLineCaretsAfterText(transaction: Transaction) {
@@ -283,6 +314,11 @@ export function markdownEditingPlugin() {
         {
           key: "Enter",
           run: confirmIncompleteInlineDestination,
+        },
+        {
+          key: "Alt-l",
+          mac: "Ctrl-l",
+          run: selectLinesWithoutTrailingBreak,
         },
         { key: "Tab", run: handleTab, shift: handleShiftTab },
         { key: "Shift-Enter", run: insertContextualHardBreak },


### PR DESCRIPTION
## Summary

- exclude the trailing line break from visual-editor whole-line selections
- cover third and subsequent primary-button clicks plus the Alt-L/Ctrl-L line-selection shortcut
- preserve double-click word selection, internal line breaks, empty lines, and multi-cursor selections
- add regression coverage for replacing selected lines without merging following content

## Why

CodeMirror includes the trailing line break when selecting a whole line. Replacing that selection therefore removes the line break and merges the replacement with the following line in Markra's WYSIWYG editor.

Closes #673

## Validation

- `pnpm --filter @markra/editor test` — 38 test files and 475 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app build` — passed
- `git diff --check` — passed
- Not run: manual desktop click-through on macOS or Windows

## Risk

- Low: custom behavior is limited to whole-line selection in the visual editor; ordinary single-click, double-click, and source-editor selection behavior still use CodeMirror defaults.
