### PR TITLE
fix: stabilize Windows frontmatter input and window sizing

### DIFF
--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -205,6 +205,16 @@ fn editor_window_decorations_for_platform(platform: &str) -> bool {
     platform != "windows" && platform != "linux"
 }
 
+fn should_preserve_inner_size_when_hiding_menu(
+    platform: &str,
+    is_menu_visible: bool,
+    is_maximized: bool,
+    is_minimized: bool,
+    is_fullscreen: bool,
+) -> bool {
+    platform == "windows" && is_menu_visible && !is_maximized && !is_minimized && !is_fullscreen
+}
+
 pub(crate) fn hide_native_menu_for_window<R>(window: &tauri::WebviewWindow<R>)
 where
     R: tauri::Runtime,
@@ -212,7 +222,27 @@ where
     match native_menu_window_action_for_platform(current_window_chrome_platform(), window.label()) {
         NativeMenuWindowAction::Keep => {}
         NativeMenuWindowAction::Hide => {
+            let platform = current_window_chrome_platform();
+            let is_menu_visible =
+                platform == "windows" && window.is_menu_visible().unwrap_or_default();
+            let inner_size = if should_preserve_inner_size_when_hiding_menu(
+                platform,
+                is_menu_visible,
+                window.is_maximized().unwrap_or_default(),
+                window.is_minimized().unwrap_or_default(),
+                window.is_fullscreen().unwrap_or_default(),
+            ) {
+                window.inner_size().ok()
+            } else {
+                None
+            };
             let _ = window.hide_menu();
+            if let Some(inner_size) = inner_size {
+                // window-state restores the saved client size while the native menu is
+                // attached. Removing that menu expands the client area unless we reapply
+                // the pre-hide size, causing the saved height to grow on every launch.
+                let _ = window.set_size(inner_size);
+            }
         }
         NativeMenuWindowAction::Remove => {
             // On GTK, hide_menu() leaves the GtkMenuBar in the widget tree and
@@ -1614,6 +1644,56 @@ mod tests {
         assert!(should_hide_native_menu_for_window_label_on_platform(
             "linux",
             "markra-editor-1"
+        ));
+    }
+
+    #[test]
+    fn windows_menu_hiding_preserves_the_restored_inner_size() {
+        let source = include_str!("windows.rs");
+        let start = source
+            .find("pub(crate) fn hide_native_menu_for_window")
+            .expect("native menu hiding function should exist");
+        let end = source[start..]
+            .find("pub(crate) fn hide_native_menus_for_app")
+            .map(|offset| start + offset)
+            .expect("native menu hiding function should have a bounded source range");
+        let function_source = &source[start..end];
+        let capture = function_source
+            .find("window.inner_size()")
+            .expect("Windows should capture the restored content size before hiding its menu");
+        let hide = function_source
+            .find("window.hide_menu()")
+            .expect("Windows should hide its native menu");
+        let restore = function_source
+            .find("window.set_size(inner_size)")
+            .expect("Windows should restore the captured content size after hiding its menu");
+
+        assert!(capture < hide);
+        assert!(hide < restore);
+    }
+
+    #[test]
+    fn menu_hiding_preserves_inner_size_only_for_normal_windows() {
+        assert!(should_preserve_inner_size_when_hiding_menu(
+            "windows", true, false, false, false
+        ));
+        assert!(!should_preserve_inner_size_when_hiding_menu(
+            "windows", false, false, false, false
+        ));
+        assert!(!should_preserve_inner_size_when_hiding_menu(
+            "windows", true, true, false, false
+        ));
+        assert!(!should_preserve_inner_size_when_hiding_menu(
+            "windows", true, false, true, false
+        ));
+        assert!(!should_preserve_inner_size_when_hiding_menu(
+            "windows", true, false, false, true
+        ));
+        assert!(!should_preserve_inner_size_when_hiding_menu(
+            "macos", true, false, false, false
+        ));
+        assert!(!should_preserve_inner_size_when_hiding_menu(
+            "linux", true, false, false, false
         ));
     }
 

--- a/packages/editor/src/codemirror/frontmatter-preview.test.ts
+++ b/packages/editor/src/codemirror/frontmatter-preview.test.ts
@@ -93,6 +93,49 @@ describe("frontmatterPreviewPlugin", () => {
     expect(view.dom.ownerDocument.activeElement).toBe(editor);
   });
 
+  it("defers frontmatter document updates until IME composition ends", () => {
+    const source = ["+++", 'title = ""', "+++", "", "# Body"].join("\n");
+    const view = createView(source);
+    const editor = view.dom.querySelector<HTMLTextAreaElement>(
+      ".cm-markra-frontmatter-editor",
+    );
+
+    editor?.focus();
+    editor?.dispatchEvent(new CompositionEvent("compositionstart", {
+      bubbles: true,
+    }));
+    if (editor) {
+      editor.value = 'title = "shili"';
+      editor.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        data: "shili",
+        inputType: "insertCompositionText",
+        isComposing: true,
+      }));
+    }
+
+    expect(view.state.doc.toString()).toBe(source);
+    expect(view.dom.ownerDocument.activeElement).toBe(editor);
+
+    if (editor) {
+      editor.value = 'title = "示例"';
+      editor.setSelectionRange(editor.value.length, editor.value.length);
+      editor.dispatchEvent(new CompositionEvent("compositionend", {
+        bubbles: true,
+        data: "示例",
+      }));
+    }
+
+    expect(view.state.doc.toString()).toBe([
+      "+++",
+      'title = "示例"',
+      "+++",
+      "",
+      "# Body",
+    ].join("\n"));
+    expect(view.dom.ownerDocument.activeElement).toBe(editor);
+  });
+
   it("ignores non-leading or malformed metadata", () => {
     const malformed = createView('{"title":"Synthetic",}\n\n# Body');
     const nonLeading = createView("# Intro\n\n---\ntitle: Synthetic\n---");

--- a/packages/editor/src/codemirror/frontmatter-preview.ts
+++ b/packages/editor/src/codemirror/frontmatter-preview.ts
@@ -192,27 +192,16 @@ class FrontmatterWidget extends WidgetType {
       `Edit ${this.range.kind.toUpperCase()} frontmatter`,
     );
     editor.spellcheck = false;
-    editor.addEventListener("keydown", (event) => {
-      if (
-        (event.key !== "Backspace" && event.key !== "Delete") ||
-        editor.selectionStart !== 0 ||
-        editor.selectionEnd !== editor.value.length
-      ) {
-        return;
-      }
-      const current = readCodeMirrorFrontmatter(view.state.doc.toString());
-      if (!current || view.state.facet(EditorState.readOnly)) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      removeFrontmatter(view, current);
-    });
-    editor.addEventListener("input", () => {
+    let composing = false;
+    const syncEditorValue = () => {
       const current = readCodeMirrorFrontmatter(view.state.doc.toString());
       if (!current) return;
       const selectionStart = editor.selectionStart;
       const selectionEnd = editor.selectionEnd;
       const insert = current.delimiter ? `${editor.value}\n` : editor.value;
+      if (view.state.doc.sliceString(current.contentFrom, current.contentTo) === insert) {
+        return;
+      }
       view.dispatch({
         changes: {
           from: current.contentFrom,
@@ -231,6 +220,34 @@ class FrontmatterWidget extends WidgetType {
       if (nextEditor) {
         nextEditor.rows = Math.max(1, nextEditor.value.split("\n").length);
       }
+    };
+    editor.addEventListener("compositionstart", () => {
+      composing = true;
+    });
+    editor.addEventListener("compositionend", () => {
+      composing = false;
+      syncEditorValue();
+    });
+    editor.addEventListener("keydown", (event) => {
+      if (
+        (event.key !== "Backspace" && event.key !== "Delete") ||
+        editor.selectionStart !== 0 ||
+        editor.selectionEnd !== editor.value.length
+      ) {
+        return;
+      }
+      const current = readCodeMirrorFrontmatter(view.state.doc.toString());
+      if (!current || view.state.facet(EditorState.readOnly)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      removeFrontmatter(view, current);
+    });
+    editor.addEventListener("input", (event) => {
+      // Refocusing or moving the textarea selection before IME commit transfers
+      // the composition to CodeMirror's contenteditable surface on Windows.
+      if (composing || event.isComposing) return;
+      syncEditorValue();
     });
     root.append(label, editor);
     this.syncDOM(root, view);


### PR DESCRIPTION
## Summary

- Defer frontmatter synchronization until IME composition ends, keeping CJK input inside the metadata editor.
- Preserve normal Windows client dimensions while hiding visible native menus so window-state persistence does not grow the window on each launch.
- Add focused regressions for IME composition and Windows menu/window-state boundaries.

## Why

The frontmatter textarea dispatched CodeMirror transactions and restored focus and selection for every composing input event, which could transfer the active IME composition into the main editor. On Windows, the window-state plugin restored the client size while the native menu was attached; hiding the menu afterwards expanded the client area and saved a larger height for the next launch.

## Validation

- `pnpm --filter @markra/editor test` — 39 files and 524 tests passed
- `pnpm --filter @markra/editor build` passed
- `pnpm --filter @markra/editor typecheck:test` passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml` — 286 tests passed
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml` passed
- `pnpm --filter @markra/desktop build` passed
- `pnpm --filter @markra/desktop typecheck:test` passed
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check` passed
- `git diff --check` passed
- Not run: Win11/WebView2 manual QA because the current development host is macOS

## Risk

- Windows size preservation is limited to visible menus on normal windows. Maximized, minimized, fullscreen, already-hidden menus, and non-Windows platforms retain their existing behavior.
- The custom-template backup item from #706 is intentionally not included.

## Related issues

Refs #706