### PR TITLE
feat(search): unify workspace file and content search

### DIFF
--- a/apps/desktop/src-tauri/src/markdown_files/search.rs
+++ b/apps/desktop/src-tauri/src/markdown_files/search.rs
@@ -373,6 +373,14 @@ fn markdown_search_line(content: &str, range: &MarkdownSearchRange) -> (usize, u
     )
 }
 
+fn markdown_search_editor_range(content: &str, range: &MarkdownSearchRange) -> MarkdownSearchRange {
+    // CodeMirror selections use UTF-16 offsets, while Rust string ranges are UTF-8 byte offsets.
+    MarkdownSearchRange {
+        from: content[..range.from].encode_utf16().count(),
+        to: content[..range.to].encode_utf16().count(),
+    }
+}
+
 fn char_slice(text: &str, start: usize, end: usize) -> String {
     text.chars()
         .skip(start)
@@ -428,6 +436,7 @@ fn markdown_workspace_search_results(
         .map(|(match_index, range)| {
             let (line_number, column_number, line_text) = markdown_search_line(content, &range);
             let match_length = content[range.from..range.to].chars().count();
+            let matched_range = markdown_search_editor_range(content, &range);
 
             MarkdownWorkspaceSearchResult {
                 column_number,
@@ -436,7 +445,7 @@ fn markdown_workspace_search_results(
                 line_number,
                 snippet: markdown_search_snippet(&line_text, column_number, match_length),
                 line_text,
-                matched_range: range,
+                matched_range,
                 match_index,
             }
         })
@@ -744,6 +753,27 @@ mod tests {
         );
 
         fs::remove_dir_all(root).expect("test tree should be removed");
+    }
+
+    #[test]
+    fn returns_editor_offsets_for_unicode_workspace_matches() {
+        let file = MarkdownFolderFile {
+            created_at: None,
+            kind: MarkdownFolderEntryKind::File,
+            modified_at: None,
+            path: "/synthetic/unicode.md".to_string(),
+            relative_path: "unicode.md".to_string(),
+            size_bytes: None,
+        };
+        let (results, truncated) =
+            markdown_workspace_search_results(&file, "前缀 alpha", None, "alpha", false, None);
+
+        assert_eq!(truncated, false);
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].matched_range,
+            MarkdownSearchRange { from: 3, to: 8 }
+        );
     }
 
     #[test]

--- a/apps/desktop/src/runtime/tauri/file.ts
+++ b/apps/desktop/src/runtime/tauri/file.ts
@@ -66,7 +66,12 @@ type MarkdownOpenPathResponse =
       path: string;
     };
 
-type MarkdownWorkspaceSearchResultResponse = Omit<WorkspaceSearchResponse["results"][number], "file"> & {
+type WorkspaceContentSearchResult = Extract<
+  WorkspaceSearchResponse["results"][number],
+  { kind?: "content" }
+>;
+
+type MarkdownWorkspaceSearchResultResponse = Omit<WorkspaceContentSearchResult, "file"> & {
   file: MarkdownFolderFileResponse;
 };
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -8233,6 +8233,9 @@ describe("Markra workspace", () => {
     expect(await screen.findByRole("button", { name: "guide.md" })).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true });
+    expect(screen.getByRole("search", { name: "Search workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Search workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
     fireEvent.change(screen.getByRole("searchbox", { name: "Search workspace" }), {
       target: { value: "alpha" }
     });
@@ -8246,6 +8249,42 @@ describe("Markra workspace", () => {
     );
     expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalledWith(guidePath);
     expect(await screen.findByRole("button", { name: "Open guide.md line 1" })).toBeInTheDocument();
+  });
+
+  it("opens files that match the workspace search by name", async () => {
+    const guidePath = "/mock-files/vault/alpha-guide.md";
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      name: "vault",
+      path: mockFolderPath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "alpha-guide.md", path: guidePath, relativePath: "alpha-guide.md" }
+    ]);
+    mockedSearchNativeMarkdownFilesForPath.mockResolvedValue({
+      results: [],
+      searchedFileCount: 1,
+      truncated: false,
+      unreadableFileCount: 0
+    });
+    mockedReadNativeMarkdownFile.mockResolvedValue({
+      content: "# Synthetic guide",
+      name: "alpha-guide.md",
+      path: guidePath
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true, shiftKey: true });
+    expect(await screen.findByRole("button", { name: "alpha-guide.md" })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true });
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search workspace" }), {
+      target: { value: "alpha" }
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Open alpha-guide.md" }));
+
+    await expectVisibleMarkdownText("Synthetic guide");
+    expect(screen.queryByRole("search", { name: "Search workspace" })).not.toBeInTheDocument();
   });
 
   it("clears workspace search after closing with Escape", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -8233,9 +8233,9 @@ describe("Markra workspace", () => {
     expect(await screen.findByRole("button", { name: "guide.md" })).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true });
-    expect(screen.getByRole("search", { name: "Search workspace" })).toBeInTheDocument();
-    expect(screen.queryByRole("dialog", { name: "Search workspace" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Search workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("search", { name: "Search workspace" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
     fireEvent.change(screen.getByRole("searchbox", { name: "Search workspace" }), {
       target: { value: "alpha" }
     });
@@ -8249,6 +8249,67 @@ describe("Markra workspace", () => {
     );
     expect(mockedReadNativeMarkdownFile).not.toHaveBeenCalledWith(guidePath);
     expect(await screen.findByRole("button", { name: "Open guide.md line 1" })).toBeInTheDocument();
+  });
+
+  it("keeps sidebar and shortcut workspace search presentations distinct", async () => {
+    const guidePath = "/mock-files/vault/guide.md";
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      name: "vault",
+      path: mockFolderPath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([
+      { name: "guide.md", path: guidePath, relativePath: "guide.md" }
+    ]);
+    mockedSearchNativeMarkdownFilesForPath.mockResolvedValue({
+      results: [],
+      searchedFileCount: 1,
+      truncated: false,
+      unreadableFileCount: 0
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true, shiftKey: true });
+    expect(await screen.findByRole("button", { name: "guide.md" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search workspace" }));
+
+    expect(screen.getByRole("search", { name: "Search workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Search workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true });
+
+    expect(screen.getByRole("dialog", { name: "Search workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("search", { name: "Search workspace" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tree", { name: "Markdown files" })).toBeInTheDocument();
+  });
+
+  it("keeps a closed file tree closed while workspace search is open", async () => {
+    mockedOpenNativeMarkdownFolder.mockResolvedValue({
+      name: "vault",
+      path: mockFolderPath
+    });
+    mockedListNativeMarkdownFilesForPath.mockResolvedValue([]);
+    mockedSearchNativeMarkdownFilesForPath.mockResolvedValue({
+      results: [],
+      searchedFileCount: 0,
+      truncated: false,
+      unreadableFileCount: 0
+    });
+
+    renderApp();
+
+    fireEvent.keyDown(window, { key: "o", metaKey: true, shiftKey: true });
+    expect(await screen.findByRole("button", { name: "Search workspace" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Toggle file list" }));
+    expect(screen.queryByRole("complementary", { name: "Markdown file tree" })).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true });
+
+    expect(screen.getByRole("dialog", { name: "Search workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("complementary", { name: "Markdown file tree" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle file list" })).toHaveAttribute("aria-pressed", "false");
   });
 
   it("opens files that match the workspace search by name", async () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -8436,7 +8436,7 @@ describe("Markra workspace", () => {
     expect(screen.getByRole("searchbox", { name: "Search workspace" })).toHaveValue("alpha");
   });
 
-  it("does not open document search after opening a workspace search result", async () => {
+  it("positions the editor without opening document search after a workspace result", async () => {
     const guidePath = "/mock-files/vault/docs/guide.md";
     mockedOpenNativeMarkdownFolder.mockResolvedValue({
       name: "vault",
@@ -8451,7 +8451,7 @@ describe("Markra workspace", () => {
       path: guidePath
     });
 
-    renderApp();
+    const { container } = renderApp();
 
     fireEvent.keyDown(window, { key: "o", metaKey: true, shiftKey: true });
     expect(await screen.findByRole("button", { name: "guide.md" })).toBeInTheDocument();
@@ -8463,6 +8463,11 @@ describe("Markra workspace", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open guide.md line 3" }));
 
     await expectVisibleMarkdownText("Guide");
+    const view = getVisibleCodeMirrorView(container);
+    await waitFor(() => {
+      expect(view.state.selection.main.from).toBe(19);
+      expect(view.state.selection.main.to).toBe(24);
+    });
     expect(screen.queryByRole("search", { name: "Find in document" })).not.toBeInTheDocument();
   });
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -327,6 +327,10 @@ type PendingEditorModeSelection = {
   tabId: string;
   targetSurface: EditorSurface;
 };
+type PendingWorkspaceSearchSelection = {
+  path: string;
+  selection: EditorSelectionSnapshot;
+};
 
 function boundedEditorSelection(selection: EditorSelectionSnapshot, documentLength: number) {
   const ranges = selection.ranges.length > 0
@@ -565,6 +569,7 @@ function WorkspaceApp() {
   const lastFocusedEditorContentRef = useRef<HTMLElement | null>(null);
   const documentTabViewStatesRef = useRef(new Map<string, DocumentTabViewState>());
   const pendingEditorModeSelectionRef = useRef<PendingEditorModeSelection | null>(null);
+  const pendingWorkspaceSearchSelectionRef = useRef<PendingWorkspaceSearchSelection | null>(null);
   const pendingEditorModeScrollRef = useRef<PendingEditorModeScroll | null>(null);
   const splitSurfaceRef = useRef<HTMLDivElement | null>(null);
   const sideDocumentSurfaceRef = useRef<HTMLDivElement | null>(null);
@@ -1071,7 +1076,6 @@ function WorkspaceApp() {
     replaceOpen: documentSearchReplaceOpen,
     resetActiveIndex: resetDocumentSearchActiveIndex,
     revealRevision: documentSearchRevealRevision,
-    selectMatch: selectDocumentSearchMatch,
     setCaseSensitive: setDocumentSearchCaseSensitive,
     setReplacement: setDocumentSearchReplacement,
     setReplaceOpen: setDocumentSearchReplaceOpen,
@@ -2706,16 +2710,16 @@ function WorkspaceApp() {
 
     if (file.kind === "asset") {
       openImageTab(file);
-      return;
+      return true;
     }
 
     if (file.kind === "attachment") {
       await handleOpenLocalAttachment(file.relativePath, null);
-      return;
+      return true;
     }
 
     setActiveImageFile(null);
-    await openTreeMarkdownFile(file);
+    return openTreeMarkdownFile(file);
   }, [captureActiveDocumentViewState, handleOpenLocalAttachment, openImageTab, openTreeMarkdownFile]);
   const handleQuickOpenOpen = useCallback(() => {
     hideGlobalSearch();
@@ -2750,24 +2754,23 @@ function WorkspaceApp() {
     await handleOpenTreeFile(file);
   }, [handleOpenTreeFile, hideGlobalSearch]);
   const handleGlobalSearchResultOpen = useCallback(async (result: WorkspaceSearchContentResult) => {
+    // The destination editor is created after the file-open state commits, so preserve the source range until then.
+    const pendingSelection: PendingWorkspaceSearchSelection = {
+      path: result.file.path,
+      selection: {
+        mainIndex: 0,
+        ranges: [{ anchor: result.match.from, head: result.match.to }]
+      }
+    };
+    pendingWorkspaceSearchSelectionRef.current = pendingSelection;
     hideGlobalSearch();
-    await handleOpenTreeFile(result.file);
-    if (!documentSearchOpen) return;
-
-    setDocumentSearchQuery(globalSearchQuery.trim());
-    setDocumentSearchCaseSensitive(globalSearchCaseSensitive);
-    setDocumentSearchReplaceOpen(false);
-    selectDocumentSearchMatch(result.matchIndex);
+    const opened = await handleOpenTreeFile(result.file);
+    if (!opened && pendingWorkspaceSearchSelectionRef.current === pendingSelection) {
+      pendingWorkspaceSearchSelectionRef.current = null;
+    }
   }, [
-    documentSearchOpen,
-    globalSearchCaseSensitive,
-    globalSearchQuery,
     handleOpenTreeFile,
-    hideGlobalSearch,
-    selectDocumentSearchMatch,
-    setDocumentSearchCaseSensitive,
-    setDocumentSearchQuery,
-    setDocumentSearchReplaceOpen
+    hideGlobalSearch
   ]);
   const handleOpenTreeFileToSide = useCallback(async (file: NativeMarkdownFolderFile) => {
     captureActiveDocumentViewState();
@@ -4047,6 +4050,30 @@ function WorkspaceApp() {
           pendingEditorModeSelectionRef.current = null;
         }
       }
+
+      const pendingWorkspaceSelection = pendingWorkspaceSearchSelectionRef.current;
+      if (
+        pendingWorkspaceSelection &&
+        document.path &&
+        sameNativePath(pendingWorkspaceSelection.path, document.path)
+      ) {
+        const workspaceTargetSurface = largeMarkdownVisualBlocked ? "source" : targetSurface;
+        const targetEditor = workspaceTargetSurface === "source"
+          ? sourceEditorRef.current
+          : mainVisualEditorsRef.current.get(activeTabId) ?? null;
+        if (targetEditor) {
+          const selection = boundedEditorSelection(
+            pendingWorkspaceSelection.selection,
+            targetEditor.state.doc.length
+          );
+          targetEditor.requestMeasure();
+          targetEditor.dispatch({ selection, scrollIntoView: true });
+          targetEditor.focus();
+          showCodeMirrorLocationCue(targetEditor, selection.main.head);
+          saveDocumentTabViewState(activeTabId, { selection: editorSelectionSnapshot(selection) });
+          pendingWorkspaceSearchSelectionRef.current = null;
+        }
+      }
     });
 
     return () => {
@@ -4056,10 +4083,12 @@ function WorkspaceApp() {
     activeImageFile,
     activeEditorSurface,
     activeTabId,
+    document.path,
     document.revision,
     editorMode,
     editorPreferences.preferences.modeSwitchHighlightEnabled,
     hasOpenDocument,
+    largeMarkdownVisualBlocked,
     saveDocumentTabViewState,
     sourceEditorReadySequence,
     visualEditorReadySequence

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1017,6 +1017,7 @@ function WorkspaceApp() {
     setCaseSensitive: setGlobalSearchCaseSensitive,
     setQuery: setGlobalSearchQuery
   } = workspaceSearch;
+  const [globalSearchPresentation, setGlobalSearchPresentation] = useState<"dialog" | "sidebar">("dialog");
   const hasOpenDocument = document.open;
   const largeMarkdownVisualBlocked =
     hasOpenDocument && !activeImageFile && shouldBlockLargeMarkdownVisual(document.content, {
@@ -2726,9 +2727,14 @@ function WorkspaceApp() {
   }, []);
   const handleGlobalSearchOpen = useCallback(() => {
     setQuickOpenOpen(false);
-    if (!fileTreeOpen) toggleFileTree(document.path);
+    setGlobalSearchPresentation("dialog");
     openGlobalSearch();
-  }, [document.path, fileTreeOpen, openGlobalSearch, toggleFileTree]);
+  }, [openGlobalSearch]);
+  const handleSidebarWorkspaceSearchOpen = useCallback(() => {
+    setQuickOpenOpen(false);
+    setGlobalSearchPresentation("sidebar");
+    openGlobalSearch();
+  }, [openGlobalSearch]);
   const handleGlobalSearchClose = closeGlobalSearch;
   const handleGlobalSearchQueryChange = useCallback((query: string) => {
     setGlobalSearchQuery(query);
@@ -4815,27 +4821,29 @@ function WorkspaceApp() {
             width: compactViewport
               ? Math.min(fileTreeWidth, Math.max(0, viewportWidth - 48))
               : fileTreeWidth,
-            workspaceSearchOpen: globalSearchOpen && visibleFileTreeOpen,
-            workspaceSearchPanel: globalSearchOpen && visibleFileTreeOpen ? (
-              <GlobalSearchPanel
-                caseSensitive={globalSearchCaseSensitive}
-                language={appLanguage.language}
-                loading={globalSearchLoading}
-                placement="sidebar"
-                query={globalSearchQuery}
-                recentQueries={globalSearchRecentQueries}
-                results={globalSearchResponse.results}
-                searchedFileCount={globalSearchResponse.searchedFileCount}
-                truncated={globalSearchResponse.truncated}
-                unreadableFileCount={globalSearchResponse.unreadableFileCount}
-                onCaseSensitiveChange={handleGlobalSearchCaseSensitiveChange}
-                onClose={handleGlobalSearchClose}
-                onOpenFile={handleGlobalSearchFileOpen}
-                onOpenResult={handleGlobalSearchResultOpen}
-                onQueryChange={handleGlobalSearchQueryChange}
-                onRecentQuerySelect={handleGlobalSearchRecentQuerySelect}
-              />
-            ) : null,
+            workspaceSearchOpen: globalSearchOpen && globalSearchPresentation === "sidebar",
+            workspaceSearchPanel: globalSearchOpen
+              && globalSearchPresentation === "sidebar"
+              && visibleFileTreeOpen ? (
+                <GlobalSearchPanel
+                  caseSensitive={globalSearchCaseSensitive}
+                  language={appLanguage.language}
+                  loading={globalSearchLoading}
+                  placement="sidebar"
+                  query={globalSearchQuery}
+                  recentQueries={globalSearchRecentQueries}
+                  results={globalSearchResponse.results}
+                  searchedFileCount={globalSearchResponse.searchedFileCount}
+                  truncated={globalSearchResponse.truncated}
+                  unreadableFileCount={globalSearchResponse.unreadableFileCount}
+                  onCaseSensitiveChange={handleGlobalSearchCaseSensitiveChange}
+                  onClose={handleGlobalSearchClose}
+                  onOpenFile={handleGlobalSearchFileOpen}
+                  onOpenResult={handleGlobalSearchResultOpen}
+                  onQueryChange={handleGlobalSearchQueryChange}
+                  onRecentQuerySelect={handleGlobalSearchRecentQuerySelect}
+                />
+              ) : null,
             onCleanUnusedImages: assetCleanupAvailable ? assetCleanup.openDialog : undefined,
             onCreateFile: handleCreateMarkdownTreeFile,
             onCreateFolder: handleCreateMarkdownTreeFolder,
@@ -4863,7 +4871,7 @@ function WorkspaceApp() {
             onSaveFileAsTemplate: handleSaveMarkdownFileAsTemplate,
             onSelectOutlineItem: editor.selectOutlineItem,
             onToggleMarkdownFiles: handleFileTreeToggle,
-            onWorkspaceSearchOpen: handleGlobalSearchOpen
+            onWorkspaceSearchOpen: handleSidebarWorkspaceSearchOpen
           }}
           windowsSelfDrawnChrome={windowsSelfDrawnChromeEnabled}
           workspaceOperationOverlay={workspaceOperationOverlay}
@@ -4873,8 +4881,9 @@ function WorkspaceApp() {
           onEditorContentDragOver={handleEditorContentDragOver}
           onEditorContentDrop={handleEditorContentDrop}
         >
-              {/* Immersive views can suppress the sidebar, so keep the dialog as a reachable fallback. */}
-              {globalSearchOpen && !visibleFileTreeOpen ? (
+              {globalSearchOpen && (
+                globalSearchPresentation === "dialog" || !visibleFileTreeOpen
+              ) ? (
                 <GlobalSearchPanel
                   caseSensitive={globalSearchCaseSensitive}
                   language={appLanguage.language}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -150,7 +150,10 @@ import {
 import { selectionAnchorFromDomSelection, type SelectionAnchor } from "./lib/selection-anchor";
 import { runEditorLinkCommand } from "./app/editor-link-command";
 import { isPandocSetupError, runPandocSetupAction } from "./app/pandoc-setup";
-import type { WorkspaceSearchResult } from "./lib/workspace-search";
+import type {
+  WorkspaceSearchContentResult,
+  WorkspaceSearchFile
+} from "./lib/workspace-search";
 import type {
   SelectionHeadingLevel,
   SelectionFormattingAction,
@@ -2723,8 +2726,9 @@ function WorkspaceApp() {
   }, []);
   const handleGlobalSearchOpen = useCallback(() => {
     setQuickOpenOpen(false);
+    if (!fileTreeOpen) toggleFileTree(document.path);
     openGlobalSearch();
-  }, [openGlobalSearch]);
+  }, [document.path, fileTreeOpen, openGlobalSearch, toggleFileTree]);
   const handleGlobalSearchClose = closeGlobalSearch;
   const handleGlobalSearchQueryChange = useCallback((query: string) => {
     setGlobalSearchQuery(query);
@@ -2735,7 +2739,11 @@ function WorkspaceApp() {
   const handleGlobalSearchRecentQuerySelect = useCallback((query: string) => {
     selectGlobalSearchRecentQuery(query);
   }, [selectGlobalSearchRecentQuery]);
-  const handleGlobalSearchResultOpen = useCallback(async (result: WorkspaceSearchResult) => {
+  const handleGlobalSearchFileOpen = useCallback(async (file: WorkspaceSearchFile) => {
+    hideGlobalSearch();
+    await handleOpenTreeFile(file);
+  }, [handleOpenTreeFile, hideGlobalSearch]);
+  const handleGlobalSearchResultOpen = useCallback(async (result: WorkspaceSearchContentResult) => {
     hideGlobalSearch();
     await handleOpenTreeFile(result.file);
     if (!documentSearchOpen) return;
@@ -4807,6 +4815,27 @@ function WorkspaceApp() {
             width: compactViewport
               ? Math.min(fileTreeWidth, Math.max(0, viewportWidth - 48))
               : fileTreeWidth,
+            workspaceSearchOpen: globalSearchOpen && visibleFileTreeOpen,
+            workspaceSearchPanel: globalSearchOpen && visibleFileTreeOpen ? (
+              <GlobalSearchPanel
+                caseSensitive={globalSearchCaseSensitive}
+                language={appLanguage.language}
+                loading={globalSearchLoading}
+                placement="sidebar"
+                query={globalSearchQuery}
+                recentQueries={globalSearchRecentQueries}
+                results={globalSearchResponse.results}
+                searchedFileCount={globalSearchResponse.searchedFileCount}
+                truncated={globalSearchResponse.truncated}
+                unreadableFileCount={globalSearchResponse.unreadableFileCount}
+                onCaseSensitiveChange={handleGlobalSearchCaseSensitiveChange}
+                onClose={handleGlobalSearchClose}
+                onOpenFile={handleGlobalSearchFileOpen}
+                onOpenResult={handleGlobalSearchResultOpen}
+                onQueryChange={handleGlobalSearchQueryChange}
+                onRecentQuerySelect={handleGlobalSearchRecentQuerySelect}
+              />
+            ) : null,
             onCleanUnusedImages: assetCleanupAvailable ? assetCleanup.openDialog : undefined,
             onCreateFile: handleCreateMarkdownTreeFile,
             onCreateFolder: handleCreateMarkdownTreeFolder,
@@ -4833,7 +4862,8 @@ function WorkspaceApp() {
             onResizeStart: compactViewport ? undefined : startFileTreeResize,
             onSaveFileAsTemplate: handleSaveMarkdownFileAsTemplate,
             onSelectOutlineItem: editor.selectOutlineItem,
-            onToggleMarkdownFiles: handleFileTreeToggle
+            onToggleMarkdownFiles: handleFileTreeToggle,
+            onWorkspaceSearchOpen: handleGlobalSearchOpen
           }}
           windowsSelfDrawnChrome={windowsSelfDrawnChromeEnabled}
           workspaceOperationOverlay={workspaceOperationOverlay}
@@ -4843,7 +4873,8 @@ function WorkspaceApp() {
           onEditorContentDragOver={handleEditorContentDragOver}
           onEditorContentDrop={handleEditorContentDrop}
         >
-              {globalSearchOpen ? (
+              {/* Immersive views can suppress the sidebar, so keep the dialog as a reachable fallback. */}
+              {globalSearchOpen && !visibleFileTreeOpen ? (
                 <GlobalSearchPanel
                   caseSensitive={globalSearchCaseSensitive}
                   language={appLanguage.language}
@@ -4856,6 +4887,7 @@ function WorkspaceApp() {
                   unreadableFileCount={globalSearchResponse.unreadableFileCount}
                   onCaseSensitiveChange={handleGlobalSearchCaseSensitiveChange}
                   onClose={handleGlobalSearchClose}
+                  onOpenFile={handleGlobalSearchFileOpen}
                   onOpenResult={handleGlobalSearchResultOpen}
                   onQueryChange={handleGlobalSearchQueryChange}
                   onRecentQuerySelect={handleGlobalSearchRecentQuerySelect}

--- a/packages/app/src/components/GlobalSearchPanel.test.tsx
+++ b/packages/app/src/components/GlobalSearchPanel.test.tsx
@@ -43,7 +43,49 @@ const otherFileResult = {
   snippet: "alpha in root"
 } satisfies WorkspaceSearchResult;
 
+const fileNameResult = {
+  file: {
+    name: "alpha-guide.md",
+    path: "/mock-vault/docs/alpha-guide.md",
+    relativePath: "docs/alpha-guide.md"
+  },
+  id: "file-name:/mock-vault/docs/alpha-guide.md",
+  kind: "fileName"
+} satisfies WorkspaceSearchResult;
+
 describe("GlobalSearchPanel", () => {
+  it("renders file-name matches as openable results in the sidebar", () => {
+    const openFile = vi.fn();
+    render(
+      <GlobalSearchPanel
+        caseSensitive={false}
+        language="en"
+        loading={false}
+        placement="sidebar"
+        query="alpha"
+        results={[fileNameResult]}
+        searchedFileCount={1}
+        truncated={false}
+        unreadableFileCount={0}
+        onCaseSensitiveChange={() => {}}
+        onClose={() => {}}
+        onOpenFile={openFile}
+        onOpenResult={() => {}}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const search = screen.getByRole("search", { name: "Search workspace" });
+    const fileButton = within(search).getByRole("button", { name: "Open docs/alpha-guide.md" });
+
+    expect(fileButton.querySelector("mark")).toHaveTextContent("alpha");
+    expect(screen.queryByRole("dialog", { name: "Search workspace" })).not.toBeInTheDocument();
+
+    fireEvent.click(fileButton);
+
+    expect(openFile).toHaveBeenCalledWith(fileNameResult.file);
+  });
+
   it("groups workspace search results by file and opens a selected match", () => {
     const openResult = vi.fn();
     render(
@@ -58,6 +100,7 @@ describe("GlobalSearchPanel", () => {
         unreadableFileCount={0}
         onCaseSensitiveChange={() => {}}
         onClose={() => {}}
+        onOpenFile={() => {}}
         onOpenResult={openResult}
         onQueryChange={() => {}}
       />
@@ -70,14 +113,16 @@ describe("GlobalSearchPanel", () => {
     expect(within(dialog).getByText("3 results")).toBeInTheDocument();
 
     const guideGroup = within(results).getByRole("group", { name: "docs/guide.md search results" });
-    expect(within(guideGroup).getByRole("button", { name: "Collapse docs/guide.md search results" })).toHaveTextContent("2");
+    expect(within(guideGroup).getByRole("button", { name: "Collapse docs/guide.md search results" })).toBeInTheDocument();
+    expect(within(guideGroup).getByText("2")).toBeInTheDocument();
     expect(within(guideGroup).getByText("guide.md")).toBeInTheDocument();
     expect(within(guideGroup).getByText("docs /")).toBeInTheDocument();
     expect(within(guideGroup).getByRole("button", { name: "Open docs/guide.md line 3" })).toHaveTextContent("First alpha note");
     expect(within(guideGroup).getByRole("button", { name: "Open docs/guide.md line 5" })).toHaveTextContent("Second alpha entry");
 
     const notesGroup = within(results).getByRole("group", { name: "notes.md search results" });
-    expect(within(notesGroup).getByRole("button", { name: "Collapse notes.md search results" })).toHaveTextContent("1");
+    expect(within(notesGroup).getByRole("button", { name: "Collapse notes.md search results" })).toBeInTheDocument();
+    expect(within(notesGroup).getByText("1")).toBeInTheDocument();
     expect(within(notesGroup).queryByText("/")).not.toBeInTheDocument();
 
     fireEvent.click(within(guideGroup).getByRole("button", { name: "Open docs/guide.md line 3" }));
@@ -98,6 +143,7 @@ describe("GlobalSearchPanel", () => {
         unreadableFileCount={0}
         onCaseSensitiveChange={() => {}}
         onClose={() => {}}
+        onOpenFile={() => {}}
         onOpenResult={() => {}}
         onQueryChange={() => {}}
       />
@@ -125,6 +171,7 @@ describe("GlobalSearchPanel", () => {
         unreadableFileCount={0}
         onCaseSensitiveChange={setCaseSensitive}
         onClose={() => {}}
+        onOpenFile={() => {}}
         onOpenResult={() => {}}
         onQueryChange={() => {}}
       />
@@ -150,6 +197,7 @@ describe("GlobalSearchPanel", () => {
         unreadableFileCount={0}
         onCaseSensitiveChange={() => {}}
         onClose={() => {}}
+        onOpenFile={() => {}}
         onOpenResult={() => {}}
         onQueryChange={() => {}}
         onRecentQuerySelect={selectRecentQuery}
@@ -177,6 +225,7 @@ describe("GlobalSearchPanel", () => {
         unreadableFileCount={0}
         onCaseSensitiveChange={() => {}}
         onClose={() => {}}
+        onOpenFile={() => {}}
         onOpenResult={() => {}}
         onQueryChange={() => {}}
       />
@@ -211,6 +260,7 @@ describe("GlobalSearchPanel", () => {
           unreadableFileCount={0}
           onCaseSensitiveChange={() => {}}
           onClose={() => {}}
+          onOpenFile={() => {}}
           onOpenResult={() => {}}
           onQueryChange={() => {}}
         />

--- a/packages/app/src/components/GlobalSearchPanel.test.tsx
+++ b/packages/app/src/components/GlobalSearchPanel.test.tsx
@@ -157,6 +157,37 @@ describe("GlobalSearchPanel", () => {
     expect(highlight).toHaveClass("global-search-match");
   });
 
+  it("highlights matching relative-path segments for file results", () => {
+    const { container } = render(
+      <GlobalSearchPanel
+        caseSensitive={false}
+        language="en"
+        loading={false}
+        query="docs"
+        results={[{
+          ...fileNameResult,
+          file: {
+            ...fileNameResult.file,
+            name: "guide.md"
+          }
+        }]}
+        searchedFileCount={1}
+        truncated={false}
+        unreadableFileCount={0}
+        onCaseSensitiveChange={() => {}}
+        onClose={() => {}}
+        onOpenFile={() => {}}
+        onOpenResult={() => {}}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const directory = container.querySelector(".font-mono");
+
+    expect(directory).toHaveTextContent("docs /");
+    expect(directory?.querySelector("mark")).toHaveTextContent("docs");
+  });
+
   it("toggles case-sensitive search", () => {
     const setCaseSensitive = vi.fn();
     render(
@@ -232,6 +263,40 @@ describe("GlobalSearchPanel", () => {
     );
 
     expect(screen.getByText("First 1 results")).toBeInTheDocument();
+  });
+
+  it("resets expanded file previews when the query changes", () => {
+    const results = Array.from({ length: 5 }, (_, index) => ({
+      ...result,
+      id: `/mock-vault/guide.md:${index}`,
+      lineNumber: index + 1,
+      matchIndex: index,
+      snippet: `alpha result ${index + 1}`
+    })) satisfies WorkspaceSearchResult[];
+    const props = {
+      caseSensitive: false,
+      language: "en" as const,
+      loading: false,
+      results,
+      searchedFileCount: 1,
+      truncated: false,
+      unreadableFileCount: 0,
+      onCaseSensitiveChange: () => {},
+      onClose: () => {},
+      onOpenFile: () => {},
+      onOpenResult: () => {},
+      onQueryChange: () => {}
+    };
+    const { rerender } = render(<GlobalSearchPanel {...props} query="alpha" />);
+
+    expect(screen.queryByRole("button", { name: "Open docs/guide.md line 5" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "show 1 more match" }));
+    expect(screen.getByRole("button", { name: "Open docs/guide.md line 5" })).toBeInTheDocument();
+
+    rerender(<GlobalSearchPanel {...props} query="beta" />);
+
+    expect(screen.queryByRole("button", { name: "Open docs/guide.md line 5" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "show 1 more match" })).toBeInTheDocument();
   });
 
   it("virtualizes large result groups instead of rendering every group", async () => {

--- a/packages/app/src/components/GlobalSearchPanel.tsx
+++ b/packages/app/src/components/GlobalSearchPanel.tsx
@@ -260,6 +260,11 @@ export function GlobalSearchPanel({
   }, [resultGroupVirtualizer, results]);
 
   useEffect(() => {
+    setCollapsedFilePaths(new Set());
+    setExpandedPreviewFilePaths(new Set());
+  }, [query]);
+
+  useEffect(() => {
     resultGroupVirtualizer.measure();
   }, [collapsedFilePaths, expandedPreviewFilePaths, resultGroupVirtualizer]);
 
@@ -330,10 +335,10 @@ export function GlobalSearchPanel({
         </button>
       </div>
       <div className={resultSurfaceClassName}>
-        <div className="flex h-8 shrink-0 items-center gap-2 border-b border-(--border-default) px-3 text-[11px] font-[560] text-(--text-secondary)">
+        <div className="flex h-8 min-w-0 shrink-0 items-center gap-2 overflow-hidden border-b border-(--border-default) px-3 text-[11px] font-[560] text-(--text-secondary)">
           {loading ? <Loader2 aria-hidden="true" className="animate-spin" size={13} /> : null}
-          <span>{statusText}</span>
-          <span>
+          <span className="min-w-0 flex-1 truncate">{statusText}</span>
+          <span className="shrink-0">
             {searchLabel(countMessageKey(
               searchedFileCount,
               "app.workspaceSearch.fileCount",
@@ -341,7 +346,9 @@ export function GlobalSearchPanel({
             ), { count: searchedFileCount })}
           </span>
           {unreadableFileCount > 0 ? (
-            <span>{searchLabel("app.workspaceSearch.unreadableFileCount", { count: unreadableFileCount })}</span>
+            <span className="min-w-0 truncate">
+              {searchLabel("app.workspaceSearch.unreadableFileCount", { count: unreadableFileCount })}
+            </span>
           ) : null}
         </div>
         {results.length > 0 ? (
@@ -424,7 +431,7 @@ export function GlobalSearchPanel({
                         <div className="pb-2 pl-7 pr-1">
                           {directoryLabel ? (
                             <div className="mb-1 truncate font-mono text-[11px] text-(--text-secondary)">
-                              {directoryLabel}
+                              {renderHighlightedSnippet(directoryLabel, query, caseSensitive)}
                             </div>
                           ) : null}
                           {visibleResults.length > 0 ? (

--- a/packages/app/src/components/GlobalSearchPanel.tsx
+++ b/packages/app/src/components/GlobalSearchPanel.tsx
@@ -2,12 +2,19 @@ import { useCallback, useEffect, useMemo, useRef, useState, type Key, type Keybo
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { CaseSensitive, ChevronDown, ChevronRight, Loader2, Search, X } from "lucide-react";
 import { findSearchRanges, t, type AppLanguage, type I18nKey } from "@markra/shared";
-import type { WorkspaceSearchResult } from "../lib/workspace-search";
+import {
+  isWorkspaceFileNameSearchResult,
+  type WorkspaceSearchContentResult,
+  type WorkspaceSearchFile,
+  type WorkspaceSearchFileNameResult,
+  type WorkspaceSearchResult
+} from "../lib/workspace-search";
 
 type GlobalSearchPanelProps = {
   caseSensitive: boolean;
   language?: AppLanguage;
   loading: boolean;
+  placement?: "dialog" | "sidebar";
   query: string;
   recentQueries?: readonly string[];
   results: readonly WorkspaceSearchResult[];
@@ -16,14 +23,16 @@ type GlobalSearchPanelProps = {
   unreadableFileCount: number;
   onCaseSensitiveChange: (caseSensitive: boolean) => unknown;
   onClose: () => unknown;
-  onOpenResult: (result: WorkspaceSearchResult) => unknown;
+  onOpenFile: (file: WorkspaceSearchFile) => unknown;
+  onOpenResult: (result: WorkspaceSearchContentResult) => unknown;
   onQueryChange: (query: string) => unknown;
   onRecentQuerySelect?: (query: string) => unknown;
 };
 
 type GlobalSearchResultGroup = {
   file: WorkspaceSearchResult["file"];
-  results: WorkspaceSearchResult[];
+  fileNameResult?: WorkspaceSearchFileNameResult;
+  results: WorkspaceSearchContentResult[];
 };
 
 type VirtualResultGroupItem = {
@@ -58,13 +67,18 @@ function groupSearchResultsByFile(results: readonly WorkspaceSearchResult[]) {
   results.forEach((result) => {
     const currentGroup = groups.get(result.file.path);
     if (currentGroup) {
-      currentGroup.results.push(result);
+      if (isWorkspaceFileNameSearchResult(result)) {
+        currentGroup.fileNameResult = result;
+      } else {
+        currentGroup.results.push(result);
+      }
       return;
     }
 
     groups.set(result.file.path, {
       file: result.file,
-      results: [result]
+      fileNameResult: isWorkspaceFileNameSearchResult(result) ? result : undefined,
+      results: isWorkspaceFileNameSearchResult(result) ? [] : [result]
     });
   });
 
@@ -86,6 +100,11 @@ function estimateResultGroupHeight(
   expandedPreviewFilePaths: Set<string>
 ) {
   if (!group || collapsedFilePaths.has(group.file.path)) return collapsedResultGroupHeight;
+
+  if (group.results.length === 0) {
+    return collapsedResultGroupHeight
+      + (directoryLabelFromRelativePath(group.file.relativePath) ? resultGroupDirectoryHeight : 0);
+  }
 
   const previewExpanded = expandedPreviewFilePaths.has(group.file.path);
   const visibleResultCount = previewExpanded
@@ -155,6 +174,7 @@ export function GlobalSearchPanel({
   caseSensitive,
   language = "en",
   loading,
+  placement = "dialog",
   query,
   recentQueries = [],
   results,
@@ -163,6 +183,7 @@ export function GlobalSearchPanel({
   unreadableFileCount,
   onCaseSensitiveChange,
   onClose,
+  onOpenFile,
   onOpenResult,
   onQueryChange,
   onRecentQuerySelect
@@ -221,6 +242,13 @@ export function GlobalSearchPanel({
           "app.workspaceSearch.resultCount",
           "app.workspaceSearch.resultCountPlural"
         ), { count: results.length });
+  const sidebarPlacement = placement === "sidebar";
+  const panelClassName = sidebarPlacement
+    ? "global-search-panel flex min-h-0 flex-1 flex-col overflow-hidden bg-(--bg-secondary) text-[12px] text-(--text-primary)"
+    : "global-search-panel absolute left-1/2 top-14 z-50 flex w-[min(calc(100%-2rem),640px)] -translate-x-1/2 flex-col overflow-hidden rounded-md border border-(--border-strong) bg-(--bg-secondary)/98 text-[12px] text-(--text-primary) shadow-[0_18px_58px_rgba(0,0,0,0.18)] backdrop-blur-sm";
+  const resultSurfaceClassName = sidebarPlacement
+    ? "flex min-h-0 flex-1 flex-col"
+    : "flex min-h-0 max-h-[min(52vh,420px)] flex-col";
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -262,8 +290,8 @@ export function GlobalSearchPanel({
 
   return (
     <div
-      className="global-search-panel absolute left-1/2 top-14 z-50 flex w-[min(calc(100%-2rem),640px)] -translate-x-1/2 flex-col overflow-hidden rounded-md border border-(--border-strong) bg-(--bg-secondary)/98 text-[12px] text-(--text-primary) shadow-[0_18px_58px_rgba(0,0,0,0.18)] backdrop-blur-sm"
-      role="dialog"
+      className={panelClassName}
+      role={sidebarPlacement ? "search" : "dialog"}
       aria-label={label("app.workspaceSearch.searchWorkspace")}
     >
       <div className="flex min-w-0 items-center gap-1.5 border-b border-(--border-default) p-2">
@@ -301,7 +329,7 @@ export function GlobalSearchPanel({
           <X aria-hidden="true" size={14} />
         </button>
       </div>
-      <div className="flex min-h-0 max-h-[min(52vh,420px)] flex-col">
+      <div className={resultSurfaceClassName}>
         <div className="flex h-8 shrink-0 items-center gap-2 border-b border-(--border-default) px-3 text-[11px] font-[560] text-(--text-secondary)">
           {loading ? <Loader2 aria-hidden="true" className="animate-spin" size={13} /> : null}
           <span>{statusText}</span>
@@ -338,6 +366,10 @@ export function GlobalSearchPanel({
                   : group.results.slice(0, collapsedGroupPreviewCount);
                 const hiddenResultCount = group.results.length - visibleResults.length;
                 const directoryLabel = directoryLabelFromRelativePath(group.file.relativePath);
+                const resultCount = group.results.length + (group.fileNameResult ? 1 : 0);
+                const fileName = group.fileNameResult
+                  ? renderHighlightedSnippet(group.file.name, query, caseSensitive)
+                  : group.file.name;
 
                 return (
                   <div
@@ -354,53 +386,68 @@ export function GlobalSearchPanel({
                         path: group.file.relativePath
                       })}
                     >
-                      <button
-                        className="grid w-full cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-sm border-0 bg-transparent px-1.5 py-2 text-left outline-none transition-[background-color,color] duration-150 hover:bg-(--bg-hover) focus-visible:bg-(--bg-active) focus-visible:ring-2 focus-visible:ring-(--accent)"
-                        aria-expanded={!collapsed}
-                        aria-label={
-                          collapsed
-                            ? searchLabel("app.workspaceSearch.expandFile", { path: group.file.relativePath })
-                            : searchLabel("app.workspaceSearch.collapseFile", { path: group.file.relativePath })
-                        }
-                        type="button"
-                        onClick={() => toggleFileGroup(group.file.path)}
-                      >
-                        {collapsed
-                          ? <ChevronRight aria-hidden="true" className="text-(--text-secondary)" size={14} />
-                          : <ChevronDown aria-hidden="true" className="text-(--text-secondary)" size={14} />}
-                        <span className="min-w-0 truncate text-[14px] font-[720] text-(--text-heading)">
-                          {group.file.name}
-                        </span>
+                      <div className="grid w-full grid-cols-[1.75rem_minmax(0,1fr)_auto] items-center rounded-sm px-1 py-1.5">
+                        {group.results.length > 0 ? (
+                          <button
+                            className="document-search-icon-button"
+                            aria-expanded={!collapsed}
+                            aria-label={
+                              collapsed
+                                ? searchLabel("app.workspaceSearch.expandFile", { path: group.file.relativePath })
+                                : searchLabel("app.workspaceSearch.collapseFile", { path: group.file.relativePath })
+                            }
+                            type="button"
+                            onClick={() => toggleFileGroup(group.file.path)}
+                          >
+                            {collapsed
+                              ? <ChevronRight aria-hidden="true" size={14} />
+                              : <ChevronDown aria-hidden="true" size={14} />}
+                          </button>
+                        ) : (
+                          <span aria-hidden="true" />
+                        )}
+                        <button
+                          className="min-w-0 cursor-pointer truncate rounded-sm border-0 bg-transparent px-1 py-1 text-left text-[13px] font-[680] text-(--text-heading) outline-none transition-colors duration-150 hover:bg-(--bg-hover) focus-visible:bg-(--bg-active) focus-visible:ring-2 focus-visible:ring-(--accent)"
+                          aria-label={searchLabel("app.workspaceSearch.openFile", {
+                            path: group.file.relativePath
+                          })}
+                          type="button"
+                          onClick={() => onOpenFile(group.file)}
+                        >
+                          {fileName}
+                        </button>
                         <span className="rounded-sm bg-(--bg-active) px-2 py-0.5 text-[12px] font-[620] tabular-nums text-(--text-heading)">
-                          {group.results.length}
+                          {resultCount}
                         </span>
-                      </button>
-                      {!collapsed ? (
+                      </div>
+                      {!collapsed && (directoryLabel || group.results.length > 0) ? (
                         <div className="pb-2 pl-7 pr-1">
                           {directoryLabel ? (
                             <div className="mb-1 truncate font-mono text-[11px] text-(--text-secondary)">
                               {directoryLabel}
                             </div>
                           ) : null}
-                          <ul className="m-0 list-none p-0" role="list" aria-label={`${group.file.relativePath} matches`}>
-                            {visibleResults.map((result) => (
-                              <li key={result.id}>
-                                <button
-                                  className="block w-full cursor-pointer rounded-sm border-0 bg-transparent px-0 py-1 text-left outline-none transition-[background-color,color] duration-150 hover:bg-(--bg-hover) focus-visible:bg-(--bg-active) focus-visible:ring-2 focus-visible:ring-(--accent)"
-                                  aria-label={searchLabel("app.workspaceSearch.openResult", {
-                                    line: result.lineNumber,
-                                    path: result.file.relativePath
-                                  })}
-                                  type="button"
-                                  onClick={() => onOpenResult(result)}
-                                >
-                                  <span className="block min-w-0 truncate font-mono text-[12px] leading-5 text-(--text-primary)">
-                                    {renderHighlightedSnippet(result.snippet, query, caseSensitive)}
-                                  </span>
-                                </button>
-                              </li>
-                            ))}
-                          </ul>
+                          {visibleResults.length > 0 ? (
+                            <ul className="m-0 list-none p-0" role="list" aria-label={`${group.file.relativePath} matches`}>
+                              {visibleResults.map((result) => (
+                                <li key={result.id}>
+                                  <button
+                                    className="block w-full cursor-pointer rounded-sm border-0 bg-transparent px-0 py-1 text-left outline-none transition-[background-color,color] duration-150 hover:bg-(--bg-hover) focus-visible:bg-(--bg-active) focus-visible:ring-2 focus-visible:ring-(--accent)"
+                                    aria-label={searchLabel("app.workspaceSearch.openResult", {
+                                      line: result.lineNumber,
+                                      path: result.file.relativePath
+                                    })}
+                                    type="button"
+                                    onClick={() => onOpenResult(result)}
+                                  >
+                                    <span className="block min-w-0 truncate font-mono text-[12px] leading-5 text-(--text-primary)">
+                                      {renderHighlightedSnippet(result.snippet, query, caseSensitive)}
+                                    </span>
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : null}
                           {hiddenResultCount > 0 ? (
                             <button
                               className="mt-0.5 cursor-pointer rounded-sm border-0 bg-transparent px-0 py-1 text-left text-[12px] font-[560] text-(--text-secondary) outline-none transition-colors duration-150 hover:text-(--text-heading) focus-visible:text-(--text-heading) focus-visible:ring-2 focus-visible:ring-(--accent)"

--- a/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.test.tsx
@@ -4396,4 +4396,34 @@ describe("MarkdownFileTreeDrawer", () => {
 
     expect(mouseDown.defaultPrevented).toBe(true);
   });
+
+  it("opens and hosts workspace search from the file toolbar", () => {
+    const openWorkspaceSearch = vi.fn();
+    const renderDrawer = (workspaceSearchOpen: boolean) => (
+      <MarkdownFileTreeDrawer
+        currentPath="/vault/Untitled.md"
+        files={markdownFiles}
+        open
+        outlineItems={[]}
+        rootName="Obsidian Vault"
+        workspaceSearchOpen={workspaceSearchOpen}
+        workspaceSearchPanel={<section aria-label="Search workspace" role="search" />}
+        onOpenFile={() => {}}
+        onSelectOutlineItem={() => {}}
+        onWorkspaceSearchOpen={openWorkspaceSearch}
+      />
+    );
+    const { rerender } = render(renderDrawer(false));
+
+    fireEvent.click(screen.getByRole("button", { name: "Search workspace" }));
+
+    expect(openWorkspaceSearch).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("search", { name: "Search workspace" })).not.toBeInTheDocument();
+
+    rerender(renderDrawer(true));
+
+    expect(screen.getByRole("search", { name: "Search workspace" })).toBeInTheDocument();
+    expect(screen.queryByRole("tree", { name: "Markdown files" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("separator", { name: "Resize outline" })).not.toBeInTheDocument();
+  });
 });

--- a/packages/app/src/components/MarkdownFileTreeDrawer.tsx
+++ b/packages/app/src/components/MarkdownFileTreeDrawer.tsx
@@ -168,6 +168,8 @@ type MarkdownFileTreeDrawerProps = {
   sidebarLayoutMode?: SidebarLayoutMode;
   updateAvailable?: boolean;
   width?: number;
+  workspaceSearchOpen?: boolean;
+  workspaceSearchPanel?: ReactNode;
   onCleanUnusedImages?: () => unknown | Promise<unknown>;
   onCreateFile?: (fileName: string, parentPath?: string | null, contents?: string) => unknown | Promise<unknown>;
   onCreateFolder?: (folderName: string, parentPath?: string | null) => unknown | Promise<unknown>;
@@ -199,6 +201,7 @@ type MarkdownFileTreeDrawerProps = {
   onSaveFileAsTemplate?: (file: NativeMarkdownFolderFile) => unknown | Promise<unknown>;
   onSelectOutlineItem: (item: MarkdownOutlineItem, index: number) => unknown;
   onToggleMarkdownFiles?: () => unknown;
+  onWorkspaceSearchOpen?: () => unknown;
 };
 
 type SidebarPanel = "files" | "outline" | "links";
@@ -486,6 +489,8 @@ export function MarkdownFileTreeDrawer({
   sidebarLayoutMode = "stacked",
   updateAvailable = false,
   width = 288,
+  workspaceSearchOpen = false,
+  workspaceSearchPanel = null,
   onCleanUnusedImages,
   onCreateFile,
   onCreateFolder,
@@ -510,7 +515,8 @@ export function MarkdownFileTreeDrawer({
   onResizeStart,
   onSaveFileAsTemplate,
   onSelectOutlineItem,
-  onToggleMarkdownFiles
+  onToggleMarkdownFiles,
+  onWorkspaceSearchOpen
 }: MarkdownFileTreeDrawerProps) {
   const resizeCleanupRef = useRef<(() => unknown) | null>(null);
   const outlineResizeCleanupRef = useRef<(() => unknown) | null>(null);
@@ -826,10 +832,12 @@ export function MarkdownFileTreeDrawer({
   ));
   const activeBacklinks = linkIndex && currentPath ? workspaceBacklinksForPath(linkIndex, currentPath) : [];
   const activeUnlinkedMentions = linkIndex && currentPath ? workspaceUnlinkedMentionsForPath(linkIndex, currentPath) : [];
+  const workspaceSearchVisible = workspaceSearchOpen && workspaceSearchPanel !== null;
   const filePanelAvailable = fileListVisible && (folderOpen || (open && fileCreationAvailable));
   const outlinePanelAvailable = outlineVisible;
   const filePanelRendered =
     filePanelAvailable &&
+    !workspaceSearchVisible &&
     (!tabbedSidebarLayout || activeSidebarPanel === "files");
   const filePanelVisible = filePanelRendered && fileTreeListOpen;
   const filePanelClassName = !fileTreeListOpen
@@ -841,8 +849,12 @@ export function MarkdownFileTreeDrawer({
     !tabbedSidebarLayout && fileTreeListOpen && outlineOpen
       ? { flex: `0 1 ${100 - outlineHeightPercent}%` }
       : undefined;
-  const outlinePanelVisible = outlinePanelAvailable && (!tabbedSidebarLayout || activeSidebarPanel === "outline");
-  const linksPanelVisible = linkPanelAvailable && (!tabbedSidebarLayout || activeSidebarPanel === "links");
+  const outlinePanelVisible = !workspaceSearchVisible
+    && outlinePanelAvailable
+    && (!tabbedSidebarLayout || activeSidebarPanel === "outline");
+  const linksPanelVisible = !workspaceSearchVisible
+    && linkPanelAvailable
+    && (!tabbedSidebarLayout || activeSidebarPanel === "links");
   const linksPanelOpen = tabbedSidebarLayout || documentLinksOpen;
   const linksPanelClassName = tabbedSidebarLayout
     ? "markdown-file-tree-links flex min-h-0 flex-1"
@@ -859,14 +871,19 @@ export function MarkdownFileTreeDrawer({
       : undefined;
   const outlinePanelFlexible = tabbedSidebarLayout || !filePanelAvailable || !fileTreeListOpen;
   const outlineResizerVisible =
+    !workspaceSearchVisible &&
     !tabbedSidebarLayout &&
     outlinePanelAvailable &&
     outlineOpen &&
     filePanelAvailable &&
     fileTreeListOpen;
-  const documentLinksResizerVisible = !tabbedSidebarLayout && linkPanelAvailable && documentLinksOpen;
+  const documentLinksResizerVisible = !workspaceSearchVisible
+    && !tabbedSidebarLayout
+    && linkPanelAvailable
+    && documentLinksOpen;
   const fileSearchVisible = filePanelRendered;
   const folderAccessVisible =
+    !workspaceSearchVisible &&
     recentFolderAreaVisible &&
     filePanelRendered;
   const fileTreeSurfaceClassName = platform === "windows" ? "bg-(--bg-chrome)" : "bg-(--bg-secondary)";
@@ -2770,9 +2787,11 @@ export function MarkdownFileTreeDrawer({
         {fileSearchVisible ? (
           <IconButton
             className={actionButtonClassName}
-            label={label("app.searchMarkdownFiles")}
-            pressed={searchOpen}
-            onClick={toggleFileSearch}
+            label={label(onWorkspaceSearchOpen
+              ? "app.workspaceSearch.searchWorkspace"
+              : "app.searchMarkdownFiles")}
+            pressed={onWorkspaceSearchOpen ? workspaceSearchOpen : searchOpen}
+            onClick={onWorkspaceSearchOpen ?? toggleFileSearch}
           >
             <Search aria-hidden="true" size={14} />
           </IconButton>
@@ -2894,7 +2913,7 @@ export function MarkdownFileTreeDrawer({
   };
 
   const renderSidebarPanelTabs = () => (
-    tabbedSidebarLayout && sidebarPanelTabs.length > 1 ? (
+    !workspaceSearchVisible && tabbedSidebarLayout && sidebarPanelTabs.length > 1 ? (
       <div
         className={`markdown-file-tree-panel-tabs grid h-10 shrink-0 border-b border-(--border-default) px-3 ${sidebarPanelTabGridClassName}`}
         role="group"
@@ -2975,7 +2994,7 @@ export function MarkdownFileTreeDrawer({
             onPointerDown={handleResizePointerDown}
           />
         ) : null}
-        {!tabbedSidebarLayout && filePanelAvailable ? (
+        {!workspaceSearchVisible && !tabbedSidebarLayout && filePanelAvailable ? (
           <div className="markdown-file-tree-files-header grid h-10 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center border-b border-(--border-default) pr-2 pl-3">
             <h2 className="m-0 truncate text-[14px] leading-5 font-[560] tracking-normal text-(--text-heading)">
               {label("app.files")}
@@ -2986,6 +3005,7 @@ export function MarkdownFileTreeDrawer({
         {folderAccessVisible ? renderFolderAccessArea() : null}
 
         <div ref={fileTreeBodyRef} className="markdown-file-tree-body flex min-h-0 flex-1 flex-col">
+          {workspaceSearchVisible ? workspaceSearchPanel : null}
           {filePanelRendered ? (
             <section
               className={`markdown-file-tree-files flex min-h-0 flex-col ${filePanelClassName}`}

--- a/packages/app/src/hooks/useMarkdownDocument.test.tsx
+++ b/packages/app/src/hooks/useMarkdownDocument.test.tsx
@@ -152,6 +152,43 @@ describe("useMarkdownDocument", () => {
     mockedSetNativeEditorWindowRestoreState.mockResolvedValue(undefined);
   });
 
+  it("reports whether a file-tree document opened successfully", async () => {
+    mockedReadNativeMarkdownFile
+      .mockResolvedValueOnce({
+        content: "# Available",
+        name: "available.md",
+        path: "/mock-files/available.md"
+      })
+      .mockRejectedValueOnce(new Error("Synthetic missing file"));
+    const { result } = renderHook(() =>
+      useMarkdownDocument({
+        getCurrentMarkdown: (fallbackContent) => fallbackContent,
+        onTreeRootFromFilePath: vi.fn(),
+        onTreeRootFromFolderPath: vi.fn(),
+        preferencesReady: false,
+        restoreWorkspaceOnStartup: false
+      })
+    );
+
+    let availableOpened = false;
+    let missingOpened = true;
+    await act(async () => {
+      availableOpened = await result.current.openTreeMarkdownFile({
+        name: "available.md",
+        path: "/mock-files/available.md",
+        relativePath: "available.md"
+      });
+      missingOpened = await result.current.openTreeMarkdownFile({
+        name: "missing.md",
+        path: "/mock-files/missing.md",
+        relativePath: "missing.md"
+      });
+    });
+
+    expect(availableOpened).toBe(true);
+    expect(missingOpened).toBe(false);
+  });
+
   it("does not ask to discard an untouched blank document when the editor still exposes stale markdown", async () => {
     let editorMarkdown = "";
     const confirmDiscardUnsavedChanges = vi.fn(() => true);

--- a/packages/app/src/hooks/useMarkdownDocument.ts
+++ b/packages/app/src/hooks/useMarkdownDocument.ts
@@ -1200,12 +1200,14 @@ export function useMarkdownDocument({
       try {
         if (!documentTabsEnabled) {
           const canDiscard = await confirmCanDiscardCurrentDocument();
-          if (!canDiscard) return;
+          if (!canDiscard) return false;
         }
 
         await loadNativeMarkdownPath(file.path, false);
+        return true;
       } catch {
         // Missing or moved files should leave the tree available for another choice.
+        return false;
       }
     },
     [confirmCanDiscardCurrentDocument, documentTabsEnabled, loadNativeMarkdownPath]

--- a/packages/app/src/hooks/useWorkspaceSearch.test.tsx
+++ b/packages/app/src/hooks/useWorkspaceSearch.test.tsx
@@ -4,6 +4,7 @@ import {
   searchNativeMarkdownFilesForPath,
   type NativeMarkdownFolderFile
 } from "../lib/tauri";
+import type { WorkspaceSearchResponse } from "../lib/workspace-search";
 import { useWorkspaceSearch } from "./useWorkspaceSearch";
 
 vi.mock("../lib/tauri", () => ({
@@ -46,6 +47,8 @@ describe("useWorkspaceSearch", () => {
       caseSensitive: false,
       currentDocument: null,
       globalIgnoreRules: "generated/",
+      maxMatches: 1_000,
+      maxMatchesPerFile: 100,
       path: "/vault",
       query: "needle"
     }));
@@ -82,5 +85,62 @@ describe("useWorkspaceSearch", () => {
         kind: "fileName"
       })
     ]));
+  });
+
+  it("clears stale results while a new query is loading", async () => {
+    const file = {
+      name: "guide.md",
+      path: "/vault/guide.md",
+      relativePath: "guide.md"
+    } satisfies NativeMarkdownFolderFile;
+    const fileTreeFiles = [file];
+    mockedSearchNativeMarkdownFilesForPath.mockResolvedValue({
+      results: [{
+        columnNumber: 1,
+        file,
+        id: "/vault/guide.md:0",
+        lineNumber: 1,
+        lineText: "alpha",
+        match: { from: 0, to: 5 },
+        matchIndex: 0,
+        snippet: "alpha"
+      }],
+      searchedFileCount: 1,
+      truncated: false,
+      unreadableFileCount: 0
+    });
+    const { result } = renderHook(() => useWorkspaceSearch({
+      activeImageFile: null,
+      documentContent: "",
+      documentPath: null,
+      fileTreeFiles,
+      fileTreeSourcePath: "/vault"
+    }));
+
+    act(() => {
+      result.current.openSearch();
+      result.current.setQuery("alpha");
+    });
+    await waitFor(() => expect(result.current.response.results).toHaveLength(1));
+
+    let resolveNextSearch: ((response: WorkspaceSearchResponse) => void) | undefined;
+    mockedSearchNativeMarkdownFilesForPath.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveNextSearch = resolve;
+    }));
+    act(() => {
+      result.current.setQuery("beta");
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(result.current.response.results).toEqual([]);
+
+    act(() => {
+      resolveNextSearch?.({
+        results: [],
+        searchedFileCount: 1,
+        truncated: false,
+        unreadableFileCount: 0
+      });
+    });
   });
 });

--- a/packages/app/src/hooks/useWorkspaceSearch.test.tsx
+++ b/packages/app/src/hooks/useWorkspaceSearch.test.tsx
@@ -50,4 +50,37 @@ describe("useWorkspaceSearch", () => {
       query: "needle"
     }));
   });
+
+  it("merges file-name matches into native workspace search results", async () => {
+    const fileTreeFiles: NativeMarkdownFolderFile[] = [{
+      name: "guide.md",
+      path: "/vault/guide.md",
+      relativePath: "guide.md"
+    }];
+    mockedSearchNativeMarkdownFilesForPath.mockResolvedValue({
+      results: [],
+      searchedFileCount: 1,
+      truncated: false,
+      unreadableFileCount: 0
+    });
+    const { result } = renderHook(() => useWorkspaceSearch({
+      activeImageFile: null,
+      documentContent: "",
+      documentPath: null,
+      fileTreeFiles,
+      fileTreeSourcePath: "/vault"
+    }));
+
+    act(() => {
+      result.current.openSearch();
+      result.current.setQuery("guide");
+    });
+
+    await waitFor(() => expect(result.current.response.results).toEqual([
+      expect.objectContaining({
+        id: "file-name:/vault/guide.md",
+        kind: "fileName"
+      })
+    ]));
+  });
 });

--- a/packages/app/src/hooks/useWorkspaceSearch.ts
+++ b/packages/app/src/hooks/useWorkspaceSearch.ts
@@ -4,6 +4,7 @@ import {
   nextGlobalSearchRecentQueries
 } from "../app/workspace-model";
 import {
+  mergeWorkspaceFileNameMatches,
   searchWorkspaceFiles,
   type WorkspaceSearchResponse
 } from "../lib/workspace-search";
@@ -129,7 +130,14 @@ export function useWorkspaceSearch({
             query: trimmedQuery
           }).catch(() => null)
         : null;
-      if (nativeResponse) return nativeResponse;
+      if (nativeResponse) {
+        return mergeWorkspaceFileNameMatches(
+          nativeResponse,
+          fileTreeFiles,
+          trimmedQuery,
+          { caseSensitive }
+        );
+      }
 
       return searchWorkspaceFiles(fileTreeFiles, trimmedQuery, {
         caseSensitive,

--- a/packages/app/src/hooks/useWorkspaceSearch.ts
+++ b/packages/app/src/hooks/useWorkspaceSearch.ts
@@ -15,6 +15,8 @@ import {
 } from "../lib/tauri";
 
 export const globalSearchDebounceMs = 180;
+export const globalSearchMaxMatches = 1_000;
+export const globalSearchMaxMatchesPerFile = 100;
 
 type WorkspaceSearchInput = {
   activeImageFile: NativeMarkdownFolderFile | null;
@@ -113,6 +115,10 @@ export function useWorkspaceSearch({
 
     let active = true;
     setLoading(true);
+    setResponse((current) => ({
+      ...emptyWorkspaceSearchResponse,
+      searchedFileCount: current.searchedFileCount
+    }));
     setRecentQueries((current) => nextGlobalSearchRecentQueries(current, trimmedQuery));
 
     const runGlobalSearch = async () => {
@@ -126,6 +132,8 @@ export function useWorkspaceSearch({
                 }
               : null,
             globalIgnoreRules,
+            maxMatches: globalSearchMaxMatches,
+            maxMatchesPerFile: globalSearchMaxMatchesPerFile,
             path: fileTreeSourcePath,
             query: trimmedQuery
           }).catch(() => null)
@@ -135,12 +143,18 @@ export function useWorkspaceSearch({
           nativeResponse,
           fileTreeFiles,
           trimmedQuery,
-          { caseSensitive }
+          {
+            caseSensitive,
+            maxMatches: globalSearchMaxMatches,
+            maxMatchesPerFile: globalSearchMaxMatchesPerFile
+          }
         );
       }
 
       return searchWorkspaceFiles(fileTreeFiles, trimmedQuery, {
         caseSensitive,
+        maxMatches: globalSearchMaxMatches,
+        maxMatchesPerFile: globalSearchMaxMatchesPerFile,
         readFile: async (path) => {
           if (!activeImageFile && documentPath === path) {
             return {

--- a/packages/app/src/lib/workspace-search.test.ts
+++ b/packages/app/src/lib/workspace-search.test.ts
@@ -1,4 +1,10 @@
-import { searchWorkspaceFiles, type WorkspaceSearchFile } from "./workspace-search";
+import {
+  isWorkspaceFileNameSearchResult,
+  searchWorkspaceFiles,
+  type WorkspaceSearchContentResult,
+  type WorkspaceSearchFile,
+  type WorkspaceSearchResult
+} from "./workspace-search";
 
 const workspaceFiles = [
   { name: "guide.md", path: "/mock-vault/guide.md", relativePath: "guide.md" },
@@ -7,7 +13,30 @@ const workspaceFiles = [
   { name: "release.md", path: "/mock-vault/release.md", relativePath: "release.md" }
 ] satisfies WorkspaceSearchFile[];
 
+function workspaceContentResults(results: readonly WorkspaceSearchResult[]): WorkspaceSearchContentResult[] {
+  return results.filter((result): result is WorkspaceSearchContentResult => (
+    !isWorkspaceFileNameSearchResult(result)
+  ));
+}
+
 describe("workspace search", () => {
+  it("returns files whose names match even when their contents do not", async () => {
+    const search = await searchWorkspaceFiles(workspaceFiles, "guide", {
+      readFile: async (path) => ({
+        content: "synthetic content without the query",
+        path
+      })
+    });
+
+    expect(search.results).toEqual([
+      expect.objectContaining({
+        file: workspaceFiles[0],
+        id: "file-name:/mock-vault/guide.md",
+        kind: "fileName"
+      })
+    ]);
+  });
+
   it("searches markdown file content and ignores folders and assets", async () => {
     const readFile = vi.fn(async (path: string) => ({
       content: path.endsWith("guide.md")
@@ -27,7 +56,7 @@ describe("workspace search", () => {
     expect(readFile).toHaveBeenNthCalledWith(2, "/mock-vault/release.md");
     expect(search.searchedFileCount).toBe(2);
     expect(search.unreadableFileCount).toBe(0);
-    expect(search.results.map((result) => ({
+    expect(workspaceContentResults(search.results).map((result) => ({
       columnNumber: result.columnNumber,
       lineNumber: result.lineNumber,
       lineText: result.lineText,
@@ -69,7 +98,7 @@ describe("workspace search", () => {
       })
     });
 
-    expect(search.results.map((result) => ({
+    expect(workspaceContentResults(search.results).map((result) => ({
       lineText: result.lineText,
       relativePath: result.file.relativePath
     }))).toEqual([
@@ -97,9 +126,10 @@ describe("workspace search", () => {
     });
 
     expect(lateMatchLine.length).toBeLessThan(160);
-    expect(search.results[0]?.snippet).toContain("alpha");
-    expect(search.results[0]?.snippet).toMatch(/^\.\.\./);
-    expect(search.results[0]?.snippet).not.toContain("opening segment");
+    const [result] = workspaceContentResults(search.results);
+    expect(result?.snippet).toContain("alpha");
+    expect(result?.snippet).toMatch(/^\.\.\./);
+    expect(result?.snippet).not.toContain("opening segment");
   });
 
   it("counts unreadable files even after the result limit is reached", async () => {
@@ -129,7 +159,7 @@ describe("workspace search", () => {
     });
 
     expect(search.results).toHaveLength(90);
-    expect(search.results[89]?.lineText).toBe("alpha line 89");
+    expect(workspaceContentResults(search.results)[89]?.lineText).toBe("alpha line 89");
     expect(search.truncated).toBe(false);
   });
 

--- a/packages/app/src/lib/workspace-search.test.ts
+++ b/packages/app/src/lib/workspace-search.test.ts
@@ -37,6 +37,28 @@ describe("workspace search", () => {
     ]);
   });
 
+  it("returns files whose relative paths match even when their names and contents do not", async () => {
+    const file = {
+      name: "guide.md",
+      path: "/mock-vault/docs/guide.md",
+      relativePath: "docs/guide.md"
+    } satisfies WorkspaceSearchFile;
+    const search = await searchWorkspaceFiles([file], "docs", {
+      readFile: async (path) => ({
+        content: "synthetic content without the query",
+        path
+      })
+    });
+
+    expect(search.results).toEqual([
+      expect.objectContaining({
+        file,
+        id: "file-name:/mock-vault/docs/guide.md",
+        kind: "fileName"
+      })
+    ]);
+  });
+
   it("searches markdown file content and ignores folders and assets", async () => {
     const readFile = vi.fn(async (path: string) => ({
       content: path.endsWith("guide.md")

--- a/packages/app/src/lib/workspace-search.test.ts
+++ b/packages/app/src/lib/workspace-search.test.ts
@@ -198,4 +198,40 @@ describe("workspace search", () => {
     expect(search.results).toHaveLength(1);
     expect(search.truncated).toBe(true);
   });
+
+  it("counts file-name matches toward the global result limit", async () => {
+    const file = {
+      name: "alpha.md",
+      path: "/mock-vault/alpha.md",
+      relativePath: "alpha.md"
+    } satisfies WorkspaceSearchFile;
+    const search = await searchWorkspaceFiles([file], "alpha", {
+      maxMatches: 1,
+      maxMatchesPerFile: 5,
+      readFile: async (path) => ({ content: "alpha", path })
+    });
+
+    expect(search.results).toEqual([
+      expect.objectContaining({ kind: "fileName" })
+    ]);
+    expect(search.truncated).toBe(true);
+  });
+
+  it("counts file-name matches toward the per-file result limit", async () => {
+    const file = {
+      name: "alpha.md",
+      path: "/mock-vault/alpha.md",
+      relativePath: "alpha.md"
+    } satisfies WorkspaceSearchFile;
+    const search = await searchWorkspaceFiles([file], "alpha", {
+      maxMatches: 10,
+      maxMatchesPerFile: 1,
+      readFile: async (path) => ({ content: "alpha", path })
+    });
+
+    expect(search.results).toEqual([
+      expect.objectContaining({ kind: "fileName" })
+    ]);
+    expect(search.truncated).toBe(true);
+  });
 });

--- a/packages/app/src/lib/workspace-search.ts
+++ b/packages/app/src/lib/workspace-search.ts
@@ -79,14 +79,16 @@ export function mergeWorkspaceFileNameMatches(
   if (!normalizedQuery) return response;
 
   const searchableFiles = files.filter(isWorkspaceSearchableFile);
-  const matchingFilePaths = new Set(searchableFiles.flatMap((file) =>
-    findSearchRanges(file.name, normalizedQuery, {
-      caseSensitive: options.caseSensitive,
-      maxMatches: 1
-    }).length > 0
-      ? [file.path]
-      : []
-  ));
+  const matchingFilePaths = new Set(searchableFiles.flatMap((file) => {
+    const matchesNameOrPath = [file.name, file.relativePath].some((candidate) =>
+      findSearchRanges(candidate, normalizedQuery, {
+        caseSensitive: options.caseSensitive,
+        maxMatches: 1
+      }).length > 0
+    );
+
+    return matchesNameOrPath ? [file.path] : [];
+  }));
   if (matchingFilePaths.size === 0) return response;
 
   const contentResultsByPath = new Map<string, WorkspaceSearchContentResult[]>();

--- a/packages/app/src/lib/workspace-search.ts
+++ b/packages/app/src/lib/workspace-search.ts
@@ -73,7 +73,11 @@ export function mergeWorkspaceFileNameMatches(
   response: WorkspaceSearchResponse,
   files: readonly WorkspaceSearchFile[],
   query: string,
-  options: { caseSensitive?: boolean } = {}
+  options: {
+    caseSensitive?: boolean;
+    maxMatches?: number;
+    maxMatchesPerFile?: number;
+  } = {}
 ): WorkspaceSearchResponse {
   const normalizedQuery = query.trim();
   if (!normalizedQuery) return response;
@@ -92,17 +96,12 @@ export function mergeWorkspaceFileNameMatches(
   if (matchingFilePaths.size === 0) return response;
 
   const contentResultsByPath = new Map<string, WorkspaceSearchContentResult[]>();
-  const contentResultsOutsideFileTree: WorkspaceSearchContentResult[] = [];
-  const searchableFilePaths = new Set(searchableFiles.map((file) => file.path));
+  const resultFilesByPath = new Map<string, WorkspaceSearchFile>();
 
   response.results.forEach((result) => {
     if (isWorkspaceFileNameSearchResult(result)) return;
 
-    if (!searchableFilePaths.has(result.file.path)) {
-      contentResultsOutsideFileTree.push(result);
-      return;
-    }
-
+    resultFilesByPath.set(result.file.path, result.file);
     const fileResults = contentResultsByPath.get(result.file.path);
     if (fileResults) {
       fileResults.push(result);
@@ -115,25 +114,65 @@ export function mergeWorkspaceFileNameMatches(
   const contentOnlyFiles = searchableFiles.filter((file) => (
     !matchingFilePaths.has(file.path) && contentResultsByPath.has(file.path)
   ));
-  const results: WorkspaceSearchResult[] = [];
+  const orderedPaths: string[] = [];
+  const orderedPathSet = new Set<string>();
+  const addOrderedPath = (path: string) => {
+    if (orderedPathSet.has(path)) return;
 
-  for (const file of [...fileNameMatchedFiles, ...contentOnlyFiles]) {
-    if (matchingFilePaths.has(file.path)) {
-      results.push({
+    orderedPathSet.add(path);
+    orderedPaths.push(path);
+  };
+
+  fileNameMatchedFiles.forEach((file) => addOrderedPath(file.path));
+  contentOnlyFiles.forEach((file) => addOrderedPath(file.path));
+  response.results.forEach((result) => {
+    if (!isWorkspaceFileNameSearchResult(result)) addOrderedPath(result.file.path);
+  });
+
+  const filesByPath = new Map(searchableFiles.map((file) => [file.path, file]));
+  const maxMatches = options.maxMatches === undefined ? undefined : Math.max(0, options.maxMatches);
+  const maxMatchesPerFile = options.maxMatchesPerFile === undefined
+    ? undefined
+    : Math.max(0, options.maxMatchesPerFile);
+  const results: WorkspaceSearchResult[] = [];
+  let truncated = response.truncated;
+
+  for (const path of orderedPaths) {
+    const file = filesByPath.get(path) ?? resultFilesByPath.get(path);
+    if (!file) continue;
+
+    const fileResults: WorkspaceSearchResult[] = [];
+    if (matchingFilePaths.has(path)) {
+      fileResults.push({
         file,
         id: `file-name:${file.path}`,
         kind: "fileName"
       });
     }
 
-    results.push(...(contentResultsByPath.get(file.path) ?? []));
-  }
+    const contentResults = contentResultsByPath.get(path) ?? [];
+    const remainingFileResultCount = maxMatchesPerFile === undefined
+      ? contentResults.length
+      : Math.max(0, maxMatchesPerFile - fileResults.length);
+    if (contentResults.length > remainingFileResultCount) truncated = true;
+    fileResults.push(...contentResults.slice(0, remainingFileResultCount));
 
-  results.push(...contentResultsOutsideFileTree);
+    const remainingResultCount = maxMatches === undefined
+      ? fileResults.length
+      : Math.max(0, maxMatches - results.length);
+    if (fileResults.length > remainingResultCount) truncated = true;
+    results.push(...fileResults.slice(0, remainingResultCount));
+
+    if (maxMatches !== undefined && results.length >= maxMatches) {
+      if (orderedPaths.at(-1) !== path) truncated = true;
+      break;
+    }
+  }
 
   return {
     ...response,
-    results
+    results,
+    truncated
   };
 }
 
@@ -200,7 +239,9 @@ export async function searchWorkspaceFiles(
     truncated: truncatedByFileLimit || (maxMatches !== undefined && collectedMatchCount > maxMatches),
     unreadableFileCount
   }, searchableFiles, normalizedQuery, {
-    caseSensitive: options.caseSensitive
+    caseSensitive: options.caseSensitive,
+    maxMatches,
+    maxMatchesPerFile
   });
 }
 

--- a/packages/app/src/lib/workspace-search.ts
+++ b/packages/app/src/lib/workspace-search.ts
@@ -3,16 +3,25 @@ import type { NativeMarkdownFolderFile } from "./tauri";
 
 export type WorkspaceSearchFile = Pick<NativeMarkdownFolderFile, "kind" | "name" | "path" | "relativePath">;
 
-export type WorkspaceSearchResult = {
+export type WorkspaceSearchContentResult = {
   columnNumber: number;
   file: WorkspaceSearchFile;
   id: string;
+  kind?: "content";
   lineNumber: number;
   lineText: string;
   match: SearchRange;
   matchIndex: number;
   snippet: string;
 };
+
+export type WorkspaceSearchFileNameResult = {
+  file: WorkspaceSearchFile;
+  id: string;
+  kind: "fileName";
+};
+
+export type WorkspaceSearchResult = WorkspaceSearchContentResult | WorkspaceSearchFileNameResult;
 
 export type WorkspaceSearchResponse = {
   results: WorkspaceSearchResult[];
@@ -50,6 +59,80 @@ const snippetMaxLength = 96;
 
 export function isWorkspaceSearchableFile(file: WorkspaceSearchFile) {
   return file.kind !== "asset" && file.kind !== "attachment" && file.kind !== "folder";
+}
+
+export function isWorkspaceFileNameSearchResult(
+  result: WorkspaceSearchResult
+): result is WorkspaceSearchFileNameResult {
+  return result.kind === "fileName";
+}
+
+// Merge names after content search so native and browser fallbacks share one result contract
+// without making the native content index return synthetic line matches.
+export function mergeWorkspaceFileNameMatches(
+  response: WorkspaceSearchResponse,
+  files: readonly WorkspaceSearchFile[],
+  query: string,
+  options: { caseSensitive?: boolean } = {}
+): WorkspaceSearchResponse {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return response;
+
+  const searchableFiles = files.filter(isWorkspaceSearchableFile);
+  const matchingFilePaths = new Set(searchableFiles.flatMap((file) =>
+    findSearchRanges(file.name, normalizedQuery, {
+      caseSensitive: options.caseSensitive,
+      maxMatches: 1
+    }).length > 0
+      ? [file.path]
+      : []
+  ));
+  if (matchingFilePaths.size === 0) return response;
+
+  const contentResultsByPath = new Map<string, WorkspaceSearchContentResult[]>();
+  const contentResultsOutsideFileTree: WorkspaceSearchContentResult[] = [];
+  const searchableFilePaths = new Set(searchableFiles.map((file) => file.path));
+
+  response.results.forEach((result) => {
+    if (isWorkspaceFileNameSearchResult(result)) return;
+
+    if (!searchableFilePaths.has(result.file.path)) {
+      contentResultsOutsideFileTree.push(result);
+      return;
+    }
+
+    const fileResults = contentResultsByPath.get(result.file.path);
+    if (fileResults) {
+      fileResults.push(result);
+    } else {
+      contentResultsByPath.set(result.file.path, [result]);
+    }
+  });
+
+  const fileNameMatchedFiles = searchableFiles.filter((file) => matchingFilePaths.has(file.path));
+  const contentOnlyFiles = searchableFiles.filter((file) => (
+    !matchingFilePaths.has(file.path) && contentResultsByPath.has(file.path)
+  ));
+  const results: WorkspaceSearchResult[] = [];
+
+  for (const file of [...fileNameMatchedFiles, ...contentOnlyFiles]) {
+    if (matchingFilePaths.has(file.path)) {
+      results.push({
+        file,
+        id: `file-name:${file.path}`,
+        kind: "fileName"
+      });
+    }
+
+    results.push(...(contentResultsByPath.get(file.path) ?? []));
+  }
+
+  results.push(...contentResultsOutsideFileTree);
+
+  return {
+    ...response,
+    results
+  };
 }
 
 export async function searchWorkspaceFiles(
@@ -109,12 +192,14 @@ export async function searchWorkspaceFiles(
     if (maxMatches !== undefined && results.length >= maxMatches) break;
   }
 
-  return {
+  return mergeWorkspaceFileNameMatches({
     results,
     searchedFileCount: searchableFiles.length,
     truncated: truncatedByFileLimit || (maxMatches !== undefined && collectedMatchCount > maxMatches),
     unreadableFileCount
-  };
+  }, searchableFiles, normalizedQuery, {
+    caseSensitive: options.caseSensitive
+  });
 }
 
 function findWorkspaceSearchResults(
@@ -143,7 +228,7 @@ function findWorkspaceSearchResults(
       match: range,
       matchIndex,
       snippet: workspaceSearchSnippet(line.text, line.columnNumber, range.to - range.from)
-    } satisfies WorkspaceSearchResult;
+    } satisfies WorkspaceSearchContentResult;
   });
 
   return {

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "Suchergebnisse für {path}",
   "app.workspaceSearch.loading": "Suche läuft...",
   "app.workspaceSearch.noResults": "Keine Ergebnisse",
+  "app.workspaceSearch.openFile": "{path} öffnen",
   "app.workspaceSearch.openResult": "{path} Zeile {line} öffnen",
   "app.workspaceSearch.placeholder": "Dateien durchsuchen",
   "app.workspaceSearch.recentSearch": "Nach {query} suchen",

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -703,6 +703,7 @@ const messages: BaseLocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "{path} search results",
   "app.workspaceSearch.loading": "Searching...",
   "app.workspaceSearch.noResults": "No results",
+  "app.workspaceSearch.openFile": "Open {path}",
   "app.workspaceSearch.openResult": "Open {path} line {line}",
   "app.workspaceSearch.placeholder": "Search files",
   "app.workspaceSearch.recentSearch": "Search for {query}",

--- a/packages/shared/src/i18n/locales/es.ts
+++ b/packages/shared/src/i18n/locales/es.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "Resultados de búsqueda de {path}",
   "app.workspaceSearch.loading": "Buscando...",
   "app.workspaceSearch.noResults": "Sin resultados",
+  "app.workspaceSearch.openFile": "Abrir {path}",
   "app.workspaceSearch.openResult": "Abrir {path} línea {line}",
   "app.workspaceSearch.placeholder": "Buscar en archivos",
   "app.workspaceSearch.recentSearch": "Buscar {query}",

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "Résultats de recherche pour {path}",
   "app.workspaceSearch.loading": "Recherche...",
   "app.workspaceSearch.noResults": "Aucun résultat",
+  "app.workspaceSearch.openFile": "Ouvrir {path}",
   "app.workspaceSearch.openResult": "Ouvrir {path} ligne {line}",
   "app.workspaceSearch.placeholder": "Rechercher dans les fichiers",
   "app.workspaceSearch.recentSearch": "Rechercher {query}",

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "Risultati di ricerca per {path}",
   "app.workspaceSearch.loading": "Ricerca...",
   "app.workspaceSearch.noResults": "Nessun risultato",
+  "app.workspaceSearch.openFile": "Apri {path}",
   "app.workspaceSearch.openResult": "Apri {path} riga {line}",
   "app.workspaceSearch.placeholder": "Cerca nei file",
   "app.workspaceSearch.recentSearch": "Cerca {query}",

--- a/packages/shared/src/i18n/locales/ja.ts
+++ b/packages/shared/src/i18n/locales/ja.ts
@@ -359,6 +359,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "{path} の検索結果",
   "app.workspaceSearch.loading": "検索中...",
   "app.workspaceSearch.noResults": "結果なし",
+  "app.workspaceSearch.openFile": "{path} を開く",
   "app.workspaceSearch.openResult": "{path} の {line} 行目を開く",
   "app.workspaceSearch.placeholder": "ファイル内容を検索",
   "app.workspaceSearch.recentSearch": "{query} を検索",

--- a/packages/shared/src/i18n/locales/ko.ts
+++ b/packages/shared/src/i18n/locales/ko.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "{path} 검색 결과",
   "app.workspaceSearch.loading": "검색 중...",
   "app.workspaceSearch.noResults": "결과 없음",
+  "app.workspaceSearch.openFile": "{path} 열기",
   "app.workspaceSearch.openResult": "{path} {line}행 열기",
   "app.workspaceSearch.placeholder": "파일 내용 검색",
   "app.workspaceSearch.recentSearch": "{query} 검색",

--- a/packages/shared/src/i18n/locales/pt-BR.ts
+++ b/packages/shared/src/i18n/locales/pt-BR.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "Resultados de busca de {path}",
   "app.workspaceSearch.loading": "Buscando...",
   "app.workspaceSearch.noResults": "Nenhum resultado",
+  "app.workspaceSearch.openFile": "Abrir {path}",
   "app.workspaceSearch.openResult": "Abrir {path} linha {line}",
   "app.workspaceSearch.placeholder": "Buscar nos arquivos",
   "app.workspaceSearch.recentSearch": "Buscar {query}",

--- a/packages/shared/src/i18n/locales/ru.ts
+++ b/packages/shared/src/i18n/locales/ru.ts
@@ -351,6 +351,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "Результаты поиска для {path}",
   "app.workspaceSearch.loading": "Идет поиск...",
   "app.workspaceSearch.noResults": "Нет результатов",
+  "app.workspaceSearch.openFile": "Открыть {path}",
   "app.workspaceSearch.openResult": "Открыть {path}, строка {line}",
   "app.workspaceSearch.placeholder": "Искать в файлах",
   "app.workspaceSearch.recentSearch": "Искать {query}",

--- a/packages/shared/src/i18n/locales/types.ts
+++ b/packages/shared/src/i18n/locales/types.ts
@@ -714,6 +714,7 @@ export type I18nKey =
   | "app.workspaceSearch.fileSearchResults"
   | "app.workspaceSearch.loading"
   | "app.workspaceSearch.noResults"
+  | "app.workspaceSearch.openFile"
   | "app.workspaceSearch.openResult"
   | "app.workspaceSearch.placeholder"
   | "app.workspaceSearch.recentSearch"

--- a/packages/shared/src/i18n/locales/zh-CN.ts
+++ b/packages/shared/src/i18n/locales/zh-CN.ts
@@ -703,6 +703,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "{path} 搜索结果",
   "app.workspaceSearch.loading": "搜索中...",
   "app.workspaceSearch.noResults": "没有结果",
+  "app.workspaceSearch.openFile": "打开 {path}",
   "app.workspaceSearch.openResult": "打开 {path} 第 {line} 行",
   "app.workspaceSearch.placeholder": "搜索文件内容",
   "app.workspaceSearch.recentSearch": "搜索 {query}",

--- a/packages/shared/src/i18n/locales/zh-TW.ts
+++ b/packages/shared/src/i18n/locales/zh-TW.ts
@@ -359,6 +359,7 @@ const messages: LocaleMessages = {
   "app.workspaceSearch.fileSearchResults": "{path} 搜尋結果",
   "app.workspaceSearch.loading": "搜尋中...",
   "app.workspaceSearch.noResults": "沒有結果",
+  "app.workspaceSearch.openFile": "開啟 {path}",
   "app.workspaceSearch.openResult": "開啟 {path} 第 {line} 行",
   "app.workspaceSearch.placeholder": "搜尋檔案內容",
   "app.workspaceSearch.recentSearch": "搜尋 {query}",

--- a/packages/shared/src/search.test.ts
+++ b/packages/shared/src/search.test.ts
@@ -26,6 +26,12 @@ describe("document search", () => {
     expect(findSearchRanges("İ, exact", ",")).toEqual([{ from: 1, to: 2 }]);
   });
 
+  it("maps case-insensitive matches back across length-changing case folds", () => {
+    expect(findSearchRanges("İstanbul.md", "i")).toEqual([{ from: 0, to: 1 }]);
+    expect(findSearchRanges("İ ΟΣ", "ος")).toEqual([{ from: 2, to: 4 }]);
+    expect(findSearchRanges("Straße.md", "STRASSE")).toEqual([{ from: 0, to: 6 }]);
+  });
+
   it("stops collecting ranges once the match limit is reached", () => {
     expect(findSearchRanges("alpha beta alpha gamma alpha", "alpha", { maxMatches: 2 })).toEqual([
       { from: 0, to: 5 },

--- a/packages/shared/src/search.ts
+++ b/packages/shared/src/search.ts
@@ -11,30 +11,83 @@ type SearchOptions = {
 export function findSearchRanges(text: string, query: string, options: SearchOptions = {}): SearchRange[] {
   if (!query) return [];
 
-  const ranges: SearchRange[] = [];
   const maxMatches = Math.max(0, options.maxMatches ?? Number.POSITIVE_INFINITY);
-  if (maxMatches === 0) return ranges;
+  if (maxMatches === 0) return [];
 
-  const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
+  if (options.caseSensitive) {
+    return searchRangesInText(text, query, maxMatches);
+  }
+
+  const normalizedText = caseFoldSearchText(text);
+  const normalizedQuery = caseFoldSearchText(query);
+  if (!normalizedQuery) return [];
+
+  if (normalizedText.length === text.length && normalizedQuery.length === query.length) {
+    return searchRangesInText(normalizedText, normalizedQuery, maxMatches);
+  }
+
+  const offsetMappedQuery = Array.from(query, caseFoldSearchText).join("");
+  return searchRangesWithOriginalOffsets(text, offsetMappedQuery, maxMatches);
+}
+
+function caseFoldSearchText(value: string) {
+  return value
+    .toLocaleLowerCase()
+    .replaceAll("ς", "σ")
+    .replaceAll("ß", "ss");
+}
+
+function searchRangesInText(text: string, query: string, maxMatches: number) {
+  const ranges: SearchRange[] = [];
   let from = 0;
 
   while (from <= text.length - query.length) {
-    const candidate = text.slice(from, from + query.length);
-    const matches = options.caseSensitive
-      ? candidate === query
-      : candidate.toLocaleLowerCase() === needle;
+    const matchFrom = text.indexOf(query, from);
+    if (matchFrom < 0) break;
 
-    if (matches) {
-      ranges.push({
-        from,
-        to: from + query.length
-      });
-      if (ranges.length >= maxMatches) return ranges;
-      from += Math.max(1, query.length);
-      continue;
+    ranges.push({
+      from: matchFrom,
+      to: matchFrom + query.length
+    });
+    if (ranges.length >= maxMatches) break;
+    from = matchFrom + Math.max(1, query.length);
+  }
+
+  return ranges;
+}
+
+function searchRangesWithOriginalOffsets(text: string, normalizedQuery: string, maxMatches: number) {
+  const normalizedCharacters: string[] = [];
+  const originalStarts: number[] = [];
+  const originalEnds: number[] = [];
+  let originalOffset = 0;
+
+  for (const character of text) {
+    const originalEnd = originalOffset + character.length;
+    const normalizedCharacter = caseFoldSearchText(character);
+
+    for (let index = 0; index < normalizedCharacter.length; index += 1) {
+      normalizedCharacters.push(normalizedCharacter[index] ?? "");
+      originalStarts.push(originalOffset);
+      originalEnds.push(originalEnd);
     }
 
-    from += 1;
+    originalOffset = originalEnd;
+  }
+
+  const normalizedText = normalizedCharacters.join("");
+  const normalizedRanges = searchRangesInText(normalizedText, normalizedQuery, maxMatches);
+  const ranges: SearchRange[] = [];
+
+  for (const range of normalizedRanges) {
+    const from = originalStarts[range.from];
+    const to = originalEnds[range.to - 1];
+    if (from === undefined || to === undefined) continue;
+
+    const previousRange = ranges.at(-1);
+    if (previousRange?.from === from && previousRange.to === to) continue;
+
+    ranges.push({ from, to });
   }
 
   return ranges;


### PR DESCRIPTION
## Summary
- keep the file-toolbar magnifier as an embedded sidebar workspace search
- keep `Cmd/Ctrl+Shift+F` opening the established editor-area search dialog
- merge file-name and relative-path matches with indexed content matches, including Unicode-aware matching and highlighted path segments
- position content results directly in the editor without opening the document search bar
- bound search work to 1,000 total results and 100 results per file, with strict truncation across file and content matches
- clear stale results during new requests, reset expanded previews between queries, and constrain narrow-sidebar status text

## Why
Issue #644 reports that the visible sidebar search only filters file paths, while workspace content search is separate and difficult to discover. The two existing entry layouts remain distinct, but now share the same hardened file/path/content search behavior.

## Validation
- `pnpm --filter @markra/app test` — 134 files, 1545 tests passed
- `pnpm --filter @markra/app typecheck:test` — passed
- `pnpm --filter @markra/shared test` — 7 files, 64 tests passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml markdown_files::search::tests --lib` — 10 tests passed
- `pnpm --filter @markra/desktop test -- src/runtime/tauri/file.test.ts` — 71 tests passed
- `pnpm --filter @markra/web build` — passed
- `pnpm --filter @markra/desktop build` — passed, including vendor chunk verification
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check` — passed
- local browser QA — sidebar magnifier opened sidebar search; `Cmd+Shift+F` switched to the editor dialog and restored the file tree; console had no warnings or errors

## Risk
- no dependency, configuration, or persisted-data changes
- native indexed content search remains unchanged; native byte ranges are converted to UTF-16 only at the editor-facing response boundary
- result limits intentionally cap very large searches and surface the existing truncated-result state
- sidebar and dialog presentations continue sharing query state, results, case sensitivity, and recent searches

Closes #644