### PR TITLE
fix(editor): recognize autolinks with port numbers

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -30,7 +30,7 @@
     "@cspell/cspell-types": "10.0.1",
     "@lezer/common": "1.5.2",
     "@lezer/highlight": "1.2.3",
-    "@lezer/markdown": "1.6.3",
+    "@lezer/markdown": "1.6.4",
     "@markra/ai": "workspace:*",
     "@markra/markdown": "workspace:*",
     "@markra/shared": "workspace:*",

--- a/packages/editor/src/codemirror/links.test.ts
+++ b/packages/editor/src/codemirror/links.test.ts
@@ -205,6 +205,7 @@ describe("linksPlugin", () => {
   it.each([
     ["angle autolink", "<https://example.test/angle>", "https://example.test/angle"],
     ["bare autolink", "https://example.test/bare", "https://example.test/bare"],
+    ["loopback port autolink", "http://127.0.0.1:8080/test", "http://127.0.0.1:8080/test"],
     ["angle email autolink", "<author@example.test>", "mailto:author@example.test"],
     ["mailto autolink", "<mailto:author@example.test>", "mailto:author@example.test"],
     ["bare email autolink", "author@example.test", "mailto:author@example.test"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,8 +403,8 @@ importers:
         specifier: 1.2.3
         version: 1.2.3
       '@lezer/markdown':
-        specifier: 1.6.3
-        version: 1.6.3
+        specifier: 1.6.4
+        version: 1.6.4
       '@markra/ai':
         specifier: workspace:*
         version: link:../ai
@@ -1103,8 +1103,8 @@ packages:
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
-  '@lezer/markdown@1.6.3':
-    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+  '@lezer/markdown@1.6.4':
+    resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -3655,7 +3655,7 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
-      '@lezer/markdown': 1.6.3
+      '@lezer/markdown': 1.6.4
 
   '@codemirror/language@6.12.3':
     dependencies:
@@ -3894,7 +3894,7 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.2
 
-  '@lezer/markdown@1.6.3':
+  '@lezer/markdown@1.6.4':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3


### PR DESCRIPTION
## Summary
- bump `@lezer/markdown` from 1.6.3 to 1.6.4 so GFM autolinks include port numbers and following paths
- add regression coverage for the reported loopback URL with a port

## Why
`@lezer/markdown` 1.6.3 stops the URL syntax node before `:8080`, so live preview only styles and opens the host portion. Version 1.6.4 includes the upstream port-number autolink fix.

## Validation
- `pnpm install --frozen-lockfile --offline` passed
- `pnpm --filter @markra/editor test` — 39 test files and 523 tests passed
- `pnpm --filter @markra/editor build` passed
- `git diff --check` passed

## Risk
- low: this is a patch-level parser dependency update with focused regression coverage
- Markdown source content and explicit link handling are unchanged

Closes #702