### PR TITLE
fix(app): report attachment open failures

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1061,6 +1061,50 @@ describe("Markra workspace", () => {
     }));
   });
 
+  it("shows native attachment open failures with the underlying path error", async () => {
+    const attachment = { name: "Reference Doc.pdf", path: "/mock-files/Reference Doc.pdf" };
+    mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({
+      copyExternalFilesToStorage: false
+    }));
+    mockedOpenNativeLocalFiles.mockResolvedValue([attachment]);
+    mockedImportNativeLocalFile.mockResolvedValue({
+      label: "Reference Doc.pdf",
+      src: "FILE:///mock-files/Reference%20Doc.pdf"
+    });
+    mockedOpenNativeMarkdownAttachment.mockRejectedValue(
+      new Error("Markdown attachment is outside the current Markdown folder")
+    );
+
+    const { container } = renderApp();
+
+    await expectVisibleMarkdownText("Welcome to Markra");
+    await waitFor(() => expect(mockedInstallNativeApplicationMenu).toHaveBeenCalled());
+    const menuHandlers = mockedInstallNativeApplicationMenu.mock.calls.at(-1)?.[0] as NativeMenuHandlers;
+
+    await act(async () => {
+      await menuHandlers.importLocalFiles?.();
+    });
+
+    revealVisualPreviews(container);
+    const link = await waitFor(() => {
+      const importedLink = container.querySelector<HTMLAnchorElement>(
+        'a[href="FILE:///mock-files/Reference%20Doc.pdf"]'
+      );
+      expect(importedLink).toBeInTheDocument();
+      return importedLink!;
+    });
+    link.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      ctrlKey: true
+    }));
+
+    expect(await screen.findByText("Could not open the file attachment.")).toBeInTheDocument();
+    expect(screen.getByText("Markdown attachment is outside the current Markdown folder")).toBeInTheDocument();
+    expect(screen.queryByText("Could not save the pasted image.")).not.toBeInTheDocument();
+  });
+
   it("does not open a relative attachment when the document has no root path", async () => {
     const attachment = { name: "Reference Doc.pdf", path: "/mock-files/Reference Doc.pdf" };
     mockedGetStoredEditorPreferences.mockResolvedValue(createStoredEditorPreferences({

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2266,9 +2266,11 @@ function WorkspaceApp() {
       documentPath: documentPath ?? null,
       rootPath,
       src
-    }).catch(() => {
+    }).catch((error) => {
+      const description = nativeFileOperationFailureDescription(error);
       showAppToast({
-        message: translate("app.clipboardImageSaveFailed"),
+        ...(description ? { description } : {}),
+        message: translate("app.markdownAttachmentOpenFailed"),
         status: "error"
       });
     });

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "Schritte",
   "app.clipboardAttachmentRequiresSavedDocument": "Speichern Sie das Dokument, bevor Sie Dateianhaenge hinzufuegen.",
   "app.clipboardAttachmentSaveFailed": "Der Dateianhang konnte nicht gespeichert werden.",
+  "app.markdownAttachmentOpenFailed": "Der Dateianhang konnte nicht geöffnet werden.",
   "app.assetCleanup.title": "Unbenutzte Bilder bereinigen",
   "app.assetCleanup.close": "Bildbereinigung schließen",
   "app.assetCleanup.scanning": "Markdown-Verweise werden durchsucht...",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -895,6 +895,7 @@ const messages: BaseLocaleMessages = {
   "app.clipboardImageSaveFailed": "Could not save the pasted image.",
   "app.clipboardAttachmentRequiresSavedDocument": "Save the document before adding file attachments.",
   "app.clipboardAttachmentSaveFailed": "Could not save the file attachment.",
+  "app.markdownAttachmentOpenFailed": "Could not open the file attachment.",
   "app.assetCleanup.title": "Clean up unused images",
   "app.assetCleanup.close": "Close image cleanup",
   "app.assetCleanup.scanning": "Scanning Markdown references...",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "pasos",
   "app.clipboardAttachmentRequiresSavedDocument": "Guarda el documento antes de agregar archivos adjuntos.",
   "app.clipboardAttachmentSaveFailed": "No se pudo guardar el archivo adjunto.",
+  "app.markdownAttachmentOpenFailed": "No se pudo abrir el archivo adjunto.",
   "app.assetCleanup.title": "Limpiar imágenes sin usar",
   "app.assetCleanup.close": "Cerrar limpieza de imágenes",
   "app.assetCleanup.scanning": "Buscando referencias Markdown...",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "étapes",
   "app.clipboardAttachmentRequiresSavedDocument": "Enregistrez le document avant d'ajouter des pieces jointes.",
   "app.clipboardAttachmentSaveFailed": "Impossible d'enregistrer la piece jointe.",
+  "app.markdownAttachmentOpenFailed": "Impossible d'ouvrir la pièce jointe.",
   "app.assetCleanup.title": "Nettoyer les images inutilisées",
   "app.assetCleanup.close": "Fermer le nettoyage des images",
   "app.assetCleanup.scanning": "Analyse des références Markdown...",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "passaggi",
   "app.clipboardAttachmentRequiresSavedDocument": "Salva il documento prima di aggiungere allegati file.",
   "app.clipboardAttachmentSaveFailed": "Impossibile salvare l'allegato file.",
+  "app.markdownAttachmentOpenFailed": "Impossibile aprire l'allegato file.",
   "app.assetCleanup.title": "Pulisci immagini inutilizzate",
   "app.assetCleanup.close": "Chiudi pulizia immagini",
   "app.assetCleanup.scanning": "Scansione dei riferimenti Markdown...",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "ステップ",
   "app.clipboardAttachmentRequiresSavedDocument": "ファイル添付を追加する前にドキュメントを保存してください。",
   "app.clipboardAttachmentSaveFailed": "ファイル添付を保存できませんでした。",
+  "app.markdownAttachmentOpenFailed": "ファイル添付を開けませんでした。",
   "app.assetCleanup.title": "未使用の画像をクリーンアップ",
   "app.assetCleanup.close": "画像クリーンアップを閉じる",
   "app.assetCleanup.scanning": "Markdown の参照をスキャン中...",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "단계",
   "app.clipboardAttachmentRequiresSavedDocument": "파일 첨부를 추가하기 전에 문서를 저장하세요.",
   "app.clipboardAttachmentSaveFailed": "파일 첨부를 저장할 수 없습니다.",
+  "app.markdownAttachmentOpenFailed": "파일 첨부를 열 수 없습니다.",
   "app.assetCleanup.title": "사용하지 않는 이미지 정리",
   "app.assetCleanup.close": "이미지 정리 닫기",
   "app.assetCleanup.scanning": "Markdown 참조 검색 중...",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "etapas",
   "app.clipboardAttachmentRequiresSavedDocument": "Salve o documento antes de adicionar anexos de arquivo.",
   "app.clipboardAttachmentSaveFailed": "Nao foi possivel salvar o anexo de arquivo.",
+  "app.markdownAttachmentOpenFailed": "Não foi possível abrir o anexo de arquivo.",
   "app.assetCleanup.title": "Limpar imagens não utilizadas",
   "app.assetCleanup.close": "Fechar limpeza de imagens",
   "app.assetCleanup.scanning": "Verificando referências Markdown...",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "шагов",
   "app.clipboardAttachmentRequiresSavedDocument": "Сохраните документ перед добавлением файловых вложений.",
   "app.clipboardAttachmentSaveFailed": "Не удалось сохранить файловое вложение.",
+  "app.markdownAttachmentOpenFailed": "Не удалось открыть файловое вложение.",
   "app.assetCleanup.title": "Очистить неиспользуемые изображения",
   "app.assetCleanup.close": "Закрыть очистку изображений",
   "app.assetCleanup.scanning": "Поиск ссылок в Markdown...",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -906,6 +906,7 @@ export type I18nKey =
   | "app.clipboardImageSaveFailed"
   | "app.clipboardAttachmentRequiresSavedDocument"
   | "app.clipboardAttachmentSaveFailed"
+  | "app.markdownAttachmentOpenFailed"
   | "app.assetCleanup.title"
   | "app.assetCleanup.close"
   | "app.assetCleanup.scanning"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.clipboardImageSaveFailed": "无法保存粘贴的图片。",
   "app.clipboardAttachmentRequiresSavedDocument": "请先保存文档，再添加文件附件。",
   "app.clipboardAttachmentSaveFailed": "无法保存文件附件。",
+  "app.markdownAttachmentOpenFailed": "无法打开文件附件。",
   "app.assetCleanup.title": "清理未引用图片",
   "app.assetCleanup.close": "关闭图片清理",
   "app.assetCleanup.scanning": "正在扫描 Markdown 引用...",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -895,6 +895,7 @@ const messages: LocaleMessages = {
   "app.aiAgentProcessSteps": "步",
   "app.clipboardAttachmentRequiresSavedDocument": "請先儲存文件，再加入檔案附件。",
   "app.clipboardAttachmentSaveFailed": "無法儲存檔案附件。",
+  "app.markdownAttachmentOpenFailed": "無法開啟檔案附件。",
   "app.assetCleanup.title": "清理未引用圖片",
   "app.assetCleanup.close": "關閉圖片清理",
   "app.assetCleanup.scanning": "正在掃描 Markdown 引用...",


### PR DESCRIPTION
## Summary
- Show an attachment-specific error toast when opening a local attachment fails.
- Surface the native path error as the toast description.
- Add localized copy and regression coverage.

## Why
- Attachment open failures were incorrectly reported as pasted-image save failures, hiding useful workspace boundary and path diagnostics.

## Validation
- `pnpm --filter @markra/app test src/App.test.tsx` passed: 242 tests
- `pnpm --filter @markra/app typecheck:test` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/shared test src/i18n/index.test.ts` passed: 5 tests
- `pnpm --filter @markra/shared typecheck:test` passed

## Risk
- Low: this only changes failure messaging; attachment resolution and workspace boundary enforcement are unchanged.

Closes #683