### PR TITLE
fix(editor): normalize mixed inline formatting

### DIFF
--- a/packages/editor/src/codemirror/formatting.test.ts
+++ b/packages/editor/src/codemirror/formatting.test.ts
@@ -105,6 +105,101 @@ describe("formattingPlugin", () => {
     ).toBe("text");
   });
 
+  it.each([
+    ["bold", "format.bold", "**"],
+    ["italic", "format.italic", "*"],
+    ["strikethrough", "format.strikethrough", "~~"],
+    ["inline code", "format.code", "`"],
+    ["highlight", "format.highlight", "=="],
+  ] as const)(
+    "normalizes mixed %s formatting before toggling it off",
+    (_label, command, marker) => {
+      const selected = `plain ${marker}marked${marker} tail`;
+      const view = createView({
+        doc: `Before ${selected} after`,
+        from: "Before ".length,
+        to: "Before ".length + selected.length,
+      });
+
+      expect(runMarkraCommand(view, command)).toBe(true);
+      expect(view.state.doc.toString()).toBe(
+        `Before ${marker}plain marked tail${marker} after`,
+      );
+      expect(
+        view.state.sliceDoc(
+          view.state.selection.main.from,
+          view.state.selection.main.to,
+        ),
+      ).toBe("plain marked tail");
+
+      expect(runMarkraCommand(view, command)).toBe(true);
+      expect(view.state.doc.toString()).toBe(
+        "Before plain marked tail after",
+      );
+    },
+  );
+
+  it("preserves nested italic formatting while normalizing mixed bold", () => {
+    const selected = "plain ***marked*** tail";
+    const view = createView({
+      doc: `Before ${selected} after`,
+      from: "Before ".length,
+      to: "Before ".length + selected.length,
+    });
+
+    expect(runMarkraCommand(view, "format.bold")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "Before **plain *marked* tail** after",
+    );
+
+    expect(runMarkraCommand(view, "format.bold")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "Before plain *marked* tail after",
+    );
+  });
+
+  it("merges bold spans that cross both selection boundaries", () => {
+    const doc = "Before **start** plain **end** after";
+    const from = doc.indexOf("start");
+    const to = doc.indexOf("end") + "end".length;
+    const view = createView({ doc, from, to });
+
+    expect(runMarkraCommand(view, "format.bold")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "Before **start plain end** after",
+    );
+    expect(
+      view.state.sliceDoc(
+        view.state.selection.main.from,
+        view.state.selection.main.to,
+      ),
+    ).toBe("start plain end");
+
+    expect(runMarkraCommand(view, "format.bold")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      "Before start plain end after",
+    );
+  });
+
+  it("preserves escaped marker text while normalizing italic", () => {
+    const selected = String.raw`plain \*literal\* and *italic* tail`;
+    const view = createView({
+      doc: `Before ${selected} after`,
+      from: "Before ".length,
+      to: "Before ".length + selected.length,
+    });
+
+    expect(runMarkraCommand(view, "format.italic")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      String.raw`Before *plain \*literal\* and italic tail* after`,
+    );
+
+    expect(runMarkraCommand(view, "format.italic")).toBe(true);
+    expect(view.state.doc.toString()).toBe(
+      String.raw`Before plain \*literal\* and italic tail after`,
+    );
+  });
+
   it("tracks and toggles nested bold and italic markers independently", () => {
     const view = createView();
 

--- a/packages/editor/src/codemirror/formatting.ts
+++ b/packages/editor/src/codemirror/formatting.ts
@@ -31,6 +31,8 @@ interface FormattingSpec {
   icon: string;
   key: string;
   marker: string;
+  markerNode: string;
+  node: string;
   order: number;
 }
 
@@ -48,6 +50,8 @@ const formattingSpecs: readonly FormattingSpec[] = [
     icon: "bold",
     key: "Mod-b",
     marker: "**",
+    markerNode: "EmphasisMark",
+    node: "StrongEmphasis",
     order: 10,
   },
   {
@@ -55,6 +59,8 @@ const formattingSpecs: readonly FormattingSpec[] = [
     icon: "italic",
     key: "Mod-i",
     marker: "*",
+    markerNode: "EmphasisMark",
+    node: "Emphasis",
     order: 20,
   },
   {
@@ -62,6 +68,8 @@ const formattingSpecs: readonly FormattingSpec[] = [
     icon: "strikethrough",
     key: "Mod-Shift-x",
     marker: "~~",
+    markerNode: "StrikethroughMark",
+    node: "Strikethrough",
     order: 30,
   },
   {
@@ -69,6 +77,8 @@ const formattingSpecs: readonly FormattingSpec[] = [
     icon: "code",
     key: "Mod-e",
     marker: "`",
+    markerNode: "CodeMark",
+    node: "InlineCode",
     order: 40,
   },
   {
@@ -76,43 +86,68 @@ const formattingSpecs: readonly FormattingSpec[] = [
     icon: "highlighter",
     key: "Mod-Shift-h",
     marker: "==",
+    markerNode: "HighlightMark",
+    node: "Highlight",
     order: 50,
   },
 ];
 
 const clearableInlineMarkers = ["**", "~~", "==", "`", "*"] as const;
 
+type SyntaxTreeNode = ReturnType<typeof syntaxTree>["topNode"];
+
+function formattingMarkers(node: SyntaxTreeNode, spec: FormattingSpec) {
+  const markers: Array<{ from: number; to: number }> = [];
+  let child = node.firstChild;
+  while (child) {
+    if (child.name === spec.markerNode) {
+      markers.push({ from: child.from, to: child.to });
+    }
+    child = child.nextSibling;
+  }
+  return markers;
+}
+
+function visitFormattingNodes(
+  state: EditorState,
+  spec: FormattingSpec,
+  from: number,
+  to: number,
+  visit: (node: SyntaxTreeNode) => unknown,
+) {
+  const walk = (node: SyntaxTreeNode) => {
+    if (node.to <= from || node.from >= to) return;
+    if (node.name === spec.node) visit(node);
+
+    let child = node.firstChild;
+    while (child) {
+      walk(child);
+      child = child.nextSibling;
+    }
+  };
+
+  walk(syntaxTree(state).topNode);
+}
+
 function rangeHasMarker(
   state: EditorState,
   range: SelectionRange,
-  marker: string,
+  spec: FormattingSpec,
 ) {
+  const { marker } = spec;
   if (range.from < marker.length) return false;
   if (range.to + marker.length > state.doc.length) return false;
   const hasMarker = (
     state.sliceDoc(range.from - marker.length, range.from) === marker &&
     state.sliceDoc(range.to, range.to + marker.length) === marker
   );
-  if (!hasMarker || marker !== "*") return hasMarker;
+  if (!hasMarker) return false;
 
-  const starRunLength = (position: number, direction: -1 | 1) => {
-    let length = 0;
-    let cursor = position;
-    while (direction < 0 ? cursor > 0 : cursor < state.doc.length) {
-      const from = direction < 0 ? cursor - 1 : cursor;
-      if (state.sliceDoc(from, from + 1) !== "*") break;
-      length += 1;
-      cursor += direction;
-    }
-    return length;
-  };
-
-  // A two-star delimiter is bold only; odd-length runs carry an italic layer
-  // as well (`*text*` or `***text***`).
-  return (
-    starRunLength(range.from, -1) % 2 === 1 &&
-    starRunLength(range.to, 1) % 2 === 1
-  );
+  let contained = false;
+  visitFormattingNodes(state, spec, range.from, range.to, (node) => {
+    if (node.from <= range.from && node.to >= range.to) contained = true;
+  });
+  return contained;
 }
 
 function selectionCanBeFormatted(view: EditorView) {
@@ -122,11 +157,11 @@ function selectionCanBeFormatted(view: EditorView) {
   );
 }
 
-function selectionHasMarker(view: EditorView, marker: string) {
+function selectionHasMarker(view: EditorView, spec: FormattingSpec) {
   const { state } = view;
   return (
     state.selection.ranges.length > 0 &&
-    state.selection.ranges.every((range) => rangeHasMarker(state, range, marker))
+    state.selection.ranges.every((range) => rangeHasMarker(state, range, spec))
   );
 }
 
@@ -140,11 +175,42 @@ function mappedSelectionRange(
     : EditorSelection.range(to, from);
 }
 
-function toggleMarker(view: EditorView, marker: string) {
+function formattingNormalization(
+  state: EditorState,
+  range: SelectionRange,
+  spec: FormattingSpec,
+) {
+  const changes: ChangeSpec[] = [];
+  let from = range.from;
+  let to = range.to;
+  visitFormattingNodes(state, spec, range.from, range.to, (node) => {
+    const markers = formattingMarkers(node, spec);
+    const opening = markers[0];
+    const closing = markers.at(-1);
+    if (
+      opening &&
+      closing &&
+      opening.to <= range.to &&
+      closing.from >= range.from
+    ) {
+      from = Math.min(from, node.from);
+      to = Math.max(to, node.to);
+      changes.push(
+        { from: opening.from, to: opening.to },
+        { from: closing.from, to: closing.to },
+      );
+    }
+  });
+
+  return { changes, from, to };
+}
+
+function toggleMarker(view: EditorView, spec: FormattingSpec) {
   if (!selectionCanBeFormatted(view)) return false;
 
   const { state } = view;
-  const removeMarker = selectionHasMarker(view, marker);
+  const { marker } = spec;
+  const removeMarker = selectionHasMarker(view, spec);
   const changes: ChangeSpec[] = [];
 
   for (const range of state.selection.ranges) {
@@ -153,10 +219,15 @@ function toggleMarker(view: EditorView, marker: string) {
         { from: range.from - marker.length, to: range.from },
         { from: range.to, to: range.to + marker.length },
       );
-    } else if (!rangeHasMarker(state, range, marker)) {
+    } else if (!rangeHasMarker(state, range, spec)) {
+      const normalization = formattingNormalization(state, range, spec);
+      // Mixed selections must first collapse same-format spans. Otherwise the
+      // new outer wrapper only gets removed on the next toggle and the original
+      // formatting survives. Syntax nodes keep literal marker text untouched.
       changes.push(
-        { from: range.from, insert: marker },
-        { from: range.to, insert: marker },
+        { from: normalization.from, insert: marker },
+        ...normalization.changes,
+        { from: normalization.to, insert: marker },
       );
     }
   }
@@ -188,9 +259,9 @@ function formattingCommand(
     keybindings: keybindings
       ? [{ key: spec.key, preventDefault: true }]
       : undefined,
-    isActive: (view) => selectionHasMarker(view, spec.marker),
+    isActive: (view) => selectionHasMarker(view, spec),
     isEnabled: selectionCanBeFormatted,
-    run: (view) => toggleMarker(view, spec.marker),
+    run: (view) => toggleMarker(view, spec),
   };
 }
 


### PR DESCRIPTION
## Summary
- validate formatting boundaries against the CodeMirror syntax tree instead of treating unrelated delimiters as one wrapper
- normalize same-format spans before applying a format across a mixed selection
- preserve nested formatting and escaped marker text while keeping the selection stable
- cover bold, italic, strikethrough, inline code, and highlight toggles

## Why
Mixed-format selections could accumulate nested Markdown delimiters. Toggling the same format again removed only the newly added outer delimiters, leaving the original formatting behind. Selections beginning and ending in separate formatted spans could also be mistaken for one formatted range.

## Validation
- `pnpm --filter @markra/editor test` — 38 test files and 483 tests passed
- `pnpm --filter @markra/editor build` — passed
- `pnpm --filter @markra/editor typecheck:test` — passed
- `pnpm --filter @markra/app test -- src/hooks/useCodeMirrorEditorController.test.tsx` — 11 tests passed
- `git diff --check origin/v2...HEAD` — passed
- Not run: manual desktop playback of the issue recording

## Risk
Formatting behavior now depends on the parser's formatting and delimiter node names. Focused coverage exercises every supported inline format, nested bold/italic content, formatting that crosses both selection boundaries, and escaped marker literals.

Closes #676
