### PR TITLE
fix(editor): render math in visual table cells

### DIFF
--- a/packages/editor/src/codemirror/inline-markdown.ts
+++ b/packages/editor/src/codemirror/inline-markdown.ts
@@ -1,4 +1,14 @@
 import { parser, GFM } from "@lezer/markdown";
+import {
+  createMarkraMathMacros,
+  renderMarkraMathToString,
+  type MarkraMathMacros,
+} from "../math-render.ts";
+import {
+  findMarkraMathRanges,
+  type MarkraMathRange,
+  type MarkraSourceRange,
+} from "../math-syntax.ts";
 import { markraHighlight } from "./highlight.ts";
 import { resolveSafeImageSource } from "./image.ts";
 import {
@@ -32,6 +42,12 @@ export interface InlineMarkdownRenderOptions {
     details: InlineMarkdownImageDetails,
   ) => string | null;
   readonly resolveLinkTarget?: (source: string) => string | null;
+}
+
+interface InlineMarkdownRenderContext {
+  readonly mathMacros: MarkraMathMacros;
+  readonly mathRanges: readonly MarkraMathRange[];
+  readonly options: InlineMarkdownRenderOptions;
 }
 
 function resolveLinkHref(
@@ -84,6 +100,79 @@ function childNodes(node: InlineNode) {
   return children;
 }
 
+function inlineCodeRanges(node: InlineNode) {
+  const ranges: MarkraSourceRange[] = [];
+  const visit = (current: InlineNode) => {
+    if (current.name === "InlineCode") {
+      ranges.push({ from: current.from, to: current.to });
+      return;
+    }
+    for (const child of childNodes(current)) visit(child);
+  };
+  visit(node);
+  return ranges;
+}
+
+function appendMath(
+  parent: Node,
+  ownerDocument: Document,
+  range: MarkraMathRange,
+  macros: MarkraMathMacros,
+) {
+  const element = ownerDocument.createElement("span");
+  element.className = "markra-math-render markra-math-render-inline";
+  element.contentEditable = "false";
+  element.dataset.markraMathMarkdown = range.source;
+  element.innerHTML = renderMarkraMathToString(range.tex, "inline", macros);
+  element.setAttribute("aria-label", "Edit math source");
+  element.setAttribute("role", "button");
+  parent.appendChild(element);
+}
+
+function appendTextWithMath(
+  parent: Node,
+  ownerDocument: Document,
+  source: string,
+  from: number,
+  to: number,
+  context: InlineMarkdownRenderContext,
+) {
+  let cursor = from;
+  for (const range of context.mathRanges) {
+    if (
+      range.kind !== "inline" ||
+      range.from < from ||
+      range.to > to
+    ) {
+      continue;
+    }
+    appendText(parent, source, cursor, range.from);
+    appendMath(parent, ownerDocument, range, context.mathMacros);
+    cursor = range.to;
+  }
+  appendText(parent, source, cursor, to);
+}
+
+function mathRangeCrossingChild(
+  child: InlineNode,
+  from: number,
+  to: number,
+  cursor: number,
+  ranges: readonly MarkraMathRange[],
+) {
+  // TeX punctuation can look like Markdown, so a formula that crosses a parsed
+  // child boundary must stay atomic instead of inheriting that child markup.
+  return ranges.find((range) =>
+    range.kind === "inline" &&
+    range.from >= cursor &&
+    range.from >= from &&
+    range.to <= to &&
+    range.from < child.to &&
+    range.to > child.from &&
+    !(child.from <= range.from && child.to >= range.to)
+  );
+}
+
 function renderRange(
   parent: Node,
   ownerDocument: Document,
@@ -91,14 +180,41 @@ function renderRange(
   node: InlineNode,
   from: number,
   to: number,
-  options: InlineMarkdownRenderOptions,
+  context: InlineMarkdownRenderContext,
 ) {
   let cursor = from;
   for (const child of childNodes(node)) {
-    if (child.to <= from || child.from >= to) continue;
+    if (child.to <= from || child.from >= to || child.to <= cursor) continue;
     const childFrom = Math.max(from, child.from);
     const childTo = Math.min(to, child.to);
-    appendText(parent, source, cursor, childFrom);
+    const crossingMath = mathRangeCrossingChild(
+      child,
+      from,
+      to,
+      cursor,
+      context.mathRanges,
+    );
+    if (crossingMath) {
+      appendTextWithMath(
+        parent,
+        ownerDocument,
+        source,
+        cursor,
+        crossingMath.from,
+        context,
+      );
+      appendMath(parent, ownerDocument, crossingMath, context.mathMacros);
+      cursor = crossingMath.to;
+      continue;
+    }
+    appendTextWithMath(
+      parent,
+      ownerDocument,
+      source,
+      cursor,
+      childFrom,
+      context,
+    );
     if (!markerNodes.has(child.name)) {
       renderNode(
         parent,
@@ -107,12 +223,12 @@ function renderRange(
         child,
         childFrom,
         childTo,
-        options,
+        context,
       );
     }
     cursor = Math.max(cursor, childTo);
   }
-  appendText(parent, source, cursor, to);
+  appendTextWithMath(parent, ownerDocument, source, cursor, to, context);
 }
 
 function wrappedNode(
@@ -121,7 +237,7 @@ function wrappedNode(
   source: string,
   node: InlineNode,
   tagName: "del" | "em" | "mark" | "strong",
-  options: InlineMarkdownRenderOptions,
+  context: InlineMarkdownRenderContext,
 ) {
   const element = ownerDocument.createElement(tagName);
   renderRange(
@@ -131,7 +247,7 @@ function wrappedNode(
     node,
     node.from,
     node.to,
-    options,
+    context,
   );
   parent.appendChild(element);
 }
@@ -141,7 +257,7 @@ function renderLink(
   ownerDocument: Document,
   source: string,
   node: InlineNode,
-  options: InlineMarkdownRenderOptions,
+  context: InlineMarkdownRenderContext,
 ) {
   const children = childNodes(node);
   const marks = children.filter((child) => child.name === "LinkMark");
@@ -156,7 +272,7 @@ function renderLink(
   const href = resolveLinkHref(
     source.slice(url.from, url.to).trim(),
     false,
-    options,
+    context.options,
   );
   const element = ownerDocument.createElement(href ? "a" : "span");
   element.dataset.markraLinkMarkdown = source.slice(node.from, node.to);
@@ -173,7 +289,7 @@ function renderLink(
     node,
     labelFrom,
     labelTo,
-    options,
+    context,
   );
   parent.appendChild(element);
   if (href) {
@@ -190,7 +306,7 @@ function renderAutolink(
   ownerDocument: Document,
   source: string,
   node: InlineNode,
-  options: InlineMarkdownRenderOptions,
+  context: InlineMarkdownRenderContext,
 ) {
   const url = node.name === "URL"
     ? node
@@ -201,7 +317,7 @@ function renderAutolink(
   }
 
   const linkSource = unescapeMarkdown(source.slice(url.from, url.to).trim());
-  const href = resolveLinkHref(linkSource, true, options);
+  const href = resolveLinkHref(linkSource, true, context.options);
   const element = ownerDocument.createElement(href ? "a" : "span");
   element.dataset.markraLinkMarkdown = source.slice(node.from, node.to);
   element.dataset.markraLinkSource = href ?? linkSource;
@@ -226,7 +342,7 @@ function renderImage(
   ownerDocument: Document,
   source: string,
   node: InlineNode,
-  options: InlineMarkdownRenderOptions,
+  context: InlineMarkdownRenderContext,
 ) {
   const children = childNodes(node);
   const marks = children.filter((child) => child.name === "LinkMark");
@@ -249,8 +365,8 @@ function renderImage(
   };
   let resolvedSource: string | null;
   try {
-    resolvedSource = options.resolveImageSource
-      ? options.resolveImageSource(details)
+    resolvedSource = context.options.resolveImageSource
+      ? context.options.resolveImageSource(details)
       : resolveSafeImageSource(details.source);
   } catch {
     resolvedSource = null;
@@ -284,20 +400,20 @@ function renderNode(
   node: InlineNode,
   from = node.from,
   to = node.to,
-  options: InlineMarkdownRenderOptions = {},
+  context: InlineMarkdownRenderContext,
 ) {
   switch (node.name) {
     case "StrongEmphasis":
-      wrappedNode(parent, ownerDocument, source, node, "strong", options);
+      wrappedNode(parent, ownerDocument, source, node, "strong", context);
       return;
     case "Emphasis":
-      wrappedNode(parent, ownerDocument, source, node, "em", options);
+      wrappedNode(parent, ownerDocument, source, node, "em", context);
       return;
     case "Strikethrough":
-      wrappedNode(parent, ownerDocument, source, node, "del", options);
+      wrappedNode(parent, ownerDocument, source, node, "del", context);
       return;
     case "Highlight":
-      wrappedNode(parent, ownerDocument, source, node, "mark", options);
+      wrappedNode(parent, ownerDocument, source, node, "mark", context);
       return;
     case "InlineCode": {
       const element = ownerDocument.createElement("code");
@@ -311,11 +427,11 @@ function renderNode(
       return;
     }
     case "Link":
-      renderLink(parent, ownerDocument, source, node, options);
+      renderLink(parent, ownerDocument, source, node, context);
       return;
     case "Autolink":
     case "URL":
-      renderAutolink(parent, ownerDocument, source, node, options);
+      renderAutolink(parent, ownerDocument, source, node, context);
       return;
     case "HardBreak":
       {
@@ -346,11 +462,11 @@ function renderNode(
       }
       return;
     case "Image": {
-      renderImage(parent, ownerDocument, source, node, options);
+      renderImage(parent, ownerDocument, source, node, context);
       return;
     }
     default:
-      renderRange(parent, ownerDocument, source, node, from, to, options);
+      renderRange(parent, ownerDocument, source, node, from, to, context);
   }
 }
 
@@ -361,6 +477,11 @@ export function renderInlineMarkdown(
 ) {
   target.replaceChildren();
   const tree = inlineParser.parse(source);
+  const context: InlineMarkdownRenderContext = {
+    mathMacros: createMarkraMathMacros(),
+    mathRanges: findMarkraMathRanges(source, inlineCodeRanges(tree.topNode)),
+    options,
+  };
   renderRange(
     target,
     target.ownerDocument,
@@ -368,7 +489,7 @@ export function renderInlineMarkdown(
     tree.topNode,
     0,
     source.length,
-    options,
+    context,
   );
 }
 
@@ -379,6 +500,11 @@ function serializeNode(node: Node): string {
       .replace(/\|/gu, "\\|");
   }
   if (!(node instanceof HTMLElement)) return "";
+  // KaTeX emits duplicate visual and accessibility text; only the authored
+  // Markdown is a valid table-cell serialization of the formula.
+  if (node.dataset.markraMathMarkdown) {
+    return node.dataset.markraMathMarkdown;
+  }
   const content = Array.from(node.childNodes, serializeNode).join("");
   switch (node.tagName) {
     case "STRONG":

--- a/packages/editor/src/codemirror/inline-markdown.ts
+++ b/packages/editor/src/codemirror/inline-markdown.ts
@@ -117,15 +117,20 @@ function appendMath(
   parent: Node,
   ownerDocument: Document,
   range: MarkraMathRange,
-  macros: MarkraMathMacros,
+  context: InlineMarkdownRenderContext,
 ) {
-  const element = ownerDocument.createElement("span");
+  const element = ownerDocument.createElement("button");
+  element.type = "button";
   element.className = "markra-math-render markra-math-render-inline";
   element.contentEditable = "false";
+  element.tabIndex = -1;
   element.dataset.markraMathMarkdown = range.source;
-  element.innerHTML = renderMarkraMathToString(range.tex, "inline", macros);
+  element.innerHTML = renderMarkraMathToString(
+    range.tex,
+    "inline",
+    context.mathMacros,
+  );
   element.setAttribute("aria-label", "Edit math source");
-  element.setAttribute("role", "button");
   parent.appendChild(element);
 }
 
@@ -147,7 +152,7 @@ function appendTextWithMath(
       continue;
     }
     appendText(parent, source, cursor, range.from);
-    appendMath(parent, ownerDocument, range, context.mathMacros);
+    appendMath(parent, ownerDocument, range, context);
     cursor = range.to;
   }
   appendText(parent, source, cursor, to);
@@ -203,7 +208,7 @@ function renderRange(
         crossingMath.from,
         context,
       );
-      appendMath(parent, ownerDocument, crossingMath, context.mathMacros);
+      appendMath(parent, ownerDocument, crossingMath, context);
       cursor = crossingMath.to;
       continue;
     }

--- a/packages/editor/src/codemirror/inline-markdown.ts
+++ b/packages/editor/src/codemirror/inline-markdown.ts
@@ -38,6 +38,7 @@ export interface InlineMarkdownImageDetails {
 }
 
 export interface InlineMarkdownRenderOptions {
+  readonly revealedMathRange?: MarkraSourceRange;
   readonly resolveImageSource?: (
     details: InlineMarkdownImageDetails,
   ) => string | null;
@@ -48,6 +49,7 @@ interface InlineMarkdownRenderContext {
   readonly mathMacros: MarkraMathMacros;
   readonly mathRanges: readonly MarkraMathRange[];
   readonly options: InlineMarkdownRenderOptions;
+  readonly revealedMathRange: MarkraSourceRange | null;
 }
 
 function resolveLinkHref(
@@ -119,12 +121,24 @@ function appendMath(
   range: MarkraMathRange,
   context: InlineMarkdownRenderContext,
 ) {
+  const revealed = context.revealedMathRange;
+  if (revealed?.from === range.from && revealed.to === range.to) {
+    const source = ownerDocument.createElement("span");
+    source.dataset.markraMathFrom = String(range.from);
+    source.dataset.markraMathTo = String(range.to);
+    source.dataset.markraTableMathSource = "true";
+    source.textContent = range.source;
+    parent.appendChild(source);
+    return;
+  }
+
   const element = ownerDocument.createElement("button");
   element.type = "button";
   element.className = "markra-math-render markra-math-render-inline";
   element.contentEditable = "false";
-  element.tabIndex = -1;
+  element.dataset.markraMathFrom = String(range.from);
   element.dataset.markraMathMarkdown = range.source;
+  element.dataset.markraMathTo = String(range.to);
   element.innerHTML = renderMarkraMathToString(
     range.tex,
     "inline",
@@ -482,10 +496,40 @@ export function renderInlineMarkdown(
 ) {
   target.replaceChildren();
   const tree = inlineParser.parse(source);
+  const requestedRange = options.revealedMathRange;
+  const revealedMathRange = requestedRange
+    ? {
+        from: Math.max(0, Math.min(source.length, requestedRange.from)),
+        to: Math.max(0, Math.min(source.length, requestedRange.to)),
+      }
+    : null;
+  const detectedMathRanges = findMarkraMathRanges(
+    source,
+    inlineCodeRanges(tree.topNode),
+  );
+  const revealedRange = revealedMathRange &&
+      revealedMathRange.to > revealedMathRange.from
+    ? {
+        from: revealedMathRange.from,
+        kind: "inline" as const,
+        source: source.slice(revealedMathRange.from, revealedMathRange.to),
+        tex: "",
+        to: revealedMathRange.to,
+      }
+    : null;
+  const mathRanges = revealedRange
+    ? [
+        ...detectedMathRanges.filter((range) =>
+          range.to <= revealedRange.from || range.from >= revealedRange.to
+        ),
+        revealedRange,
+      ].sort((left, right) => left.from - right.from)
+    : detectedMathRanges;
   const context: InlineMarkdownRenderContext = {
     mathMacros: createMarkraMathMacros(),
-    mathRanges: findMarkraMathRanges(source, inlineCodeRanges(tree.topNode)),
+    mathRanges,
     options,
+    revealedMathRange,
   };
   renderRange(
     target,

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -279,7 +279,12 @@ function revealedMathRangesKey(
 
 const mathTheme = EditorView.baseTheme({
   ".markra-math-render": {
+    appearance: "none",
+    background: "transparent",
+    border: "0",
     cursor: "text",
+    font: "inherit",
+    padding: "0",
   },
   ".markra-math-render-display": {
     display: "block",

--- a/packages/editor/src/codemirror/math-preview.ts
+++ b/packages/editor/src/codemirror/math-preview.ts
@@ -17,9 +17,13 @@ import {
   createMarkraMathMacros,
   isMarkraMathMacroDefinitionSource,
   renderMarkraMathToString,
-  type MarkraMathKind,
   type MarkraMathMacros,
 } from "../math-render.ts";
+import {
+  findMarkraMathRanges,
+  type MarkraMathRange,
+  type MarkraSourceRange,
+} from "../math-syntax.ts";
 import { defineMarkraPlugin } from "./plugin.ts";
 import { selectionRevealsRange } from "./policy.ts";
 import {
@@ -28,39 +32,12 @@ import {
 } from "./changes.ts";
 import { codeMirrorVimModeChangedEffect } from "./vim.ts";
 
-export interface CodeMirrorMathRange {
-  readonly from: number;
-  readonly kind: MarkraMathKind;
-  readonly source: string;
-  readonly tex: string;
-  readonly to: number;
-}
-
-interface SourceRange {
-  readonly from: number;
-  readonly to: number;
-}
+export type CodeMirrorMathRange = MarkraMathRange;
 
 const codeNodeNames = new Set(["CodeBlock", "FencedCode", "InlineCode"]);
 
-function isEscaped(source: string, index: number) {
-  let count = 0;
-  for (let cursor = index - 1; cursor >= 0 && source[cursor] === "\\"; cursor -= 1) {
-    count += 1;
-  }
-  return count % 2 === 1;
-}
-
-function overlaps(range: SourceRange, other: SourceRange) {
-  return range.from < other.to && range.to > other.from;
-}
-
-function insideAnyRange(from: number, to: number, ranges: readonly SourceRange[]) {
-  return ranges.some((range) => overlaps({ from, to }, range));
-}
-
 function codeRanges(state: EditorState) {
-  const ranges: SourceRange[] = [];
+  const ranges: MarkraSourceRange[] = [];
   syntaxTree(state).iterate({
     enter(node) {
       if (codeNodeNames.has(node.name)) ranges.push({ from: node.from, to: node.to });
@@ -69,166 +46,9 @@ function codeRanges(state: EditorState) {
   return ranges;
 }
 
-function findClosingDelimiter(
-  source: string,
-  from: number,
-  delimiter: string,
-  blocked: readonly SourceRange[],
-) {
-  let cursor = from;
-  while (cursor < source.length) {
-    const match = source.indexOf(delimiter, cursor);
-    if (match < 0) return null;
-    if (!isEscaped(source, match) && !insideAnyRange(match, match + delimiter.length, blocked)) {
-      return match;
-    }
-    cursor = match + delimiter.length;
-  }
-  return null;
-}
-
-function displayMathRanges(source: string, blocked: readonly SourceRange[]) {
-  const ranges: CodeMirrorMathRange[] = [];
-  const delimiters = [
-    { close: "$$", open: "$$" },
-    { close: String.raw`\]`, open: String.raw`\[` },
-  ] as const;
-
-  for (const { close, open } of delimiters) {
-    let cursor = 0;
-    while (cursor < source.length) {
-      const from = source.indexOf(open, cursor);
-      if (from < 0) break;
-      if (isEscaped(source, from) || insideAnyRange(from, from + open.length, blocked)) {
-        cursor = from + open.length;
-        continue;
-      }
-
-      const closeFrom = findClosingDelimiter(
-        source,
-        from + open.length,
-        close,
-        blocked,
-      );
-      if (closeFrom === null) break;
-
-      const to = closeFrom + close.length;
-      const range = {
-        from,
-        kind: "display" as const,
-        source: source.slice(from, to),
-        tex: source.slice(from + open.length, closeFrom).trim(),
-        to,
-      };
-      ranges.push(range);
-      blocked = [...blocked, range];
-      cursor = to;
-    }
-  }
-
-  return ranges;
-}
-
-function inlineDollarRanges(source: string, blocked: readonly SourceRange[]) {
-  const ranges: CodeMirrorMathRange[] = [];
-  let cursor = 0;
-
-  while (cursor < source.length) {
-    const from = source.indexOf("$", cursor);
-    if (from < 0) break;
-    const afterOpen = source[from + 1];
-    if (
-      source[from + 1] === "$" ||
-      source[from - 1] === "$" ||
-      isEscaped(source, from) ||
-      !afterOpen ||
-      /\s/u.test(afterOpen) ||
-      insideAnyRange(from, from + 1, blocked)
-    ) {
-      cursor = from + 1;
-      continue;
-    }
-
-    let closeFrom = from + 1;
-    while (closeFrom < source.length) {
-      closeFrom = source.indexOf("$", closeFrom);
-      if (closeFrom < 0 || source.slice(from, closeFrom).includes("\n")) break;
-      const beforeClose = source[closeFrom - 1];
-      if (
-        source[closeFrom + 1] !== "$" &&
-        source[closeFrom - 1] !== "$" &&
-        !isEscaped(source, closeFrom) &&
-        beforeClose &&
-        !/\s/u.test(beforeClose) &&
-        !insideAnyRange(closeFrom, closeFrom + 1, blocked)
-      ) {
-        const to = closeFrom + 1;
-        ranges.push({
-          from,
-          kind: "inline",
-          source: source.slice(from, to),
-          tex: source.slice(from + 1, closeFrom),
-          to,
-        });
-        cursor = to;
-        break;
-      }
-      closeFrom += 1;
-    }
-
-    if (closeFrom < 0 || source.slice(from, closeFrom).includes("\n")) cursor = from + 1;
-  }
-
-  return ranges;
-}
-
-function inlineHugoRanges(source: string, blocked: readonly SourceRange[]) {
-  const ranges: CodeMirrorMathRange[] = [];
-  const open = String.raw`\(`;
-  const close = String.raw`\)`;
-  let cursor = 0;
-
-  while (cursor < source.length) {
-    const from = source.indexOf(open, cursor);
-    if (from < 0) break;
-    if (insideAnyRange(from, from + open.length, blocked)) {
-      cursor = from + open.length;
-      continue;
-    }
-    const closeFrom = source.indexOf(close, from + open.length);
-    if (
-      closeFrom < 0 ||
-      source.slice(from, closeFrom).includes("\n") ||
-      insideAnyRange(closeFrom, closeFrom + close.length, blocked)
-    ) {
-      cursor = from + open.length;
-      continue;
-    }
-
-    const to = closeFrom + close.length;
-    ranges.push({
-      from,
-      kind: "inline",
-      source: source.slice(from, to),
-      tex: source.slice(from + open.length, closeFrom),
-      to,
-    });
-    cursor = to;
-  }
-
-  return ranges;
-}
-
 export function findCodeMirrorMathRanges(state: EditorState) {
   const source = state.doc.toString();
-  const code = codeRanges(state);
-  const display = displayMathRanges(source, code);
-  const blocked = [...code, ...display];
-  const inline = [
-    ...inlineDollarRanges(source, blocked),
-    ...inlineHugoRanges(source, blocked),
-  ];
-  return [...display, ...inline].sort((left, right) => left.from - right.from);
+  return findMarkraMathRanges(source, codeRanges(state));
 }
 
 function activateMath(view: CodeMirrorView, range: CodeMirrorMathRange) {

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -2,7 +2,8 @@ import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { dispatchPlainTextPaste } from "../plain-text-paste.ts";
-import { liveMarkdown } from "./index.ts";
+import { liveMarkdown, mathPreviewPlugin } from "./index.ts";
+import type { MarkraPlugin } from "./plugin.ts";
 import {
   focusVisualTableCell,
   tablePreviewPlugin,
@@ -13,7 +14,7 @@ const views: EditorView[] = [];
 
 function createView(
   doc: string,
-  plugin = tablePreviewPlugin(),
+  plugin: MarkraPlugin | readonly MarkraPlugin[] = tablePreviewPlugin(),
 ) {
   const parent = document.createElement("div");
   document.body.append(parent);
@@ -21,7 +22,11 @@ function createView(
     parent,
     state: EditorState.create({
       doc,
-      extensions: [liveMarkdown({ plugins: [plugin] })],
+      extensions: [
+        liveMarkdown({
+          plugins: Array.isArray(plugin) ? plugin : [plugin],
+        }),
+      ],
       selection: EditorSelection.cursor(doc.length),
     }),
   });
@@ -180,6 +185,167 @@ describe("tablePreviewPlugin", () => {
       "https://example.test",
     );
     expect(cells[1]?.querySelector(".markra-live-link-icon")).not.toBeNull();
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("renders inline math inside visual table cells without changing Markdown", () => {
+    const doc = [
+      "| Expression | Gradient |",
+      "| --- | --- |",
+      String.raw`| $\mathbf{A}x$ | \(\mathbf{A}^{\mathsf{T}}\) |`,
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const formulas = view.dom.querySelectorAll<HTMLElement>(
+      ".cm-markra-table .markra-math-render-inline",
+    );
+
+    expect(formulas).toHaveLength(2);
+    expect(formulas[0]?.querySelector(".katex")).not.toBeNull();
+    expect(formulas[0]?.dataset.markraMathMarkdown).toBe(
+      String.raw`$\mathbf{A}x$`,
+    );
+    expect(formulas[1]?.dataset.markraMathMarkdown).toBe(
+      String.raw`\(\mathbf{A}^{\mathsf{T}}\)`,
+    );
+    expect(view.state.doc.toString()).toBe(doc);
+  });
+
+  it("preserves rendered math while editing surrounding table-cell text", async () => {
+    const formula = String.raw`$\lVert\mathbf{X}\rVert_F^2$`;
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      `| Row | Before ${formula} after |`,
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+
+    cell?.focus();
+    if (cell?.firstChild) cell.firstChild.textContent = "Updated before ";
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toContain(
+      `| Row | Updated before ${formula} after |`,
+    );
+    expect(
+      view.dom.querySelector(
+        ".cm-markra-table tbody td:nth-child(2) .markra-math-render-inline .katex",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("keeps the caret outside rendered math when editing following text", async () => {
+    const formula = String.raw`$x^2$`;
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      `| Row | Before ${formula} after |`,
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const followingText = cell?.lastChild;
+
+    expect(followingText?.nodeType).toBe(Node.TEXT_NODE);
+    cell?.focus();
+    if (followingText) followingText.textContent = " updated";
+    const range = document.createRange();
+    range.setStart(followingText!, followingText?.textContent?.length ?? 0);
+    range.collapse(true);
+    document.getSelection()?.removeAllRanges();
+    document.getSelection()?.addRange(range);
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const anchorNode = document.getSelection()?.anchorNode;
+    expect(view.state.doc.toString()).toContain(
+      `| Row | Before ${formula} updated |`,
+    );
+    expect(updatedCell?.contains(anchorNode ?? null)).toBe(true);
+    expect(anchorNode?.parentNode).toBe(updatedCell);
+    expect(anchorNode?.textContent).toBe(" updated");
+    expect(document.getSelection()?.anchorOffset).toBe(" updated".length);
+  });
+
+  it("reveals and updates editable math Markdown inside a visual table cell", async () => {
+    const formula = String.raw`$\mathbf{A}x$`;
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      `| Row | ${formula} |`,
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const math = cell?.querySelector<HTMLElement>(
+      ".markra-math-render-inline",
+    );
+
+    expect(math).not.toBeNull();
+    expect(math?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }))).toBe(false);
+    expect(cell?.querySelector(".markra-math-render-inline")).toBeNull();
+    expect(cell?.textContent).toBe(formula);
+    expect(document.activeElement).toBe(cell);
+    expect(view.state.doc.toString()).toBe(doc);
+
+    if (cell) cell.textContent = "$y^2$";
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    expect(updatedCell?.textContent).toBe("$y^2$");
+    expect(view.state.doc.toString()).toContain("| Row | $y^2$ |");
+
+    updatedCell?.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+    }));
+    expect(
+      view.dom.querySelector<HTMLElement>(
+        ".cm-markra-table tbody td:nth-child(2) [data-markra-math-markdown]",
+      )?.dataset.markraMathMarkdown,
+    ).toBe("$y^2$");
+  });
+
+  it("keeps escaped dollars and inline code as table-cell source", () => {
+    const doc = [
+      "| Escaped | Code |",
+      "| --- | --- |",
+      "| \\$x$ | `$y$` |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cells = view.dom.querySelectorAll<HTMLTableCellElement>(
+      ".cm-markra-table tbody td",
+    );
+
+    expect(view.dom.querySelector(".cm-markra-table .katex")).toBeNull();
+    expect(cells[0]?.textContent).toBe("$x$");
+    expect(cells[1]?.querySelector("code")?.textContent).toBe("$y$");
     expect(view.state.doc.toString()).toBe(doc);
   });
 

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -339,7 +339,10 @@ describe("tablePreviewPlugin", () => {
     expect(cell?.contains(document.getSelection()?.anchorNode ?? null)).toBe(true);
     expect(view.state.doc.toString()).toBe(doc);
 
-    if (cell) cell.textContent = "$y^2$";
+    const editableMath = cell?.querySelector<HTMLElement>(
+      "[data-markra-table-math-source]",
+    );
+    if (editableMath) editableMath.textContent = "$y^2$";
     cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await Promise.resolve();
 
@@ -382,7 +385,10 @@ describe("tablePreviewPlugin", () => {
       button: 0,
       cancelable: true,
     }));
-    if (cell) cell.textContent = "$y^2$";
+    const editableMath = cell?.querySelector<HTMLElement>(
+      "[data-markra-table-math-source]",
+    );
+    if (editableMath) editableMath.textContent = "$y^2$";
     cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await Promise.resolve();
 
@@ -391,7 +397,9 @@ describe("tablePreviewPlugin", () => {
     );
     const table = updatedCell?.closest<HTMLTableElement>("table");
     table?.focus();
-    const sourceText = updatedCell?.firstChild;
+    const sourceText = updatedCell?.querySelector<HTMLElement>(
+      "[data-markra-table-math-source]",
+    )?.firstChild;
     if (sourceText) {
       const sourceRange = document.createRange();
       sourceRange.setStart(sourceText, 1);
@@ -416,6 +424,238 @@ describe("tablePreviewPlugin", () => {
       )?.dataset.markraMathMarkdown,
     ).toBe("$y^2$");
     expect(view.state.doc.toString()).toContain("| Row | $y^2$ |");
+  });
+
+  it("routes Escape from the shared table to the active math source", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Row | $x^2$ |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const math = cell?.querySelector<HTMLElement>(
+      "[data-markra-math-markdown]",
+    );
+
+    math?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    const source = cell?.querySelector<HTMLElement>(
+      "[data-markra-table-math-source]",
+    );
+    if (source) source.textContent = "$y^2$";
+    else if (cell) cell.textContent = "$y^2$";
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const table = updatedCell?.closest<HTMLTableElement>("table");
+    table?.focus();
+    table?.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Escape",
+    }));
+
+    expect(view.state.doc.toString()).toBe(doc);
+    expect(
+      view.dom.querySelector<HTMLElement>(
+        ".cm-markra-table tbody td:nth-child(2) [data-markra-math-markdown]",
+      )?.dataset.markraMathMarkdown,
+    ).toBe("$x^2$");
+  });
+
+  it("commits active math before shared-table Tab navigation", async () => {
+    const doc = [
+      "| Formula | Next |",
+      "| --- | --- |",
+      "| $x$ | Target |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const sourceCell = table?.querySelector<HTMLTableCellElement>(
+      "tbody td:first-child",
+    );
+    const math = sourceCell?.querySelector<HTMLElement>(
+      "[data-markra-math-markdown]",
+    );
+
+    math?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    const source = sourceCell?.querySelector<HTMLElement>(
+      "[data-markra-table-math-source]",
+    );
+    if (source) source.textContent = "$y$";
+    else if (sourceCell) sourceCell.textContent = "$y$";
+    sourceCell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    const updatedTable = view.dom.querySelector<HTMLTableElement>(
+      ".cm-markra-table",
+    );
+    const updatedTargetCell = updatedTable?.querySelector<HTMLTableCellElement>(
+      "tbody td:nth-child(2)",
+    );
+    updatedTable?.focus();
+    updatedTable?.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    }));
+    await Promise.resolve();
+
+    expect(
+      view.dom.querySelector<HTMLElement>(
+        ".cm-markra-table tbody td:first-child [data-markra-math-markdown]",
+      )?.dataset.markraMathMarkdown,
+    ).toBe("$y$");
+    expect(
+      updatedTargetCell?.contains(document.getSelection()?.anchorNode ?? null),
+    ).toBe(true);
+  });
+
+  it("uses Enter on the shared table to edit its first formula", () => {
+    const doc = [
+      "| Formula |",
+      "| --- |",
+      "| $x$ |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const table = view.dom.querySelector<HTMLTableElement>(".cm-markra-table");
+    const cell = table?.querySelector<HTMLTableCellElement>("tbody td");
+    const text = cell?.querySelector(".katex-html")?.firstChild;
+
+    table?.focus();
+    if (text) {
+      const range = document.createRange();
+      range.selectNodeContents(text);
+      range.collapse(false);
+      document.getSelection()?.removeAllRanges();
+      document.getSelection()?.addRange(range);
+    }
+    table?.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+    }));
+
+    expect(
+      cell?.querySelector<HTMLElement>("[data-markra-table-math-source]")
+        ?.textContent,
+    ).toBe("$x$");
+  });
+
+  it("activates a visual table formula from its native button click", () => {
+    const doc = [
+      "| Formula |",
+      "| --- |",
+      "| $x$ |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const button = view.dom.querySelector<HTMLButtonElement>(
+      ".cm-markra-table [data-markra-math-markdown]",
+    );
+
+    button?.click();
+
+    expect(
+      view.dom.querySelector<HTMLElement>("[data-markra-table-math-source]")
+        ?.textContent,
+    ).toBe("$x$");
+  });
+
+  it("keeps only the active formula as source inside a mixed table cell", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Row | Before $x$ plus $z$ after |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const firstMath = cell?.querySelector<HTMLElement>(
+      "[data-markra-math-markdown]",
+    );
+
+    firstMath?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    const source = cell?.querySelector<HTMLElement>(
+      "[data-markra-table-math-source]",
+    );
+    expect(source?.textContent).toBe("$x$");
+    expect(cell?.querySelectorAll("[data-markra-math-markdown]")).toHaveLength(1);
+
+    if (source) source.textContent = "$yx$";
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    expect(
+      updatedCell?.querySelector<HTMLElement>("[data-markra-table-math-source]")
+        ?.textContent,
+    ).toBe("$yx$");
+    expect(
+      updatedCell?.querySelector<HTMLElement>("[data-markra-math-markdown]")
+        ?.dataset.markraMathMarkdown,
+    ).toBe("$z$");
+
+    updatedCell
+      ?.querySelector<HTMLElement>("[data-markra-math-markdown]")
+      ?.dispatchEvent(new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      }));
+    expect(
+      updatedCell?.querySelector<HTMLElement>("[data-markra-table-math-source]")
+        ?.textContent,
+    ).toBe("$z$");
+    expect(
+      updatedCell?.querySelector<HTMLElement>("[data-markra-math-markdown]")
+        ?.dataset.markraMathMarkdown,
+    ).toBe("$yx$");
+
+    updatedCell?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    await Promise.resolve();
+
+    expect(
+      view.dom.querySelector<HTMLElement>(
+        ".cm-markra-table tbody td:nth-child(2) [data-markra-math-markdown]",
+      )?.dataset.markraMathMarkdown,
+    ).toBe("$yx$");
+    expect(view.state.doc.toString()).toContain(
+      "| Row | Before $yx$ plus $z$ after |",
+    );
   });
 
   it("keeps escaped dollars and inline code as table-cell source", () => {

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -298,14 +298,45 @@ describe("tablePreviewPlugin", () => {
     );
 
     expect(math).not.toBeNull();
+    expect(math?.tagName).toBe("BUTTON");
+    expect(math?.getAttribute("type")).toBe("button");
+    math?.addEventListener("mousedown", (event) => event.stopPropagation());
+    math?.addEventListener("mouseup", (event) => event.stopPropagation());
+    math?.addEventListener("click", (event) => event.stopPropagation());
     expect(math?.dispatchEvent(new MouseEvent("mousedown", {
       bubbles: true,
       button: 0,
       cancelable: true,
     }))).toBe(false);
     expect(cell?.querySelector(".markra-math-render-inline")).toBeNull();
+    const table = cell?.closest<HTMLTableElement>("table");
+    table?.focus();
+    expect(document.activeElement).toBe(table);
+    const sourceText = cell?.firstChild;
+    if (sourceText) {
+      const sourceRange = document.createRange();
+      sourceRange.setStart(sourceText, 1);
+      sourceRange.collapse(true);
+      document.getSelection()?.removeAllRanges();
+      document.getSelection()?.addRange(sourceRange);
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(cell?.querySelector(".markra-math-render-inline")).toBeNull();
     expect(cell?.textContent).toBe(formula);
-    expect(document.activeElement).toBe(cell);
+    math?.dispatchEvent(new MouseEvent("mouseup", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    math?.dispatchEvent(new MouseEvent("click", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    expect(cell?.querySelector(".markra-math-render-inline")).toBeNull();
+    expect(cell?.textContent).toBe(formula);
+    expect(document.activeElement).toBe(table);
+    expect(cell?.contains(document.getSelection()?.anchorNode ?? null)).toBe(true);
     expect(view.state.doc.toString()).toBe(doc);
 
     if (cell) cell.textContent = "$y^2$";

--- a/packages/editor/src/codemirror/table.test.ts
+++ b/packages/editor/src/codemirror/table.test.ts
@@ -361,6 +361,63 @@ describe("tablePreviewPlugin", () => {
     ).toBe("$y^2$");
   });
 
+  it("renders updated math when the shared visual table loses focus", async () => {
+    const doc = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| Row | $x^2$ |",
+      "",
+      "Edit",
+    ].join("\n");
+    const view = createView(doc, [mathPreviewPlugin(), tablePreviewPlugin()]);
+    const cell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const math = cell?.querySelector<HTMLElement>(
+      "[data-markra-math-markdown]",
+    );
+
+    math?.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    if (cell) cell.textContent = "$y^2$";
+    cell?.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await Promise.resolve();
+
+    const updatedCell = view.dom.querySelector<HTMLTableCellElement>(
+      ".cm-markra-table tbody td:nth-child(2)",
+    );
+    const table = updatedCell?.closest<HTMLTableElement>("table");
+    table?.focus();
+    const sourceText = updatedCell?.firstChild;
+    if (sourceText) {
+      const sourceRange = document.createRange();
+      sourceRange.setStart(sourceText, 1);
+      sourceRange.collapse(true);
+      document.getSelection()?.removeAllRanges();
+      document.getSelection()?.addRange(sourceRange);
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(updatedCell?.textContent).toBe("$y^2$");
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    }));
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(
+      view.dom.querySelector<HTMLElement>(
+        ".cm-markra-table tbody td:nth-child(2) [data-markra-math-markdown]",
+      )?.dataset.markraMathMarkdown,
+    ).toBe("$y^2$");
+    expect(view.state.doc.toString()).toContain("| Row | $y^2$ |");
+  });
+
   it("keeps escaped dollars and inline code as table-cell source", () => {
     const doc = [
       "| Escaped | Code |",

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -58,6 +58,16 @@ interface TableCellPreview {
   readonly to: number;
 }
 
+type EditVisualTableMathSource = (
+  element: HTMLElement,
+  markdown: string,
+) => void;
+
+const visualTableMathSourceEditors = new WeakMap<
+  HTMLTableCellElement,
+  EditVisualTableMathSource
+>();
+
 const TABLE_CARET_PLACEHOLDER = "\u200b";
 
 function createVisualTableCaretHost(ownerDocument: Document) {
@@ -988,6 +998,22 @@ function appendCell(
   links: LinksPluginOptions | undefined,
 ) {
   const cell = row.ownerDocument.createElement(header ? "th" : "td");
+  const editMathSource: EditVisualTableMathSource = (element, markdown) => {
+    const previousSession = tableEditingSessions.get(view);
+    tableEditingSessions.set(view, {
+      column: columnIndex,
+      header,
+      inlineSourceVisible: true,
+      originalSource: cellPreview.source,
+      row: rowIndex,
+      tableFrom: preview.from,
+    });
+    const handled = revealVisualTableInlineSource(cell, element, markdown);
+    if (handled) return;
+    if (previousSession) tableEditingSessions.set(view, previousSession);
+    else tableEditingSessions.delete(view);
+  };
+  visualTableMathSourceEditors.set(cell, editMathSource);
   const currentSession = tableEditingSessions.get(view);
   const keepInlineSourceVisible =
     currentSession?.tableFrom === preview.from &&
@@ -1034,15 +1060,14 @@ function appendCell(
       }
       return;
     }
-    const editableInline = target?.closest<HTMLElement>(
-      "[data-markra-image-markdown], [data-markra-math-markdown]",
+    const image = target?.closest<HTMLElement>(
+      "[data-markra-image-markdown]",
     );
-    if (editableInline && cell.contains(editableInline)) {
+    if (image && cell.contains(image)) {
       const handled = revealVisualTableInlineSource(
         cell,
-        editableInline,
-        editableInline.dataset.markraImageMarkdown ??
-          editableInline.dataset.markraMathMarkdown,
+        image,
+        image.dataset.markraImageMarkdown,
       );
       if (handled) {
         tableEditingSessions.set(view, {
@@ -1082,7 +1107,23 @@ function appendCell(
   });
   cell.addEventListener("blur", () => {
     cell.ownerDocument.defaultView?.setTimeout(() => {
-      const activeCell = cell.ownerDocument.activeElement;
+      const table = cell.closest<HTMLTableElement>("table");
+      const activeElement = cell.ownerDocument.activeElement;
+      let activeCell = activeElement instanceof HTMLTableCellElement
+        ? activeElement
+        : null;
+      if (!activeCell && table && activeElement === table) {
+        const selectionNode = cell.ownerDocument.getSelection()?.anchorNode;
+        const selectionElement = selectionNode instanceof Element
+          ? selectionNode
+          : selectionNode?.parentElement;
+        const selectedCell = selectionElement?.closest<HTMLTableCellElement>(
+          "th, td",
+        );
+        if (selectedCell && table.contains(selectedCell)) {
+          activeCell = selectedCell;
+        }
+      }
       const session = tableEditingSessions.get(view);
       if (
         activeCell instanceof HTMLTableCellElement &&
@@ -1419,6 +1460,33 @@ class TableWidget extends WidgetType {
     wrapper.dataset.tableFrom = String(this.preview.from);
     wrapper.dataset.tableAlignment = tableAlignment;
     wrapper.dataset.widthMode = widthMode;
+    wrapper.addEventListener("mousedown", (event) => {
+      if (view.state.readOnly || event.button !== 0) return;
+      const target = event.target instanceof Element ? event.target : null;
+      const math = target?.closest<HTMLElement>(
+        "[data-markra-math-markdown]",
+      );
+      const cell = math?.closest<HTMLTableCellElement>("th, td");
+      const editMathSource = cell
+        ? visualTableMathSourceEditors.get(cell)
+        : undefined;
+      const markdown = math?.dataset.markraMathMarkdown;
+      if (
+        !math ||
+        !cell ||
+        !table.contains(cell) ||
+        !editMathSource ||
+        !markdown
+      ) {
+        return;
+      }
+
+      // CodeMirror owns the widget boundary and can consume target/bubble
+      // events, so formula activation must happen before editor selection work.
+      event.preventDefault();
+      event.stopPropagation();
+      editMathSource(math, markdown);
+    }, true);
     tableScroll.className = "markra-table-scroll";
     tableScroll.dataset.tableAlignment = tableAlignment;
     alignControls.className = "markra-table-align-controls";

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -1034,14 +1034,15 @@ function appendCell(
       }
       return;
     }
-    const image = target?.closest<HTMLElement>(
-      "[data-markra-image-markdown]",
+    const editableInline = target?.closest<HTMLElement>(
+      "[data-markra-image-markdown], [data-markra-math-markdown]",
     );
-    if (image && cell.contains(image)) {
+    if (editableInline && cell.contains(editableInline)) {
       const handled = revealVisualTableInlineSource(
         cell,
-        image,
-        image.dataset.markraImageMarkdown,
+        editableInline,
+        editableInline.dataset.markraImageMarkdown ??
+          editableInline.dataset.markraMathMarkdown,
       );
       if (handled) {
         tableEditingSessions.set(view, {

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -7,6 +7,7 @@ import {
 } from "@codemirror/view";
 import { createLucideIcon, popoverPosition } from "@markra/shared";
 import { Minus, Plus, Trash2 } from "lucide";
+import type { MarkraSourceRange } from "../math-syntax.ts";
 import {
   renderInlineMarkdown,
   serializeInlineMarkdown,
@@ -90,6 +91,8 @@ interface TableEditingSession {
   readonly column: number;
   readonly header: boolean;
   readonly inlineSourceVisible: boolean;
+  readonly mathFrom?: number;
+  readonly mathTo?: number;
   readonly originalSource: string;
   readonly row: number;
   readonly tableFrom: number;
@@ -757,8 +760,9 @@ function moveVisualTableCellFocus(
   view: CodeMirrorView,
   table: HTMLTableElement,
   backward: boolean,
+  sourceCell?: HTMLTableCellElement,
 ) {
-  const cell = activeVisualTableCell(view, table);
+  const cell = sourceCell ?? activeVisualTableCell(view, table);
   if (!cell) return false;
 
   const cells = Array.from(
@@ -891,6 +895,17 @@ function handleVisualTableCellEnter(
   }
 
   const session = tableEditingSessions.get(view);
+  if (!session?.inlineSourceVisible) {
+    const math = cell.querySelector<HTMLElement>(
+      "[data-markra-math-markdown]",
+    );
+    const editMathSource = visualTableMathSourceEditors.get(cell);
+    const markdown = math?.dataset.markraMathMarkdown;
+    if (math && editMathSource && markdown) {
+      editMathSource(math, markdown);
+      return;
+    }
+  }
   tableEditingSessions.delete(view);
   if (session?.inlineSourceVisible) {
     renderVisualTableCell(
@@ -902,6 +917,82 @@ function handleVisualTableCellEnter(
     );
   }
   view.focus();
+}
+
+function handleVisualTableCellEscape(
+  view: CodeMirrorView,
+  preview: TablePreview,
+  cell: HTMLTableCellElement,
+  event: KeyboardEvent,
+  rowIndex: number,
+  columnIndex: number,
+  header: boolean,
+  images: ImagePreviewPluginOptions | undefined,
+  links: LinksPluginOptions | undefined,
+) {
+  event.preventDefault();
+  event.stopPropagation();
+  const session = tableEditingSessions.get(view);
+  tableEditingSessions.delete(view);
+  if (session) {
+    const changed = replaceVisualTableCell(
+      view,
+      preview,
+      rowIndex,
+      columnIndex,
+      header,
+      session.originalSource,
+    );
+    if (!changed && session.inlineSourceVisible) {
+      renderVisualTableCell(view, cell, session.originalSource, images, links);
+    }
+  }
+  view.focus();
+}
+
+function closestSourceIndex(source: string, value: string, expected: number) {
+  let closest = -1;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  let cursor = source.indexOf(value);
+  while (cursor >= 0) {
+    const distance = Math.abs(cursor - expected);
+    if (distance < closestDistance) {
+      closest = cursor;
+      closestDistance = distance;
+    }
+    cursor = source.indexOf(value, cursor + Math.max(1, value.length));
+  }
+  return closest;
+}
+
+function updateVisualTableMathSourceRange(
+  view: CodeMirrorView,
+  cell: HTMLTableCellElement,
+  source: string,
+) {
+  const session = tableEditingSessions.get(view);
+  if (
+    !session?.inlineSourceVisible ||
+    session.mathFrom === undefined ||
+    session.mathTo === undefined
+  ) {
+    return;
+  }
+  const element = cell.querySelector<HTMLElement>(
+    "[data-markra-table-math-source]",
+  );
+  const value = element?.textContent ?? "";
+  if (!value) {
+    tableEditingSessions.delete(view);
+    return;
+  }
+  const from = closestSourceIndex(source, value, session.mathFrom);
+  if (from < 0) return;
+  tableEditingSessions.set(view, {
+    ...session,
+    mathFrom: from,
+    mathTo: from + value.length,
+  });
 }
 
 function syncVisualTableCell(
@@ -917,13 +1008,15 @@ function syncVisualTableCell(
   if (!Number.isInteger(rowIndex) || !Number.isInteger(columnIndex)) return;
 
   const caretOffset = tableCellCaretOffset(cell);
+  const source = visualTableCellSource(cell);
+  updateVisualTableMathSourceRange(view, cell, source);
   const changed = replaceVisualTableCell(
     view,
     preview,
     rowIndex,
     columnIndex,
     header,
-    visualTableCellSource(cell),
+    source,
   );
   const selectionNode = cell.ownerDocument.getSelection()?.anchorNode;
   if (changed || !selectionNode || !cell.contains(selectionNode)) {
@@ -966,10 +1059,12 @@ function renderVisualTableCell(
   source: string,
   images: ImagePreviewPluginOptions | undefined,
   links: LinksPluginOptions | undefined,
+  revealedMathRange?: MarkraSourceRange,
 ) {
   const imageResolver = images?.resolveSource;
   const linkResolver = links?.resolveTarget;
   renderInlineMarkdown(cell, source, {
+    ...(revealedMathRange ? { revealedMathRange } : {}),
     ...(imageResolver
       ? {
           resolveImageSource: (details: InlineMarkdownImageDetails) =>
@@ -1018,16 +1113,50 @@ function appendCell(
 ) {
   const cell = row.ownerDocument.createElement(header ? "th" : "td");
   const editMathSource: EditVisualTableMathSource = (element, markdown) => {
+    const mathFrom = Number(element.dataset.markraMathFrom);
+    const mathTo = Number(element.dataset.markraMathTo);
     const previousSession = tableEditingSessions.get(view);
+    const originalSource = visualTableCellSource(cell);
     tableEditingSessions.set(view, {
       column: columnIndex,
       header,
       inlineSourceVisible: true,
-      originalSource: cellPreview.source,
+      ...(Number.isInteger(mathFrom) && Number.isInteger(mathTo)
+        ? { mathFrom, mathTo }
+        : {}),
+      originalSource,
       row: rowIndex,
       tableFrom: preview.from,
     });
-    const handled = revealVisualTableInlineSource(cell, element, markdown);
+    let handled = false;
+    if (Number.isInteger(mathFrom) && Number.isInteger(mathTo)) {
+      renderVisualTableCell(
+        view,
+        cell,
+        originalSource,
+        images,
+        links,
+        { from: mathFrom, to: mathTo },
+      );
+      const source = cell.querySelector<HTMLElement>(
+        "[data-markra-table-math-source]",
+      );
+      const text = source?.firstChild;
+      if (source && text) {
+        cell.focus();
+        const selection = cell.ownerDocument.getSelection();
+        if (selection) {
+          const range = cell.ownerDocument.createRange();
+          range.setStart(text, Math.min(1, text.textContent?.length ?? 0));
+          range.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+        handled = true;
+      }
+    } else {
+      handled = revealVisualTableInlineSource(cell, element, markdown);
+    }
     if (handled) return;
     if (previousSession) tableEditingSessions.set(view, previousSession);
     else tableEditingSessions.delete(view);
@@ -1040,8 +1169,23 @@ function appendCell(
     currentSession.column === columnIndex &&
     currentSession.header === header &&
     currentSession.inlineSourceVisible;
-  if (keepInlineSourceVisible) cell.textContent = cellPreview.source;
-  else renderVisualTableCell(view, cell, cellPreview.source, images, links);
+  const revealedMathRange = keepInlineSourceVisible &&
+      currentSession.mathFrom !== undefined &&
+      currentSession.mathTo !== undefined
+    ? { from: currentSession.mathFrom, to: currentSession.mathTo }
+    : undefined;
+  if (keepInlineSourceVisible && !revealedMathRange) {
+    cell.textContent = cellPreview.source;
+  } else {
+    renderVisualTableCell(
+      view,
+      cell,
+      cellPreview.source,
+      images,
+      links,
+      revealedMathRange,
+    );
+  }
   cell.tabIndex = view.state.readOnly ? -1 : 0;
   cell.dataset.tableColumn = String(columnIndex);
   cell.dataset.tableHeader = String(header);
@@ -1178,25 +1322,17 @@ function appendCell(
       return;
     }
     if (event.key !== "Escape") return;
-
-    event.preventDefault();
-    event.stopPropagation();
-    const session = tableEditingSessions.get(view);
-    tableEditingSessions.delete(view);
-    if (session) {
-      const changed = replaceVisualTableCell(
-        view,
-        preview,
-        rowIndex,
-        columnIndex,
-        header,
-        session.originalSource,
-      );
-      if (!changed && session.inlineSourceVisible) {
-        renderVisualTableCell(view, cell, session.originalSource, images, links);
-      }
-    }
-    view.focus();
+    handleVisualTableCellEscape(
+      view,
+      preview,
+      cell,
+      event,
+      rowIndex,
+      columnIndex,
+      header,
+      images,
+      links,
+    );
   });
   row.append(cell);
 }
@@ -1492,9 +1628,9 @@ class TableWidget extends WidgetType {
     wrapper.dataset.tableFrom = String(this.preview.from);
     wrapper.dataset.tableAlignment = tableAlignment;
     wrapper.dataset.widthMode = widthMode;
-    wrapper.addEventListener("mousedown", (event) => {
-      if (view.state.readOnly || event.button !== 0) return;
-      const target = event.target instanceof Element ? event.target : null;
+    const activateMathSource = (eventTarget: EventTarget | null) => {
+      if (view.state.readOnly) return false;
+      const target = eventTarget instanceof Element ? eventTarget : null;
       const math = target?.closest<HTMLElement>(
         "[data-markra-math-markdown]",
       );
@@ -1510,14 +1646,22 @@ class TableWidget extends WidgetType {
         !editMathSource ||
         !markdown
       ) {
-        return;
+        return false;
       }
-
+      editMathSource(math, markdown);
+      return true;
+    };
+    wrapper.addEventListener("mousedown", (event) => {
+      if (event.button !== 0 || !activateMathSource(event.target)) return;
       // CodeMirror owns the widget boundary and can consume target/bubble
       // events, so formula activation must happen before editor selection work.
       event.preventDefault();
       event.stopPropagation();
-      editMathSource(math, markdown);
+    }, true);
+    wrapper.addEventListener("click", (event) => {
+      if (!activateMathSource(event.target)) return;
+      event.preventDefault();
+      event.stopPropagation();
     }, true);
     const inlineSourceMouseDownHandler = (event: MouseEvent) => {
       if (event.button !== 0) return;
@@ -1529,8 +1673,37 @@ class TableWidget extends WidgetType {
           `[data-table-header="${String(session.header)}"]`,
       );
       const target = event.target instanceof Node ? event.target : null;
-      if (!cell || (target && cell.contains(target))) return;
+      if (!cell) return;
+      const activeSource = cell.querySelector<HTMLElement>(
+        "[data-markra-table-math-source]",
+      );
+      if (target && activeSource?.contains(target)) return;
+
+      const targetElement = target instanceof Element
+        ? target
+        : target?.parentElement;
+      const nextMath = targetElement?.closest<HTMLElement>(
+        "[data-markra-math-markdown]",
+      );
+      const nextMathFrom = nextMath?.dataset.markraMathFrom;
+      const nextMathTo = nextMath?.dataset.markraMathTo;
+      const nextMathInCell = Boolean(nextMath && cell.contains(nextMath));
+      if (nextMathInCell) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       finishVisualTableInlineSource(view, cell, this.images, this.links);
+      if (!nextMathInCell || !nextMathFrom || !nextMathTo) return;
+
+      const replacement = cell.querySelector<HTMLElement>(
+        `[data-markra-math-from="${nextMathFrom}"]` +
+          `[data-markra-math-to="${nextMathTo}"]`,
+      );
+      const editMathSource = visualTableMathSourceEditors.get(cell);
+      const markdown = replacement?.dataset.markraMathMarkdown;
+      if (replacement && editMathSource && markdown) {
+        editMathSource(replacement, markdown);
+      }
     };
     this.runtime.inlineSourceDocument = document;
     this.runtime.inlineSourceMouseDownHandler = inlineSourceMouseDownHandler;
@@ -1547,7 +1720,7 @@ class TableWidget extends WidgetType {
     table.dataset.widthMode = widthMode;
     table.classList.toggle("markra-table-width-auto", widthMode === "auto");
     table.addEventListener("keydown", (event) => {
-      if (event.key === "Enter") {
+      if (event.key === "Enter" || event.key === "Escape") {
         const cell = activeVisualTableCell(view, table);
         if (!cell) return;
         const rowIndex = Number(cell.dataset.tableRow);
@@ -1558,28 +1731,48 @@ class TableWidget extends WidgetType {
         }
         // Safari targets keyboard events at the shared contenteditable table
         // instead of the focused cell, so route both targets through one path.
-        handleVisualTableCellEnter(
-          view,
-          this.preview,
-          cell,
-          event,
-          rowIndex,
-          columnIndex,
-          header,
-          this.images,
-          this.links,
-        );
+        if (event.key === "Enter") {
+          handleVisualTableCellEnter(
+            view,
+            this.preview,
+            cell,
+            event,
+            rowIndex,
+            columnIndex,
+            header,
+            this.images,
+            this.links,
+          );
+        } else {
+          handleVisualTableCellEscape(
+            view,
+            this.preview,
+            cell,
+            event,
+            rowIndex,
+            columnIndex,
+            header,
+            this.images,
+            this.links,
+          );
+        }
         return;
       }
       if (
         event.key !== "Tab" ||
         event.altKey ||
         event.ctrlKey ||
-        event.metaKey ||
-        !moveVisualTableCellFocus(view, table, event.shiftKey)
+        event.metaKey
       ) {
         return;
       }
+      const cell = activeVisualTableCell(view, table);
+      if (!cell) return;
+      const session = tableEditingSessions.get(view);
+      if (session?.inlineSourceVisible) {
+        finishVisualTableInlineSource(view, cell, this.images, this.links);
+      }
+      if (!moveVisualTableCellFocus(view, table, event.shiftKey, cell)) return;
       // WebKit preserves the old editing position during native Tab focus
       // navigation, so move the caret before its next insertion begins.
       event.preventDefault();

--- a/packages/editor/src/codemirror/table.ts
+++ b/packages/editor/src/codemirror/table.ts
@@ -985,6 +985,25 @@ function renderVisualTableCell(
   });
 }
 
+function finishVisualTableInlineSource(
+  view: CodeMirrorView,
+  cell: HTMLTableCellElement,
+  images: ImagePreviewPluginOptions | undefined,
+  links: LinksPluginOptions | undefined,
+) {
+  const session = tableEditingSessions.get(view);
+  tableEditingSessions.delete(view);
+  if (session?.inlineSourceVisible && cell.isConnected) {
+    renderVisualTableCell(
+      view,
+      cell,
+      visualTableCellSource(cell),
+      images,
+      links,
+    );
+  }
+}
+
 function appendCell(
   view: CodeMirrorView,
   row: HTMLTableRowElement,
@@ -1139,10 +1158,7 @@ function appendCell(
         session.column === columnIndex &&
         session.header === header
       ) {
-        tableEditingSessions.delete(view);
-        if (session.inlineSourceVisible && cell.isConnected) {
-          renderVisualTableCell(view, cell, cellPreview.source, images, links);
-        }
+        finishVisualTableInlineSource(view, cell, images, links);
       }
     }, 0);
   });
@@ -1187,6 +1203,8 @@ function appendCell(
 
 interface TableWidgetRuntime {
   documentMouseDownHandler: ((event: MouseEvent) => void) | null;
+  inlineSourceDocument: Document | null;
+  inlineSourceMouseDownHandler: ((event: MouseEvent) => void) | null;
   preview: TablePreview;
   sizeButton: HTMLButtonElement | null;
   sizePopover: HTMLElement | null;
@@ -1218,6 +1236,8 @@ class TableWidget extends WidgetType {
     this.labelsKey = JSON.stringify(labels);
     this.runtime = {
       documentMouseDownHandler: null,
+      inlineSourceDocument: null,
+      inlineSourceMouseDownHandler: null,
       preview,
       sizeButton: null,
       sizePopover: null,
@@ -1432,6 +1452,18 @@ class TableWidget extends WidgetType {
 
   destroy() {
     this.closeSizePicker();
+    if (
+      this.runtime.inlineSourceDocument &&
+      this.runtime.inlineSourceMouseDownHandler
+    ) {
+      this.runtime.inlineSourceDocument.removeEventListener(
+        "mousedown",
+        this.runtime.inlineSourceMouseDownHandler,
+        true,
+      );
+    }
+    this.runtime.inlineSourceDocument = null;
+    this.runtime.inlineSourceMouseDownHandler = null;
   }
 
   toDOM(view: CodeMirrorView) {
@@ -1487,6 +1519,22 @@ class TableWidget extends WidgetType {
       event.stopPropagation();
       editMathSource(math, markdown);
     }, true);
+    const inlineSourceMouseDownHandler = (event: MouseEvent) => {
+      if (event.button !== 0) return;
+      const session = tableEditingSessions.get(view);
+      if (!session || session.tableFrom !== this.preview.from) return;
+      const cell = table.querySelector<HTMLTableCellElement>(
+        `[data-table-row="${session.row}"]` +
+          `[data-table-column="${session.column}"]` +
+          `[data-table-header="${String(session.header)}"]`,
+      );
+      const target = event.target instanceof Node ? event.target : null;
+      if (!cell || (target && cell.contains(target))) return;
+      finishVisualTableInlineSource(view, cell, this.images, this.links);
+    };
+    this.runtime.inlineSourceDocument = document;
+    this.runtime.inlineSourceMouseDownHandler = inlineSourceMouseDownHandler;
+    document.addEventListener("mousedown", inlineSourceMouseDownHandler, true);
     tableScroll.className = "markra-table-scroll";
     tableScroll.dataset.tableAlignment = tableAlignment;
     alignControls.className = "markra-table-align-controls";

--- a/packages/editor/src/math-syntax.ts
+++ b/packages/editor/src/math-syntax.ts
@@ -1,0 +1,208 @@
+import type { MarkraMathKind } from "./math-render.ts";
+
+export interface MarkraMathRange {
+  readonly from: number;
+  readonly kind: MarkraMathKind;
+  readonly source: string;
+  readonly tex: string;
+  readonly to: number;
+}
+
+export interface MarkraSourceRange {
+  readonly from: number;
+  readonly to: number;
+}
+
+function isEscaped(source: string, index: number) {
+  let count = 0;
+  for (let cursor = index - 1; cursor >= 0 && source[cursor] === "\\"; cursor -= 1) {
+    count += 1;
+  }
+  return count % 2 === 1;
+}
+
+function overlaps(range: MarkraSourceRange, other: MarkraSourceRange) {
+  return range.from < other.to && range.to > other.from;
+}
+
+function insideAnyRange(
+  from: number,
+  to: number,
+  ranges: readonly MarkraSourceRange[],
+) {
+  return ranges.some((range) => overlaps({ from, to }, range));
+}
+
+function findClosingDelimiter(
+  source: string,
+  from: number,
+  delimiter: string,
+  blocked: readonly MarkraSourceRange[],
+) {
+  let cursor = from;
+  while (cursor < source.length) {
+    const match = source.indexOf(delimiter, cursor);
+    if (match < 0) return null;
+    if (!isEscaped(source, match) && !insideAnyRange(match, match + delimiter.length, blocked)) {
+      return match;
+    }
+    cursor = match + delimiter.length;
+  }
+  return null;
+}
+
+function displayMathRanges(
+  source: string,
+  blocked: readonly MarkraSourceRange[],
+) {
+  const ranges: MarkraMathRange[] = [];
+  const delimiters = [
+    { close: "$$", open: "$$" },
+    { close: String.raw`\]`, open: String.raw`\[` },
+  ] as const;
+
+  for (const { close, open } of delimiters) {
+    let cursor = 0;
+    while (cursor < source.length) {
+      const from = source.indexOf(open, cursor);
+      if (from < 0) break;
+      if (isEscaped(source, from) || insideAnyRange(from, from + open.length, blocked)) {
+        cursor = from + open.length;
+        continue;
+      }
+
+      const closeFrom = findClosingDelimiter(
+        source,
+        from + open.length,
+        close,
+        blocked,
+      );
+      if (closeFrom === null) break;
+
+      const to = closeFrom + close.length;
+      const range = {
+        from,
+        kind: "display" as const,
+        source: source.slice(from, to),
+        tex: source.slice(from + open.length, closeFrom).trim(),
+        to,
+      };
+      ranges.push(range);
+      blocked = [...blocked, range];
+      cursor = to;
+    }
+  }
+
+  return ranges;
+}
+
+function inlineDollarRanges(
+  source: string,
+  blocked: readonly MarkraSourceRange[],
+) {
+  const ranges: MarkraMathRange[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const from = source.indexOf("$", cursor);
+    if (from < 0) break;
+    const afterOpen = source[from + 1];
+    if (
+      source[from + 1] === "$" ||
+      source[from - 1] === "$" ||
+      isEscaped(source, from) ||
+      !afterOpen ||
+      /\s/u.test(afterOpen) ||
+      insideAnyRange(from, from + 1, blocked)
+    ) {
+      cursor = from + 1;
+      continue;
+    }
+
+    let closeFrom = from + 1;
+    while (closeFrom < source.length) {
+      closeFrom = source.indexOf("$", closeFrom);
+      if (closeFrom < 0 || source.slice(from, closeFrom).includes("\n")) break;
+      const beforeClose = source[closeFrom - 1];
+      if (
+        source[closeFrom + 1] !== "$" &&
+        source[closeFrom - 1] !== "$" &&
+        !isEscaped(source, closeFrom) &&
+        beforeClose &&
+        !/\s/u.test(beforeClose) &&
+        !insideAnyRange(closeFrom, closeFrom + 1, blocked)
+      ) {
+        const to = closeFrom + 1;
+        ranges.push({
+          from,
+          kind: "inline",
+          source: source.slice(from, to),
+          tex: source.slice(from + 1, closeFrom),
+          to,
+        });
+        cursor = to;
+        break;
+      }
+      closeFrom += 1;
+    }
+
+    if (closeFrom < 0 || source.slice(from, closeFrom).includes("\n")) {
+      cursor = from + 1;
+    }
+  }
+
+  return ranges;
+}
+
+function inlineHugoRanges(
+  source: string,
+  blocked: readonly MarkraSourceRange[],
+) {
+  const ranges: MarkraMathRange[] = [];
+  const open = String.raw`\(`;
+  const close = String.raw`\)`;
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const from = source.indexOf(open, cursor);
+    if (from < 0) break;
+    if (insideAnyRange(from, from + open.length, blocked)) {
+      cursor = from + open.length;
+      continue;
+    }
+    const closeFrom = source.indexOf(close, from + open.length);
+    if (
+      closeFrom < 0 ||
+      source.slice(from, closeFrom).includes("\n") ||
+      insideAnyRange(closeFrom, closeFrom + close.length, blocked)
+    ) {
+      cursor = from + open.length;
+      continue;
+    }
+
+    const to = closeFrom + close.length;
+    ranges.push({
+      from,
+      kind: "inline",
+      source: source.slice(from, to),
+      tex: source.slice(from + open.length, closeFrom),
+      to,
+    });
+    cursor = to;
+  }
+
+  return ranges;
+}
+
+export function findMarkraMathRanges(
+  source: string,
+  blocked: readonly MarkraSourceRange[] = [],
+) {
+  const display = displayMathRanges(source, blocked);
+  const unavailable = [...blocked, ...display];
+  const inline = [
+    ...inlineDollarRanges(source, unavailable),
+    ...inlineHugoRanges(source, unavailable),
+  ];
+  return [...display, ...inline].sort((left, right) => left.from - right.from);
+}


### PR DESCRIPTION
## Summary
- render inline `$...$` and `\(...\)` math inside visual table cells with KaTeX
- share math range detection between the editor preview and table-cell renderer
- keep only the active formula as editable Markdown while preserving surrounding text and other rendered formulas
- support mouse, native button activation, shared-table Enter, Escape, Tab, and Shift+Tab interactions
- commit the active formula when clicking adjacent text, another formula, another cell, table controls, or outside the table
- keep escaped dollars, inline code, links, images, and table caret behavior unchanged

## Validation
- `pnpm test` — 11 workspace projects and 2,692 tests passed
- `pnpm build`
- `pnpm typecheck:test`
- local CodeMirror browser QA:
  - physical click revealed formula source and outside click rendered the updated formula
  - Escape restored the original formula
  - Tab committed the formula and moved selection to the next cell
  - Enter and native button click opened formula editing
  - mixed cells retained surrounding text and other rendered formulas
  - switching between two formulas in one cell committed the first and opened the second in one click
  - Preview/Source transitions preserved the updated Markdown

## Risk
- localized to inline math rendering and interaction inside visual table cells
- stores the active formula as a cell-local source range and refreshes it after input
- reuses the existing math delimiter rules to avoid parser drift
- scopes document listeners to the active table session and removes them with the table widget

Closes #697
