### PR TITLE
feat(updater): support Windows portable updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,24 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: node .release-scripts/scripts/release/normalize-release-artifacts.mjs
 
+      - name: Sign Windows portable bundle
+        if: matrix.asset_platform == 'windows'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          portable_path="$(find "${DESKTOP_DIR}/src-tauri/target/${{ matrix.target }}/release/bundle/portable" -maxdepth 1 -type f -name '*_portable.zip' -print -quit)"
+          if [[ -z "${portable_path}" ]]; then
+            echo "Windows portable bundle was not found." >&2
+            exit 1
+          fi
+
+          "${DESKTOP_DIR}/node_modules/.bin/tauri" signer sign "${portable_path}"
+          test -s "${portable_path}.sig"
+
       - name: Collect bundle paths
         id: bundle_paths
         shell: bash
@@ -510,13 +528,22 @@ jobs:
           UPDATER_PLATFORM: ${{ matrix.updater_platform }}
         run: node .release-scripts/scripts/release/create-updater-metadata.mjs
 
+      - name: Create Windows portable updater metadata
+        if: matrix.asset_platform == 'windows'
+        shell: bash
+        env:
+          ARTIFACT_PATHS_RAW: ${{ steps.bundle_paths.outputs.paths }}
+          OUTPUT_PATH: release-metadata.windows-portable-x86_64.json
+          UPDATER_PLATFORM: windows-portable-x86_64
+        run: node .release-scripts/scripts/release/create-updater-metadata.mjs
+
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APP_SLUG }}-${{ matrix.artifact_name }}-bundles
           path: |
             ${{ steps.bundle_paths.outputs.paths }}
-            release-metadata.json
+            release-metadata*.json
           if-no-files-found: error
 
   publish_release:
@@ -627,7 +654,7 @@ jobs:
 
       - name: Generate updater manifest
         env:
-          EXPECTED_UPDATER_PLATFORMS: darwin-aarch64,darwin-x86_64,linux-aarch64,linux-x86_64,windows-x86_64
+          EXPECTED_UPDATER_PLATFORMS: darwin-aarch64,darwin-x86_64,linux-aarch64,linux-x86_64,windows-x86_64,windows-portable-x86_64
           GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_ASSETS_ROOT: release-assets
           RELEASE_NOTES_PATH: release-notes.md

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2481,10 +2481,12 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "time",
  "trash",
  "windows-sys 0.61.2",
  "winreg",
+ "zip",
 ]
 
 [[package]]
@@ -6676,6 +6678,7 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -38,6 +38,10 @@ tauri-plugin-store = "2.4.3"
 tauri-plugin-updater = "2.10.1"
 time = "0.3.44"
 trash = "5.2.6"
+zip = { version = "4.6.1", default-features = false, features = ["deflate-flate2"] }
+
+[dev-dependencies]
+tempfile = "3.27.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10.1"
@@ -50,7 +54,7 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = ["s
 rustix = { version = "1.1.4", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
 winreg = "0.55.0"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod menu;
 mod menu_labels;
 mod network;
 mod opened_files;
+mod portable_update;
 mod remote_sync;
 mod s3;
 mod s3_text_file;
@@ -65,6 +66,10 @@ use opened_files::{
     opened_markdown_paths_from_args, opened_markdown_paths_from_args_with_cwd,
     opened_markdown_paths_from_urls, queue_opened_markdown_paths, take_opened_markdown_paths,
     OpenedMarkdownPathsState,
+};
+use portable_update::{
+    check_portable_app_update, cleanup_portable_update_helpers, download_portable_app_update,
+    is_native_portable_app, restart_portable_app_update, PortableUpdateState,
 };
 use remote_sync::sync_webdav_markdown_folder;
 use s3_text_file::{read_s3_text_file, write_s3_text_file};
@@ -184,6 +189,10 @@ fn spawn_startup_window_reveal_fallback<R: tauri::Runtime>(app: &tauri::AppHandl
     });
 }
 
+pub fn run_portable_update_helper_if_requested() -> bool {
+    portable_update::run_portable_update_helper_if_requested()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default()
@@ -194,7 +203,8 @@ pub fn run() {
         .manage(NativeApplicationMenuState::default())
         .manage(NativeMenuTargetState::default())
         .manage(EditorWindowRestoreState::default())
-        .manage(AcpAgentProcessState::default());
+        .manage(AcpAgentProcessState::default())
+        .manage(PortableUpdateState::default());
 
     #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
@@ -228,6 +238,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
+            cleanup_portable_update_helpers();
             apply_main_window_chrome(app);
             spawn_startup_window_reveal_fallback(&app.handle());
             if let Some(window) = app.get_webview_window("main") {
@@ -348,6 +359,10 @@ pub fn run() {
             delete_spellcheck_dictionary,
             get_spellcheck_dictionary_status,
             load_spellcheck_dictionary,
+            is_native_portable_app,
+            check_portable_app_update,
+            download_portable_app_update,
+            restart_portable_app_update,
             open_log_folder
         ])
         .build(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if markra_lib::run_portable_update_helper_if_requested() {
+        return;
+    }
     markra_lib::run();
 }

--- a/apps/desktop/src-tauri/src/portable_update.rs
+++ b/apps/desktop/src-tauri/src/portable_update.rs
@@ -1,0 +1,945 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeSet,
+    env,
+    ffi::{OsStr, OsString},
+    fs,
+    io::{Cursor, Read},
+    path::{Component, Path, PathBuf},
+    process::Command,
+    sync::Mutex,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tauri::{ipc::Channel, AppHandle, State};
+use tauri_plugin_updater::{Update, UpdaterExt};
+use zip::ZipArchive;
+
+pub(crate) const PORTABLE_MANIFEST_NAME: &str = "markra-portable.json";
+const PORTABLE_ARCHIVE_ROOT: &str = "Markra";
+const PORTABLE_UPDATE_TARGET: &str = "windows-portable-x86_64";
+const PORTABLE_UPDATE_WORK_DIR: &str = ".markra-update";
+const PORTABLE_UPDATE_HELPER_PREFIX: &str = "markra-portable-helper-";
+pub(crate) const PORTABLE_UPDATE_HELPER_ARG: &str = "--apply-portable-update";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PortableManifest {
+    format_version: u32,
+    executable: String,
+    files: Vec<String>,
+}
+
+#[derive(Debug)]
+struct PortableHelperRequest {
+    parent_process_id: u32,
+    staged_dir: PathBuf,
+    install_dir: PathBuf,
+    backup_dir: PathBuf,
+}
+
+#[derive(Debug)]
+struct StagedPortableUpdate {
+    staged_dir: PathBuf,
+    install_dir: PathBuf,
+    backup_dir: PathBuf,
+    work_dir: PathBuf,
+}
+
+#[derive(Default)]
+struct PortableUpdateSession {
+    pending: Option<Update>,
+    staged: Option<StagedPortableUpdate>,
+}
+
+#[derive(Default)]
+pub(crate) struct PortableUpdateState(Mutex<PortableUpdateSession>);
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PortableUpdateMetadata {
+    body: Option<String>,
+    current_version: String,
+    date: Option<String>,
+    version: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(tag = "event", content = "data")]
+pub(crate) enum PortableDownloadEvent {
+    Started {
+        #[serde(rename = "contentLength")]
+        content_length: Option<u64>,
+    },
+    Progress {
+        #[serde(rename = "chunkLength")]
+        chunk_length: usize,
+    },
+    Finished,
+}
+
+fn portable_error(context: &str, error: impl std::fmt::Display) -> String {
+    format!("{context}: {error}")
+}
+
+fn validate_portable_path(path: &str) -> Result<PathBuf, String> {
+    if path.is_empty() || path.contains('\\') || path.contains(':') {
+        return Err(format!("unsafe portable path: {path}"));
+    }
+
+    let relative = PathBuf::from(path);
+    if !relative
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Err(format!("unsafe portable path: {path}"));
+    }
+
+    Ok(relative)
+}
+
+fn validate_manifest(manifest: &PortableManifest) -> Result<Vec<PathBuf>, String> {
+    if manifest.format_version != 1 {
+        return Err(format!(
+            "unsupported portable manifest format: {}",
+            manifest.format_version
+        ));
+    }
+
+    let executable = validate_portable_path(&manifest.executable)?;
+    let mut unique_files = BTreeSet::new();
+    let mut files = Vec::with_capacity(manifest.files.len());
+
+    for file in &manifest.files {
+        let relative = validate_portable_path(file)?;
+        if !unique_files.insert(relative.clone()) {
+            return Err(format!("duplicate portable path: {file}"));
+        }
+        files.push(relative);
+    }
+
+    if !unique_files.contains(&executable) {
+        return Err("portable manifest does not manage its executable".to_string());
+    }
+    if !unique_files.contains(Path::new(PORTABLE_MANIFEST_NAME)) {
+        return Err("portable manifest does not manage itself".to_string());
+    }
+
+    Ok(files)
+}
+
+fn read_manifest(path: &Path) -> Result<PortableManifest, String> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| portable_error("failed to read portable manifest", error))?;
+    let manifest = serde_json::from_str::<PortableManifest>(&contents)
+        .map_err(|error| portable_error("failed to parse portable manifest", error))?;
+    validate_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+fn manifest_for_root(root: &Path) -> Result<PortableManifest, String> {
+    read_manifest(&root.join(PORTABLE_MANIFEST_NAME))
+}
+
+fn is_portable_executable(executable: &Path) -> bool {
+    let Some(root) = executable.parent() else {
+        return false;
+    };
+    let Ok(manifest) = manifest_for_root(root) else {
+        return false;
+    };
+
+    executable.file_name().is_some_and(|file_name| {
+        file_name
+            .to_string_lossy()
+            .eq_ignore_ascii_case(&manifest.executable)
+    })
+}
+
+fn archive_entry_name(relative: &Path) -> String {
+    format!(
+        "{PORTABLE_ARCHIVE_ROOT}/{}",
+        relative.to_string_lossy().replace('\\', "/")
+    )
+}
+
+fn extract_portable_package(bytes: &[u8], output_dir: &Path) -> Result<PortableManifest, String> {
+    let mut archive = ZipArchive::new(Cursor::new(bytes))
+        .map_err(|error| portable_error("failed to open portable update archive", error))?;
+    let manifest_entry_name = format!("{PORTABLE_ARCHIVE_ROOT}/{PORTABLE_MANIFEST_NAME}");
+    let manifest = {
+        let mut entry = archive
+            .by_name(&manifest_entry_name)
+            .map_err(|error| portable_error("portable update manifest is missing", error))?;
+        let mut contents = String::new();
+        entry
+            .read_to_string(&mut contents)
+            .map_err(|error| portable_error("failed to read portable update manifest", error))?;
+        serde_json::from_str::<PortableManifest>(&contents)
+            .map_err(|error| portable_error("failed to parse portable update manifest", error))?
+    };
+    let files = validate_manifest(&manifest)?;
+
+    for relative in files {
+        let archive_name = archive_entry_name(&relative);
+        let mut entry = archive.by_name(&archive_name).map_err(|error| {
+            portable_error(
+                &format!("portable update file is missing: {archive_name}"),
+                error,
+            )
+        })?;
+        if entry.is_dir() {
+            return Err(format!(
+                "portable update file is a directory: {archive_name}"
+            ));
+        }
+
+        let output_path = output_dir.join(&relative);
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                portable_error("failed to create portable staging directory", error)
+            })?;
+        }
+        let mut output = fs::File::create(&output_path)
+            .map_err(|error| portable_error("failed to create staged portable file", error))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|error| portable_error("failed to extract staged portable file", error))?;
+    }
+
+    Ok(manifest)
+}
+
+fn restore_backup_files(
+    moved_files: &[PathBuf],
+    install_dir: &Path,
+    backup_dir: &Path,
+) -> Result<(), String> {
+    for relative in moved_files.iter().rev() {
+        let backup_path = backup_dir.join(relative);
+        if !backup_path.exists() {
+            continue;
+        }
+        let install_path = install_dir.join(relative);
+        if install_path.exists() {
+            fs::remove_file(&install_path).map_err(|error| {
+                portable_error("failed to remove incomplete portable file", error)
+            })?;
+        }
+        if let Some(parent) = install_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                portable_error("failed to recreate portable install directory", error)
+            })?;
+        }
+        fs::rename(&backup_path, &install_path)
+            .map_err(|error| portable_error("failed to restore portable update backup", error))?;
+    }
+    Ok(())
+}
+
+fn apply_staged_update(
+    staged_dir: &Path,
+    install_dir: &Path,
+    backup_dir: &Path,
+) -> Result<(), String> {
+    let old_manifest = manifest_for_root(install_dir)?;
+    let new_manifest = manifest_for_root(staged_dir)?;
+    let old_files = validate_manifest(&old_manifest)?;
+    let new_files = validate_manifest(&new_manifest)?;
+    let old_file_set = old_files.iter().cloned().collect::<BTreeSet<_>>();
+
+    for relative in &new_files {
+        if !staged_dir.join(relative).is_file() {
+            return Err(format!(
+                "staged portable file is missing: {}",
+                relative.display()
+            ));
+        }
+        if !old_file_set.contains(relative) && install_dir.join(relative).exists() {
+            return Err(format!(
+                "new package file would replace an unmanaged portable file: {}",
+                relative.display()
+            ));
+        }
+    }
+
+    let managed_files = old_files
+        .iter()
+        .chain(new_files.iter())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    fs::create_dir_all(backup_dir)
+        .map_err(|error| portable_error("failed to create portable update backup", error))?;
+
+    let mut moved_files = Vec::new();
+    for relative in managed_files {
+        let install_path = install_dir.join(&relative);
+        if !install_path.is_file() {
+            continue;
+        }
+        let backup_path = backup_dir.join(&relative);
+        if let Some(parent) = backup_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                portable_error("failed to create portable backup directory", error)
+            })?;
+        }
+        if let Err(error) = fs::rename(&install_path, &backup_path) {
+            restore_backup_files(&moved_files, install_dir, backup_dir)?;
+            return Err(portable_error("failed to back up portable file", error));
+        }
+        moved_files.push(relative);
+    }
+
+    let mut installed_files = Vec::new();
+    for relative in &new_files {
+        let staged_path = staged_dir.join(relative);
+        let install_path = install_dir.join(relative);
+        if let Some(parent) = install_path.parent() {
+            if let Err(error) = fs::create_dir_all(parent) {
+                for installed in installed_files.iter().rev() {
+                    let _ = fs::remove_file(install_dir.join(installed));
+                }
+                restore_backup_files(&moved_files, install_dir, backup_dir)?;
+                return Err(portable_error(
+                    "failed to create portable install directory",
+                    error,
+                ));
+            }
+        }
+        if let Err(error) = fs::rename(&staged_path, &install_path) {
+            for installed in installed_files.iter().rev() {
+                let _ = fs::remove_file(install_dir.join(installed));
+            }
+            restore_backup_files(&moved_files, install_dir, backup_dir)?;
+            return Err(portable_error("failed to install portable file", error));
+        }
+        installed_files.push(relative.clone());
+    }
+
+    fs::remove_dir_all(backup_dir)
+        .map_err(|error| portable_error("failed to remove portable update backup", error))?;
+    Ok(())
+}
+
+fn parse_portable_update_helper_request<I>(args: I) -> Option<PortableHelperRequest>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter();
+    args.next()?;
+    if args.next()?.as_os_str() != OsStr::new(PORTABLE_UPDATE_HELPER_ARG) {
+        return None;
+    }
+
+    let parent_process_id = args.next()?.to_string_lossy().parse().ok()?;
+    let request = PortableHelperRequest {
+        parent_process_id,
+        staged_dir: PathBuf::from(args.next()?),
+        install_dir: PathBuf::from(args.next()?),
+        backup_dir: PathBuf::from(args.next()?),
+    };
+    if args.next().is_some() {
+        return None;
+    }
+    Some(request)
+}
+
+#[cfg(windows)]
+fn wait_for_parent_process(parent_process_id: u32) -> Result<(), String> {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, WAIT_FAILED, WAIT_OBJECT_0},
+        System::Threading::{OpenProcess, WaitForSingleObject, SYNCHRONIZE},
+    };
+
+    let handle = unsafe { OpenProcess(SYNCHRONIZE, 0, parent_process_id) };
+    if handle.is_null() {
+        return Ok(());
+    }
+    let result = unsafe { WaitForSingleObject(handle, 60_000) };
+    unsafe { CloseHandle(handle) };
+
+    if result == WAIT_OBJECT_0 {
+        Ok(())
+    } else if result == WAIT_FAILED {
+        Err(portable_error(
+            "failed to wait for Markra to exit",
+            std::io::Error::last_os_error(),
+        ))
+    } else {
+        Err("timed out waiting for Markra to exit".to_string())
+    }
+}
+
+#[cfg(not(windows))]
+fn wait_for_parent_process(_parent_process_id: u32) -> Result<(), String> {
+    Ok(())
+}
+
+fn run_portable_update_helper_with<W, R>(
+    request: PortableHelperRequest,
+    wait_for_parent: W,
+    restart_app: R,
+) -> Result<(), String>
+where
+    W: FnOnce(u32) -> Result<(), String>,
+    R: FnOnce(&Path) -> Result<(), String>,
+{
+    wait_for_parent(request.parent_process_id)?;
+    let update_result = apply_staged_update(
+        &request.staged_dir,
+        &request.install_dir,
+        &request.backup_dir,
+    );
+    let restart_result = manifest_for_root(&request.install_dir)
+        .and_then(|manifest| restart_app(&request.install_dir.join(&manifest.executable)));
+
+    if update_result.is_ok() {
+        if let Some(work_dir) = request.staged_dir.parent() {
+            let _ = fs::remove_dir_all(work_dir);
+        }
+    }
+
+    match (update_result, restart_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(update_error), Ok(())) => Err(update_error),
+        (Ok(()), Err(restart_error)) => Err(restart_error),
+        (Err(update_error), Err(restart_error)) => Err(format!(
+            "{update_error}; failed to restart the existing portable app: {restart_error}"
+        )),
+    }
+}
+
+fn run_portable_update_helper(request: PortableHelperRequest) -> Result<(), String> {
+    run_portable_update_helper_with(request, wait_for_parent_process, |executable| {
+        Command::new(executable)
+            .spawn()
+            .map(|_| ())
+            .map_err(|error| portable_error("failed to restart portable app", error))
+    })
+}
+
+pub fn run_portable_update_helper_if_requested() -> bool {
+    let Some(request) = parse_portable_update_helper_request(env::args_os()) else {
+        return false;
+    };
+    if let Err(error) = run_portable_update_helper(request) {
+        eprintln!("Portable update failed: {error}");
+    }
+    true
+}
+
+fn unique_suffix() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("{}-{timestamp}", std::process::id())
+}
+
+fn create_staging_paths(install_dir: &Path) -> Result<StagedPortableUpdate, String> {
+    // Keep staging beside the app so every final rename stays atomic even when the
+    // portable folder lives on a different drive than the system temp directory.
+    let work_dir = install_dir
+        .join(PORTABLE_UPDATE_WORK_DIR)
+        .join(unique_suffix());
+    let staged_dir = work_dir.join("staged");
+    let backup_dir = work_dir.join("backup");
+    fs::create_dir_all(&staged_dir).map_err(|error| {
+        portable_error("failed to create portable update staging directory", error)
+    })?;
+    Ok(StagedPortableUpdate {
+        staged_dir,
+        install_dir: install_dir.to_path_buf(),
+        backup_dir,
+        work_dir,
+    })
+}
+
+fn current_portable_executable() -> Result<PathBuf, String> {
+    let executable = env::current_exe()
+        .map_err(|error| portable_error("failed to locate the Markra executable", error))?;
+    if !cfg!(windows) || !is_portable_executable(&executable) {
+        return Err("Markra is not running from a supported portable package".to_string());
+    }
+    Ok(executable)
+}
+
+#[tauri::command]
+pub(crate) fn is_native_portable_app() -> bool {
+    current_portable_executable().is_ok()
+}
+
+#[tauri::command]
+pub(crate) async fn check_portable_app_update(
+    app: AppHandle,
+    state: State<'_, PortableUpdateState>,
+    proxy: Option<String>,
+) -> Result<Option<PortableUpdateMetadata>, String> {
+    current_portable_executable()?;
+    {
+        let mut session = state
+            .0
+            .lock()
+            .map_err(|error| portable_error("portable updater state is unavailable", error))?;
+        session.pending = None;
+    }
+
+    let mut builder = app.updater_builder().target(PORTABLE_UPDATE_TARGET);
+    if let Some(proxy) = proxy {
+        let proxy = proxy
+            .parse()
+            .map_err(|error| portable_error("invalid portable updater proxy", error))?;
+        builder = builder.proxy(proxy);
+    }
+    let update = builder
+        .build()
+        .map_err(|error| portable_error("failed to configure portable updater", error))?
+        .check()
+        .await
+        .map_err(|error| portable_error("failed to check for portable updates", error))?;
+    let metadata = update.as_ref().map(|update| PortableUpdateMetadata {
+        body: update.body.clone(),
+        current_version: update.current_version.clone(),
+        date: update.date.map(|date| date.to_string()),
+        version: update.version.clone(),
+    });
+    let mut session = state
+        .0
+        .lock()
+        .map_err(|error| portable_error("portable updater state is unavailable", error))?;
+    session.pending = update;
+    Ok(metadata)
+}
+
+#[tauri::command]
+pub(crate) async fn download_portable_app_update(
+    state: State<'_, PortableUpdateState>,
+    on_event: Channel<PortableDownloadEvent>,
+) -> Result<(), String> {
+    let update = {
+        let mut session = state
+            .0
+            .lock()
+            .map_err(|error| portable_error("portable updater state is unavailable", error))?;
+        session
+            .pending
+            .take()
+            .ok_or_else(|| "there is no pending portable update".to_string())?
+    };
+    let progress_events = on_event.clone();
+    let finished_events = on_event.clone();
+    let mut started = false;
+    // Tauri verifies the signed portable target before returning these bytes. Do not
+    // replace this with an unsigned direct download.
+    let bytes = update
+        .download(
+            move |chunk_length, content_length| {
+                if !started {
+                    started = true;
+                    let _ = progress_events.send(PortableDownloadEvent::Started { content_length });
+                }
+                let _ = progress_events.send(PortableDownloadEvent::Progress { chunk_length });
+            },
+            move || {
+                let _ = finished_events.send(PortableDownloadEvent::Finished);
+            },
+        )
+        .await
+        .map_err(|error| portable_error("failed to download or verify portable update", error))?;
+
+    let executable = current_portable_executable()?;
+    let install_dir = executable
+        .parent()
+        .ok_or_else(|| "portable executable has no parent directory".to_string())?;
+    let staged = create_staging_paths(install_dir)?;
+    if let Err(error) = extract_portable_package(&bytes, &staged.staged_dir) {
+        let _ = fs::remove_dir_all(&staged.work_dir);
+        return Err(error);
+    }
+
+    let mut session = state
+        .0
+        .lock()
+        .map_err(|error| portable_error("portable updater state is unavailable", error))?;
+    if let Some(previous) = session.staged.replace(staged) {
+        let _ = fs::remove_dir_all(previous.work_dir);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn parent_process_id() -> u32 {
+    unsafe { windows_sys::Win32::System::Threading::GetCurrentProcessId() }
+}
+
+#[cfg(not(windows))]
+fn parent_process_id() -> u32 {
+    std::process::id()
+}
+
+fn spawn_portable_update_helper(staged: &StagedPortableUpdate) -> Result<(), String> {
+    let executable = current_portable_executable()?;
+    let helper_dir = env::temp_dir().join(format!(
+        "{PORTABLE_UPDATE_HELPER_PREFIX}{}",
+        unique_suffix()
+    ));
+    fs::create_dir_all(&helper_dir).map_err(|error| {
+        portable_error("failed to create portable update helper directory", error)
+    })?;
+    let helper_path = helper_dir.join("MarkraPortableUpdate.exe");
+    // Windows locks the running executable. A temporary copy can wait for this
+    // process to exit, replace the original files, and then launch the new version.
+    fs::copy(&executable, &helper_path)
+        .map_err(|error| portable_error("failed to prepare portable update helper", error))?;
+    Command::new(&helper_path)
+        .arg(PORTABLE_UPDATE_HELPER_ARG)
+        .arg(parent_process_id().to_string())
+        .arg(&staged.staged_dir)
+        .arg(&staged.install_dir)
+        .arg(&staged.backup_dir)
+        .spawn()
+        .map_err(|error| portable_error("failed to launch portable update helper", error))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn restart_portable_app_update(
+    app: AppHandle,
+    state: State<'_, PortableUpdateState>,
+) -> Result<(), String> {
+    let staged = {
+        let mut session = state
+            .0
+            .lock()
+            .map_err(|error| portable_error("portable updater state is unavailable", error))?;
+        session
+            .staged
+            .take()
+            .ok_or_else(|| "there is no staged portable update".to_string())?
+    };
+    spawn_portable_update_helper(&staged)?;
+    app.exit(0);
+    Ok(())
+}
+
+pub(crate) fn cleanup_portable_update_helpers() {
+    let Ok(entries) = fs::read_dir(env::temp_dir()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(PORTABLE_UPDATE_HELPER_PREFIX)
+        {
+            let _ = fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        io::{Cursor, Write},
+        path::Path,
+    };
+    use tempfile::tempdir;
+    use zip::{write::SimpleFileOptions, ZipWriter};
+
+    fn manifest(executable: &str, files: &[&str]) -> String {
+        serde_json::json!({
+            "formatVersion": 1,
+            "executable": executable,
+            "files": files,
+        })
+        .to_string()
+    }
+
+    fn write_manifest(root: &Path, executable: &str, files: &[&str]) {
+        fs::write(
+            root.join(PORTABLE_MANIFEST_NAME),
+            manifest(executable, files),
+        )
+        .expect("portable manifest should be written");
+    }
+
+    fn portable_archive(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut archive = ZipWriter::new(Cursor::new(Vec::new()));
+        let options = SimpleFileOptions::default();
+
+        for (name, bytes) in entries {
+            archive
+                .start_file(*name, options)
+                .expect("archive entry should start");
+            archive
+                .write_all(bytes)
+                .expect("archive entry should be written");
+        }
+
+        archive
+            .finish()
+            .expect("archive should finish")
+            .into_inner()
+    }
+
+    #[test]
+    fn detects_portable_installations_from_the_managed_manifest() {
+        let root = tempdir().expect("temporary directory should exist");
+        let executable = root.path().join("Markra.exe");
+        fs::write(&executable, b"binary").expect("executable should be written");
+        write_manifest(
+            root.path(),
+            "Markra.exe",
+            &["Markra.exe", PORTABLE_MANIFEST_NAME],
+        );
+
+        assert!(is_portable_executable(&executable));
+        assert!(!is_portable_executable(&root.path().join("Other.exe")));
+    }
+
+    #[test]
+    fn detects_portable_executable_names_case_insensitively_like_windows() {
+        let root = tempdir().expect("temporary directory should exist");
+        let executable = root.path().join("markra.exe");
+        fs::write(&executable, b"binary").expect("executable should be written");
+        write_manifest(
+            root.path(),
+            "Markra.exe",
+            &["Markra.exe", PORTABLE_MANIFEST_NAME],
+        );
+
+        assert!(is_portable_executable(&executable));
+    }
+
+    #[test]
+    fn extracts_a_valid_portable_package_into_the_staging_directory() {
+        let root = tempdir().expect("temporary directory should exist");
+        let archive = portable_archive(&[
+            ("Markra/Markra.exe", b"new-binary"),
+            ("Markra/support.dll", b"new-library"),
+            (
+                "Markra/markra-portable.json",
+                manifest(
+                    "Markra.exe",
+                    &["Markra.exe", "support.dll", PORTABLE_MANIFEST_NAME],
+                )
+                .as_bytes(),
+            ),
+        ]);
+
+        let extracted = extract_portable_package(&archive, root.path())
+            .expect("portable package should extract");
+
+        assert_eq!(extracted.executable, "Markra.exe");
+        assert_eq!(
+            fs::read(root.path().join("Markra.exe")).unwrap(),
+            b"new-binary"
+        );
+        assert_eq!(
+            fs::read(root.path().join("support.dll")).unwrap(),
+            b"new-library"
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_paths_before_extracting_portable_files() {
+        let root = tempdir().expect("temporary directory should exist");
+        let archive = portable_archive(&[
+            ("Markra/Markra.exe", b"new-binary"),
+            (
+                "Markra/markra-portable.json",
+                manifest(
+                    "Markra.exe",
+                    &["Markra.exe", "../outside.dll", PORTABLE_MANIFEST_NAME],
+                )
+                .as_bytes(),
+            ),
+        ]);
+
+        let error = extract_portable_package(&archive, root.path())
+            .expect_err("unsafe portable paths should be rejected");
+
+        assert!(error.contains("unsafe portable path"));
+        assert!(!root.path().join("Markra.exe").exists());
+    }
+
+    #[test]
+    fn applies_managed_files_and_preserves_user_files() {
+        let root = tempdir().expect("temporary directory should exist");
+        let install = root.path().join("install");
+        let staged = root.path().join("staged");
+        let backup = root.path().join("backup");
+        fs::create_dir_all(&install).unwrap();
+        fs::create_dir_all(&staged).unwrap();
+
+        fs::write(install.join("Markra.exe"), b"old-binary").unwrap();
+        fs::write(install.join("support.dll"), b"old-library").unwrap();
+        fs::write(install.join("obsolete.dll"), b"obsolete-library").unwrap();
+        fs::write(install.join("notes.md"), b"user-file").unwrap();
+        write_manifest(
+            &install,
+            "Markra.exe",
+            &[
+                "Markra.exe",
+                "support.dll",
+                "obsolete.dll",
+                PORTABLE_MANIFEST_NAME,
+            ],
+        );
+
+        fs::write(staged.join("Markra.exe"), b"new-binary").unwrap();
+        fs::write(staged.join("support.dll"), b"new-library").unwrap();
+        write_manifest(
+            &staged,
+            "Markra.exe",
+            &["Markra.exe", "support.dll", PORTABLE_MANIFEST_NAME],
+        );
+
+        apply_staged_update(&staged, &install, &backup)
+            .expect("staged portable update should apply");
+
+        assert_eq!(fs::read(install.join("Markra.exe")).unwrap(), b"new-binary");
+        assert_eq!(
+            fs::read(install.join("support.dll")).unwrap(),
+            b"new-library"
+        );
+        assert!(!install.join("obsolete.dll").exists());
+        assert_eq!(fs::read(install.join("notes.md")).unwrap(), b"user-file");
+    }
+
+    #[test]
+    fn refuses_to_replace_an_unmanaged_file_with_a_new_package_file() {
+        let root = tempdir().expect("temporary directory should exist");
+        let install = root.path().join("install");
+        let staged = root.path().join("staged");
+        let backup = root.path().join("backup");
+        fs::create_dir_all(&install).unwrap();
+        fs::create_dir_all(&staged).unwrap();
+
+        fs::write(install.join("Markra.exe"), b"old-binary").unwrap();
+        fs::write(install.join("future.dll"), b"user-library").unwrap();
+        write_manifest(
+            &install,
+            "Markra.exe",
+            &["Markra.exe", PORTABLE_MANIFEST_NAME],
+        );
+        fs::write(staged.join("Markra.exe"), b"new-binary").unwrap();
+        fs::write(staged.join("future.dll"), b"package-library").unwrap();
+        write_manifest(
+            &staged,
+            "Markra.exe",
+            &["Markra.exe", "future.dll", PORTABLE_MANIFEST_NAME],
+        );
+
+        let error = apply_staged_update(&staged, &install, &backup)
+            .expect_err("unmanaged files should not be overwritten");
+
+        assert!(error.contains("unmanaged portable file"));
+        assert_eq!(fs::read(install.join("Markra.exe")).unwrap(), b"old-binary");
+        assert_eq!(
+            fs::read(install.join("future.dll")).unwrap(),
+            b"user-library"
+        );
+    }
+
+    #[test]
+    fn rolls_back_managed_files_when_installing_a_staged_file_fails() {
+        let root = tempdir().expect("temporary directory should exist");
+        let install = root.path().join("install");
+        let staged = root.path().join("staged");
+        let backup = root.path().join("backup");
+        fs::create_dir_all(install.join("blocked.dll")).unwrap();
+        fs::create_dir_all(&staged).unwrap();
+
+        fs::write(install.join("Markra.exe"), b"old-binary").unwrap();
+        write_manifest(
+            &install,
+            "Markra.exe",
+            &["Markra.exe", "blocked.dll", PORTABLE_MANIFEST_NAME],
+        );
+        fs::write(staged.join("Markra.exe"), b"new-binary").unwrap();
+        fs::write(staged.join("blocked.dll"), b"new-library").unwrap();
+        write_manifest(
+            &staged,
+            "Markra.exe",
+            &["Markra.exe", "blocked.dll", PORTABLE_MANIFEST_NAME],
+        );
+
+        apply_staged_update(&staged, &install, &backup)
+            .expect_err("the blocked destination should fail the update");
+
+        assert_eq!(fs::read(install.join("Markra.exe")).unwrap(), b"old-binary");
+        assert!(install.join("blocked.dll").is_dir());
+        assert!(manifest_for_root(&install).is_ok());
+    }
+
+    #[test]
+    fn restarts_the_existing_portable_app_after_a_rolled_back_update() {
+        let root = tempdir().expect("temporary directory should exist");
+        let install = root.path().join("install");
+        let work = root.path().join("work");
+        let staged = work.join("staged");
+        let backup = work.join("backup");
+        fs::create_dir_all(install.join("blocked.dll")).unwrap();
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(install.join("Markra.exe"), b"old-binary").unwrap();
+        write_manifest(
+            &install,
+            "Markra.exe",
+            &["Markra.exe", "blocked.dll", PORTABLE_MANIFEST_NAME],
+        );
+        fs::write(staged.join("Markra.exe"), b"new-binary").unwrap();
+        fs::write(staged.join("blocked.dll"), b"new-library").unwrap();
+        write_manifest(
+            &staged,
+            "Markra.exe",
+            &["Markra.exe", "blocked.dll", PORTABLE_MANIFEST_NAME],
+        );
+        let restarted = std::cell::Cell::new(false);
+        let request = PortableHelperRequest {
+            parent_process_id: 42,
+            staged_dir: staged,
+            install_dir: install.clone(),
+            backup_dir: backup,
+        };
+
+        run_portable_update_helper_with(
+            request,
+            |_| Ok(()),
+            |executable| {
+                restarted.set(true);
+                assert_eq!(executable, install.join("Markra.exe"));
+                Ok(())
+            },
+        )
+        .expect_err("the failed update should still be reported");
+
+        assert!(restarted.get());
+        assert_eq!(fs::read(install.join("Markra.exe")).unwrap(), b"old-binary");
+    }
+
+    #[test]
+    fn parses_only_complete_portable_update_helper_requests() {
+        let args = [
+            "Markra.exe",
+            PORTABLE_UPDATE_HELPER_ARG,
+            "42",
+            "/mock/staged",
+            "/mock/install",
+            "/mock/backup",
+        ];
+
+        let request = parse_portable_update_helper_request(args.iter().map(Into::into))
+            .expect("complete helper request should parse");
+
+        assert_eq!(request.parent_process_id, 42);
+        assert_eq!(request.staged_dir, Path::new("/mock/staged"));
+        assert_eq!(request.install_dir, Path::new("/mock/install"));
+        assert_eq!(request.backup_dir, Path::new("/mock/backup"));
+        assert!(parse_portable_update_helper_request(
+            ["Markra.exe", PORTABLE_UPDATE_HELPER_ARG]
+                .iter()
+                .map(Into::into)
+        )
+        .is_none());
+    }
+}

--- a/apps/desktop/src/runtime/tauri/updater.test.ts
+++ b/apps/desktop/src/runtime/tauri/updater.test.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { getStoredNetworkSettings, saveStoredWorkspaceState } from "@markra/app/settings";
@@ -6,6 +7,13 @@ import { checkNativeAppUpdate } from "./updater";
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
   check: vi.fn()
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: vi.fn().mockImplementation(function Channel(callback: unknown) {
+    return { callback };
+  }),
+  invoke: vi.fn()
 }));
 
 vi.mock("@tauri-apps/plugin-process", () => ({
@@ -22,6 +30,7 @@ vi.mock("./window", () => ({
 }));
 
 const mockedCheck = vi.mocked(check);
+const mockedInvoke = vi.mocked(invoke);
 const mockedGetStoredNetworkSettings = vi.mocked(getStoredNetworkSettings);
 const mockedRelaunch = vi.mocked(relaunch);
 const mockedSaveStoredWorkspaceState = vi.mocked(saveStoredWorkspaceState);
@@ -30,6 +39,11 @@ const mockedListNativeEditorWindowRestoreStates = vi.mocked(listNativeEditorWind
 describe("native app updater", () => {
   beforeEach(() => {
     mockedCheck.mockReset();
+    mockedInvoke.mockReset();
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === "is_native_portable_app") return false;
+      return undefined;
+    });
     mockedGetStoredNetworkSettings.mockReset();
     mockedRelaunch.mockReset();
     mockedSaveStoredWorkspaceState.mockReset();
@@ -193,5 +207,48 @@ describe("native app updater", () => {
       ]
     });
     expect(mockedRelaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the signed portable update channel without launching an installer", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mockedInvoke.mockImplementation(async (command, args) => {
+      if (command === "is_native_portable_app") return true;
+      if (command === "check_portable_app_update") {
+        return {
+          body: "Portable release notes",
+          currentVersion: "0.0.6",
+          date: "2026-05-11T00:00:00Z",
+          version: "0.0.7"
+        };
+      }
+      if (command === "download_portable_app_update") {
+        const channel = (args as { onEvent: { callback: (event: unknown) => unknown } }).onEvent;
+        channel.callback({ data: { contentLength: 80 }, event: "Started" });
+        channel.callback({ data: { chunkLength: 80 }, event: "Progress" });
+        channel.callback({ event: "Finished" });
+      }
+      return undefined;
+    });
+    const onProgress = vi.fn();
+
+    const update = await checkNativeAppUpdate();
+    await update?.downloadAndInstall({ onProgress });
+    await update?.restart();
+
+    expect(mockedCheck).not.toHaveBeenCalled();
+    expect(mockedInvoke).toHaveBeenCalledWith("check_portable_app_update", {
+      proxy: "http://127.0.0.1:7890"
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith("download_portable_app_update", {
+      onEvent: expect.anything()
+    });
+    expect(onProgress).toHaveBeenLastCalledWith({
+      contentLength: 80,
+      downloaded: 80,
+      progress: 100
+    });
+    expect(mockedSaveStoredWorkspaceState).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledWith("restart_portable_app_update");
+    expect(mockedRelaunch).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/runtime/tauri/updater.ts
+++ b/apps/desktop/src/runtime/tauri/updater.ts
@@ -1,3 +1,4 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { check, type DownloadEvent } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { getStoredNetworkSettings, saveStoredWorkspaceState } from "@markra/app/settings";
@@ -26,6 +27,15 @@ export type NativeAppUpdate = {
   version: string;
 };
 
+type NativePortableUpdateMetadata = {
+  body?: string;
+  currentVersion: string;
+  date?: string;
+  version: string;
+};
+
+type NativePortableDownloadEvent = DownloadEvent;
+
 function isTauriRuntime() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
@@ -42,6 +52,20 @@ async function checkWithLocalProxyFallback() {
   }
 
   return check();
+}
+
+async function checkPortableWithLocalProxyFallback() {
+  const proxies = await updaterProxyUrls();
+
+  for (const proxy of proxies) {
+    try {
+      return await invoke<NativePortableUpdateMetadata | null>("check_portable_app_update", { proxy });
+    } catch {
+      // Local proxies are optional; fall through to the next candidate or direct check.
+    }
+  }
+
+  return invoke<NativePortableUpdateMetadata | null>("check_portable_app_update");
 }
 
 async function updaterProxyUrls() {
@@ -87,8 +111,54 @@ async function persistEditorWindowRestoreSnapshot() {
   }
 }
 
+function createProgressListener(onProgress?: (progress: NativeAppUpdateProgress) => unknown) {
+  let contentLength: number | null = null;
+  let downloaded = 0;
+
+  return (event: DownloadEvent) => {
+    if (event.event === "Started") {
+      contentLength = event.data.contentLength ?? null;
+      downloaded = 0;
+      emitProgress({ contentLength, downloaded, onProgress });
+      return;
+    }
+
+    if (event.event === "Progress") {
+      downloaded += event.data.chunkLength;
+      emitProgress({ contentLength, downloaded, onProgress });
+      return;
+    }
+
+    if (event.event === "Finished") {
+      if (contentLength !== null) downloaded = contentLength;
+      emitProgress({ contentLength, downloaded, onProgress });
+    }
+  };
+}
+
+async function checkNativePortableAppUpdate(): Promise<NativeAppUpdate | null> {
+  const update = await checkPortableWithLocalProxyFallback();
+  if (!update) return null;
+
+  return {
+    ...update,
+    async downloadAndInstall(callbacks = {}) {
+      const onEvent = new Channel<NativePortableDownloadEvent>(createProgressListener(callbacks.onProgress));
+      await invoke("download_portable_app_update", { onEvent });
+    },
+    async restart() {
+      await persistEditorWindowRestoreSnapshot();
+      await invoke("restart_portable_app_update");
+    }
+  };
+}
+
 export async function checkNativeAppUpdate(): Promise<NativeAppUpdate | null> {
   if (!isTauriRuntime()) return null;
+
+  if (await invoke<boolean>("is_native_portable_app")) {
+    return checkNativePortableAppUpdate();
+  }
 
   const update = await checkWithLocalProxyFallback();
   if (!update) return null;
@@ -98,28 +168,7 @@ export async function checkNativeAppUpdate(): Promise<NativeAppUpdate | null> {
     currentVersion: update.currentVersion,
     date: update.date,
     async downloadAndInstall(callbacks = {}) {
-      let contentLength: number | null = null;
-      let downloaded = 0;
-
-      await update.downloadAndInstall((event: DownloadEvent) => {
-        if (event.event === "Started") {
-          contentLength = event.data.contentLength ?? null;
-          downloaded = 0;
-          emitProgress({ contentLength, downloaded, onProgress: callbacks.onProgress });
-          return;
-        }
-
-        if (event.event === "Progress") {
-          downloaded += event.data.chunkLength;
-          emitProgress({ contentLength, downloaded, onProgress: callbacks.onProgress });
-          return;
-        }
-
-        if (event.event === "Finished") {
-          if (contentLength !== null) downloaded = contentLength;
-          emitProgress({ contentLength, downloaded, onProgress: callbacks.onProgress });
-        }
-      });
+      await update.downloadAndInstall(createProgressListener(callbacks.onProgress));
     },
     async restart() {
       await persistEditorWindowRestoreSnapshot();

--- a/scripts/release/create-updater-metadata.mjs
+++ b/scripts/release/create-updater-metadata.mjs
@@ -39,6 +39,10 @@ function signatureMatchersForPlatform(platform) {
     return [/\.AppImage\.sig$/, /\.AppImage\.tar\.gz\.sig$/, /\.tar\.gz\.sig$/];
   }
 
+  if (platform.startsWith("windows-portable-")) {
+    return [/_portable\.zip\.sig$/];
+  }
+
   if (platform.startsWith("windows-")) {
     return [/setup\.exe\.sig$/, /\.msi\.sig$/, /nsis.*\.zip\.sig$/, /msi.*\.zip\.sig$/, /\.exe\.sig$/, /\.zip\.sig$/];
   }

--- a/scripts/release/create-updater-metadata.test.mjs
+++ b/scripts/release/create-updater-metadata.test.mjs
@@ -51,6 +51,27 @@ test("create-updater-metadata prefers the Windows setup updater bundle", () => {
   });
 });
 
+test("create-updater-metadata selects the signed Windows portable bundle", () => {
+  const rootDir = makeTempDir();
+  const [, msiSignature] = writeBundle(rootDir, "Markra_0.0.8_windows_x64_en-US.msi");
+  const [, setupSignature] = writeBundle(rootDir, "Markra_0.0.8_windows_x64_setup.exe");
+  const [bundlePath, signaturePath] = writeBundle(rootDir, "Markra_0.0.8_windows_x64_portable.zip");
+  const outputPath = path.join(rootDir, "release-metadata.windows-portable-x86_64.json");
+
+  const result = runMetadataScript({
+    ARTIFACT_PATHS_RAW: [msiSignature, setupSignature, signaturePath].join("\n"),
+    OUTPUT_PATH: outputPath,
+    UPDATER_PLATFORM: "windows-portable-x86_64",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(outputPath, "utf8")), {
+    updaterPlatform: "windows-portable-x86_64",
+    bundleName: path.basename(bundlePath),
+    signatureName: path.basename(signaturePath),
+  });
+});
+
 test("create-updater-metadata selects AppImage bundles for Linux updater metadata", () => {
   const rootDir = makeTempDir();
   const [bundlePath, signaturePath] = writeBundle(rootDir, "Markra_0.0.8_linux_x64.AppImage");

--- a/scripts/release/generate-updater-manifest.mjs
+++ b/scripts/release/generate-updater-manifest.mjs
@@ -53,7 +53,10 @@ const expectedPlatforms = (process.env.EXPECTED_UPDATER_PLATFORMS || "")
   .map((platform) => platform.trim())
   .filter(Boolean);
 const metadataPaths = walkFiles(root)
-  .filter((filePath) => path.basename(filePath) === "release-metadata.json")
+  .filter((filePath) => {
+    const fileName = path.basename(filePath);
+    return fileName.startsWith("release-metadata") && fileName.endsWith(".json");
+  })
   .sort();
 
 const platforms = {};

--- a/scripts/release/generate-updater-manifest.test.mjs
+++ b/scripts/release/generate-updater-manifest.test.mjs
@@ -12,7 +12,7 @@ function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "markra-updater-manifest-"));
 }
 
-function writeArtifact(rootDir, platform, bundleName, signature) {
+function writeArtifact(rootDir, platform, bundleName, signature, metadataName = "release-metadata.json") {
   const artifactDir = path.join(rootDir, platform);
   const signatureName = `${bundleName}.sig`;
 
@@ -20,7 +20,7 @@ function writeArtifact(rootDir, platform, bundleName, signature) {
   fs.writeFileSync(path.join(artifactDir, bundleName), "bundle");
   fs.writeFileSync(path.join(artifactDir, signatureName), signature);
   fs.writeFileSync(
-    path.join(artifactDir, "release-metadata.json"),
+    path.join(artifactDir, metadataName),
     `${JSON.stringify(
       {
         updaterPlatform: platform,
@@ -53,6 +53,13 @@ test("generate-updater-manifest writes latest.json for every updater platform", 
   writeArtifact(rootDir, "linux-aarch64", "Markra_0.0.8_linux_arm64.AppImage", "linux-arm-signature");
   writeArtifact(rootDir, "linux-x86_64", "Markra_0.0.8_linux_x64.AppImage", "linux-signature");
   writeArtifact(rootDir, "windows-x86_64", "Markra_0.0.8_windows_x64_setup.exe", "windows-signature");
+  writeArtifact(
+    rootDir,
+    "windows-portable-x86_64",
+    "Markra_0.0.8_windows_x64_portable.zip",
+    "windows-portable-signature",
+    "release-metadata.windows-portable-x86_64.json",
+  );
   fs.writeFileSync(notesPath, "Release notes");
 
   const result = runManifestScript({
@@ -88,6 +95,10 @@ test("generate-updater-manifest writes latest.json for every updater platform", 
     "windows-x86_64": {
       signature: "windows-signature",
       url: "https://github.com/markrahq/markra/releases/download/v0.0.8/Markra_0.0.8_windows_x64_setup.exe",
+    },
+    "windows-portable-x86_64": {
+      signature: "windows-portable-signature",
+      url: "https://github.com/markrahq/markra/releases/download/v0.0.8/Markra_0.0.8_windows_x64_portable.zip",
     },
   });
 });

--- a/scripts/release/normalize-release-artifacts.mjs
+++ b/scripts/release/normalize-release-artifacts.mjs
@@ -249,7 +249,7 @@ function writeZip(outputPath, inputFiles) {
 
   for (const inputFile of inputFiles) {
     const name = Buffer.from(inputFile.name.replace(/\\/g, "/"), "utf8");
-    const data = fs.readFileSync(inputFile.path);
+    const data = inputFile.data ?? fs.readFileSync(inputFile.path);
     const compressedData = zlib.deflateRawSync(data, { level: 9 });
     const entry = {
       name,
@@ -319,7 +319,11 @@ function createWindowsPortableZip(releaseRoot, bundleRoot, context) {
     },
   ];
 
-  for (const entry of fs.readdirSync(executableDir, { withFileTypes: true })) {
+  const executableEntries = fs
+    .readdirSync(executableDir, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of executableEntries) {
     if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".dll")) {
       continue;
     }
@@ -329,6 +333,17 @@ function createWindowsPortableZip(releaseRoot, bundleRoot, context) {
       name: `${appFolder}/${entry.name}`,
     });
   }
+
+  const manifestName = "markra-portable.json";
+  const manifest = {
+    formatVersion: 1,
+    executable: `${productName}.exe`,
+    files: [...portableFiles.map((file) => file.name.slice(`${appFolder}/`.length)), manifestName],
+  };
+  portableFiles.push({
+    data: Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8"),
+    name: `${appFolder}/${manifestName}`,
+  });
 
   const outputPath = path.join(bundleRoot, "portable", `${productName}_${version}_windows_${arch}_portable.zip`);
   writeZip(outputPath, portableFiles);

--- a/scripts/release/normalize-release-artifacts.test.mjs
+++ b/scripts/release/normalize-release-artifacts.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const releaseWorkflowPath = path.join(repoRoot, ".github", "workflows", "release.yml");
@@ -31,6 +32,29 @@ function runNormalizeScript(rootDir, env) {
       ...env,
     },
   });
+}
+
+function readZipEntries(archive) {
+  const entries = new Map();
+  let offset = 0;
+
+  while (archive.readUInt32LE(offset) === 0x04034b50) {
+    const compression = archive.readUInt16LE(offset + 8);
+    const compressedSize = archive.readUInt32LE(offset + 18);
+    const nameLength = archive.readUInt16LE(offset + 26);
+    const extraLength = archive.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    const dataEnd = dataStart + compressedSize;
+    const name = archive.subarray(nameStart, nameStart + nameLength).toString("utf8");
+    const compressed = archive.subarray(dataStart, dataEnd);
+    const data = compression === 8 ? zlib.inflateRawSync(compressed) : compressed;
+
+    entries.set(name, data);
+    offset = dataEnd;
+  }
+
+  return entries;
 }
 
 function readReleaseMatrixEntry(name) {
@@ -97,6 +121,15 @@ test("release workflow excludes Wayland client from Linux AppImage bundling", ()
   assert.match(verifyStep, /if:\s*matrix\.asset_platform == 'linux'/);
   assert.match(verifyStep, /verify-linux-appimage-libraries\.mjs/);
   assert.match(verifyStep, /verify-linux-appimage-gtk-ime\.mjs/);
+});
+
+test("release workflow signs the Windows portable bundle", () => {
+  const signStep = readReleaseStep("Sign Windows portable bundle");
+
+  assert.match(signStep, /if:\s*matrix\.asset_platform == 'windows'/);
+  assert.match(signStep, /tauri" signer sign/);
+  assert.match(signStep, /portable\.zip/);
+  assert.match(signStep, /portable_path.*\.sig/);
 });
 
 test("normalize-release-artifacts adds macOS platform labels to updater and dmg assets", () => {
@@ -174,9 +207,16 @@ test("normalize-release-artifacts adds Windows platform labels and creates a por
   assert.equal(fs.existsSync(portableZip), true);
 
   const zipContents = fs.readFileSync(portableZip);
+  const zipEntries = readZipEntries(zipContents);
   assert.equal(zipContents.subarray(0, 4).toString("latin1"), "PK\u0003\u0004");
   assert.match(zipContents.toString("latin1"), /Markra\/Markra\.exe/);
   assert.match(zipContents.toString("latin1"), /Markra\/support\.dll/);
+  assert.match(zipContents.toString("latin1"), /Markra\/markra-portable\.json/);
+  assert.deepEqual(JSON.parse(zipEntries.get("Markra/markra-portable.json").toString("utf8")), {
+    executable: "Markra.exe",
+    files: ["Markra.exe", "support.dll", "markra-portable.json"],
+    formatVersion: 1,
+  });
 });
 
 test("normalize-release-artifacts adds Linux platform labels to package assets", () => {


### PR DESCRIPTION
## Summary
- publish signed Windows portable archives through a dedicated updater target
- detect portable distributions and route them through a verified staged update flow
- replace managed files with rollback support while preserving unmanaged user files
- keep installed Windows builds on the existing Tauri NSIS/MSI updater path

## Validation
- pnpm test — 2,639 tests passed
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml — 283 tests passed
- pnpm test:release — 52 tests passed
- pnpm typecheck:test — passed
- pnpm build — passed
- cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check — passed
- git diff --check — passed

## Risk
- Windows end-to-end update QA was not run locally because this macOS host lacks the MSVC SDK headers required for cross-compiling native dependencies.
- Existing portable users must manually download the first release containing markra-portable.json; automatic portable updates work from that release onward.

Closes #681