### PR TITLE
fix(editor): disambiguate single-character setext input

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -28,6 +28,7 @@
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.41.1",
     "@cspell/cspell-types": "10.0.1",
+    "@lezer/common": "1.5.2",
     "@lezer/highlight": "1.2.3",
     "@lezer/markdown": "1.6.3",
     "@markra/ai": "workspace:*",

--- a/packages/editor/src/codemirror/controller.test.ts
+++ b/packages/editor/src/codemirror/controller.test.ts
@@ -191,6 +191,26 @@ describe("CodeMirror editor controller", () => {
     expect(sections[0]?.text).toBe(doc.slice(0, doc.indexOf("# Three")));
   });
 
+  it("omits single-character Setext underlines from heading anchors", () => {
+    expect(
+      readCodeMirrorHeadingAnchors(createView("Synthetic title\n-").state),
+    ).toEqual([]);
+    expect(
+      readCodeMirrorHeadingAnchors(createView("Synthetic title\n=").state),
+    ).toEqual([]);
+
+    expect(
+      readCodeMirrorHeadingAnchors(createView("Synthetic title\n--").state),
+    ).toEqual([
+      {
+        from: 0,
+        level: 2,
+        title: "Synthetic title",
+        to: "Synthetic title\n--".length,
+      },
+    ]);
+  });
+
   it("reuses heading anchors when an edit cannot affect headings", () => {
     const doc = "# Synthetic heading\n\nBody";
     const view = createView(doc);

--- a/packages/editor/src/codemirror/index.ts
+++ b/packages/editor/src/codemirror/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./plugin.ts";
 import { livePreview, type LivePreviewConfig } from "./preview.ts";
 import { markraSlashMenu } from "./slash-menu.ts";
+import { markraSetextHeading } from "./setext-heading.ts";
 import { markraTheme } from "./theme.ts";
 
 export type {
@@ -255,7 +256,7 @@ export interface LiveMarkdownConfig extends LivePreviewConfig {
 }
 
 export const markraLanguage = markdown({
-  extensions: [GFM, markraHighlight],
+  extensions: [GFM, markraHighlight, markraSetextHeading],
 });
 
 export function liveMarkdown(config: LiveMarkdownConfig = {}): Extension {
@@ -268,7 +269,7 @@ export function liveMarkdown(config: LiveMarkdownConfig = {}): Extension {
   return [
     highlight
       ? markraLanguage
-      : markdown({ extensions: [GFM] }),
+      : markdown({ extensions: [GFM, markraSetextHeading] }),
     markdownSyntaxHighlighting,
     codeFolding(),
     livePreview(previewConfig),

--- a/packages/editor/src/codemirror/live-markdown.test.ts
+++ b/packages/editor/src/codemirror/live-markdown.test.ts
@@ -1,4 +1,4 @@
-import { forceParsing } from "@codemirror/language";
+import { forceParsing, syntaxTree } from "@codemirror/language";
 import {
   EditorSelection,
   EditorState,
@@ -108,6 +108,156 @@ describe("liveMarkdown", () => {
 
     expect(view.state.doc.toString()).toBe("#");
     expect(renderedLines(view)).toEqual(["#"]);
+  });
+
+  it("keeps a lone dash below text as an unfinished list marker", () => {
+    const doc = "Synthetic title\n";
+    const view = createView({ doc });
+
+    view.dispatch({
+      changes: { from: doc.length, insert: "-" },
+      selection: { anchor: doc.length + 1 },
+      userEvent: "input.type",
+    });
+
+    expect(view.state.doc.toString()).toBe("Synthetic title\n-");
+    expect(syntaxTree(view.state).toString()).toBe(
+      "Document(Paragraph(HeaderMark))",
+    );
+    expect(renderedLines(view)).toEqual(["Synthetic title", "-"]);
+    expect(view.dom.querySelector(".cm-markra-h2")).toBeNull();
+
+    view.dispatch({ selection: { anchor: 0 } });
+    expect(renderedLines(view)).toEqual(["Synthetic title", "-"]);
+
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: "-" },
+      selection: { anchor: view.state.doc.length + 1 },
+      userEvent: "input.type",
+    });
+
+    expect(syntaxTree(view.state).toString()).toBe(
+      "Document(SetextHeading2(HeaderMark))",
+    );
+    expect(view.dom.querySelector(".cm-markra-h2")?.textContent).toBe(
+      "Synthetic title",
+    );
+
+    view.dispatch({
+      changes: {
+        from: view.state.doc.length - 1,
+        to: view.state.doc.length,
+      },
+      selection: { anchor: view.state.doc.length - 1 },
+      userEvent: "delete.backward",
+    });
+
+    expect(syntaxTree(view.state).toString()).toBe(
+      "Document(Paragraph(HeaderMark))",
+    );
+    expect(renderedLines(view)).toEqual(["Synthetic title", "-"]);
+    expect(view.dom.querySelector(".cm-markra-h2")).toBeNull();
+  });
+
+  it.each([
+    [
+      "nothing",
+      "Synthetic title\n-",
+      "Document(Paragraph(HeaderMark))",
+      null,
+    ],
+    [
+      "a trailing space",
+      "Synthetic title\n- ",
+      "Document(Paragraph(HeaderMark))",
+      null,
+    ],
+    [
+      "list content",
+      "Synthetic title\n- item",
+      "Document(Paragraph,BulletList(ListItem(ListMark,Paragraph)))",
+      null,
+    ],
+    [
+      "a lone equals underline",
+      "Synthetic title\n=",
+      "Document(Paragraph(HeaderMark))",
+      null,
+    ],
+    [
+      "a two-character equals underline",
+      "Synthetic title\n==",
+      "Document(SetextHeading1(HeaderMark))",
+      "cm-markra-h1",
+    ],
+  ])("disambiguates %s", (
+    _label,
+    doc,
+    expectedTree,
+    expectedHeadingClass,
+  ) => {
+    const view = createView({ doc });
+
+    expect(syntaxTree(view.state).toString()).toBe(expectedTree);
+    if (expectedHeadingClass) {
+      expect(view.dom.querySelector(`.${expectedHeadingClass}`)).not.toBeNull();
+    } else {
+      expect(view.dom.querySelector(".cm-markra-h1, .cm-markra-h2")).toBeNull();
+    }
+  });
+
+  it("uses the same lone-dash parsing when syntax highlighting is disabled", () => {
+    const view = createView({
+      doc: "Synthetic title\n-",
+      extensions: [liveMarkdown({ highlight: false })],
+    });
+
+    expect(syntaxTree(view.state).toString()).toBe(
+      "Document(Paragraph(HeaderMark))",
+    );
+    expect(renderedLines(view)).toEqual(["Synthetic title", "-"]);
+  });
+
+  it("keeps inline formatting and a buffered lone underline visible", () => {
+    const title = Array.from(
+      { length: 80 },
+      (_, index) => `**segment-${index}**`,
+    ).join(" ");
+    const view = createView({ doc: `${title}\n-`, anchor: 0 });
+
+    expect(syntaxTree(view.state).toString()).not.toContain("SetextHeading");
+    expect(view.dom.querySelectorAll(".cm-markra-strong")).toHaveLength(80);
+    expect(renderedLines(view).at(-1)).toBe("-");
+    expect(view.dom.querySelector(".cm-markra-h1, .cm-markra-h2")).toBeNull();
+  });
+
+  it.each([
+    [
+      "rule",
+      "> Synthetic quote\n---",
+      "Document(Blockquote(QuoteMark,Paragraph),HorizontalRule)",
+    ],
+    [
+      "two-dash line",
+      "> Synthetic quote\n--",
+      "Document(Blockquote(QuoteMark,Paragraph))",
+    ],
+  ])("does not absorb a deindented %s into a nested Setext heading", (
+    _label,
+    doc,
+    expectedTree,
+  ) => {
+    const view = createView({ doc });
+
+    expect(syntaxTree(view.state).toString()).toBe(expectedTree);
+  });
+
+  it("preserves unambiguous Setext headings inside blockquotes", () => {
+    const view = createView({ doc: "> Synthetic quote\n> ---" });
+
+    expect(syntaxTree(view.state).toString()).toBe(
+      "Document(Blockquote(QuoteMark,SetextHeading2(HeaderMark)))",
+    );
   });
 
   it("hides Markdown markers outside the active line", () => {

--- a/packages/editor/src/codemirror/preview.ts
+++ b/packages/editor/src/codemirror/preview.ts
@@ -672,11 +672,14 @@ function buildDecorations(
       node.name === "LinkLabel" && parentName === "Link";
     const isReferenceDefinitionMark =
       node.name === "LinkMark" && parentName === "LinkReference";
+    const isUncommittedSetextMark =
+      node.name === "HeaderMark" && parentName === "Paragraph";
     const isHideable =
       !unfinishedInlineDestination &&
       !isFootnoteLinkSyntax(state, node.node as MarkraSyntaxNode) &&
       !taskSourceRemainsVisible &&
       !isReferenceDefinitionMark &&
+      !isUncommittedSetextMark &&
       (HIDEABLE_MARKS.has(node.name) ||
         isReferenceLinkLabel ||
         isLinkDestination(node.name, parentName));

--- a/packages/editor/src/codemirror/setext-heading.ts
+++ b/packages/editor/src/codemirror/setext-heading.ts
@@ -1,0 +1,66 @@
+import { Tree, type PartialParse } from "@lezer/common";
+import { parser, type MarkdownConfig } from "@lezer/markdown";
+
+function markdownNodeType(name: string) {
+  const type = parser.nodeSet.types.find((candidate) => candidate.name === name);
+  if (!type) throw new Error(`Markdown parser does not define a ${name} node.`);
+  return type;
+}
+
+const paragraphType = markdownNodeType("Paragraph");
+
+function rewriteSingleCharacterSetextHeadings(tree: Tree) {
+  if (tree.type.name !== "Document") return tree;
+
+  let changed = false;
+  const children = tree.children.map((child) => {
+    if (
+      !(child instanceof Tree) ||
+      (child.type.name !== "SetextHeading1" &&
+        child.type.name !== "SetextHeading2")
+    ) {
+      return child;
+    }
+
+    const headerMark = child.topNode.getChild("HeaderMark");
+    if (!headerMark || headerMark.to - headerMark.from !== 1) return child;
+
+    changed = true;
+    return new Tree(
+      paragraphType,
+      child.children,
+      child.positions,
+      child.length,
+      child.propValues,
+    );
+  });
+
+  return changed
+    ? new Tree(tree.type, children, tree.positions, tree.length, tree.propValues)
+    : tree;
+}
+
+function wrapSetextHeadings(inner: PartialParse): PartialParse {
+  return {
+    advance() {
+      const tree = inner.advance();
+      return tree ? rewriteSingleCharacterSetextHeadings(tree) : null;
+    },
+    get parsedPos() {
+      return inner.parsedPos;
+    },
+    get stoppedAt() {
+      return inner.stoppedAt;
+    },
+    stopAt(position) {
+      inner.stopAt(position);
+    },
+  };
+}
+
+export const markraSetextHeading: MarkdownConfig = {
+  // Keep Lezer's native Setext parser and block precedence intact. Rewriting
+  // only the completed top-level tree avoids turning deindented rules into
+  // nested headings while treating single-character underlines as uncommitted.
+  wrap: (inner) => wrapSetextHeadings(inner),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       '@cspell/cspell-types':
         specifier: 10.0.1
         version: 10.0.1
+      '@lezer/common':
+        specifier: 1.5.2
+        version: 1.5.2
       '@lezer/highlight':
         specifier: 1.2.3
         version: 1.2.3


### PR DESCRIPTION
## Summary
- Treat top-level single-character `-` and `=` Setext underlines as uncommitted visual input.
- Keep the underline source visible while preserving normal `--`, `==`, list, horizontal-rule, blockquote, and nested-heading parsing.
- Add regression coverage for typing, deletion, recreation, buffered inline formatting, disabled highlighting, nested blocks, and heading anchors.

## Why
Typing a paragraph followed by a newline and a single `-` immediately made Lezer classify the pair as a Setext H2. Live preview then resized the preceding line before the user could finish a bullet list. A single `=` had the equivalent H1 behavior.

The fix wraps the completed top-level syntax tree instead of replacing the Setext parser, so native Markdown block precedence remains intact.

## Validation
- `corepack pnpm --filter @markra/editor test` — 38 files and 495 tests passed.
- `corepack pnpm --filter @markra/editor typecheck:test` — passed.
- `corepack pnpm --filter @markra/editor build` — passed.
- Browser QA reproduced `你好\n-` after reload: both lines remained 16px/400-weight paragraphs with zero H1/H2 decorations.
- Compared representative upstream and wrapped Lezer syntax trees; only top-level single-character `-` and `=` cases differed.

## Risk
- Visual mode intentionally treats top-level one-character Setext underlines differently from CommonMark. The Markdown source is unchanged, so another CommonMark renderer may still interpret that exact source as a heading.
- Multi-character Setext headings and nested Markdown retain the upstream parser behavior.