### PR TITLE
feat(macos): add Finder Quick Look previews

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,13 @@ jobs:
             $wixObjects
           exit $LASTEXITCODE
 
+      - name: Verify macOS Quick Look extension
+        if: startsWith(matrix.os, 'macos-')
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: pnpm --filter @markra/desktop verify:quicklook-bundle
+
       - name: Rebuild Linux AppImage library policy
         if: matrix.asset_platform == 'linux'
         shell: bash

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,11 +7,16 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.app.json && vite build && pnpm verify:chunks",
+    "build:quicklook-renderer": "vite build --config vite.quicklook.config.ts",
+    "build:quicklook-extension": "bash scripts/build-macos-quicklook.sh",
+    "build:quicklook": "node scripts/quicklook.mjs",
     "build:icon": "node scripts/icon.mjs",
     "test": "vitest run",
+    "test:quicklook": "bash scripts/test-macos-quicklook.sh",
     "test:watch": "vitest",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "verify:chunks": "node ../../packages/scripts/src/verify-vendor-chunks.mjs dist/assets",
+    "verify:quicklook-bundle": "bash scripts/verify-macos-quicklook.sh",
     "tauri": "tauri"
   },
   "dependencies": {
@@ -25,6 +30,7 @@
     "@tauri-apps/plugin-process": "2.3.1",
     "@tauri-apps/plugin-store": "^2.4.3",
     "@tauri-apps/plugin-updater": "2.10.1",
+    "katex": "0.16.45",
     "react": "19.2.5",
     "react-dom": "19.2.5"
   },
@@ -33,6 +39,7 @@
     "@tailwindcss/vite": "^4.2.4",
     "@tauri-apps/cli": "2.11.0",
     "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
     "@types/node": "24.10.0",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
@@ -41,6 +48,7 @@
     "tailwindcss": "^4.2.4",
     "typescript": "6.0.3",
     "vite": "8.0.10",
+    "vite-plugin-singlefile": "2.3.3",
     "vitest": "4.1.5"
   }
 }

--- a/apps/desktop/scripts/build-macos-quicklook.sh
+++ b/apps/desktop/scripts/build-macos-quicklook.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Markra Quick Look extension can only be built on macOS." >&2
+  exit 1
+fi
+
+DESKTOP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE_DIR="$(cd "$DESKTOP_DIR/../.." && pwd)"
+SOURCE_DIR="$DESKTOP_DIR/src-tauri/macos/MarkraQuickLookPreview"
+RENDERER_DIR="$DESKTOP_DIR/src-tauri/target/quicklook-renderer"
+OUTPUT_DIR="$DESKTOP_DIR/src-tauri/target/quicklook/MarkraQuickLookPreview.appex"
+CONTENTS_DIR="$OUTPUT_DIR/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+PNPM_BIN="${PNPM_BIN:-pnpm}"
+
+"$PNPM_BIN" --dir "$WORKSPACE_DIR" --filter @markra/desktop build:quicklook-renderer
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+cp "$SOURCE_DIR/Info.plist" "$CONTENTS_DIR/Info.plist"
+cp -R "$RENDERER_DIR" "$RESOURCES_DIR/quicklook-renderer"
+
+APP_VERSION="$(node -p "require('$DESKTOP_DIR/package.json').version")"
+APP_BUNDLE_VERSION="$(node -p "const config=require('$DESKTOP_DIR/src-tauri/tauri.conf.json'); config.bundle?.macOS?.bundleVersion || config.version")"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $APP_VERSION" "$CONTENTS_DIR/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $APP_BUNDLE_VERSION" "$CONTENTS_DIR/Info.plist"
+
+ARCH="${QUICKLOOK_ARCH:-$(uname -m)}"
+case "$ARCH" in
+  arm64|aarch64)
+    SWIFT_TARGET_ARCH="arm64"
+    ;;
+  x86_64|amd64|x64)
+    SWIFT_TARGET_ARCH="x86_64"
+    ;;
+  *)
+    echo "Unsupported Quick Look architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+SWIFT_SOURCES=("$SOURCE_DIR"/*.swift)
+# Xcode extension targets supply this entry point automatically; direct swiftc builds must set it.
+xcrun swiftc \
+  "${SWIFT_SOURCES[@]}" \
+  -emit-executable \
+  -parse-as-library \
+  -module-name MarkraQuickLookPreview \
+  -application-extension \
+  -O \
+  -target "${SWIFT_TARGET_ARCH}-apple-macosx12.0" \
+  -Xlinker -e \
+  -Xlinker _NSExtensionMain \
+  -Xlinker -rpath \
+  -Xlinker @executable_path/../Frameworks \
+  -Xlinker -rpath \
+  -Xlinker @executable_path/../../../../Frameworks \
+  -o "$MACOS_DIR/MarkraQuickLookPreview" \
+  -framework Cocoa \
+  -framework QuickLook \
+  -framework QuickLookUI \
+  -framework WebKit
+
+CODESIGN_IDENTITY="${APPLE_CODESIGN_IDENTITY:-${APPLE_SIGNING_IDENTITY:--}}"
+CODESIGN_ARGS=(
+  --force
+  --options runtime
+  --sign "$CODESIGN_IDENTITY"
+  --entitlements "$SOURCE_DIR/MarkraQuickLookPreview.entitlements"
+)
+if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
+  CODESIGN_ARGS+=(--timestamp)
+fi
+/usr/bin/codesign "${CODESIGN_ARGS[@]}" "$OUTPUT_DIR"
+
+/usr/bin/codesign --verify --strict --verbose=2 "$OUTPUT_DIR"
+echo "Built $OUTPUT_DIR"

--- a/apps/desktop/scripts/quicklook.mjs
+++ b/apps/desktop/scripts/quicklook.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+
+if (process.platform !== "darwin") process.exit(0);
+
+const targetTriple = process.env.TAURI_ENV_TARGET_TRIPLE?.trim() ?? "";
+const quickLookArch = targetTriple.startsWith("aarch64-")
+  ? "arm64"
+  : targetTriple.startsWith("x86_64-")
+    ? "x86_64"
+    : process.env.QUICKLOOK_ARCH?.trim() ?? "";
+
+const result = spawnSync("bash", ["scripts/build-macos-quicklook.sh"], {
+  cwd: new URL("..", import.meta.url),
+  env: {
+    ...process.env,
+    ...(quickLookArch ? { QUICKLOOK_ARCH: quickLookArch } : {})
+  },
+  stdio: "inherit"
+});
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/apps/desktop/scripts/test-macos-quicklook.sh
+++ b/apps/desktop/scripts/test-macos-quicklook.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Quick Look Swift tests require macOS." >&2
+  exit 1
+fi
+
+DESKTOP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_DIR="$DESKTOP_DIR/src-tauri/macos/MarkraQuickLookPreview"
+TEST_DIR="$DESKTOP_DIR/src-tauri/macos/MarkraQuickLookPreviewTests"
+OUTPUT_DIR="$DESKTOP_DIR/src-tauri/target/quicklook-tests"
+TEST_BINARY="$OUTPUT_DIR/PreviewPayloadTests"
+
+mkdir -p "$OUTPUT_DIR"
+
+xcrun swiftc \
+  "$SOURCE_DIR/PreviewPayload.swift" \
+  "$TEST_DIR/PreviewPayloadTests.swift" \
+  "$TEST_DIR/PreviewPayloadRunner.swift" \
+  -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/apps/desktop/scripts/verify-macos-quicklook.sh
+++ b/apps/desktop/scripts/verify-macos-quicklook.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Quick Look bundle verification requires macOS." >&2
+  exit 1
+fi
+
+DESKTOP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_PREFIX="${TARGET:+$TARGET/}"
+PROFILE="${PROFILE:-release}"
+BUNDLE_DIR="$DESKTOP_DIR/src-tauri/target/${TARGET_PREFIX}${PROFILE}/bundle/macos"
+APP_PRODUCT_NAME="${APP_PRODUCT_NAME:-Markra}"
+APP_BUNDLE="$BUNDLE_DIR/$APP_PRODUCT_NAME.app"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "Expected macOS app bundle at $APP_BUNDLE." >&2
+  exit 1
+fi
+
+APP_INFO="$APP_BUNDLE/Contents/Info.plist"
+EXTENSION_BUNDLE="$APP_BUNDLE/Contents/PlugIns/MarkraQuickLookPreview.appex"
+EXTENSION_INFO="$EXTENSION_BUNDLE/Contents/Info.plist"
+RENDERER_INDEX="$EXTENSION_BUNDLE/Contents/Resources/quicklook-renderer/src/quicklook/index.html"
+
+if [[ ! -f "$EXTENSION_INFO" || ! -f "$RENDERER_INDEX" ]]; then
+  echo "Markra Quick Look extension or renderer is missing from $APP_BUNDLE." >&2
+  exit 1
+fi
+
+DECLARED_EXTENSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundlePlugIns:0' "$APP_INFO")"
+if [[ "$DECLARED_EXTENSION" != "Contents/PlugIns/MarkraQuickLookPreview.appex" ]]; then
+  echo "Containing app does not declare the embedded Quick Look extension." >&2
+  exit 1
+fi
+
+EXTENSION_POINT="$(/usr/libexec/PlistBuddy -c 'Print :NSExtension:NSExtensionPointIdentifier' "$EXTENSION_INFO")"
+if [[ "$EXTENSION_POINT" != "com.apple.quicklook.preview" ]]; then
+  echo "Embedded extension does not declare the Quick Look preview extension point." >&2
+  exit 1
+fi
+
+APP_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_INFO")"
+APP_BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_INFO")"
+EXTENSION_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$EXTENSION_INFO")"
+EXTENSION_BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$EXTENSION_INFO")"
+if [[ "$EXTENSION_VERSION" != "$APP_VERSION" || "$EXTENSION_BUNDLE_VERSION" != "$APP_BUNDLE_VERSION" ]]; then
+  echo "Quick Look and app bundle versions do not match." >&2
+  exit 1
+fi
+
+EXTENSION_SIGNATURE="$(/usr/bin/codesign -dvv "$EXTENSION_BUNDLE" 2>&1)"
+if [[ "$EXTENSION_SIGNATURE" != *"runtime"* ]]; then
+  echo "Quick Look extension is missing the hardened runtime signature option." >&2
+  exit 1
+fi
+
+if [[ -n "${TARGET:-}" ]]; then
+  EXPECTED_ARCH="${TARGET%%-*}"
+  [[ "$EXPECTED_ARCH" == "aarch64" ]] && EXPECTED_ARCH="arm64"
+  EXTENSION_ARCHS="$(/usr/bin/lipo -archs "$EXTENSION_BUNDLE/Contents/MacOS/MarkraQuickLookPreview")"
+  if [[ " $EXTENSION_ARCHS " != *" $EXPECTED_ARCH "* ]]; then
+    echo "Quick Look extension architecture mismatch: target=$EXPECTED_ARCH binary=$EXTENSION_ARCHS." >&2
+    exit 1
+  fi
+fi
+
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+echo "Verified embedded Quick Look extension: $EXTENSION_BUNDLE"

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -22,5 +22,35 @@
     <string>it</string>
     <string>ru</string>
   </array>
+  <key>CFBundlePlugIns</key>
+  <array>
+    <string>Contents/PlugIns/MarkraQuickLookPreview.appex</string>
+  </array>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>net.daringfireball.markdown</string>
+      <key>UTTypeDescription</key>
+      <string>Markdown Document</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.plain-text</string>
+        <string>public.text</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>md</string>
+          <string>markdown</string>
+        </array>
+        <key>public.mime-type</key>
+        <array>
+          <string>text/markdown</string>
+        </array>
+      </dict>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/Info.plist
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Markra Quick Look</string>
+  <key>CFBundleExecutable</key>
+  <string>MarkraQuickLookPreview</string>
+  <key>CFBundleIdentifier</key>
+  <string>dev.markra.app.quicklook</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>MarkraQuickLookPreview</string>
+  <key>CFBundlePackageType</key>
+  <string>XPC!</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2.8.0</string>
+  <key>CFBundleVersion</key>
+  <string>2.8.0</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.quicklook.preview</string>
+    <key>NSExtensionPrincipalClass</key>
+    <string>PreviewViewController</string>
+    <key>NSExtensionAttributes</key>
+    <dict>
+      <key>QLSupportedContentTypes</key>
+      <array>
+        <string>net.daringfireball.markdown</string>
+        <string>public.markdown</string>
+      </array>
+      <key>QLIsDataBasedPreview</key>
+      <false/>
+      <key>QLSupportsSearchableItems</key>
+      <false/>
+    </dict>
+  </dict>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/MarkraQuickLookPreview.entitlements
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/MarkraQuickLookPreview.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-only</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/PreviewPayload.swift
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/PreviewPayload.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct PreviewPayload {
+    let appearance: String
+    let fileName: String
+    let markdown: String
+
+    var bridgeArguments: [String: Any] {
+        [
+            "appearance": appearance,
+            "fileName": fileName,
+            "markdown": markdown,
+        ]
+    }
+}

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/PreviewViewController.swift
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreview/PreviewViewController.swift
@@ -1,0 +1,186 @@
+import Cocoa
+import OSLog
+import QuickLookUI
+import WebKit
+
+private let previewLogger = Logger(
+    subsystem: "dev.markra.app.quicklook",
+    category: "preview"
+)
+
+@objc(PreviewViewController)
+final class PreviewViewController: NSViewController, QLPreviewingController, WKNavigationDelegate {
+    private var pendingPayload: [String: Any]?
+    private var webView: WKWebView!
+
+    override func loadView() {
+        previewLogger.info("Creating Quick Look preview view")
+        let rootView = NSView()
+        rootView.wantsLayer = true
+        rootView.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
+
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+
+        let previewWebView = WKWebView(frame: .zero, configuration: configuration)
+        previewWebView.navigationDelegate = self
+        previewWebView.translatesAutoresizingMaskIntoConstraints = false
+        rootView.addSubview(previewWebView)
+
+        NSLayoutConstraint.activate([
+            previewWebView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+            previewWebView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+            previewWebView.topAnchor.constraint(equalTo: rootView.topAnchor),
+            previewWebView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
+        ])
+
+        webView = previewWebView
+        view = rootView
+    }
+
+    @MainActor
+    func preparePreviewOfFile(at url: URL) async throws {
+        previewLogger.info("Preparing Markdown preview")
+        do {
+            try loadMarkdownPreview(for: url)
+            previewLogger.info("Submitted renderer navigation")
+        } catch {
+            previewLogger.error("Preview preparation failed: \(String(describing: error), privacy: .public)")
+            pendingPayload = nil
+            loadErrorPreview(error)
+        }
+    }
+
+    private func loadMarkdownPreview(for documentURL: URL) throws {
+        let markdown = try String(contentsOf: documentURL, encoding: .utf8)
+
+        guard let rendererRootURL = Bundle.main.resourceURL?
+            .appendingPathComponent("quicklook-renderer", isDirectory: true) else {
+            throw PreviewError.rendererMissing
+        }
+        let rendererIndexURL = rendererRootURL
+            .appendingPathComponent("src/quicklook/index.html", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: rendererIndexURL.path) else {
+            throw PreviewError.rendererMissing
+        }
+
+        pendingPayload = PreviewPayload(
+            appearance: effectiveAppearanceName(),
+            fileName: documentURL.lastPathComponent,
+            markdown: markdown
+        ).bridgeArguments
+
+        guard webView.loadFileURL(rendererIndexURL, allowingReadAccessTo: rendererRootURL) != nil else {
+            pendingPayload = nil
+            throw PreviewError.rendererNavigationFailed
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        previewLogger.info("Quick Look renderer navigation finished")
+        guard let payload = pendingPayload else { return }
+        pendingPayload = nil
+
+        webView.callAsyncJavaScript(
+            """
+            if (typeof window.__MARKRA_RENDER_QUICKLOOK__ !== 'function') {
+              throw new Error('Quick Look renderer bridge is unavailable');
+            }
+            return window.__MARKRA_RENDER_QUICKLOOK__(payload);
+            """,
+            arguments: ["payload": payload],
+            in: nil,
+            in: .page
+        ) { [weak self] result in
+            switch result {
+            case .success:
+                previewLogger.info("Delivered Markdown payload to renderer")
+            case let .failure(error):
+                previewLogger.error("Renderer bridge failed: \(String(describing: error), privacy: .public)")
+                self?.pendingPayload = nil
+                self?.loadErrorPreview(error)
+            }
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        previewLogger.error("Renderer navigation failed: \(String(describing: error), privacy: .public)")
+        pendingPayload = nil
+        loadErrorPreview(error)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        previewLogger.error("Renderer provisional navigation failed: \(String(describing: error), privacy: .public)")
+        pendingPayload = nil
+        loadErrorPreview(error)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        decisionHandler(navigationAction.navigationType == .linkActivated ? .cancel : .allow)
+    }
+
+    private func effectiveAppearanceName() -> String {
+        view.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? "dark"
+            : "light"
+    }
+
+    private func loadErrorPreview(_ error: Error) {
+        let message = htmlEscape(errorMessage(for: error))
+        webView.loadHTMLString(
+            """
+            <!doctype html>
+            <html lang="en">
+              <head><meta charset="utf-8"></head>
+              <body style="margin:0;display:grid;min-height:100vh;place-items:center;font:14px -apple-system,BlinkMacSystemFont,sans-serif;color:#68707a;background:#fff;">
+                <main style="display:grid;gap:8px;text-align:center;padding:24px;">
+                  <strong style="color:#202428;font-size:16px;">Unable to generate Markra preview</strong>
+                  <span>\(message)</span>
+                </main>
+              </body>
+            </html>
+            """,
+            baseURL: nil
+        )
+    }
+
+    private func errorMessage(for error: Error) -> String {
+        if let previewError = error as? PreviewError {
+            return previewError.description
+        }
+        if error is CocoaError {
+            return "The Markdown file could not be read as UTF-8"
+        }
+        return "The preview renderer could not be loaded"
+    }
+}
+
+private enum PreviewError: Error, CustomStringConvertible {
+    case rendererMissing
+    case rendererNavigationFailed
+
+    var description: String {
+        switch self {
+        case .rendererMissing:
+            return "Quick Look renderer resources are missing"
+        case .rendererNavigationFailed:
+            return "Quick Look renderer navigation failed"
+        }
+    }
+}
+
+private func htmlEscape(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "&", with: "&amp;")
+        .replacingOccurrences(of: "<", with: "&lt;")
+        .replacingOccurrences(of: ">", with: "&gt;")
+        .replacingOccurrences(of: "\"", with: "&quot;")
+}

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/Fixtures/PreviewFixture.md
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/Fixtures/PreviewFixture.md
@@ -1,0 +1,19 @@
+# Synthetic Quick Look Preview
+
+This fixture verifies **Markdown**, tables, math, diagrams, and local images.
+
+> [!WARNING]
+> Synthetic callout content.
+
+| Feature | Status |
+| --- | --- |
+| Quick Look | Ready |
+
+Inline math: $x^2 + y^2 = z^2$.
+
+![Synthetic local image](mock.svg)
+
+```mermaid
+flowchart LR
+  A[Finder] --> B[Markra]
+```

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/Fixtures/mock.svg
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/Fixtures/mock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="96" viewBox="0 0 320 96">
+  <rect width="320" height="96" rx="16" fill="#0969da"/>
+  <text x="160" y="56" fill="white" font-family="-apple-system, sans-serif" font-size="22" text-anchor="middle">Markra Quick Look</text>
+</svg>

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/PreviewPayloadRunner.swift
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/PreviewPayloadRunner.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@main
+enum PreviewPayloadRunner {
+    static func main() throws {
+        try PreviewPayloadTests.run()
+        print("Markra Quick Look Swift tests passed")
+    }
+}

--- a/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/PreviewPayloadTests.swift
+++ b/apps/desktop/src-tauri/macos/MarkraQuickLookPreviewTests/PreviewPayloadTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum PreviewPayloadTests {
+    static func run() throws {
+        let payload = PreviewPayload(
+            appearance: "dark",
+            fileName: "mock.md",
+            markdown: "# Synthetic preview"
+        )
+        let arguments = payload.bridgeArguments
+
+        try expect(arguments["appearance"] as? String == "dark", "appearance should cross the bridge")
+        try expect(arguments["fileName"] as? String == "mock.md", "file name should cross the bridge")
+        try expect(
+            arguments["markdown"] as? String == "# Synthetic preview",
+            "Markdown should cross the bridge without JavaScript string interpolation"
+        )
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+        if !condition() {
+            throw PreviewPayloadTestFailure(message: message)
+        }
+    }
+}
+
+private struct PreviewPayloadTestFailure: Error, CustomStringConvertible {
+    let message: String
+
+    var description: String { message }
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "pnpm dev --host 127.0.0.1 --port 1420 --strictPort",
     "devUrl": "http://127.0.0.1:1420",
-    "beforeBuildCommand": "pnpm build && pnpm build:icon",
+    "beforeBuildCommand": "pnpm build && pnpm build:icon && pnpm build:quicklook",
     "frontendDist": "../dist"
   },
   "app": {
@@ -73,6 +73,7 @@
     },
     "macOS": {
       "files": {
+        "PlugIns/MarkraQuickLookPreview.appex": "target/quicklook/MarkraQuickLookPreview.appex",
         "Resources/Assets.car": "icons/generated/Assets.car",
         "Resources/de.lproj": "macos-locales/de.lproj",
         "Resources/en.lproj": "macos-locales/en.lproj",

--- a/apps/desktop/src/quicklook/QuickLookPreview.test.tsx
+++ b/apps/desktop/src/quicklook/QuickLookPreview.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/react";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async () => ({ svg: "<svg><g></g></svg>" }))
+  }
+}));
+
+import { QuickLookPreview } from "./QuickLookPreview";
+
+describe("QuickLookPreview", () => {
+  it("shows a loading state until native Markdown data arrives", () => {
+    const { getByText } = render(<QuickLookPreview payload={null} />);
+    expect(getByText("Preparing preview…")).toBeInTheDocument();
+  });
+
+  it("renders the selected file name and Markdown body", () => {
+    const { container, getByRole, getByText } = render(
+      <QuickLookPreview
+        payload={{
+          appearance: "light",
+          fileName: "mock.md",
+          markdown: "# Synthetic heading\n\nSynthetic body."
+        }}
+      />
+    );
+
+    expect(getByRole("heading", { name: "mock.md", level: 1 })).toBeInTheDocument();
+    expect(getByText("Synthetic heading")).toBeInTheDocument();
+    expect(container.querySelector(".markra-quicklook-document .markdown-preview-paper")).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/quicklook/QuickLookPreview.tsx
+++ b/apps/desktop/src/quicklook/QuickLookPreview.tsx
@@ -1,0 +1,30 @@
+import { MarkdownPreviewDocument } from "@markra/app/markdown-preview";
+import { resolveQuickLookImageSrc, type QuickLookPreviewPayload } from "./payload";
+
+type QuickLookPreviewProps = {
+  payload: QuickLookPreviewPayload | null;
+};
+
+export function QuickLookPreview({ payload }: QuickLookPreviewProps) {
+  if (!payload) {
+    return (
+      <main className="markra-quicklook-state" role="status">
+        <span className="markra-quicklook-spinner" aria-hidden="true" />
+        <span>Preparing preview…</span>
+      </main>
+    );
+  }
+
+  return (
+    <main className="markra-quicklook-document">
+      <header className="markra-quicklook-header">
+        <span>Markra Quick Look</span>
+        <h1>{payload.fileName}</h1>
+      </header>
+      <MarkdownPreviewDocument
+        markdown={payload.markdown}
+        resolveImageSrc={resolveQuickLookImageSrc}
+      />
+    </main>
+  );
+}

--- a/apps/desktop/src/quicklook/index.html
+++ b/apps/desktop/src/quicklook/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Markra Quick Look</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      window.__MARKRA_QUICKLOOK_PAYLOAD__ = null;
+    </script>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/quicklook/main.tsx
+++ b/apps/desktop/src/quicklook/main.tsx
@@ -1,0 +1,41 @@
+import { createRoot } from "react-dom/client";
+import { QuickLookPreview } from "./QuickLookPreview";
+import {
+  applyQuickLookAppearance,
+  normalizeQuickLookPayload,
+  type QuickLookAppearance,
+  type QuickLookPreviewPayload
+} from "./payload";
+import "./styles.css";
+
+declare global {
+  interface Window {
+    __MARKRA_QUICKLOOK_PAYLOAD__?: unknown;
+    __MARKRA_RENDER_QUICKLOOK__?: (payload: unknown) => boolean;
+  }
+}
+
+const mountNode = document.getElementById("root");
+if (!mountNode) throw new Error("Quick Look root element is unavailable");
+
+const root = createRoot(mountNode);
+
+function systemAppearance(): QuickLookAppearance {
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function renderPayload(payload: QuickLookPreviewPayload | null) {
+  if (payload) applyQuickLookAppearance(payload.appearance ?? systemAppearance());
+  root.render(<QuickLookPreview payload={payload} />);
+}
+
+window.__MARKRA_RENDER_QUICKLOOK__ = (value) => {
+  const payload = normalizeQuickLookPayload(value);
+  if (!payload) throw new Error("Quick Look received an invalid Markdown payload");
+
+  window.__MARKRA_QUICKLOOK_PAYLOAD__ = payload;
+  renderPayload(payload);
+  return true;
+};
+
+renderPayload(normalizeQuickLookPayload(window.__MARKRA_QUICKLOOK_PAYLOAD__));

--- a/apps/desktop/src/quicklook/payload.test.ts
+++ b/apps/desktop/src/quicklook/payload.test.ts
@@ -1,0 +1,51 @@
+import {
+  applyQuickLookAppearance,
+  normalizeQuickLookPayload,
+  resolveQuickLookImageSrc
+} from "./payload";
+
+describe("Quick Look payload", () => {
+  it("accepts structured Markdown data and rejects malformed payloads", () => {
+    expect(normalizeQuickLookPayload({
+      appearance: "dark",
+      fileName: "mock.md",
+      markdown: "# Mock preview"
+    })).toEqual({
+      appearance: "dark",
+      fileName: "mock.md",
+      markdown: "# Mock preview"
+    });
+
+    expect(normalizeQuickLookPayload({ fileName: "mock.md" })).toBeNull();
+    expect(normalizeQuickLookPayload({ markdown: 42 })).toBeNull();
+  });
+
+  it("uses a visible safe placeholder for local images blocked by the extension sandbox", () => {
+    expect(resolveQuickLookImageSrc("assets/mock image.png")).toMatch(
+      /^data:image\/svg\+xml;charset=utf-8,/
+    );
+    expect(resolveQuickLookImageSrc("../outside.png")).not.toContain("markra-asset:");
+  });
+
+  it("allows web and raster data images while blocking active or local URL schemes", () => {
+    expect(resolveQuickLookImageSrc("https://example.test/mock.png")).toBe(
+      "https://example.test/mock.png"
+    );
+    expect(resolveQuickLookImageSrc("data:image/png;base64,bW9jaw==")).toBe(
+      "data:image/png;base64,bW9jaw=="
+    );
+    expect(resolveQuickLookImageSrc("javascript:alert(1)")).toBe("");
+    expect(resolveQuickLookImageSrc("file:///tmp/mock.png")).toBe("");
+    expect(resolveQuickLookImageSrc("data:image/svg+xml,<svg></svg>")).toBe("");
+  });
+
+  it("applies the native effective appearance to the document root", () => {
+    applyQuickLookAppearance("dark", document.documentElement);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+
+    applyQuickLookAppearance("light", document.documentElement);
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+  });
+});

--- a/apps/desktop/src/quicklook/payload.ts
+++ b/apps/desktop/src/quicklook/payload.ts
@@ -1,0 +1,52 @@
+export type QuickLookAppearance = "dark" | "light";
+
+export type QuickLookPreviewPayload = {
+  appearance?: QuickLookAppearance;
+  fileName: string;
+  markdown: string;
+};
+
+const rasterDataImagePattern = /^data:image\/(?:avif|gif|jpeg|png|webp);base64,[a-z\d+/=\s]+$/iu;
+// Finder grants a Quick Look extension access to the selected Markdown file, not arbitrary siblings.
+// Keep relative images visible without requesting a broad filesystem entitlement.
+const localImagePlaceholderSrc = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(`
+  <svg xmlns="http://www.w3.org/2000/svg" width="560" height="88" viewBox="0 0 560 88">
+    <rect x="0.5" y="0.5" width="559" height="87" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text x="280" y="50" fill="#656d76" font-family="-apple-system, BlinkMacSystemFont, sans-serif" font-size="15" text-anchor="middle">Local image unavailable in Quick Look</text>
+  </svg>
+`)}`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeQuickLookPayload(value: unknown): QuickLookPreviewPayload | null {
+  if (!isRecord(value) || typeof value.markdown !== "string") return null;
+
+  return {
+    ...(value.appearance === "dark" || value.appearance === "light"
+      ? { appearance: value.appearance }
+      : {}),
+    fileName: typeof value.fileName === "string" && value.fileName.trim()
+      ? value.fileName
+      : "Markdown Preview",
+    markdown: value.markdown
+  };
+}
+
+export function resolveQuickLookImageSrc(src: string) {
+  const value = src.trim();
+  if (!value) return "";
+  if (/^https?:\/\//iu.test(value)) return value;
+  if (rasterDataImagePattern.test(value)) return value;
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/u.test(value) || value.startsWith("//")) return "";
+  return localImagePlaceholderSrc;
+}
+
+export function applyQuickLookAppearance(
+  appearance: QuickLookAppearance,
+  root: HTMLElement = document.documentElement
+) {
+  root.dataset.theme = appearance;
+  root.style.colorScheme = appearance;
+}

--- a/apps/desktop/src/quicklook/styles.css
+++ b/apps/desktop/src/quicklook/styles.css
@@ -1,0 +1,339 @@
+@import "katex/dist/katex.css";
+
+:root {
+  color-scheme: light;
+  --preview-bg: #ffffff;
+  --preview-surface: #f6f8fa;
+  --preview-text: #24292f;
+  --preview-heading: #1f2328;
+  --preview-muted: #656d76;
+  --preview-border: #d0d7de;
+  --preview-link: #0969da;
+  --preview-code: #eff1f3;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--preview-bg);
+  color: var(--preview-text);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --preview-bg: #0d1117;
+  --preview-surface: #161b22;
+  --preview-text: #e6edf3;
+  --preview-heading: #f0f6fc;
+  --preview-muted: #8b949e;
+  --preview-border: #30363d;
+  --preview-link: #58a6ff;
+  --preview-code: #1f242c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  margin: 0;
+  background: var(--preview-bg);
+}
+
+body {
+  overflow-x: hidden;
+}
+
+.markra-quicklook-state {
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  color: var(--preview-muted);
+  font-size: 14px;
+}
+
+.markra-quicklook-spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--preview-border);
+  border-top-color: var(--preview-link);
+  border-radius: 999px;
+  animation: markra-quicklook-spin 700ms linear infinite;
+}
+
+@keyframes markra-quicklook-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.markra-quicklook-document {
+  width: min(100%, 920px);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 34px clamp(24px, 6vw, 64px) 72px;
+}
+
+.markra-quicklook-header {
+  margin-bottom: 32px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--preview-border);
+}
+
+.markra-quicklook-header > span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--preview-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.markra-quicklook-header h1 {
+  margin: 0;
+  overflow: hidden;
+  color: var(--preview-heading);
+  font-size: clamp(20px, 3vw, 28px);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.markdown-preview-paper {
+  color: var(--preview-text);
+  font-size: 16px;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.markdown-preview-paper > :first-child {
+  margin-top: 0;
+}
+
+.markdown-preview-paper > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-preview-paper h1,
+.markdown-preview-paper h2,
+.markdown-preview-paper h3,
+.markdown-preview-paper h4,
+.markdown-preview-paper h5,
+.markdown-preview-paper h6 {
+  margin: 1.45em 0 0.55em;
+  color: var(--preview-heading);
+  line-height: 1.3;
+}
+
+.markdown-preview-paper h1 {
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--preview-border);
+  font-size: 2em;
+}
+
+.markdown-preview-paper h2 {
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid var(--preview-border);
+  font-size: 1.5em;
+}
+
+.markdown-preview-paper h3 {
+  font-size: 1.25em;
+}
+
+.markdown-preview-paper p,
+.markdown-preview-paper ul,
+.markdown-preview-paper ol,
+.markdown-preview-paper blockquote,
+.markdown-preview-paper table,
+.markdown-preview-paper pre {
+  margin: 0 0 1em;
+}
+
+.markdown-preview-paper a {
+  color: var(--preview-link);
+  text-decoration: none;
+}
+
+.markdown-preview-paper a:hover {
+  text-decoration: underline;
+}
+
+.markdown-preview-paper hr {
+  height: 1px;
+  margin: 1.8em 0;
+  border: 0;
+  background: var(--preview-border);
+}
+
+.markdown-preview-paper blockquote {
+  padding: 0 1em;
+  border-left: 4px solid var(--preview-border);
+  color: var(--preview-muted);
+}
+
+.markdown-preview-paper blockquote.markra-callout {
+  --callout-color: #3578c8;
+  padding: 0.8em 1em 0.9em;
+  border: 1px solid color-mix(in srgb, var(--callout-color) 30%, var(--preview-border));
+  border-left-width: 4px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--callout-color) 8%, var(--preview-bg));
+  color: var(--preview-text);
+}
+
+.markdown-preview-paper .markra-callout-tip {
+  --callout-color: #2d8a57;
+}
+
+.markdown-preview-paper .markra-callout-important {
+  --callout-color: #8250df;
+}
+
+.markdown-preview-paper .markra-callout-warning {
+  --callout-color: #bf8700;
+}
+
+.markdown-preview-paper .markra-callout-caution {
+  --callout-color: #cf222e;
+}
+
+.markdown-preview-paper .markra-callout-header {
+  display: flex;
+  align-items: center;
+  gap: 0.45em;
+  margin-bottom: 0.45em;
+  color: var(--callout-color);
+  font-size: 0.82em;
+  font-weight: 700;
+}
+
+.markdown-preview-paper .markra-callout-icon {
+  width: 0.65em;
+  height: 0.65em;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.markdown-preview-paper blockquote.markra-callout p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-preview-paper :not(pre) > code {
+  padding: 0.18em 0.38em;
+  border-radius: 5px;
+  background: var(--preview-code);
+  font-size: 0.9em;
+}
+
+.markdown-preview-paper pre {
+  max-width: 100%;
+  overflow: auto;
+  padding: 16px;
+  border: 1px solid var(--preview-border);
+  border-radius: 8px;
+  background: var(--preview-surface);
+}
+
+.markdown-preview-paper code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.markdown-preview-paper pre code {
+  font-size: 0.88em;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.markdown-preview-paper table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.markdown-preview-paper th,
+.markdown-preview-paper td {
+  padding: 7px 12px;
+  border: 1px solid var(--preview-border);
+}
+
+.markdown-preview-paper th {
+  background: var(--preview-surface);
+  color: var(--preview-heading);
+  font-weight: 650;
+}
+
+.markdown-preview-paper img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 1em auto;
+  border-radius: 6px;
+}
+
+.markdown-preview-paper .contains-task-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.markdown-preview-paper .task-list-item {
+  list-style: none;
+}
+
+.markdown-preview-paper input[type="checkbox"] {
+  margin-right: 0.45em;
+}
+
+.markdown-preview-paper .markra-math-render-display {
+  display: block;
+  max-width: 100%;
+  margin: 1em 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-align: center;
+}
+
+.markdown-preview-paper .markra-math-render-inline {
+  display: inline-flex;
+  vertical-align: -0.08em;
+}
+
+.markdown-preview-paper .markra-mermaid-render {
+  max-width: 100%;
+  margin: 1.25em 0;
+  overflow-x: auto;
+  text-align: center;
+}
+
+.markdown-preview-paper .markra-mermaid-render svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
+.markdown-preview-paper .markra-mermaid-render-invalid {
+  padding: 0.8em 1em;
+  border: 1px solid #cf222e;
+  border-radius: 7px;
+  background: color-mix(in srgb, #cf222e 8%, var(--preview-bg));
+  color: #cf222e;
+  text-align: left;
+}
+
+@media (max-width: 520px) {
+  .markra-quicklook-document {
+    padding: 24px 20px 48px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .markra-quicklook-spinner {
+    animation: none;
+  }
+}

--- a/apps/desktop/vite.quicklook.config.ts
+++ b/apps/desktop/vite.quicklook.config.ts
@@ -1,0 +1,23 @@
+import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+export default defineConfig({
+  base: "./",
+  define: {
+    __MARKRA_APP_VERSION__: JSON.stringify("quicklook"),
+    __MARKRA_DEBUG__: JSON.stringify(false)
+  },
+  // WKWebView loads this page from the signed extension bundle. Inlining avoids file:// module
+  // loading restrictions and also keeps the extension independent from the main Tauri assets.
+  plugins: [react(), viteSingleFile()],
+  build: {
+    assetsInlineLimit: Number.MAX_SAFE_INTEGER,
+    emptyOutDir: true,
+    outDir: "src-tauri/target/quicklook-renderer",
+    rolldownOptions: {
+      input: resolve(import.meta.dirname, "src/quicklook/index.html")
+    }
+  }
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,6 +13,10 @@
       "types": "./src/runtime/index.ts",
       "default": "./src/runtime/index.ts"
     },
+    "./markdown-preview": {
+      "types": "./src/components/MarkdownPreviewDocument.tsx",
+      "default": "./src/components/MarkdownPreviewDocument.tsx"
+    },
     "./settings": {
       "types": "./src/lib/settings/app-settings.ts",
       "default": "./src/lib/settings/app-settings.ts"

--- a/packages/app/src/components/MarkdownExportDocument.tsx
+++ b/packages/app/src/components/MarkdownExportDocument.tsx
@@ -1,21 +1,7 @@
-import { Children, cloneElement, isValidElement, useEffect, useRef, type ReactElement, type ReactNode } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkBreaks from "remark-breaks";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import {
-  createMarkraMathMacros,
-  isMarkraMathMacroDefinitionSource,
-  isMermaidLanguage,
-  mermaidThemeFromElement,
-  remarkHugoMath,
-  renderMarkraMathToString,
-  renderMermaidToSvg,
-  type MarkraMathMacros
-} from "@markra/editor";
-import { parseMarkdownCalloutMarker, type ParsedMarkdownCalloutMarker } from "@markra/shared";
+import { useCallback } from "react";
 import type { ExportDocumentFormat } from "../lib/document-export";
 import type { ExtendedSyntaxPreferences } from "../lib/settings/app-settings";
+import { MarkdownPreviewDocument } from "./MarkdownPreviewDocument";
 
 export type MarkdownExportSnapshot = {
   id: number;
@@ -38,226 +24,24 @@ type MarkdownExportDocumentProps = {
   snapshot: MarkdownExportSnapshot | null;
 };
 
-function childrenToText(children: ReactNode) {
-  return Children.toArray(children)
-    .map((child) => typeof child === "string" || typeof child === "number" ? String(child) : "")
-    .join("");
-}
-
-type MarkdownAstNode = {
-  children?: MarkdownAstNode[];
-  type?: string;
-  value?: string;
-};
-
-function replaceHtmlBreakNodes(node: MarkdownAstNode) {
-  if (!Array.isArray(node.children)) return;
-
-  node.children = node.children.map((child) => {
-    if (child.type === "html" && typeof child.value === "string" && /^\s*<br\s*\/?>\s*$/iu.test(child.value)) {
-      return { type: "break" };
-    }
-
-    replaceHtmlBreakNodes(child);
-    return child;
-  });
-}
-
-function remarkMarkraHtmlBreaks() {
-  return (tree: MarkdownAstNode) => {
-    replaceHtmlBreakNodes(tree);
-  };
-}
-
-function hasMathClass(className: unknown, kind: "display" | "inline") {
-  return typeof className === "string" && className.split(/\s+/u).includes(`math-${kind}`);
-}
-
-function isMathMacroDefinitionMarker(child: ReactNode) {
-  return isValidElement<Record<string, unknown>>(child) && child.props["data-markra-math-macro-definition"] === "";
-}
-
-function renderMathSource(source: string, kind: "display" | "inline", macros: MarkraMathMacros) {
-  const html = renderMarkraMathToString(source, kind, macros);
-  if (isMarkraMathMacroDefinitionSource(source)) {
-    return <span data-markra-math-macro-definition="" hidden />;
-  }
-
-  return (
-    <span
-      aria-label={kind === "display" ? "Math formula" : "Inline math formula"}
-      className={`markra-math-render markra-math-render-${kind}`}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
-
-function mermaidSourceFromPre(pre: HTMLPreElement) {
-  const code = pre.querySelector("code");
-  if (!code) return null;
-
-  const language = Array.from(code.classList)
-    .find((className) => className.startsWith("language-"))
-    ?.replace(/^language-/u, "");
-  if (!language || !isMermaidLanguage(language)) return null;
-
-  return code.textContent ?? "";
-}
-
-async function renderMermaidExportBlocks(root: HTMLElement) {
-  const blocks = Array.from(root.querySelectorAll<HTMLPreElement>("pre"))
-    .map((pre) => ({
-      pre,
-      source: mermaidSourceFromPre(pre)
-    }))
-    .filter((block): block is { pre: HTMLPreElement; source: string } => block.source !== null);
-
-  await Promise.all(blocks.map(async ({ pre, source }, index) => {
-    const render = root.ownerDocument.createElement("div");
-    render.className = "markra-mermaid-render";
-    render.setAttribute("aria-label", "Mermaid diagram");
-
-    try {
-      render.innerHTML = await renderMermaidToSvg(source, {
-        idPrefix: `markra-export-mermaid-${index}`,
-        theme: mermaidThemeFromElement(root)
-      });
-    } catch (error) {
-      render.className = "markra-mermaid-render markra-mermaid-render-invalid";
-      render.dataset.error = error instanceof Error ? error.message : "Unknown Mermaid render error";
-      render.textContent = "Unable to render Mermaid diagram";
-    }
-
-    pre.replaceWith(render);
-  }));
-}
-
-function removeCalloutMarkerFromChildren(children: ReactNode, marker: string) {
-  let remainingMarkerLength = marker.length;
-  let trimLeadingBreak = false;
-
-  return Children.toArray(children)
-    .map((child) => {
-      if (remainingMarkerLength <= 0 && !trimLeadingBreak) return child;
-
-      if (typeof child === "string" || typeof child === "number") {
-        let text = String(child);
-
-        if (remainingMarkerLength > 0) {
-          const removeLength = Math.min(remainingMarkerLength, text.length);
-          text = text.slice(removeLength);
-          remainingMarkerLength -= removeLength;
-          if (remainingMarkerLength === 0) trimLeadingBreak = true;
-        }
-
-        if (trimLeadingBreak) {
-          text = text.replace(/^[\s\r\n]+/u, "");
-          if (text.length > 0) trimLeadingBreak = false;
-        }
-
-        return text || null;
-      }
-
-      if (trimLeadingBreak && isValidElement(child) && child.type === "br") {
-        return null;
-      }
-
-      return child;
-    })
-    .filter((child) => child !== null);
-}
-
-function renderCalloutHeader(marker: ParsedMarkdownCalloutMarker) {
-  return (
-    <div className="markra-callout-header">
-      <span aria-hidden="true" className="markra-callout-icon" />
-      <span className="markra-callout-title">{marker.label}</span>
-    </div>
-  );
-}
-
-function renderCalloutBlockquote(props: {
-  children?: ReactNode;
-}) {
-  const children = Children.toArray(props.children);
-  const firstParagraphIndex = children.findIndex((child) =>
-    isValidElement<{ children?: ReactNode }>(child) && child.type === "p"
-  );
-  const firstChild = children[firstParagraphIndex];
-  if (!isValidElement<{ children?: ReactNode }>(firstChild) || firstChild.type !== "p") {
-    return <blockquote>{props.children}</blockquote>;
-  }
-
-  const marker = parseMarkdownCalloutMarker(childrenToText(firstChild.props.children));
-  if (!marker) return <blockquote>{props.children}</blockquote>;
-
-  const nextFirstChildContent = removeCalloutMarkerFromChildren(firstChild.props.children, marker.source);
-  const nextFirstChild = nextFirstChildContent.length > 0
-    ? cloneElement(firstChild as ReactElement<{ children?: ReactNode }>, undefined, nextFirstChildContent)
-    : null;
-  const nextChildren = [
-    ...children.slice(0, firstParagraphIndex),
-    ...(nextFirstChild ? [nextFirstChild] : []),
-    ...children.slice(firstParagraphIndex + 1)
-  ];
-
-  return (
-    <blockquote
-      className={`markra-callout markra-callout-${marker.type}`}
-      data-callout-label={marker.label}
-      data-callout-type={marker.type}
-    >
-      {renderCalloutHeader(marker)}
-      {nextChildren}
-    </blockquote>
-  );
-}
-
 export function MarkdownExportDocument({
   extendedSyntax,
   onRendered,
   resolveImageSrc,
   snapshot
 }: MarkdownExportDocumentProps) {
-  const articleRef = useRef<HTMLElement | null>(null);
-  const githubAlertsEnabled = extendedSyntax?.githubAlerts ?? true;
+  const handleRendered = useCallback((article: HTMLElement) => {
+    if (!snapshot) return;
 
-  useEffect(() => {
-    if (!snapshot || !articleRef.current) return;
-
-    let cancelled = false;
-    const article = articleRef.current;
-    const renderExport = async () => {
-      await renderMermaidExportBlocks(article);
-      if (cancelled) return;
-
-      onRendered({
-        bodyHtml: article.innerHTML,
-        id: snapshot.id,
-        kind: snapshot.kind,
-        title: snapshot.title
-      });
-    };
-
-    renderExport().catch(() => {
-      if (cancelled) return;
-
-      onRendered({
-        bodyHtml: article.innerHTML,
-        id: snapshot.id,
-        kind: snapshot.kind,
-        title: snapshot.title
-      });
+    onRendered({
+      bodyHtml: article.innerHTML,
+      id: snapshot.id,
+      kind: snapshot.kind,
+      title: snapshot.title
     });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [githubAlertsEnabled, onRendered, snapshot]);
+  }, [onRendered, snapshot]);
 
   if (!snapshot) return null;
-
-  const mathMacros = createMarkraMathMacros();
 
   return (
     <section
@@ -265,48 +49,13 @@ export function MarkdownExportDocument({
       className="markdown-export-document"
       data-markra-export-document={snapshot.kind}
     >
-      <article className="markdown-paper markdown-export-paper" ref={articleRef}>
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkHugoMath, remarkMarkraHtmlBreaks]}
-          components={{
-            a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
-            blockquote: ({ node: _node, ...props }) =>
-              githubAlertsEnabled ? renderCalloutBlockquote(props) : <blockquote {...props} />,
-            code: ({ node: _node, className, children, ...props }) => {
-              if (hasMathClass(className, "inline")) {
-                return renderMathSource(childrenToText(children), "inline", mathMacros);
-              }
-
-              if (hasMathClass(className, "display")) {
-                return renderMathSource(childrenToText(children), "display", mathMacros);
-              }
-
-              return <code {...props} className={className}>{children}</code>;
-            },
-            img: ({ node: _node, src, alt, ...props }) => (
-              <img
-                {...props}
-                alt={alt ?? ""}
-                src={resolveImageSrc && typeof src === "string" ? resolveImageSrc(src) : src}
-              />
-            ),
-            pre: ({ node: _node, children, ...props }) => {
-              const onlyChild = Children.toArray(children)[0];
-              if (isMathMacroDefinitionMarker(onlyChild)) return null;
-              if (
-                isValidElement<{ className?: string }>(onlyChild) &&
-                hasMathClass(onlyChild.props.className, "display")
-              ) {
-                return onlyChild;
-              }
-
-              return <pre {...props}>{children}</pre>;
-            }
-          }}
-        >
-          {snapshot.markdown}
-        </ReactMarkdown>
-      </article>
+      <MarkdownPreviewDocument
+        className="markdown-export-paper"
+        extendedSyntax={extendedSyntax}
+        markdown={snapshot.markdown}
+        onRendered={handleRendered}
+        resolveImageSrc={resolveImageSrc}
+      />
     </section>
   );
 }

--- a/packages/app/src/components/MarkdownPreviewDocument.test.tsx
+++ b/packages/app/src/components/MarkdownPreviewDocument.test.tsx
@@ -1,0 +1,49 @@
+import { render, waitFor } from "@testing-library/react";
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async (id: string) => ({
+      svg: `<svg id="${id}" data-testid="mock-mermaid"><g></g></svg>`
+    }))
+  }
+}));
+
+import { MarkdownPreviewDocument } from "./MarkdownPreviewDocument";
+
+describe("MarkdownPreviewDocument", () => {
+  it("renders a reusable visible Markdown preview with extended content", async () => {
+    const onRendered = vi.fn();
+    const resolveImageSrc = vi.fn((src: string) => `markra-preview://${src}`);
+
+    const { container } = render(
+      <MarkdownPreviewDocument
+        markdown={[
+          "> [!WARNING]",
+          "> Check this synthetic preview.",
+          "",
+          "Inline $x^2$ formula.",
+          "",
+          "![Mock](assets/mock.png)",
+          "",
+          "```mermaid",
+          "flowchart TD",
+          "  A --> B",
+          "```"
+        ].join("\n")}
+        onRendered={onRendered}
+        resolveImageSrc={resolveImageSrc}
+      />
+    );
+
+    const article = container.querySelector("article");
+    expect(article).toHaveClass("markdown-paper", "markdown-preview-paper");
+    expect(article).toHaveTextContent("Check this synthetic preview.");
+    expect(article?.querySelector(".markra-callout-warning")).not.toBeNull();
+    expect(article?.querySelector(".markra-math-render-inline")).not.toBeNull();
+    expect(article?.querySelector("img")).toHaveAttribute("src", "markra-preview://assets/mock.png");
+
+    await waitFor(() => expect(article?.querySelector(".markra-mermaid-render svg")).not.toBeNull());
+    expect(onRendered).toHaveBeenCalledWith(article);
+  });
+});

--- a/packages/app/src/components/MarkdownPreviewDocument.tsx
+++ b/packages/app/src/components/MarkdownPreviewDocument.tsx
@@ -1,0 +1,289 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode
+} from "react";
+import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import {
+  createMarkraMathMacros,
+  isMarkraMathMacroDefinitionSource,
+  isMermaidLanguage,
+  mermaidThemeFromElement,
+  remarkHugoMath,
+  renderMarkraMathToString,
+  renderMermaidToSvg,
+  type MarkraMathMacros
+} from "@markra/editor";
+import { parseMarkdownCalloutMarker, type ParsedMarkdownCalloutMarker } from "@markra/shared";
+import type { ExtendedSyntaxPreferences } from "../lib/settings/app-settings";
+
+export type MarkdownPreviewDocumentProps = {
+  className?: string;
+  extendedSyntax?: ExtendedSyntaxPreferences;
+  markdown: string;
+  onRendered?: (article: HTMLElement) => unknown;
+  resolveImageSrc?: (src: string) => string;
+};
+
+function childrenToText(children: ReactNode) {
+  return Children.toArray(children)
+    .map((child) => typeof child === "string" || typeof child === "number" ? String(child) : "")
+    .join("");
+}
+
+type MarkdownAstNode = {
+  children?: MarkdownAstNode[];
+  type?: string;
+  value?: string;
+};
+
+function replaceHtmlBreakNodes(node: MarkdownAstNode) {
+  if (!Array.isArray(node.children)) return;
+
+  node.children = node.children.map((child) => {
+    if (child.type === "html" && typeof child.value === "string" && /^\s*<br\s*\/?>\s*$/iu.test(child.value)) {
+      return { type: "break" };
+    }
+
+    replaceHtmlBreakNodes(child);
+    return child;
+  });
+}
+
+function remarkMarkraHtmlBreaks() {
+  return (tree: MarkdownAstNode) => {
+    replaceHtmlBreakNodes(tree);
+  };
+}
+
+function hasMathClass(className: unknown, kind: "display" | "inline") {
+  return typeof className === "string" && className.split(/\s+/u).includes(`math-${kind}`);
+}
+
+function isMathMacroDefinitionMarker(child: ReactNode) {
+  return isValidElement<Record<string, unknown>>(child) && child.props["data-markra-math-macro-definition"] === "";
+}
+
+function renderMathSource(source: string, kind: "display" | "inline", macros: MarkraMathMacros) {
+  const html = renderMarkraMathToString(source, kind, macros);
+  if (isMarkraMathMacroDefinitionSource(source)) {
+    return <span data-markra-math-macro-definition="" hidden />;
+  }
+
+  return (
+    <span
+      aria-label={kind === "display" ? "Math formula" : "Inline math formula"}
+      className={`markra-math-render markra-math-render-${kind}`}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+function mermaidSourceFromPre(pre: HTMLPreElement) {
+  const code = pre.querySelector("code");
+  if (!code) return null;
+
+  const language = Array.from(code.classList)
+    .find((className) => className.startsWith("language-"))
+    ?.replace(/^language-/u, "");
+  if (!language || !isMermaidLanguage(language)) return null;
+
+  return code.textContent ?? "";
+}
+
+async function renderMermaidPreviewBlocks(root: HTMLElement) {
+  const blocks = Array.from(root.querySelectorAll<HTMLPreElement>("pre"))
+    .map((pre) => ({
+      pre,
+      source: mermaidSourceFromPre(pre)
+    }))
+    .filter((block): block is { pre: HTMLPreElement; source: string } => block.source !== null);
+
+  await Promise.all(blocks.map(async ({ pre, source }, index) => {
+    const render = root.ownerDocument.createElement("div");
+    render.className = "markra-mermaid-render";
+    render.setAttribute("aria-label", "Mermaid diagram");
+
+    try {
+      render.innerHTML = await renderMermaidToSvg(source, {
+        idPrefix: `markra-preview-mermaid-${index}`,
+        theme: mermaidThemeFromElement(root)
+      });
+    } catch (error) {
+      render.className = "markra-mermaid-render markra-mermaid-render-invalid";
+      render.dataset.error = error instanceof Error ? error.message : "Unknown Mermaid render error";
+      render.textContent = "Unable to render Mermaid diagram";
+    }
+
+    pre.replaceWith(render);
+  }));
+}
+
+function removeCalloutMarkerFromChildren(children: ReactNode, marker: string) {
+  let remainingMarkerLength = marker.length;
+  let trimLeadingBreak = false;
+
+  return Children.toArray(children)
+    .map((child) => {
+      if (remainingMarkerLength <= 0 && !trimLeadingBreak) return child;
+
+      if (typeof child === "string" || typeof child === "number") {
+        let text = String(child);
+
+        if (remainingMarkerLength > 0) {
+          const removeLength = Math.min(remainingMarkerLength, text.length);
+          text = text.slice(removeLength);
+          remainingMarkerLength -= removeLength;
+          if (remainingMarkerLength === 0) trimLeadingBreak = true;
+        }
+
+        if (trimLeadingBreak) {
+          text = text.replace(/^[\s\r\n]+/u, "");
+          if (text.length > 0) trimLeadingBreak = false;
+        }
+
+        return text || null;
+      }
+
+      if (trimLeadingBreak && isValidElement(child) && child.type === "br") {
+        return null;
+      }
+
+      return child;
+    })
+    .filter((child) => child !== null);
+}
+
+function renderCalloutHeader(marker: ParsedMarkdownCalloutMarker) {
+  return (
+    <div className="markra-callout-header">
+      <span aria-hidden="true" className="markra-callout-icon" />
+      <span className="markra-callout-title">{marker.label}</span>
+    </div>
+  );
+}
+
+function renderCalloutBlockquote(props: {
+  children?: ReactNode;
+}) {
+  const children = Children.toArray(props.children);
+  const firstParagraphIndex = children.findIndex((child) =>
+    isValidElement<{ children?: ReactNode }>(child) && child.type === "p"
+  );
+  const firstChild = children[firstParagraphIndex];
+  if (!isValidElement<{ children?: ReactNode }>(firstChild) || firstChild.type !== "p") {
+    return <blockquote>{props.children}</blockquote>;
+  }
+
+  const marker = parseMarkdownCalloutMarker(childrenToText(firstChild.props.children));
+  if (!marker) return <blockquote>{props.children}</blockquote>;
+
+  const nextFirstChildContent = removeCalloutMarkerFromChildren(firstChild.props.children, marker.source);
+  const nextFirstChild = nextFirstChildContent.length > 0
+    ? cloneElement(firstChild as ReactElement<{ children?: ReactNode }>, undefined, nextFirstChildContent)
+    : null;
+  const nextChildren = [
+    ...children.slice(0, firstParagraphIndex),
+    ...(nextFirstChild ? [nextFirstChild] : []),
+    ...children.slice(firstParagraphIndex + 1)
+  ];
+
+  return (
+    <blockquote
+      className={`markra-callout markra-callout-${marker.type}`}
+      data-callout-label={marker.label}
+      data-callout-type={marker.type}
+    >
+      {renderCalloutHeader(marker)}
+      {nextChildren}
+    </blockquote>
+  );
+}
+
+function previewClassName(className: string | undefined) {
+  return ["markdown-paper", "markdown-preview-paper", className].filter(Boolean).join(" ");
+}
+
+export function MarkdownPreviewDocument({
+  className,
+  extendedSyntax,
+  markdown,
+  onRendered,
+  resolveImageSrc
+}: MarkdownPreviewDocumentProps) {
+  const articleRef = useRef<HTMLElement | null>(null);
+  const githubAlertsEnabled = extendedSyntax?.githubAlerts ?? true;
+
+  useEffect(() => {
+    const article = articleRef.current;
+    if (!article) return;
+
+    let cancelled = false;
+    const finishRendering = async () => {
+      await renderMermaidPreviewBlocks(article);
+      if (!cancelled) onRendered?.(article);
+    };
+
+    finishRendering().catch(() => {
+      if (!cancelled) onRendered?.(article);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [githubAlertsEnabled, markdown, onRendered, resolveImageSrc]);
+
+  const mathMacros = createMarkraMathMacros();
+
+  return (
+    <article className={previewClassName(className)} ref={articleRef}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkHugoMath, remarkMarkraHtmlBreaks]}
+        components={{
+          a: ({ node: _node, ...props }) => <a {...props} rel="noreferrer" target="_blank" />,
+          blockquote: ({ node: _node, ...props }) =>
+            githubAlertsEnabled ? renderCalloutBlockquote(props) : <blockquote {...props} />,
+          code: ({ node: _node, className: codeClassName, children, ...props }) => {
+            if (hasMathClass(codeClassName, "inline")) {
+              return renderMathSource(childrenToText(children), "inline", mathMacros);
+            }
+
+            if (hasMathClass(codeClassName, "display")) {
+              return renderMathSource(childrenToText(children), "display", mathMacros);
+            }
+
+            return <code {...props} className={codeClassName}>{children}</code>;
+          },
+          img: ({ node: _node, src, alt, ...props }) => (
+            <img
+              {...props}
+              alt={alt ?? ""}
+              src={resolveImageSrc && typeof src === "string" ? resolveImageSrc(src) : src}
+            />
+          ),
+          pre: ({ node: _node, children, ...props }) => {
+            const onlyChild = Children.toArray(children)[0];
+            if (isMathMacroDefinitionMarker(onlyChild)) return null;
+            if (
+              isValidElement<{ className?: string }>(onlyChild) &&
+              hasMathClass(onlyChild.props.className, "display")
+            ) {
+              return onlyChild;
+            }
+
+            return <pre {...props}>{children}</pre>;
+          }
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </article>
+  );
+}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -42,7 +42,8 @@
     "mermaid": "11.15.0",
     "remark-frontmatter": "5.0.0",
     "remark-math": "6.0.0",
-    "turndown": "7.2.4"
+    "turndown": "7.2.4",
+    "unified": "11.0.5"
   },
   "devDependencies": {
     "@types/node": "24.10.0",

--- a/packages/editor/src/hugo-math.ts
+++ b/packages/editor/src/hugo-math.ts
@@ -1,3 +1,5 @@
+import type { Processor } from "unified";
+
 type MarkdownNode = {
   data?: unknown;
   meta?: unknown;
@@ -425,8 +427,8 @@ export function markraHugoMathFromMarkdown() {
   };
 }
 
-export function remarkHugoMath(this: { data: () => RemarkProcessorData }) {
-  const data = this.data();
+export function remarkHugoMath(this: Processor) {
+  const data = this.data() as RemarkProcessorData;
   const micromarkExtensions = data.micromarkExtensions ?? (data.micromarkExtensions = []);
   const fromMarkdownExtensions = data.fromMarkdownExtensions ?? (data.fromMarkdownExtensions = []);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@tauri-apps/plugin-updater':
         specifier: 2.10.1
         version: 2.10.1
+      katex:
+        specifier: 0.16.45
+        version: 0.16.45
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -69,6 +72,9 @@ importers:
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/node':
         specifier: 24.10.0
         version: 24.10.0
@@ -93,6 +99,9 @@ importers:
       vite:
         specifier: 8.0.10
         version: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite-plugin-singlefile:
+        specifier: 2.3.3
+        version: 2.3.3(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0))
@@ -429,6 +438,9 @@ importers:
       turndown:
         specifier: 7.2.4
         version: 7.2.4
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
     devDependencies:
       '@types/node':
         specifier: 24.10.0
@@ -1162,42 +1174,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1321,28 +1327,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1412,35 +1414,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.0':
     resolution: {integrity: sha512-DtSE8ZBlB9H+L+eHkfZ3myt00EVEyAB3e41juEHoE2qT88fgVlJvyrwa9SZYc/xTwCS9TnmK+R84tpg+ZsAg7Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.0':
     resolution: {integrity: sha512-5QdgS4LD+kntClI1aj2JmwjW38LosNXxwCe8viIHEwqYIWuMPdNEIau6/cLogI38Yzx9DnfCPRfEWLyI+5li8Q==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.0':
     resolution: {integrity: sha512-5UynPXo3Zq9khjVdAbD+YogeLltdVUeOah2ioSIM3tu6H7wY9vMy6rgGJhv9r5R8ZXmk9GttMippdqYJWrnLnA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.0':
     resolution: {integrity: sha512-CNz7fHbApz1Zyhhq73jtGn9JqgNEV/lIWnTnUo6h6ujw+mHsTmkLszvJSM8W6JBaDjNpTTFr/RSNoVL5FMwcTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.0':
     resolution: {integrity: sha512-K+br+VXZ+Xx0n/9FdWohpW5Ugq+2FQUpJScqcPl1hTxXfh3fgjYgt4qA2NgrjlJo+zZPNrmUMl+NLvm0ufEqBQ==}
@@ -1761,6 +1758,10 @@ packages:
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2141,6 +2142,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
@@ -2247,6 +2252,10 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
@@ -2341,28 +2350,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2576,6 +2581,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2650,6 +2659,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -2858,6 +2871,10 @@ packages:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -2945,6 +2962,16 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-plugin-singlefile@2.3.3:
+    resolution: {integrity: sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==}
+    engines: {node: '>18.0.0'}
+    peerDependencies:
+      rollup: ^4.59.0
+      vite: ^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -4394,6 +4421,10 @@ snapshots:
 
   bowser@2.14.1: {}
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   buffer-equal-constant-time@1.0.1: {}
 
   bumpp@11.1.0:
@@ -4791,6 +4822,10 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   format@0.2.2: {}
 
   formdata-polyfill@4.0.10:
@@ -4920,6 +4955,8 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-hexadecimal@2.0.1: {}
+
+  is-number@7.0.0: {}
 
   is-obj@2.0.0: {}
 
@@ -5489,6 +5526,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   min-indent@1.0.1: {}
 
   minimist@1.2.8: {}
@@ -5550,6 +5592,8 @@ snapshots:
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -5808,6 +5852,10 @@ snapshots:
     dependencies:
       tldts-core: 7.0.30
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
@@ -5908,6 +5956,11 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vite-plugin-singlefile@2.3.3(vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)):
+    dependencies:
+      micromatch: 4.0.8
+      vite: 8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0)
 
   vite@8.0.10(@types/node@24.10.0)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## Summary
- bundle a native macOS Quick Look preview extension into the Tauri app and register Markdown UTIs
- share the static React Markdown renderer between document exports and Finder previews, including GFM, callouts, KaTeX, Mermaid, and light/dark appearance
- add macOS build, dual-architecture compilation, hardened-runtime signing, bundle verification, and release CI coverage

## Why
Finder currently falls back to plain Markdown text. This adds a system-native preview path without launching the full Markra application or duplicating the Markdown renderer.

## Validation
- `pnpm test` — 2,638 tests passed
- `pnpm typecheck:test` — all workspace test typechecks passed
- `pnpm build` — all workspace builds passed
- `pnpm --filter @markra/desktop test:quicklook` — Swift bridge tests passed
- `QUICKLOOK_ARCH=x86_64 APPLE_SIGNING_IDENTITY=- pnpm --filter @markra/desktop build:quicklook-extension` — Intel extension cross-build passed
- `APPLE_SIGNING_IDENTITY=- pnpm tauri build --debug --bundles app` — macOS app bundle built successfully
- `PROFILE=debug pnpm --filter @markra/desktop verify:quicklook-bundle` — embedded extension, versions, architecture, resources, hardened runtime, and deep signature verified
- Finder manual QA — Markdown, callouts, tables, KaTeX, Mermaid, and the local-image fallback rendered through the Markra extension

## Risk
- the renderer is intentionally emitted as a self-contained HTML file (about 5.2 MB) because `file://` module chunks do not execute reliably in the Quick Look WKWebView
- Finder grants the extension access to the selected Markdown file but not sibling files; relative local images therefore render a clear placeholder, while HTTPS and safe embedded raster images remain supported
