### PR TITLE
feat(ai): add append action to editing previews

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -5960,7 +5960,7 @@ describe("Markra workspace", () => {
       }
     });
 
-    await expectVisibleMarkdownText("Before Original Improved After");
+    await expectVisibleMarkdownText("Before Original After\n\nImproved");
   });
 
   it("does not expose side-open file tree actions when document tabs are hidden", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -5936,6 +5936,33 @@ describe("Markra workspace", () => {
     expect(mockedConfirmNativeUnsavedMarkdownDocumentDiscard).not.toHaveBeenCalled();
   });
 
+  it("appends an AI preview result without replacing the original selection", async () => {
+    mockOpenMarkdownFile({
+      content: "Before Original After",
+      name: "native.md",
+      path: mockNativePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true });
+    expect(await screen.findByText("Before Original After")).toBeInTheDocument();
+
+    dispatchAiEditorPreviewAction({
+      action: "append",
+      previewId: "synthetic-preview",
+      result: {
+        from: 7,
+        original: "Original",
+        replacement: "Improved",
+        to: 15,
+        type: "replace"
+      }
+    });
+
+    await expectVisibleMarkdownText("Before Original Improved After");
+  });
+
   it("does not expose side-open file tree actions when document tabs are hidden", async () => {
     mockedGetStoredEditorPreferences.mockResolvedValue({
       aiQuickActionPrompts: defaultAiQuickActionPrompts,

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1471,6 +1471,7 @@ function WorkspaceApp() {
       editor.clearAiSelection();
       appliedAiPreviewKeysRef.current.clear();
       editor.previewAiResult(result, {
+        append: translate("app.aiAppend"),
         apply: translate("app.aiApply"),
         chars: translate("app.aiPreviewChars"),
         copied: translate("app.aiCopied"),
@@ -2076,7 +2077,11 @@ function WorkspaceApp() {
     reveal: scrollAiSelectionAboveCommand,
     selection: activeAiSelection
   });
-  const handleApplyAiResult = useCallback((restoredResult?: AiDiffResult | null, previewId?: string) => {
+  const handleApplyAiResult = useCallback((
+    restoredResult?: AiDiffResult | null,
+    previewId?: string,
+    mode: "append" | "replace" = "replace"
+  ) => {
     if (readOnlyMode) return;
 
     const result = restoredResult ?? aiResults.at(-1) ?? null;
@@ -2091,6 +2096,7 @@ function WorkspaceApp() {
 
     debug(() => ["[markra-ai-preview] app handle apply", {
       from: result.type === "error" ? null : result.from,
+      mode,
       replacementLength: result.type === "error" ? null : result.replacement.length,
       to: result.type === "error" ? null : result.to,
       type: result.type
@@ -2107,7 +2113,7 @@ function WorkspaceApp() {
     }
 
     appliedAiPreviewKeysRef.current.add(actionKey);
-    const applied = editor.applyAiResult(result, { previewId });
+    const applied = editor.applyAiResult(result, { mode, previewId });
     debug(() => ["[markra-ai-preview] app apply result", { applied }]);
 
     if (!applied) {
@@ -4150,6 +4156,11 @@ function WorkspaceApp() {
 
       if (action === "apply") {
         handleApplyAiResult(detail.result, detail.previewId);
+        return;
+      }
+
+      if (action === "append") {
+        handleApplyAiResult(detail.result, detail.previewId, "append");
         return;
       }
 

--- a/packages/app/src/hooks/useCodeMirrorEditorController.ts
+++ b/packages/app/src/hooks/useCodeMirrorEditorController.ts
@@ -31,6 +31,7 @@ import {
   showCodeMirrorAiPreview,
   showCodeMirrorAiSelectionHold,
   type AiEditorPreviewLabels,
+  type CodeMirrorAiApplyOptions,
   type CodeMirrorMarkdownImageReference,
   type CodeMirrorMarkdownLinkReference,
   type ReplaceCodeMirrorMarkdownOptions,
@@ -441,7 +442,7 @@ export function useCodeMirrorEditorController() {
   );
 
   const applyAiResult = useCallback(
-    (result: AiDiffResult, options: { previewId?: string } = {}) => {
+    (result: AiDiffResult, options: CodeMirrorAiApplyOptions = {}) => {
       const view = viewRef.current;
       return view ? applyCodeMirrorAiResult(view, result, options) : false;
     },

--- a/packages/editor/src/ai-preview-events.ts
+++ b/packages/editor/src/ai-preview-events.ts
@@ -9,7 +9,7 @@ export type AiTextDiffResult = Extract<
   { type: "insert" | "replace" }
 >;
 
-export type AiEditorPreviewAction = "apply" | "copy" | "reject";
+export type AiEditorPreviewAction = "append" | "apply" | "copy" | "reject";
 
 export interface AiEditorPreviewAppliedDetail {
   previewId?: string;
@@ -30,6 +30,7 @@ export interface AiEditorPreviewRestoreDetail {
 }
 
 export interface AiEditorPreviewLabels {
+  append?: string;
   apply: string;
   chars?: string;
   copied: string;

--- a/packages/editor/src/codemirror/ai-preview.test.ts
+++ b/packages/editor/src/codemirror/ai-preview.test.ts
@@ -244,6 +244,88 @@ describe("CodeMirror AI preview", () => {
     window.removeEventListener(AI_EDITOR_PREVIEW_ACTION_EVENT, onAction);
   });
 
+  it("emits an append action from the preview controls", () => {
+    const doc = "Before Original After";
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    const onAction = vi.fn();
+    window.addEventListener(AI_EDITOR_PREVIEW_ACTION_EVENT, onAction);
+
+    showCodeMirrorAiPreview(view, result, {
+      append: "Append",
+      apply: "Apply",
+      copied: "Copied",
+      copy: "Copy",
+      reject: "Reject",
+    }, { previewId: "synthetic-preview" });
+    const append = view.dom.querySelector<HTMLButtonElement>(
+      ".markra-ai-preview-append",
+    );
+    append?.click();
+
+    expect(append?.title).toBe("Append");
+    expect(onAction).toHaveBeenCalledOnce();
+    expect((onAction.mock.calls[0]?.[0] as CustomEvent).detail).toMatchObject({
+      action: "append",
+      previewId: "synthetic-preview",
+      result,
+    });
+    window.removeEventListener(AI_EDITOR_PREVIEW_ACTION_EVENT, onAction);
+  });
+
+  it("does not offer append when applying the AI result already inserts text", () => {
+    const doc = "# Synthetic";
+    const result: AiDiffResult = {
+      from: doc.length,
+      original: "",
+      replacement: "\n\nContinuation",
+      to: doc.length,
+      type: "insert",
+    };
+    const view = createView(doc);
+
+    showCodeMirrorAiPreview(view, result);
+
+    expect(view.dom.querySelector(".markra-ai-preview-append")).toBeNull();
+    expect(view.dom.querySelector(".markra-ai-preview-apply")).not.toBeNull();
+  });
+
+  it("appends an inline AI result after the original selection", () => {
+    const doc = "Before Original After";
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    showCodeMirrorAiPreview(view, result, undefined, { previewId: "append" });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append",
+      }),
+    ).toBe(true);
+
+    expect(view.state.doc.toString()).toBe("Before Original Improved After");
+    expect(view.state.selection.main.head).toBe("Before Original Improved".length);
+    expect(listCodeMirrorAiPreviewResults(view)).toEqual([]);
+  });
+
+  it("appends a block AI result as a separate Markdown block", () => {
+    const doc = "# Synthetic\n\nOriginal\n\nAfter";
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    showCodeMirrorAiPreview(view, result, undefined, { previewId: "append-block" });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append-block",
+      }),
+    ).toBe(true);
+
+    expect(view.state.doc.toString()).toBe(
+      "# Synthetic\n\nOriginal\n\nImproved\n\nAfter",
+    );
+  });
+
   it("applies one preview and rebases later previews through the same transaction", () => {
     const doc = "One Original Two Summary";
     const first = replacementResult(doc, "Original", "Much better");
@@ -372,6 +454,35 @@ describe("CodeMirror AI preview", () => {
     expect(onRestore).toHaveBeenCalledWith(
       expect.objectContaining({
         detail: expect.objectContaining({ previewId: "replacement", result }),
+      }),
+    );
+    window.removeEventListener(AI_EDITOR_PREVIEW_RESTORE_EVENT, onRestore);
+  });
+
+  it("restores an appended comparison when undo removes the appended text", () => {
+    const doc = "Before Original After";
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    const onRestore = vi.fn();
+    window.addEventListener(AI_EDITOR_PREVIEW_RESTORE_EVENT, onRestore);
+    showCodeMirrorAiPreview(view, result, undefined, { previewId: "append" });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append",
+      }),
+    ).toBe(true);
+    expect(view.state.doc.toString()).toBe("Before Original Improved After");
+    expect(undo(view)).toBe(true);
+
+    expect(view.state.doc.toString()).toBe(doc);
+    expect(listCodeMirrorAiPreviewResults(view)).toEqual([result]);
+    expect(view.dom.querySelector(".markra-ai-preview-delete")?.textContent).toContain("Original");
+    expect(view.dom.querySelector(".markra-ai-preview-insert")?.textContent).toContain("Improved");
+    expect(onRestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ previewId: "append", result }),
       }),
     );
     window.removeEventListener(AI_EDITOR_PREVIEW_RESTORE_EVENT, onRestore);

--- a/packages/editor/src/codemirror/ai-preview.test.ts
+++ b/packages/editor/src/codemirror/ai-preview.test.ts
@@ -290,7 +290,7 @@ describe("CodeMirror AI preview", () => {
     expect(view.dom.querySelector(".markra-ai-preview-apply")).not.toBeNull();
   });
 
-  it("appends an inline AI result after the original selection", () => {
+  it("appends an AI result after the selection's Markdown block", () => {
     const doc = "Before Original After";
     const result = replacementResult(doc, "Original", "Improved");
     const view = createView(doc);
@@ -303,9 +303,136 @@ describe("CodeMirror AI preview", () => {
       }),
     ).toBe(true);
 
-    expect(view.state.doc.toString()).toBe("Before Original Improved After");
-    expect(view.state.selection.main.head).toBe("Before Original Improved".length);
+    expect(view.state.doc.toString()).toBe("Before Original After\n\nImproved");
+    expect(view.state.selection.main.head).toBe(
+      "Before Original After\n\nImproved".length,
+    );
     expect(listCodeMirrorAiPreviewResults(view)).toEqual([]);
+  });
+
+  it.each([
+    {
+      doc: "Before Original, After",
+      expected: "Before Original, After\n\nImproved",
+      name: "punctuation",
+      original: "Original",
+      replacement: "Improved",
+    },
+    {
+      doc: "原文，后文",
+      expected: "原文，后文\n\n译文",
+      name: "CJK text",
+      original: "原文",
+      replacement: "译文",
+    },
+  ])(
+    "keeps the original $name block unchanged",
+    ({ doc, expected, original, replacement }) => {
+      const result = replacementResult(doc, original, replacement);
+      const view = createView(doc);
+      showCodeMirrorAiPreview(view, result, undefined, {
+        previewId: "append-block",
+      });
+
+      expect(
+        applyCodeMirrorAiResult(view, result, {
+          mode: "append",
+          previewId: "append-block",
+        }),
+      ).toBe(true);
+
+      expect(view.state.doc.toString()).toBe(expected);
+    },
+  );
+
+  it("separates an appended result from an adjacent Markdown block", () => {
+    const doc = "Original\n# After";
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    showCodeMirrorAiPreview(view, result, undefined, {
+      previewId: "append-adjacent",
+    });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append-adjacent",
+      }),
+    ).toBe(true);
+
+    expect(view.state.doc.toString()).toBe("Original\n\nImproved\n\n# After");
+  });
+
+  it("appends multiline output after the containing paragraph", () => {
+    const doc = "Before Original After";
+    const result = replacementResult(doc, "Original", "- First\n- Second");
+    const view = createView(doc);
+    showCodeMirrorAiPreview(view, result, undefined, { previewId: "append-list" });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append-list",
+      }),
+    ).toBe(true);
+
+    expect(view.state.doc.toString()).toBe(
+      "Before Original After\n\n- First\n- Second",
+    );
+  });
+
+  it("appends after a complete list instead of splitting a list item", () => {
+    const doc = "- Original\n- After\n\nTail";
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    showCodeMirrorAiPreview(view, result, undefined, {
+      previewId: "append-after-list",
+    });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append-after-list",
+      }),
+    ).toBe(true);
+
+    expect(view.state.doc.toString()).toBe(
+      "- Original\n- After\n\nImproved\n\nTail",
+    );
+  });
+
+  it("appends after a complete table instead of splitting a table cell", () => {
+    const doc = [
+      "| Field | Value |",
+      "| --- | --- |",
+      "| Original | After |",
+      "",
+      "Tail",
+    ].join("\n");
+    const result = replacementResult(doc, "Original", "Improved");
+    const view = createView(doc);
+    showCodeMirrorAiPreview(view, result, undefined, {
+      previewId: "append-after-table",
+    });
+
+    expect(
+      applyCodeMirrorAiResult(view, result, {
+        mode: "append",
+        previewId: "append-after-table",
+      }),
+    ).toBe(true);
+
+    expect(view.state.doc.toString()).toBe(
+      [
+        "| Field | Value |",
+        "| --- | --- |",
+        "| Original | After |",
+        "",
+        "Improved",
+        "",
+        "Tail",
+      ].join("\n"),
+    );
   });
 
   it("appends a block AI result as a separate Markdown block", () => {
@@ -473,7 +600,7 @@ describe("CodeMirror AI preview", () => {
         previewId: "append",
       }),
     ).toBe(true);
-    expect(view.state.doc.toString()).toBe("Before Original Improved After");
+    expect(view.state.doc.toString()).toBe("Before Original After\n\nImproved");
     expect(undo(view)).toBe(true);
 
     expect(view.state.doc.toString()).toBe(doc);

--- a/packages/editor/src/codemirror/ai-preview.ts
+++ b/packages/editor/src/codemirror/ai-preview.ts
@@ -33,6 +33,10 @@ export interface CodeMirrorAiPreviewOptions {
   previewId?: string;
 }
 
+export interface CodeMirrorAiApplyOptions extends CodeMirrorAiPreviewOptions {
+  mode?: "append" | "replace";
+}
+
 interface CodeMirrorAiPreviewSnapshot {
   readonly id: string;
   readonly labels?: AiEditorPreviewLabels;
@@ -49,6 +53,10 @@ interface CodeMirrorAiPreviewState {
 
 interface CodeMirrorAppliedPreviewSnapshot {
   readonly from: number;
+  readonly inserted: string;
+  readonly removed: string;
+  readonly resultFromOffset: number;
+  readonly resultToOffset: number;
   readonly snapshot: CodeMirrorAiPreviewSnapshot;
   readonly to: number;
 }
@@ -64,15 +72,21 @@ interface ClearPreviewEffect {
   readonly result?: AiTextDiffResult;
 }
 
-interface ApplyPreviewEffect {
+interface PreviewResultEffect {
   readonly previewId?: string;
   readonly result: AiTextDiffResult;
+}
+
+interface ApplyPreviewEffect extends PreviewResultEffect {
+  readonly from: number;
+  readonly inserted: string;
+  readonly removed: string;
 }
 
 const showPreviewEffect = StateEffect.define<ShowPreviewEffect>();
 const clearPreviewEffect = StateEffect.define<ClearPreviewEffect>();
 const applyPreviewEffect = StateEffect.define<ApplyPreviewEffect>();
-const confirmPreviewEffect = StateEffect.define<ApplyPreviewEffect>();
+const confirmPreviewEffect = StateEffect.define<PreviewResultEffect>();
 const restorePreviewEffect = StateEffect.define<null>();
 
 const emptyPreviewState: CodeMirrorAiPreviewState = {
@@ -83,6 +97,7 @@ const emptyPreviewState: CodeMirrorAiPreviewState = {
 };
 
 const defaultLabels: AiEditorPreviewLabels = {
+  append: "Append",
   apply: "Apply",
   chars: "chars",
   copied: "Copied",
@@ -229,6 +244,50 @@ function normalizeResultRange(
   return { from, to };
 }
 
+function edgeLineBreakCount(text: string, edge: "leading" | "trailing") {
+  const sample = edge === "leading" ? text.slice(0, 2) : text.slice(-2);
+  const match = edge === "leading" ? /^\n*/u.exec(sample) : /\n*$/u.exec(sample);
+  return match?.[0].length ?? 0;
+}
+
+function appendAiResultChange(
+  state: EditorState,
+  replacement: string,
+  to: number,
+) {
+  if (!replacement) return { cursor: to, from: to, insert: "", to };
+
+  const line = state.doc.lineAt(to);
+  if (to === line.to) {
+    // Keep an appended paragraph structurally separate without duplicating
+    // line breaks already supplied by the document or the AI result.
+    const existingBreaks = edgeLineBreakCount(
+      state.sliceDoc(Math.max(0, to - 2), to),
+      "trailing",
+    ) +
+      edgeLineBreakCount(replacement, "leading");
+    const prefix = "\n".repeat(Math.max(0, 2 - existingBreaks));
+    const insert = `${prefix}${replacement}`;
+    return { cursor: to + insert.length, from: to, insert, to };
+  }
+
+  const before = state.sliceDoc(Math.max(0, to - 1), to);
+  const after = state.sliceDoc(to, Math.min(state.doc.length, to + 1));
+  const prefix = !before || /\s$/u.test(before) || /^\s/u.test(replacement)
+    ? ""
+    : " ";
+  const suffix = !after || /^\s/u.test(after) || /\s$/u.test(replacement)
+    ? ""
+    : " ";
+  const insert = `${prefix}${replacement}${suffix}`;
+  return {
+    cursor: to + prefix.length + replacement.length,
+    from: to,
+    insert,
+    to,
+  };
+}
+
 function previewStateUpdate(
   value: CodeMirrorAiPreviewState,
   transaction: Transaction,
@@ -239,43 +298,51 @@ function previewStateUpdate(
   let nextSequence = value.nextSequence;
 
   if (transaction.docChanged && applied) {
-    const { result } = applied.snapshot;
+    const { inserted, removed, resultFromOffset, resultToOffset } = applied;
     const nextFrom = transaction.changes.mapPos(applied.from, -1);
     const previousStillApplied = transaction.startState.sliceDoc(
       applied.from,
       applied.to,
-    ) === result.replacement;
-    const nextReplacement = transaction.newDoc.sliceString(
+    ) === inserted;
+    const nextInserted = transaction.newDoc.sliceString(
       nextFrom,
-      nextFrom + result.replacement.length,
+      nextFrom + inserted.length,
     );
-    const nextOriginal = transaction.newDoc.sliceString(
+    const nextRemoved = transaction.newDoc.sliceString(
       nextFrom,
-      nextFrom + result.original.length,
+      nextFrom + removed.length,
     );
+    // Append removes no source text, so only a history undo can distinguish
+    // reverting that insertion from the user editing the appended result.
+    const revertedToRemoved = removed.length > 0
+      ? nextRemoved === removed
+      : transaction.isUserEvent("undo");
 
     if (
       previousStillApplied &&
-      nextReplacement !== result.replacement &&
-      nextOriginal === result.original
+      nextInserted !== inserted &&
+      revertedToRemoved
     ) {
+      const from = Math.max(0, nextFrom + resultFromOffset);
+      const to = Math.max(from, nextFrom + resultToOffset);
       pending = sortSnapshots([
         ...pending,
         {
           ...applied.snapshot,
           result: {
-            ...result,
-            from: nextFrom,
-            to: nextFrom + result.original.length,
+            ...applied.snapshot.result,
+            from,
+            original: transaction.newDoc.sliceString(from, to),
+            to,
           },
         },
       ]);
       applied = null;
-    } else if (nextReplacement === result.replacement) {
+    } else if (nextInserted === inserted) {
       applied = {
         ...applied,
         from: nextFrom,
-        to: nextFrom + result.replacement.length,
+        to: nextFrom + inserted.length,
       };
     } else {
       // Once the applied replacement itself is edited into a third value, an
@@ -334,15 +401,20 @@ function previewStateUpdate(
           !removed.includes(snapshot) && !conflictingIds.has(snapshot.id),
       );
       const snapshot = removed[0];
-      const from = effect.value.result.from;
-      if (snapshot && from !== undefined) {
+      const resultFrom = effect.value.result.from;
+      const resultTo = effect.value.result.to;
+      if (snapshot && resultFrom !== undefined && resultTo !== undefined) {
         applied = {
-          from,
+          from: effect.value.from,
+          inserted: effect.value.inserted,
+          removed: effect.value.removed,
+          resultFromOffset: resultFrom - effect.value.from,
+          resultToOffset: resultTo - effect.value.from,
           snapshot: {
             ...snapshot,
             result: effect.value.result,
           },
-          to: from + effect.value.result.replacement.length,
+          to: effect.value.from + effect.value.inserted.length,
         };
       }
       continue;
@@ -484,6 +556,7 @@ function createActionIcon(document: Document, action: AiEditorPreviewAction) {
   icon.setAttribute("width", "15");
 
   const pathsByAction: Record<AiEditorPreviewAction, string[]> = {
+    append: ["M12 5v14", "M5 12h14"],
     apply: ["M20 6 9 17l-5-5"],
     copy: [
       "M16 4h2a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-2",
@@ -521,7 +594,7 @@ function createLoadingIcon(document: Document) {
   return icon;
 }
 
-function markApplyButtonBusy(document: Document, button: HTMLButtonElement) {
+function markActionButtonBusy(document: Document, button: HTMLButtonElement) {
   button.dataset.applying = "true";
   button.disabled = true;
   button.classList.add("markra-ai-preview-applying");
@@ -566,7 +639,9 @@ function createActionButton(
 
   const triggerAction = () => {
     if (button.dataset.applying === "true") return;
-    if (action === "apply") markApplyButtonBusy(document, button);
+    if (action === "apply" || action === "append") {
+      markActionButtonBusy(document, button);
+    }
     onAction();
     if (action === "copy" && copiedLabel) {
       showCopySuccessFeedback(document, button, copiedLabel, label);
@@ -652,8 +727,16 @@ class AiPreviewWidget extends WidgetType {
       labels.apply,
       () => dispatchAction(view, this.snapshot, "apply"),
     );
-
-    actions.append(scope, copy, reject, apply);
+    actions.append(scope, copy, reject);
+    if (this.snapshot.result.type === "replace") {
+      actions.append(createActionButton(
+        document,
+        "append",
+        labels.append ?? defaultLabels.append ?? "Append",
+        () => dispatchAction(view, this.snapshot, "append"),
+      ));
+    }
+    actions.append(apply);
     widget.append(insertion, actions);
     return widget;
   }
@@ -856,7 +939,7 @@ export function listCodeMirrorAiPreviewResults(view: CodeMirrorView) {
 export function applyCodeMirrorAiResult(
   view: CodeMirrorView,
   result: AiDiffResult,
-  options: CodeMirrorAiPreviewOptions = {},
+  options: CodeMirrorAiApplyOptions = {},
 ) {
   if (view.state.readOnly || !isTextDiffResult(result)) return false;
   const { from, to } = normalizeResultRange(view.state, result);
@@ -866,11 +949,26 @@ export function applyCodeMirrorAiResult(
     sameResult(snapshot.result, appliedResult)
   )?.id;
 
+  const change = options.mode === "append"
+    ? appendAiResultChange(view.state, result.replacement, to)
+    : {
+        cursor: from + result.replacement.length,
+        from,
+        insert: result.replacement,
+        to,
+      };
+
   view.dispatch({
-    changes: { from, insert: result.replacement, to },
-    effects: applyPreviewEffect.of({ previewId, result: appliedResult }),
+    changes: { from: change.from, insert: change.insert, to: change.to },
+    effects: applyPreviewEffect.of({
+      from: change.from,
+      inserted: change.insert,
+      previewId,
+      removed: view.state.sliceDoc(change.from, change.to),
+      result: appliedResult,
+    }),
     scrollIntoView: true,
-    selection: EditorSelection.cursor(from + result.replacement.length),
+    selection: EditorSelection.cursor(change.cursor),
   });
   view.focus();
 

--- a/packages/editor/src/codemirror/ai-preview.ts
+++ b/packages/editor/src/codemirror/ai-preview.ts
@@ -8,6 +8,7 @@ import {
   type Extension,
 } from "@codemirror/state";
 import { invertedEffects } from "@codemirror/commands";
+import { syntaxTree } from "@codemirror/language";
 import {
   Decoration,
   EditorView,
@@ -250,6 +251,15 @@ function edgeLineBreakCount(text: string, edge: "leading" | "trailing") {
   return match?.[0].length ?? 0;
 }
 
+function appendTargetPosition(state: EditorState, to: number) {
+  if (to >= state.doc.length) return state.doc.length;
+
+  let node = syntaxTree(state).resolveInner(to, to === 0 ? 1 : -1);
+  while (node.parent && node.parent.name !== "Document") node = node.parent;
+  if (node.name !== "Document" && node.to >= to) return node.to;
+  return state.doc.lineAt(to).to;
+}
+
 function appendAiResultChange(
   state: EditorState,
   replacement: string,
@@ -257,34 +267,29 @@ function appendAiResultChange(
 ) {
   if (!replacement) return { cursor: to, from: to, insert: "", to };
 
-  const line = state.doc.lineAt(to);
-  if (to === line.to) {
-    // Keep an appended paragraph structurally separate without duplicating
-    // line breaks already supplied by the document or the AI result.
-    const existingBreaks = edgeLineBreakCount(
-      state.sliceDoc(Math.max(0, to - 2), to),
-      "trailing",
-    ) +
-      edgeLineBreakCount(replacement, "leading");
-    const prefix = "\n".repeat(Math.max(0, 2 - existingBreaks));
-    const insert = `${prefix}${replacement}`;
-    return { cursor: to + insert.length, from: to, insert, to };
-  }
-
-  const before = state.sliceDoc(Math.max(0, to - 1), to);
-  const after = state.sliceDoc(to, Math.min(state.doc.length, to + 1));
-  const prefix = !before || /\s$/u.test(before) || /^\s/u.test(replacement)
-    ? ""
-    : " ";
-  const suffix = !after || /^\s/u.test(after) || /\s$/u.test(replacement)
-    ? ""
-    : " ";
+  const position = appendTargetPosition(state, to);
+  // Treat append as a structural Markdown operation. The original block stays
+  // byte-for-byte intact while the AI result receives block boundaries on
+  // both sides without removing authored blank lines.
+  const leadingBreaks = edgeLineBreakCount(
+    state.sliceDoc(Math.max(0, position - 2), position),
+    "trailing",
+  ) + edgeLineBreakCount(replacement, "leading");
+  const trailingBreaks = edgeLineBreakCount(replacement, "trailing") +
+    edgeLineBreakCount(
+      state.sliceDoc(position, Math.min(state.doc.length, position + 2)),
+      "leading",
+    );
+  const prefix = "\n".repeat(Math.max(0, 2 - leadingBreaks));
+  const suffix = position < state.doc.length
+    ? "\n".repeat(Math.max(0, 2 - trailingBreaks))
+    : "";
   const insert = `${prefix}${replacement}${suffix}`;
   return {
-    cursor: to + prefix.length + replacement.length,
-    from: to,
+    cursor: position + prefix.length + replacement.length,
+    from: position,
     insert,
-    to,
+    to: position,
   };
 }
 

--- a/packages/editor/src/codemirror/index.ts
+++ b/packages/editor/src/codemirror/index.ts
@@ -26,6 +26,7 @@ export {
   AI_EDITOR_PREVIEW_RESTORE_EVENT,
 } from "../ai-preview-events.ts";
 export type {
+  CodeMirrorAiApplyOptions,
   CodeMirrorAiPreviewOptions,
 } from "./ai-preview.ts";
 export {

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "Zusammenfassen...",
   "app.aiTranslate": "Übersetzen",
   "app.aiTranslating": "Übersetzen...",
+  "app.aiAppend": "Anhängen",
   "app.aiApply": "Anwenden",
   "app.aiReject": "Ablehnen",
   "app.aiCopy": "Kopieren",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -872,6 +872,7 @@ const messages: BaseLocaleMessages = {
   "app.aiSummarizing": "Summarizing...",
   "app.aiTranslate": "Translate",
   "app.aiTranslating": "Translating...",
+  "app.aiAppend": "Append",
   "app.aiApply": "Apply",
   "app.aiReject": "Reject",
   "app.aiCopy": "Copy",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "Resumiendo...",
   "app.aiTranslate": "Traducir",
   "app.aiTranslating": "Traduciendo...",
+  "app.aiAppend": "Añadir",
   "app.aiApply": "Aplicar",
   "app.aiReject": "Rechazar",
   "app.aiCopy": "Copiar",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "Résumé...",
   "app.aiTranslate": "Traduire",
   "app.aiTranslating": "Traduction...",
+  "app.aiAppend": "Ajouter",
   "app.aiApply": "Appliquer",
   "app.aiReject": "Refuser",
   "app.aiCopy": "Copier",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "Riassunto...",
   "app.aiTranslate": "Traduci",
   "app.aiTranslating": "Traduzione...",
+  "app.aiAppend": "Aggiungi",
   "app.aiApply": "Applica",
   "app.aiReject": "Rifiuta",
   "app.aiCopy": "Copia",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -502,6 +502,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "要約中...",
   "app.aiTranslate": "翻訳",
   "app.aiTranslating": "翻訳中...",
+  "app.aiAppend": "追加",
   "app.aiApply": "適用",
   "app.aiReject": "却下",
   "app.aiCopy": "コピー",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "요약 중...",
   "app.aiTranslate": "번역",
   "app.aiTranslating": "번역 중...",
+  "app.aiAppend": "추가",
   "app.aiApply": "적용",
   "app.aiReject": "거부",
   "app.aiCopy": "복사",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "Resumindo...",
   "app.aiTranslate": "Traduzir",
   "app.aiTranslating": "Traduzindo...",
+  "app.aiAppend": "Acrescentar",
   "app.aiApply": "Aplicar",
   "app.aiReject": "Rejeitar",
   "app.aiCopy": "Copiar",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -494,6 +494,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "Сжатие...",
   "app.aiTranslate": "Перевести",
   "app.aiTranslating": "Перевод...",
+  "app.aiAppend": "Добавить",
   "app.aiApply": "Применить",
   "app.aiReject": "Отклонить",
   "app.aiCopy": "Копировать",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -883,6 +883,7 @@ export type I18nKey =
   | "app.aiSummarizing"
   | "app.aiTranslate"
   | "app.aiTranslating"
+  | "app.aiAppend"
   | "app.aiApply"
   | "app.aiReject"
   | "app.aiCopy"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -872,6 +872,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "总结中……",
   "app.aiTranslate": "翻译",
   "app.aiTranslating": "翻译中……",
+  "app.aiAppend": "追加",
   "app.aiApply": "应用",
   "app.aiReject": "拒绝",
   "app.aiCopy": "复制",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -502,6 +502,7 @@ const messages: LocaleMessages = {
   "app.aiSummarizing": "總結中……",
   "app.aiTranslate": "翻譯",
   "app.aiTranslating": "翻譯中……",
+  "app.aiAppend": "附加",
   "app.aiApply": "套用",
   "app.aiReject": "拒絕",
   "app.aiCopy": "複製",


### PR DESCRIPTION
## Summary
- add a localized Append action to AI replacement previews
- preserve the complete Markdown target block and insert the AI result after it
- keep paragraph, list, table, punctuation, and CJK source content unchanged
- normalize missing block boundaries on both sides without removing authored blank lines
- keep preview mapping, duplicate-action protection, and undo restoration working for appended results
- hide Append for results that are already insertions

## Why
AI editing currently only lets users replace the selected content. This adds an explicit non-destructive option for keeping the original alongside an edited or translated result.

## Validation
- `pnpm --filter @markra/editor test` — 38 files, 506 tests passed
- `pnpm --filter @markra/app test` — 133 files, 1525 tests passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/app build` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- `pnpm --filter @markra/app typecheck:test` passed
- focused coverage includes punctuation, CJK text, adjacent blocks, multiline output, lists, tables, and undo restoration

## Risk
- append placement uses the parsed top-level Markdown block containing the target end, with a source-line fallback when no parsed block is available

Closes #687
